### PR TITLE
[GeoMechanicsApplication] Reorder DOFs of non-diff order U-Pw elements and conditions (#12061)

### DIFF
--- a/applications/GeoMechanicsApplication/custom_conditions/Pw_normal_flux_condition.cpp
+++ b/applications/GeoMechanicsApplication/custom_conditions/Pw_normal_flux_condition.cpp
@@ -83,7 +83,7 @@ void PwNormalFluxCondition<TDim,TNumNodes>::
 {
     noalias(rVariables.PVector) = - rVariables.NormalFlux * rVariables.Np * rVariables.IntegrationCoefficient;
 
-    GeoElementUtilities::AssemblePBlockVector<0, TNumNodes>(rRightHandSideVector, rVariables.PVector);
+    rRightHandSideVector += rVariables.PVector;
 }
 
 

--- a/applications/GeoMechanicsApplication/custom_conditions/Pw_normal_flux_condition.cpp
+++ b/applications/GeoMechanicsApplication/custom_conditions/Pw_normal_flux_condition.cpp
@@ -83,9 +83,7 @@ void PwNormalFluxCondition<TDim,TNumNodes>::
 {
     noalias(rVariables.PVector) = - rVariables.NormalFlux * rVariables.Np * rVariables.IntegrationCoefficient;
 
-    GeoElementUtilities::
-        AssemblePBlockVector< 0, TNumNodes >(rRightHandSideVector,
-                                                rVariables.PVector);
+    GeoElementUtilities::AssemblePBlockVector<0, TNumNodes>(rRightHandSideVector, rVariables.PVector);
 }
 
 

--- a/applications/GeoMechanicsApplication/custom_conditions/T_microclimate_flux_condition.cpp
+++ b/applications/GeoMechanicsApplication/custom_conditions/T_microclimate_flux_condition.cpp
@@ -167,14 +167,11 @@ void GeoTMicroClimateFluxCondition<TDim, TNumNodes>::CalculateAndAddRHS(
 {
     auto temporary_matrix = BoundedMatrix<double, TNumNodes, TNumNodes>{
         outer_prod(rN, rN) * IntegrationCoefficient};
-    auto temporary_vector =
-        array_1d<double, TNumNodes>{prod(temporary_matrix, rRightHandSideFluxes)};
-    rRightHandSideVector += temporary_vector;
+    rRightHandSideVector += prod(temporary_matrix, rRightHandSideFluxes);
 
     temporary_matrix = BoundedMatrix<double, TNumNodes, TNumNodes>{
         outer_prod(rN, element_prod(rN, rLeftHandSideFluxes)) * IntegrationCoefficient};
-    temporary_vector = -prod(temporary_matrix, rNodalTemperatures);
-    rRightHandSideVector += temporary_vector;
+    rRightHandSideVector -= prod(temporary_matrix, rNodalTemperatures);
 }
 
 template <unsigned int TDim, unsigned int TNumNodes>

--- a/applications/GeoMechanicsApplication/custom_conditions/T_microclimate_flux_condition.cpp
+++ b/applications/GeoMechanicsApplication/custom_conditions/T_microclimate_flux_condition.cpp
@@ -151,7 +151,7 @@ void GeoTMicroClimateFluxCondition<TDim, TNumNodes>::CalculateAndAddLHS(
     const auto flux_matrix = BoundedMatrix<double, TNumNodes, TNumNodes>{
         outer_prod(rN, element_prod(rN, rLeftHandSideFluxes)) * IntegrationCoefficient};
 
-    GeoElementUtilities::AssemblePBlockMatrix<0, TNumNodes>(rLeftHandSideMatrix, flux_matrix);
+    GeoElementUtilities::AssemblePPBlockMatrix<0, TNumNodes>(rLeftHandSideMatrix, flux_matrix);
 
     KRATOS_CATCH("")
 }

--- a/applications/GeoMechanicsApplication/custom_conditions/T_microclimate_flux_condition.cpp
+++ b/applications/GeoMechanicsApplication/custom_conditions/T_microclimate_flux_condition.cpp
@@ -151,7 +151,7 @@ void GeoTMicroClimateFluxCondition<TDim, TNumNodes>::CalculateAndAddLHS(
     const auto flux_matrix = BoundedMatrix<double, TNumNodes, TNumNodes>{
         outer_prod(rN, element_prod(rN, rLeftHandSideFluxes)) * IntegrationCoefficient};
 
-    GeoElementUtilities::AssemblePPBlockMatrix<0, TNumNodes>(rLeftHandSideMatrix, flux_matrix);
+    rLeftHandSideMatrix += flux_matrix;
 
     KRATOS_CATCH("")
 }
@@ -169,14 +169,12 @@ void GeoTMicroClimateFluxCondition<TDim, TNumNodes>::CalculateAndAddRHS(
         outer_prod(rN, rN) * IntegrationCoefficient};
     auto temporary_vector =
         array_1d<double, TNumNodes>{prod(temporary_matrix, rRightHandSideFluxes)};
-    GeoElementUtilities::AssemblePBlockVector<0, TNumNodes>(
-        rRightHandSideVector, temporary_vector);
+    rRightHandSideVector += temporary_vector;
 
     temporary_matrix = BoundedMatrix<double, TNumNodes, TNumNodes>{
         outer_prod(rN, element_prod(rN, rLeftHandSideFluxes)) * IntegrationCoefficient};
     temporary_vector = -prod(temporary_matrix, rNodalTemperatures);
-    GeoElementUtilities::AssemblePBlockVector<0, TNumNodes>(
-        rRightHandSideVector, temporary_vector);
+    rRightHandSideVector += temporary_vector;
 }
 
 template <unsigned int TDim, unsigned int TNumNodes>

--- a/applications/GeoMechanicsApplication/custom_conditions/T_normal_flux_condition.cpp
+++ b/applications/GeoMechanicsApplication/custom_conditions/T_normal_flux_condition.cpp
@@ -81,8 +81,7 @@ void GeoTNormalFluxCondition<TDim, TNumNodes>::CalculateRHS(Vector& rRightHandSi
 
         // Contributions to the right hand side
         auto normal_flux_on_DOF = normal_flux_on_integration_point * N * weighting_integration_coefficient;
-        GeoElementUtilities::AssemblePBlockVector<0, TNumNodes>(rRightHandSideVector,
-                                                                normal_flux_on_DOF);
+        rRightHandSideVector += normal_flux_on_DOF;
     }
 }
 

--- a/applications/GeoMechanicsApplication/custom_conditions/T_normal_flux_condition.cpp
+++ b/applications/GeoMechanicsApplication/custom_conditions/T_normal_flux_condition.cpp
@@ -80,8 +80,7 @@ void GeoTNormalFluxCondition<TDim, TNumNodes>::CalculateRHS(Vector& rRightHandSi
                 r_integration_points[integration_point].Weight());
 
         // Contributions to the right hand side
-        auto normal_flux_on_DOF = normal_flux_on_integration_point * N * weighting_integration_coefficient;
-        rRightHandSideVector += normal_flux_on_DOF;
+        rRightHandSideVector += (normal_flux_on_integration_point * N * weighting_integration_coefficient);
     }
 }
 

--- a/applications/GeoMechanicsApplication/custom_conditions/U_Pw_condition.cpp
+++ b/applications/GeoMechanicsApplication/custom_conditions/U_Pw_condition.cpp
@@ -127,14 +127,7 @@ void UPwCondition<TDim,TNumNodes>::
 template <unsigned int TDim, unsigned int TNumNodes>
 Condition::DofsVectorType UPwCondition<TDim, TNumNodes>::GetDofs() const
 {
-    auto result = Condition::DofsVectorType{};
-    for (const auto& r_node : GetGeometry()) {
-        result.push_back(r_node.pGetDof(DISPLACEMENT_X));
-        result.push_back(r_node.pGetDof(DISPLACEMENT_Y));
-        if constexpr (TDim == 3) result.push_back(r_node.pGetDof(DISPLACEMENT_Z));
-        result.push_back(r_node.pGetDof(WATER_PRESSURE));
-    }
-    return result;
+    return Geo::DofUtilities::ExtractUPwDofsFromNodes(GetGeometry(), TDim);
 }
 
 //----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

--- a/applications/GeoMechanicsApplication/custom_conditions/U_Pw_face_load_condition.cpp
+++ b/applications/GeoMechanicsApplication/custom_conditions/U_Pw_face_load_condition.cpp
@@ -72,7 +72,7 @@ void UPwFaceLoadCondition<TDim,TNumNodes>::
 
         //Contributions to the right hand side
         noalias(UVector) = prod(trans(Nu),TractionVector) * integration_coefficient;
-        GeoElementUtilities::AssembleUBlockVector<TDim, TNumNodes>(rRightHandSideVector, UVector);
+        GeoElementUtilities::AssembleUBlockVector(rRightHandSideVector, UVector);
     }
 }
 

--- a/applications/GeoMechanicsApplication/custom_conditions/U_Pw_face_load_condition.cpp
+++ b/applications/GeoMechanicsApplication/custom_conditions/U_Pw_face_load_condition.cpp
@@ -15,6 +15,7 @@
 
 // Application includes
 #include "custom_conditions/U_Pw_face_load_condition.hpp"
+#include "custom_utilities/element_utilities.hpp"
 
 namespace Kratos
 {
@@ -71,7 +72,7 @@ void UPwFaceLoadCondition<TDim,TNumNodes>::
 
         //Contributions to the right hand side
         noalias(UVector) = prod(trans(Nu),TractionVector) * integration_coefficient;
-        ConditionUtilities::AssembleUBlockVector<TDim, TNumNodes>(rRightHandSideVector, UVector);
+        GeoElementUtilities::AssembleUBlockVector<TDim, TNumNodes>(rRightHandSideVector, UVector);
     }
 }
 

--- a/applications/GeoMechanicsApplication/custom_conditions/U_Pw_face_load_interface_condition.cpp
+++ b/applications/GeoMechanicsApplication/custom_conditions/U_Pw_face_load_interface_condition.cpp
@@ -14,6 +14,7 @@
 
 // Application includes
 #include "custom_conditions/U_Pw_face_load_interface_condition.hpp"
+#include "custom_utilities/element_utilities.hpp"
 
 namespace Kratos
 {
@@ -119,7 +120,7 @@ void UPwFaceLoadInterfaceCondition<TDim,TNumNodes>::
                 
         //Contributions to the right hand side
         noalias(UVector) = prod(trans(Nu),TractionVector) * integration_coefficient;
-        ConditionUtilities::AssembleUBlockVector<TDim, TNumNodes>(rRightHandSideVector,UVector);
+        GeoElementUtilities::AssembleUBlockVector<TDim, TNumNodes>(rRightHandSideVector,UVector);
     }
 }
 

--- a/applications/GeoMechanicsApplication/custom_conditions/U_Pw_face_load_interface_condition.cpp
+++ b/applications/GeoMechanicsApplication/custom_conditions/U_Pw_face_load_interface_condition.cpp
@@ -120,7 +120,7 @@ void UPwFaceLoadInterfaceCondition<TDim,TNumNodes>::
                 
         //Contributions to the right hand side
         noalias(UVector) = prod(trans(Nu),TractionVector) * integration_coefficient;
-        GeoElementUtilities::AssembleUBlockVector<TDim, TNumNodes>(rRightHandSideVector,UVector);
+        GeoElementUtilities::AssembleUBlockVector(rRightHandSideVector,UVector);
     }
 }
 

--- a/applications/GeoMechanicsApplication/custom_conditions/U_Pw_normal_face_load_condition.cpp
+++ b/applications/GeoMechanicsApplication/custom_conditions/U_Pw_normal_face_load_condition.cpp
@@ -69,7 +69,7 @@ void UPwNormalFaceLoadCondition<TDim,TNumNodes>::
 
         //Contributions to the right hand side
         noalias(UVector) = prod(trans(Nu),TractionVector) * IntegrationCoefficient;
-        GeoElementUtilities::AssembleUBlockVector<TDim, TNumNodes>(rRightHandSideVector, UVector);
+        GeoElementUtilities::AssembleUBlockVector(rRightHandSideVector, UVector);
     }
 }
 

--- a/applications/GeoMechanicsApplication/custom_conditions/U_Pw_normal_face_load_condition.cpp
+++ b/applications/GeoMechanicsApplication/custom_conditions/U_Pw_normal_face_load_condition.cpp
@@ -15,6 +15,7 @@
 
 // Application includes
 #include "custom_conditions/U_Pw_normal_face_load_condition.hpp"
+#include "custom_utilities/element_utilities.hpp"
 
 namespace Kratos
 {
@@ -68,7 +69,7 @@ void UPwNormalFaceLoadCondition<TDim,TNumNodes>::
 
         //Contributions to the right hand side
         noalias(UVector) = prod(trans(Nu),TractionVector) * IntegrationCoefficient;
-        ConditionUtilities::AssembleUBlockVector<TDim, TNumNodes>(rRightHandSideVector, UVector);
+        GeoElementUtilities::AssembleUBlockVector<TDim, TNumNodes>(rRightHandSideVector, UVector);
     }
 }
 

--- a/applications/GeoMechanicsApplication/custom_conditions/U_Pw_normal_flux_FIC_condition.cpp
+++ b/applications/GeoMechanicsApplication/custom_conditions/U_Pw_normal_flux_FIC_condition.cpp
@@ -203,7 +203,7 @@ void UPwNormalFluxFICCondition<TDim,TNumNodes>::CalculateAndAddBoundaryMassMatri
                                         outer_prod(rVariables.Np,rVariables.Np)*rVariables.IntegrationCoefficient;
 
     //Distribute boundary mass matrix into the elemental matrix
-    GeoElementUtilities::AssemblePBlockMatrix< TDim, TNumNodes >(rLeftHandSideMatrix,rFICVariables.PMatrix);
+    GeoElementUtilities::AssemblePPBlockMatrix< TDim, TNumNodes >(rLeftHandSideMatrix,rFICVariables.PMatrix);
 }
 
 //----------------------------------------------------------------------------------------

--- a/applications/GeoMechanicsApplication/custom_conditions/U_Pw_normal_flux_FIC_condition.cpp
+++ b/applications/GeoMechanicsApplication/custom_conditions/U_Pw_normal_flux_FIC_condition.cpp
@@ -199,11 +199,11 @@ template< unsigned int TDim, unsigned int TNumNodes >
 void UPwNormalFluxFICCondition<TDim,TNumNodes>::CalculateAndAddBoundaryMassMatrix(MatrixType& rLeftHandSideMatrix, NormalFluxVariables& rVariables,
                                                                                     NormalFluxFICVariables& rFICVariables)
 {
-    noalias(rFICVariables.PMatrix) = -rFICVariables.DtPressureCoefficient*rFICVariables.ElementLength*rFICVariables.BiotModulusInverse/6.0*
+    noalias(rFICVariables.PPMatrix) = -rFICVariables.DtPressureCoefficient*rFICVariables.ElementLength*rFICVariables.BiotModulusInverse/6.0*
                                         outer_prod(rVariables.Np,rVariables.Np)*rVariables.IntegrationCoefficient;
 
     //Distribute boundary mass matrix into the elemental matrix
-    GeoElementUtilities::AssemblePPBlockMatrix< TDim, TNumNodes >(rLeftHandSideMatrix,rFICVariables.PMatrix);
+    GeoElementUtilities::AssemblePPBlockMatrix(rLeftHandSideMatrix,rFICVariables.PPMatrix);
 }
 
 //----------------------------------------------------------------------------------------
@@ -222,14 +222,14 @@ template< unsigned int TDim, unsigned int TNumNodes >
 void UPwNormalFluxFICCondition<TDim,TNumNodes>::CalculateAndAddBoundaryMassFlow(VectorType& rRightHandSideVector, NormalFluxVariables& rVariables,
                                                                                     NormalFluxFICVariables& rFICVariables)
 {
-    noalias(rFICVariables.PMatrix) = rFICVariables.ElementLength*rFICVariables.BiotModulusInverse/6.0*
+    noalias(rFICVariables.PPMatrix) = rFICVariables.ElementLength*rFICVariables.BiotModulusInverse/6.0*
                                         outer_prod(rVariables.Np,rVariables.Np)*rVariables.IntegrationCoefficient;
 
 
-    noalias(rVariables.PVector) = prod(rFICVariables.PMatrix,rFICVariables.DtPressureVector);
+    noalias(rVariables.PVector) = prod(rFICVariables.PPMatrix,rFICVariables.DtPressureVector);
 
     //Distribute boundary mass flow vector into elemental vector
-    GeoElementUtilities::AssemblePBlockVector< TDim, TNumNodes >(rRightHandSideVector,rVariables.PVector);
+    GeoElementUtilities::AssemblePBlockVector(rRightHandSideVector,rVariables.PVector);
 }
 
 //----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

--- a/applications/GeoMechanicsApplication/custom_conditions/U_Pw_normal_flux_FIC_condition.hpp
+++ b/applications/GeoMechanicsApplication/custom_conditions/U_Pw_normal_flux_FIC_condition.hpp
@@ -79,7 +79,7 @@ protected:
         double BiotModulusInverse;
 
         array_1d<double,TNumNodes> DtPressureVector;
-        BoundedMatrix<double,TNumNodes,TNumNodes> PMatrix;
+        BoundedMatrix<double,TNumNodes,TNumNodes> PPMatrix;
     };
 
     // Member Variables

--- a/applications/GeoMechanicsApplication/custom_conditions/U_Pw_normal_flux_condition.cpp
+++ b/applications/GeoMechanicsApplication/custom_conditions/U_Pw_normal_flux_condition.cpp
@@ -83,7 +83,7 @@ void UPwNormalFluxCondition<TDim,TNumNodes>::
 {
     noalias(rVariables.PVector) = - rVariables.NormalFlux * rVariables.Np * rVariables.IntegrationCoefficient;
 
-    GeoElementUtilities::AssemblePBlockVector<TDim, TNumNodes>(rRightHandSideVector, rVariables.PVector);
+    GeoElementUtilities::AssemblePBlockVector(rRightHandSideVector, rVariables.PVector);
 }
 
 //----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

--- a/applications/GeoMechanicsApplication/custom_conditions/U_Pw_normal_flux_condition.cpp
+++ b/applications/GeoMechanicsApplication/custom_conditions/U_Pw_normal_flux_condition.cpp
@@ -83,9 +83,7 @@ void UPwNormalFluxCondition<TDim,TNumNodes>::
 {
     noalias(rVariables.PVector) = - rVariables.NormalFlux * rVariables.Np * rVariables.IntegrationCoefficient;
 
-    GeoElementUtilities::
-        AssemblePBlockVector< TDim, TNumNodes >(rRightHandSideVector,
-                                                rVariables.PVector);
+    GeoElementUtilities::AssemblePBlockVector<TDim, TNumNodes>(rRightHandSideVector, rVariables.PVector);
 }
 
 //----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

--- a/applications/GeoMechanicsApplication/custom_conditions/U_Pw_normal_flux_interface_condition.cpp
+++ b/applications/GeoMechanicsApplication/custom_conditions/U_Pw_normal_flux_interface_condition.cpp
@@ -90,7 +90,7 @@ void UPwNormalFluxInterfaceCondition<TDim,TNumNodes>::
                 
         //Contributions to the right hand side
         noalias(PVector) = -NormalFlux * Np * IntegrationCoefficient;
-        GeoElementUtilities::AssemblePBlockVector< TDim, TNumNodes >(rRightHandSideVector,PVector);
+        GeoElementUtilities::AssemblePBlockVector(rRightHandSideVector,PVector);
     }
 }
 

--- a/applications/GeoMechanicsApplication/custom_conditions/U_Pw_normal_lysmer_absorbing_condition.cpp
+++ b/applications/GeoMechanicsApplication/custom_conditions/U_Pw_normal_lysmer_absorbing_condition.cpp
@@ -104,7 +104,7 @@ void UPwLysmerAbsorbingCondition<TDim, TNumNodes>::CalculateRightHandSide(Vector
     this->CalculateConditionStiffnessMatrix(stiffness_matrix, rCurrentProcessInfo);
 
     MatrixType global_stiffness_matrix = ZeroMatrix(CONDITION_SIZE, CONDITION_SIZE);
-    GeoElementUtilities::AssembleUBlockMatrix(global_stiffness_matrix, stiffness_matrix);
+    GeoElementUtilities::AssembleUUBlockMatrix(global_stiffness_matrix, stiffness_matrix);
 
     this->CalculateAndAddRHS(rRightHandSideVector, global_stiffness_matrix);
 }
@@ -426,7 +426,7 @@ AddLHS(MatrixType& rLeftHandSideMatrix, const ElementMatrixType& rUMatrix)
     rLeftHandSideMatrix = ZeroMatrix(CONDITION_SIZE, CONDITION_SIZE);
 
     //Adding contribution to left hand side
-    GeoElementUtilities::AssembleUBlockMatrix(rLeftHandSideMatrix, rUMatrix);
+    GeoElementUtilities::AssembleUUBlockMatrix(rLeftHandSideMatrix, rUMatrix);
 }
 
 template< unsigned int TDim, unsigned int TNumNodes >

--- a/applications/GeoMechanicsApplication/custom_conditions/U_Pw_normal_lysmer_absorbing_condition.cpp
+++ b/applications/GeoMechanicsApplication/custom_conditions/U_Pw_normal_lysmer_absorbing_condition.cpp
@@ -420,13 +420,13 @@ CalculateAndAddRHS(VectorType& rRightHandSideVector, const MatrixType& rStiffnes
 
 template< unsigned int TDim, unsigned int TNumNodes >
 void UPwLysmerAbsorbingCondition<TDim, TNumNodes>::
-AddLHS(MatrixType& rLeftHandSideMatrix, const ElementMatrixType& rUMatrix)
+AddLHS(MatrixType& rLeftHandSideMatrix, const ElementMatrixType& rUUMatrix)
 {
 	// assemble left hand side vector
     rLeftHandSideMatrix = ZeroMatrix(CONDITION_SIZE, CONDITION_SIZE);
 
     //Adding contribution to left hand side
-    GeoElementUtilities::AssembleUUBlockMatrix(rLeftHandSideMatrix, rUMatrix);
+    GeoElementUtilities::AssembleUUBlockMatrix(rLeftHandSideMatrix, rUUMatrix);
 }
 
 template< unsigned int TDim, unsigned int TNumNodes >

--- a/applications/GeoMechanicsApplication/custom_conditions/U_Pw_normal_lysmer_absorbing_condition.cpp
+++ b/applications/GeoMechanicsApplication/custom_conditions/U_Pw_normal_lysmer_absorbing_condition.cpp
@@ -104,7 +104,7 @@ void UPwLysmerAbsorbingCondition<TDim, TNumNodes>::CalculateRightHandSide(Vector
     this->CalculateConditionStiffnessMatrix(stiffness_matrix, rCurrentProcessInfo);
 
     MatrixType global_stiffness_matrix = ZeroMatrix(CONDITION_SIZE, CONDITION_SIZE);
-    GeoElementUtilities::AssembleUBlockMatrix< TDim, TNumNodes >(global_stiffness_matrix, stiffness_matrix);
+    GeoElementUtilities::AssembleUBlockMatrix(global_stiffness_matrix, stiffness_matrix);
 
     this->CalculateAndAddRHS(rRightHandSideVector, global_stiffness_matrix);
 }
@@ -426,9 +426,7 @@ AddLHS(MatrixType& rLeftHandSideMatrix, const ElementMatrixType& rUMatrix)
     rLeftHandSideMatrix = ZeroMatrix(CONDITION_SIZE, CONDITION_SIZE);
 
     //Adding contribution to left hand side
-    GeoElementUtilities::
-        AssembleUBlockMatrix< TDim, TNumNodes >(rLeftHandSideMatrix,
-            rUMatrix);
+    GeoElementUtilities::AssembleUBlockMatrix(rLeftHandSideMatrix, rUMatrix);
 }
 
 template< unsigned int TDim, unsigned int TNumNodes >

--- a/applications/GeoMechanicsApplication/custom_conditions/U_Pw_normal_lysmer_absorbing_condition.hpp
+++ b/applications/GeoMechanicsApplication/custom_conditions/U_Pw_normal_lysmer_absorbing_condition.hpp
@@ -131,9 +131,9 @@ protected:
     /**
     * @brief Adds the condition matrix to the global left hand side
     * @param rLeftHandSideMatrix Global Left hand side
-    * @param rUMatrix LHS displacement matrix of the current condition
+    * @param rUUMatrix LHS displacement matrix of the current condition
     */
-    void AddLHS(MatrixType& rLeftHandSideMatrix, const ElementMatrixType& rUMatrix);
+    void AddLHS(MatrixType& rLeftHandSideMatrix, const ElementMatrixType& rUUMatrix);
 
     /**
     * @brief Calculates and adds terms to the RHS

--- a/applications/GeoMechanicsApplication/custom_elements/README.md
+++ b/applications/GeoMechanicsApplication/custom_elements/README.md
@@ -1,3 +1,15 @@
+# U-Pw Continuum Elements
+
+For simulating soil behavior, the geomechanics application offers continuum elements that take into account the displacement field ($u$) as well as the pore water pressure field ($p_w$). In fact, the two fields can be coupled.
+
+Depending on your needs, you may opt for either so-called "diff order" elements or "non-diff order" elements. The former implies that the order of the interpolation polynomials that will be used for the pore water pressure field is one less than the order of the interpolation polynomials of the displacement field. The latter, on the other hand, assumes one and the same order for the interpolation polynomials of both fields.
+
+Regardless of the above distinction, the application orders the degrees of freedom (DOFs) in the same way. The first part relates to the displacement DOFs (grouped per node), followed by a second part that contains the pore water pressure DOFs. For instance, assuming a 6-noded triangular diff order element, the DOFs are ordered as follows:
+
+$$ u_{x,1}, u_{y,1}, u_{x,2}, u_{y,2}, \dots, u_{x,6}, u_{y,6}, p_1, p_2, p_3 $$
+
+where the directions of the displacements are denoted by a suffix (here either $x$ or $y$), and the node number is also added as a suffix. Note that in this case, there are only three pore water pressure DOFs (due to the diff order nature of the element). For a non-diff order quadratic element the above list of DOFs is appended by $p_4$, $p_5$, and $p_6$.
+
 # Transient Thermal Element
 
 ## Introduction

--- a/applications/GeoMechanicsApplication/custom_elements/U_Pw_base_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/U_Pw_base_element.cpp
@@ -618,14 +618,8 @@ unsigned int UPwBaseElement<TDim, TNumNodes>::GetNumberOfDOF() const
 template <unsigned int TDim, unsigned int TNumNodes>
 Element::DofsVectorType UPwBaseElement<TDim, TNumNodes>::GetDofs() const
 {
-    auto result = Element::DofsVectorType{};
-    for (const auto& r_node : this->GetGeometry()) {
-        result.push_back(r_node.pGetDof(DISPLACEMENT_X));
-        result.push_back(r_node.pGetDof(DISPLACEMENT_Y));
-        if constexpr (TDim == 3) result.push_back(r_node.pGetDof(DISPLACEMENT_Z));
-        result.push_back(r_node.pGetDof(WATER_PRESSURE));
-    }
-    return result;
+    return Geo::DofUtilities::ExtractUPwDofsFromNodes(this->GetGeometry(),
+                                                      this->GetGeometry().WorkingSpaceDimension());
 }
 
 template <unsigned int TDim, unsigned int TNumNodes>

--- a/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_FIC_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_FIC_element.cpp
@@ -1277,7 +1277,7 @@ void UPwSmallStrainFICElement<TDim, TNumNodes>::CalculateAndAddPressureGradientM
         prod(rVariables.GradNpT, trans(rVariables.GradNpT)) * rVariables.IntegrationCoefficient;
 
     // Distribute pressure gradient block matrix into the elemental matrix
-    GeoElementUtilities::AssemblePBlockMatrix<TDim, TNumNodes>(rLeftHandSideMatrix, rVariables.PMatrix);
+    GeoElementUtilities::AssemblePPBlockMatrix<TDim, TNumNodes>(rLeftHandSideMatrix, rVariables.PMatrix);
 
     KRATOS_CATCH("")
 }

--- a/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_FIC_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_FIC_element.cpp
@@ -917,7 +917,7 @@ void UPwSmallStrainFICElement<2, 4>::CalculateAndAddStrainGradientMatrix(MatrixT
         prod(rVariables.GradNpT, rFICVariables.StrainGradients) * rVariables.IntegrationCoefficient;
 
     // Distribute strain gradient matrix into the elemental matrix
-    GeoElementUtilities::AssemblePUBlockMatrix<2, 4>(rLeftHandSideMatrix, rVariables.PUMatrix);
+    GeoElementUtilities::AssemblePUBlockMatrix(rLeftHandSideMatrix, rVariables.PUMatrix);
 
     KRATOS_CATCH("")
 }
@@ -946,7 +946,7 @@ void UPwSmallStrainFICElement<3, 8>::CalculateAndAddStrainGradientMatrix(MatrixT
         prod(rVariables.GradNpT, rFICVariables.StrainGradients) * rVariables.IntegrationCoefficient;
 
     // Distribute strain gradient matrix into the elemental matrix
-    GeoElementUtilities::AssemblePUBlockMatrix<3, 8>(rLeftHandSideMatrix, rVariables.PUMatrix);
+    GeoElementUtilities::AssemblePUBlockMatrix(rLeftHandSideMatrix, rVariables.PUMatrix);
 
     KRATOS_CATCH("")
 }
@@ -970,7 +970,7 @@ void UPwSmallStrainFICElement<TDim, TNumNodes>::CalculateAndAddDtStressGradientM
                                    rVariables.IntegrationCoefficient;
 
     // Distribute DtStressGradient Matrix into the elemental matrix
-    GeoElementUtilities::AssemblePUBlockMatrix<TDim, TNumNodes>(rLeftHandSideMatrix, rVariables.PUMatrix);
+    GeoElementUtilities::AssemblePUBlockMatrix(rLeftHandSideMatrix, rVariables.PUMatrix);
 
     KRATOS_CATCH("")
 }
@@ -1270,14 +1270,14 @@ void UPwSmallStrainFICElement<TDim, TNumNodes>::CalculateAndAddPressureGradientM
     const double StabilizationParameter = rFICVariables.ElementLength * rFICVariables.ElementLength *
                                           SignBiotCoefficient / (8.0 * rFICVariables.ShearModulus);
 
-    noalias(rVariables.PMatrix) =
+    noalias(rVariables.PPMatrix) =
         rVariables.DtPressureCoefficient * StabilizationParameter *
         (SignBiotCoefficient - 2.0 * rFICVariables.ShearModulus * rVariables.BiotModulusInverse /
                                    (3.0 * SignBiotCoefficient)) *
         prod(rVariables.GradNpT, trans(rVariables.GradNpT)) * rVariables.IntegrationCoefficient;
 
     // Distribute pressure gradient block matrix into the elemental matrix
-    GeoElementUtilities::AssemblePPBlockMatrix<TDim, TNumNodes>(rLeftHandSideMatrix, rVariables.PMatrix);
+    GeoElementUtilities::AssemblePPBlockMatrix(rLeftHandSideMatrix, rVariables.PPMatrix);
 
     KRATOS_CATCH("")
 }
@@ -1324,7 +1324,7 @@ void UPwSmallStrainFICElement<2, 4>::CalculateAndAddStrainGradientFlow(VectorTyp
     noalias(rVariables.PVector) = prod(rVariables.PUMatrix, rVariables.VelocityVector);
 
     // Distribute Strain Gradient vector into elemental vector
-    GeoElementUtilities::AssemblePBlockVector<2, 4>(rRightHandSideVector, rVariables.PVector);
+    GeoElementUtilities::AssemblePBlockVector(rRightHandSideVector, rVariables.PVector);
 
     KRATOS_CATCH("")
 }
@@ -1354,7 +1354,7 @@ void UPwSmallStrainFICElement<3, 8>::CalculateAndAddStrainGradientFlow(VectorTyp
     noalias(rVariables.PVector) = prod(rVariables.PUMatrix, rVariables.VelocityVector);
 
     // Distribute Strain Gradient vector into elemental vector
-    GeoElementUtilities::AssemblePBlockVector<3, 8>(rRightHandSideVector, rVariables.PVector);
+    GeoElementUtilities::AssemblePBlockVector(rRightHandSideVector, rVariables.PVector);
 
     KRATOS_CATCH("")
 }
@@ -1377,7 +1377,7 @@ void UPwSmallStrainFICElement<TDim, TNumNodes>::CalculateAndAddDtStressGradientF
                                   rVariables.IntegrationCoefficient;
 
     // Distribute DtStressGradient block vector into elemental vector
-    GeoElementUtilities::AssemblePBlockVector<TDim, TNumNodes>(rRightHandSideVector, rVariables.PVector);
+    GeoElementUtilities::AssemblePBlockVector(rRightHandSideVector, rVariables.PVector);
 
     KRATOS_CATCH("")
 }
@@ -1430,16 +1430,16 @@ void UPwSmallStrainFICElement<TDim, TNumNodes>::CalculateAndAddPressureGradientF
     double StabilizationParameter = rFICVariables.ElementLength * rFICVariables.ElementLength *
                                     SignBiotCoefficient / (8.0 * rFICVariables.ShearModulus);
 
-    noalias(rVariables.PMatrix) =
+    noalias(rVariables.PPMatrix) =
         StabilizationParameter *
         (SignBiotCoefficient - 2.0 * rFICVariables.ShearModulus * rVariables.BiotModulusInverse /
                                    (3.0 * SignBiotCoefficient)) *
         prod(rVariables.GradNpT, trans(rVariables.GradNpT)) * rVariables.IntegrationCoefficient;
 
-    noalias(rVariables.PVector) = -1.0 * prod(rVariables.PMatrix, rVariables.DtPressureVector);
+    noalias(rVariables.PVector) = -1.0 * prod(rVariables.PPMatrix, rVariables.DtPressureVector);
 
     // Distribute PressureGradient block vector into elemental vector
-    GeoElementUtilities::AssemblePBlockVector<TDim, TNumNodes>(rRightHandSideVector, rVariables.PVector);
+    GeoElementUtilities::AssemblePBlockVector(rRightHandSideVector, rVariables.PVector);
 
     KRATOS_CATCH("")
 }

--- a/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_element.cpp
@@ -925,12 +925,12 @@ void UPwSmallStrainElement<TDim, TNumNodes>::CalculateAndAddGeometricStiffnessMa
         prod(rVariables.GradNpT,
              rVariables.IntegrationCoefficient * Matrix(prod(StressTensor, trans(rVariables.GradNpT)))); // to be optimized
 
-    Matrix UMatrix(TNumNodes * TDim, TNumNodes * TDim);
-    noalias(UMatrix) = ZeroMatrix(TNumNodes * TDim, TNumNodes * TDim);
-    MathUtils<double>::ExpandAndAddReducedMatrix(UMatrix, ReducedKgMatrix, TDim);
+    Matrix UUMatrix(TNumNodes * TDim, TNumNodes * TDim);
+    noalias(UUMatrix) = ZeroMatrix(TNumNodes * TDim, TNumNodes * TDim);
+    MathUtils<double>::ExpandAndAddReducedMatrix(UUMatrix, ReducedKgMatrix, TDim);
 
     // Distribute stiffness block matrix into the elemental matrix
-    GeoElementUtilities::AssembleUUBlockMatrix(rLeftHandSideMatrix, UMatrix);
+    GeoElementUtilities::AssembleUUBlockMatrix(rLeftHandSideMatrix, UUMatrix);
 
     KRATOS_CATCH("")
 }
@@ -1236,10 +1236,10 @@ void UPwSmallStrainElement<TDim, TNumNodes>::CalculateAndAddStiffnessMatrix(Matr
     KRATOS_TRY
 
     noalias(rVariables.UVoigtMatrix) = prod(trans(rVariables.B), rVariables.ConstitutiveMatrix);
-    noalias(rVariables.UMatrix) = prod(rVariables.UVoigtMatrix, rVariables.B) * rVariables.IntegrationCoefficient;
+    noalias(rVariables.UUMatrix) = prod(rVariables.UVoigtMatrix, rVariables.B) * rVariables.IntegrationCoefficient;
 
     // Distribute stiffness block matrix into the elemental matrix
-    GeoElementUtilities::AssembleUUBlockMatrix(rLeftHandSideMatrix, rVariables.UMatrix);
+    GeoElementUtilities::AssembleUUBlockMatrix(rLeftHandSideMatrix, rVariables.UUMatrix);
 
     KRATOS_CATCH("")
 }
@@ -1257,7 +1257,7 @@ void UPwSmallStrainElement<TDim, TNumNodes>::CalculateAndAddCouplingMatrix(Matri
         outer_prod(rVariables.UVector, rVariables.Np) * rVariables.IntegrationCoefficient;
 
     // Distribute coupling block matrix into the elemental matrix
-    GeoElementUtilities::AssembleUPBlockMatrix<TDim, TNumNodes>(rLeftHandSideMatrix, rVariables.UPMatrix);
+    GeoElementUtilities::AssembleUPBlockMatrix(rLeftHandSideMatrix, rVariables.UPMatrix);
 
     if (!rVariables.IgnoreUndrained) {
         const double SaturationCoefficient = rVariables.DegreeOfSaturation / rVariables.BishopCoefficient;
@@ -1265,7 +1265,7 @@ void UPwSmallStrainElement<TDim, TNumNodes>::CalculateAndAddCouplingMatrix(Matri
                                        rVariables.VelocityCoefficient * trans(rVariables.UPMatrix);
 
         // Distribute transposed coupling block matrix into the elemental matrix
-        GeoElementUtilities::AssemblePUBlockMatrix<TDim, TNumNodes>(rLeftHandSideMatrix, rVariables.PUMatrix);
+        GeoElementUtilities::AssemblePUBlockMatrix(rLeftHandSideMatrix, rVariables.PUMatrix);
     }
 
     KRATOS_CATCH("")
@@ -1290,10 +1290,10 @@ void UPwSmallStrainElement<TDim, TNumNodes>::CalculateAndAddCompressibilityMatri
 {
     KRATOS_TRY
 
-    this->CalculateCompressibilityMatrix(rVariables.PMatrix, rVariables);
+    this->CalculateCompressibilityMatrix(rVariables.PPMatrix, rVariables);
 
     // Distribute compressibility block matrix into the elemental matrix
-    GeoElementUtilities::AssemblePPBlockMatrix<TDim, TNumNodes>(rLeftHandSideMatrix, rVariables.PMatrix);
+    GeoElementUtilities::AssemblePPBlockMatrix(rLeftHandSideMatrix, rVariables.PPMatrix);
 
     KRATOS_CATCH("")
 }
@@ -1321,10 +1321,10 @@ void UPwSmallStrainElement<TDim, TNumNodes>::CalculateAndAddPermeabilityMatrix(M
 {
     KRATOS_TRY
 
-    this->CalculatePermeabilityMatrix(rVariables.PDimMatrix, rVariables.PMatrix, rVariables);
+    this->CalculatePermeabilityMatrix(rVariables.PDimMatrix, rVariables.PPMatrix, rVariables);
 
     // Distribute permeability block matrix into the elemental matrix
-    GeoElementUtilities::AssemblePPBlockMatrix<TDim, TNumNodes>(rLeftHandSideMatrix, rVariables.PMatrix);
+    GeoElementUtilities::AssemblePPBlockMatrix(rLeftHandSideMatrix, rVariables.PPMatrix);
 
     KRATOS_CATCH("")
 }
@@ -1364,7 +1364,7 @@ void UPwSmallStrainElement<TDim, TNumNodes>::CalculateAndAddStiffnessForce(Vecto
         -1.0 * prod(trans(rVariables.B), mStressVector[GPoint]) * rVariables.IntegrationCoefficient;
 
     // Distribute stiffness block vector into elemental vector
-    GeoElementUtilities::AssembleUBlockVector<TDim, TNumNodes>(rRightHandSideVector, rVariables.UVector);
+    GeoElementUtilities::AssembleUBlockVector(rRightHandSideVector, rVariables.UVector);
 
     KRATOS_CATCH("")
 }
@@ -1381,7 +1381,7 @@ void UPwSmallStrainElement<TDim, TNumNodes>::CalculateAndAddMixBodyForce(VectorT
                                   rVariables.IntegrationCoefficientInitialConfiguration;
 
     // Distribute body force block vector into elemental vector
-    GeoElementUtilities::AssembleUBlockVector<TDim, TNumNodes>(rRightHandSideVector, rVariables.UVector);
+    GeoElementUtilities::AssembleUBlockVector(rRightHandSideVector, rVariables.UVector);
 
     KRATOS_CATCH("")
 }
@@ -1424,7 +1424,7 @@ void UPwSmallStrainElement<TDim, TNumNodes>::CalculateAndAddCouplingTerms(Vector
     noalias(rVariables.UVector) = prod(rVariables.UPMatrix, rVariables.PressureVector);
 
     // Distribute coupling block vector 1 into elemental vector
-    GeoElementUtilities::AssembleUBlockVector<TDim, TNumNodes>(rRightHandSideVector, rVariables.UVector);
+    GeoElementUtilities::AssembleUBlockVector(rRightHandSideVector, rVariables.UVector);
 
     if (!rVariables.IgnoreUndrained) {
         const double SaturationCoefficient = rVariables.DegreeOfSaturation / rVariables.BishopCoefficient;
@@ -1432,7 +1432,7 @@ void UPwSmallStrainElement<TDim, TNumNodes>::CalculateAndAddCouplingTerms(Vector
                                       prod(trans(rVariables.UPMatrix), rVariables.VelocityVector);
 
         // Distribute coupling block vector 2 into elemental vector
-        GeoElementUtilities::AssemblePBlockVector<TDim, TNumNodes>(rRightHandSideVector, rVariables.PVector);
+        GeoElementUtilities::AssemblePBlockVector(rRightHandSideVector, rVariables.PVector);
     }
 
     KRATOS_CATCH("")
@@ -1460,10 +1460,10 @@ void UPwSmallStrainElement<TDim, TNumNodes>::CalculateAndAddCompressibilityFlow(
 {
     KRATOS_TRY
 
-    this->CalculateCompressibilityFlow(rVariables.PMatrix, rVariables.PVector, rVariables);
+    this->CalculateCompressibilityFlow(rVariables.PPMatrix, rVariables.PVector, rVariables);
 
     // Distribute compressibility block vector into elemental vector
-    GeoElementUtilities::AssemblePBlockVector<TDim, TNumNodes>(rRightHandSideVector, rVariables.PVector);
+    GeoElementUtilities::AssemblePBlockVector(rRightHandSideVector, rVariables.PVector);
 
     KRATOS_CATCH("")
 }
@@ -1494,10 +1494,10 @@ void UPwSmallStrainElement<TDim, TNumNodes>::CalculateAndAddPermeabilityFlow(Vec
 {
     KRATOS_TRY
 
-    this->CalculatePermeabilityFlow(rVariables.PDimMatrix, rVariables.PMatrix, rVariables.PVector, rVariables);
+    this->CalculatePermeabilityFlow(rVariables.PDimMatrix, rVariables.PPMatrix, rVariables.PVector, rVariables);
 
     // Distribute permeability block vector into elemental vector
-    GeoElementUtilities::AssemblePBlockVector<TDim, TNumNodes>(rRightHandSideVector, rVariables.PVector);
+    GeoElementUtilities::AssemblePBlockVector(rRightHandSideVector, rVariables.PVector);
 
     KRATOS_CATCH("")
 }
@@ -1527,7 +1527,7 @@ void UPwSmallStrainElement<TDim, TNumNodes>::CalculateAndAddFluidBodyFlow(Vector
     this->CalculateFluidBodyFlow(rVariables.PDimMatrix, rVariables.PVector, rVariables);
 
     // Distribute fluid body flow block vector into elemental vector
-    GeoElementUtilities::AssemblePBlockVector<TDim, TNumNodes>(rRightHandSideVector, rVariables.PVector);
+    GeoElementUtilities::AssemblePBlockVector(rRightHandSideVector, rVariables.PVector);
 
     KRATOS_CATCH("")
 }

--- a/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_element.cpp
@@ -930,7 +930,7 @@ void UPwSmallStrainElement<TDim, TNumNodes>::CalculateAndAddGeometricStiffnessMa
     MathUtils<double>::ExpandAndAddReducedMatrix(UMatrix, ReducedKgMatrix, TDim);
 
     // Distribute stiffness block matrix into the elemental matrix
-    GeoElementUtilities::AssembleUBlockMatrix(rLeftHandSideMatrix, UMatrix, TNumNodes, TDim);
+    GeoElementUtilities::AssembleUBlockMatrix(rLeftHandSideMatrix, UMatrix);
 
     KRATOS_CATCH("")
 }
@@ -1239,7 +1239,7 @@ void UPwSmallStrainElement<TDim, TNumNodes>::CalculateAndAddStiffnessMatrix(Matr
     noalias(rVariables.UMatrix) = prod(rVariables.UVoigtMatrix, rVariables.B) * rVariables.IntegrationCoefficient;
 
     // Distribute stiffness block matrix into the elemental matrix
-    GeoElementUtilities::AssembleUBlockMatrix<TDim, TNumNodes>(rLeftHandSideMatrix, rVariables.UMatrix);
+    GeoElementUtilities::AssembleUBlockMatrix(rLeftHandSideMatrix, rVariables.UMatrix);
 
     KRATOS_CATCH("")
 }

--- a/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_element.cpp
@@ -930,7 +930,7 @@ void UPwSmallStrainElement<TDim, TNumNodes>::CalculateAndAddGeometricStiffnessMa
     MathUtils<double>::ExpandAndAddReducedMatrix(UMatrix, ReducedKgMatrix, TDim);
 
     // Distribute stiffness block matrix into the elemental matrix
-    GeoElementUtilities::AssembleUBlockMatrix(rLeftHandSideMatrix, UMatrix);
+    GeoElementUtilities::AssembleUUBlockMatrix(rLeftHandSideMatrix, UMatrix);
 
     KRATOS_CATCH("")
 }
@@ -1239,7 +1239,7 @@ void UPwSmallStrainElement<TDim, TNumNodes>::CalculateAndAddStiffnessMatrix(Matr
     noalias(rVariables.UMatrix) = prod(rVariables.UVoigtMatrix, rVariables.B) * rVariables.IntegrationCoefficient;
 
     // Distribute stiffness block matrix into the elemental matrix
-    GeoElementUtilities::AssembleUBlockMatrix(rLeftHandSideMatrix, rVariables.UMatrix);
+    GeoElementUtilities::AssembleUUBlockMatrix(rLeftHandSideMatrix, rVariables.UMatrix);
 
     KRATOS_CATCH("")
 }
@@ -1293,7 +1293,7 @@ void UPwSmallStrainElement<TDim, TNumNodes>::CalculateAndAddCompressibilityMatri
     this->CalculateCompressibilityMatrix(rVariables.PMatrix, rVariables);
 
     // Distribute compressibility block matrix into the elemental matrix
-    GeoElementUtilities::AssemblePBlockMatrix<TDim, TNumNodes>(rLeftHandSideMatrix, rVariables.PMatrix);
+    GeoElementUtilities::AssemblePPBlockMatrix<TDim, TNumNodes>(rLeftHandSideMatrix, rVariables.PMatrix);
 
     KRATOS_CATCH("")
 }
@@ -1324,7 +1324,7 @@ void UPwSmallStrainElement<TDim, TNumNodes>::CalculateAndAddPermeabilityMatrix(M
     this->CalculatePermeabilityMatrix(rVariables.PDimMatrix, rVariables.PMatrix, rVariables);
 
     // Distribute permeability block matrix into the elemental matrix
-    GeoElementUtilities::AssemblePBlockMatrix<TDim, TNumNodes>(rLeftHandSideMatrix, rVariables.PMatrix);
+    GeoElementUtilities::AssemblePPBlockMatrix<TDim, TNumNodes>(rLeftHandSideMatrix, rVariables.PMatrix);
 
     KRATOS_CATCH("")
 }

--- a/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_element.hpp
+++ b/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_element.hpp
@@ -193,10 +193,10 @@ protected:
         double IntegrationCoefficientInitialConfiguration;
 
         // Auxiliary Variables
-        BoundedMatrix<double, TNumNodes * TDim, TNumNodes * TDim> UMatrix;
+        BoundedMatrix<double, TNumNodes * TDim, TNumNodes * TDim> UUMatrix;
         BoundedMatrix<double, TNumNodes * TDim, TNumNodes>        UPMatrix;
         BoundedMatrix<double, TNumNodes, TNumNodes * TDim>        PUMatrix;
-        BoundedMatrix<double, TNumNodes, TNumNodes>               PMatrix;
+        BoundedMatrix<double, TNumNodes, TNumNodes>               PPMatrix;
         Matrix                                                    UVoigtMatrix;
         BoundedMatrix<double, TNumNodes, TDim>                    PDimMatrix;
         array_1d<double, TNumNodes * TDim>                        UVector;

--- a/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_interface_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_interface_element.cpp
@@ -1868,7 +1868,7 @@ void UPwSmallStrainInterfaceElement<TDim, TNumNodes>::CalculateAndAddStiffnessMa
     noalias(rVariables.UMatrix) = prod(rVariables.UDimMatrix, rVariables.Nu) * rVariables.IntegrationCoefficient;
 
     // Distribute stiffness block matrix into the elemental matrix
-    GeoElementUtilities::AssembleUBlockMatrix(rLeftHandSideMatrix, rVariables.UMatrix);
+    GeoElementUtilities::AssembleUUBlockMatrix(rLeftHandSideMatrix, rVariables.UMatrix);
 
     KRATOS_CATCH("")
 }
@@ -1913,7 +1913,7 @@ void UPwSmallStrainInterfaceElement<TDim, TNumNodes>::CalculateAndAddCompressibi
         outer_prod(rVariables.Np, rVariables.Np) * rVariables.JointWidth * rVariables.IntegrationCoefficient;
 
     // Distribute compressibility block matrix into the elemental matrix
-    GeoElementUtilities::AssemblePBlockMatrix<TDim, TNumNodes>(rLeftHandSideMatrix, rVariables.PMatrix);
+    GeoElementUtilities::AssemblePPBlockMatrix<TDim, TNumNodes>(rLeftHandSideMatrix, rVariables.PMatrix);
 
     KRATOS_CATCH("")
 }
@@ -1932,7 +1932,7 @@ void UPwSmallStrainInterfaceElement<TDim, TNumNodes>::CalculateAndAddPermeabilit
                                   rVariables.JointWidth * rVariables.IntegrationCoefficient;
 
     // Distribute permeability block matrix into the elemental matrix
-    GeoElementUtilities::AssemblePBlockMatrix<TDim, TNumNodes>(rLeftHandSideMatrix, rVariables.PMatrix);
+    GeoElementUtilities::AssemblePPBlockMatrix<TDim, TNumNodes>(rLeftHandSideMatrix, rVariables.PMatrix);
 
     KRATOS_CATCH("")
 }

--- a/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_interface_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_interface_element.cpp
@@ -1868,7 +1868,7 @@ void UPwSmallStrainInterfaceElement<TDim, TNumNodes>::CalculateAndAddStiffnessMa
     noalias(rVariables.UMatrix) = prod(rVariables.UDimMatrix, rVariables.Nu) * rVariables.IntegrationCoefficient;
 
     // Distribute stiffness block matrix into the elemental matrix
-    GeoElementUtilities::AssembleUBlockMatrix<TDim, TNumNodes>(rLeftHandSideMatrix, rVariables.UMatrix);
+    GeoElementUtilities::AssembleUBlockMatrix(rLeftHandSideMatrix, rVariables.UMatrix);
 
     KRATOS_CATCH("")
 }

--- a/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_interface_element.hpp
+++ b/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_interface_element.hpp
@@ -164,10 +164,10 @@ protected:
 
         double                                                    IntegrationCoefficient;
         double                                                    JointWidth;
-        BoundedMatrix<double, TNumNodes * TDim, TNumNodes * TDim> UMatrix;
+        BoundedMatrix<double, TNumNodes * TDim, TNumNodes * TDim> UUMatrix;
         BoundedMatrix<double, TNumNodes * TDim, TNumNodes>        UPMatrix;
         BoundedMatrix<double, TNumNodes, TNumNodes * TDim>        PUMatrix;
-        BoundedMatrix<double, TNumNodes, TNumNodes>               PMatrix;
+        BoundedMatrix<double, TNumNodes, TNumNodes>               PPMatrix;
         BoundedMatrix<double, TDim, TDim>                         DimMatrix;
         BoundedMatrix<double, TNumNodes * TDim, TDim>             UDimMatrix;
         BoundedMatrix<double, TNumNodes, TDim>                    PDimMatrix;

--- a/applications/GeoMechanicsApplication/custom_elements/geo_curved_beam_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/geo_curved_beam_element.cpp
@@ -340,7 +340,7 @@ void GeoCurvedBeamElement<TDim, TNumNodes>::CalculateAndAddBodyForce(VectorType&
         density * prod(trans(rVariables.NuTot), rVariables.GaussVolumeAcceleration) * rVariables.IntegrationCoefficient;
 
     // Distribute body force block vector into elemental vector
-    GeoElementUtilities::AssembleUBlockVector<TDim, TNumNodes>(rRightHandSideVector, rVariables.UVector);
+    GeoElementUtilities::AssembleUBlockVector(rRightHandSideVector, rVariables.UVector);
 
     KRATOS_CATCH("")
 }

--- a/applications/GeoMechanicsApplication/custom_elements/small_strain_U_Pw_diff_order_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/small_strain_U_Pw_diff_order_element.cpp
@@ -1774,17 +1774,7 @@ void SmallStrainUPwDiffOrderElement::CalculateAndAddCouplingMatrix(MatrixType& r
                             rVariables.IntegrationCoefficient;
 
     // Distribute coupling block matrix into the elemental matrix
-    const SizeType NumUNodes = rGeom.PointsNumber();
-    const SizeType NumPNodes = mpPressureGeometry->PointsNumber();
-
-    for (SizeType i = 0; i < NumUNodes; ++i) {
-        SizeType Index_i = i * Dim;
-        for (SizeType j = 0; j < NumPNodes; ++j) {
-            for (unsigned int idim = 0; idim < Dim; ++idim)
-                rLeftHandSideMatrix(Index_i + idim, NumUNodes * Dim + j) +=
-                    CouplingMatrix(Index_i + idim, j);
-        }
-    }
+    GeoElementUtilities::AssembleUPBlockMatrix(rLeftHandSideMatrix, CouplingMatrix);
 
     if (!rVariables.IgnoreUndrained) {
         const double SaturationCoefficient = rVariables.DegreeOfSaturation / rVariables.BishopCoefficient;
@@ -1792,15 +1782,7 @@ void SmallStrainUPwDiffOrderElement::CalculateAndAddCouplingMatrix(MatrixType& r
                                  rVariables.VelocityCoefficient * trans(CouplingMatrix);
 
         // Distribute transposed coupling block matrix into the elemental matrix
-
-        for (SizeType i = 0; i < NumPNodes; ++i) {
-            for (SizeType j = 0; j < NumUNodes; ++j) {
-                SizeType Index_j = j * Dim;
-                for (unsigned int idim = 0; idim < Dim; ++idim)
-                    rLeftHandSideMatrix(NumUNodes * Dim + i, Index_j + idim) +=
-                        CouplingMatrixT(i, Index_j + idim);
-            }
-        }
+        GeoElementUtilities::AssemblePUBlockMatrix(rLeftHandSideMatrix, CouplingMatrixT);
     }
 
     KRATOS_CATCH("")
@@ -1816,16 +1798,7 @@ void SmallStrainUPwDiffOrderElement::CalculateAndAddCompressibilityMatrix(Matrix
         outer_prod(rVariables.Np, rVariables.Np) * rVariables.IntegrationCoefficient;
 
     // Distribute compressibility block matrix into the elemental matrix
-    const GeometryType& rGeom     = GetGeometry();
-    const SizeType      Dim       = rGeom.WorkingSpaceDimension();
-    const SizeType      NumUNodes = rGeom.PointsNumber();
-    const SizeType      NumPNodes = mpPressureGeometry->PointsNumber();
-
-    for (SizeType i = 0; i < NumPNodes; ++i) {
-        for (SizeType j = 0; j < NumPNodes; ++j) {
-            rLeftHandSideMatrix(NumUNodes * Dim + i, NumUNodes * Dim + j) += CompressibilityMatrix(i, j);
-        }
-    }
+    GeoElementUtilities::AssemblePPBlockMatrix(rLeftHandSideMatrix, CompressibilityMatrix);
 
     KRATOS_CATCH("")
 }
@@ -1842,16 +1815,7 @@ void SmallStrainUPwDiffOrderElement::CalculateAndAddPermeabilityMatrix(MatrixTyp
         rVariables.IntegrationCoefficient;
 
     // Distribute permeability block matrix into the elemental matrix
-    const GeometryType& rGeom     = GetGeometry();
-    const SizeType      Dim       = rGeom.WorkingSpaceDimension();
-    const SizeType      NumUNodes = rGeom.PointsNumber();
-    const SizeType      NumPNodes = mpPressureGeometry->PointsNumber();
-
-    for (SizeType i = 0; i < NumPNodes; ++i) {
-        for (SizeType j = 0; j < NumPNodes; ++j) {
-            rLeftHandSideMatrix(NumUNodes * Dim + i, NumUNodes * Dim + j) += PermeabilityMatrix(i, j);
-        }
-    }
+    GeoElementUtilities::AssemblePPBlockMatrix(rLeftHandSideMatrix, PermeabilityMatrix);
 
     KRATOS_CATCH("")
 }
@@ -1885,20 +1849,11 @@ void SmallStrainUPwDiffOrderElement::CalculateAndAddStiffnessForce(VectorType& r
 {
     KRATOS_TRY
 
-    const GeometryType& rGeom = GetGeometry();
-    const SizeType      Dim   = rGeom.WorkingSpaceDimension();
-
-    Vector StiffnessForce = prod(trans(rVariables.B), mStressVector[GPoint]) * rVariables.IntegrationCoefficient;
+    Vector StiffnessForce =
+        -1.0 * prod(trans(rVariables.B), mStressVector[GPoint]) * rVariables.IntegrationCoefficient;
 
     // Distribute stiffness block vector into the elemental vector
-    const SizeType NumUNodes = rGeom.PointsNumber();
-
-    for (SizeType i = 0; i < NumUNodes; ++i) {
-        SizeType Index = i * Dim;
-        for (SizeType idim = 0; idim < Dim; ++idim) {
-            rRightHandSideVector[Index + idim] -= StiffnessForce[Index + idim];
-        }
-    }
+    GeoElementUtilities::AssembleUBlockVector(rRightHandSideVector, StiffnessForce);
 
     KRATOS_CATCH("")
 }
@@ -1967,14 +1922,7 @@ void SmallStrainUPwDiffOrderElement::CalculateAndAddCouplingTerms(VectorType& rR
     Vector CouplingForce = prod(CouplingMatrix, rVariables.PressureVector);
 
     // Distribute coupling block vector 1 into the elemental vector
-    const SizeType NumUNodes = rGeom.PointsNumber();
-
-    for (SizeType i = 0; i < NumUNodes; ++i) {
-        SizeType Index = i * Dim;
-        for (SizeType idim = 0; idim < Dim; ++idim) {
-            rRightHandSideVector[Index + idim] += CouplingForce[Index + idim];
-        }
-    }
+    GeoElementUtilities::AssembleUBlockVector(rRightHandSideVector, CouplingForce);
 
     if (!rVariables.IgnoreUndrained) {
         const double SaturationCoefficient = rVariables.DegreeOfSaturation / rVariables.BishopCoefficient;
@@ -1982,10 +1930,7 @@ void SmallStrainUPwDiffOrderElement::CalculateAndAddCouplingTerms(VectorType& rR
                               prod(trans(CouplingMatrix), rVariables.VelocityVector);
 
         // Distribute coupling block vector 2 into the elemental vector
-        const SizeType NumPNodes = mpPressureGeometry->PointsNumber();
-        for (SizeType i = 0; i < NumPNodes; ++i) {
-            rRightHandSideVector[NumUNodes * Dim + i] += CouplingFlow[i];
-        }
+        GeoElementUtilities::AssemblePBlockVector(rRightHandSideVector, CouplingFlow);
     }
 
     KRATOS_CATCH("")
@@ -2002,14 +1947,7 @@ void SmallStrainUPwDiffOrderElement::CalculateAndAddCompressibilityFlow(VectorTy
     Vector CompressibilityFlow = -prod(CompressibilityMatrix, rVariables.PressureDtVector);
 
     // Distribute compressibility block vector into the elemental vector
-    const GeometryType& rGeom     = GetGeometry();
-    const SizeType      Dim       = rGeom.WorkingSpaceDimension();
-    const SizeType      NumUNodes = rGeom.PointsNumber();
-    const SizeType      NumPNodes = mpPressureGeometry->PointsNumber();
-
-    for (SizeType i = 0; i < NumPNodes; ++i) {
-        rRightHandSideVector[NumUNodes * Dim + i] += CompressibilityFlow[i];
-    }
+    GeoElementUtilities::AssemblePBlockVector(rRightHandSideVector, CompressibilityFlow);
 
     KRATOS_CATCH("")
 }
@@ -2028,14 +1966,7 @@ void SmallStrainUPwDiffOrderElement::CalculateAndAddPermeabilityFlow(VectorType&
     Vector PermeabilityFlow = -prod(PermeabilityMatrix, rVariables.PressureVector);
 
     // Distribute permeability block vector into the elemental vector
-    const GeometryType& rGeom     = GetGeometry();
-    const SizeType      Dim       = rGeom.WorkingSpaceDimension();
-    const SizeType      NumUNodes = rGeom.PointsNumber();
-    const SizeType      NumPNodes = mpPressureGeometry->PointsNumber();
-
-    for (SizeType i = 0; i < NumPNodes; ++i) {
-        rRightHandSideVector[NumUNodes * Dim + i] += PermeabilityFlow[i];
-    }
+    GeoElementUtilities::AssemblePBlockVector(rRightHandSideVector, PermeabilityFlow);
 
     KRATOS_CATCH("")
 }

--- a/applications/GeoMechanicsApplication/custom_elements/small_strain_U_Pw_diff_order_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/small_strain_U_Pw_diff_order_element.cpp
@@ -1749,7 +1749,7 @@ void SmallStrainUPwDiffOrderElement::CalculateAndAddStiffnessMatrix(MatrixType& 
         rVariables.IntegrationCoefficient;
 
     // Distribute stiffness block matrix into the elemental matrix
-    GeoElementUtilities::AssembleUBlockMatrix(rLeftHandSideMatrix, StiffnessMatrix);
+    GeoElementUtilities::AssembleUUBlockMatrix(rLeftHandSideMatrix, StiffnessMatrix);
 
     KRATOS_CATCH("")
 }

--- a/applications/GeoMechanicsApplication/custom_elements/small_strain_U_Pw_diff_order_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/small_strain_U_Pw_diff_order_element.cpp
@@ -2230,21 +2230,8 @@ void SmallStrainUPwDiffOrderElement::CalculateRetentionResponse(ElementVariables
 
 Element::DofsVectorType SmallStrainUPwDiffOrderElement::GetDofs() const
 {
-    auto result = Element::DofsVectorType{};
-
-    for (const auto& r_node : GetGeometry()) {
-        result.push_back(r_node.pGetDof(DISPLACEMENT_X));
-        result.push_back(r_node.pGetDof(DISPLACEMENT_Y));
-        if (GetGeometry().WorkingSpaceDimension() == 3) {
-            result.push_back(r_node.pGetDof(DISPLACEMENT_Z));
-        }
-    }
-
-    const auto water_pressure_dofs =
-        Geo::DofUtilities::ExtractDofsFromNodes(*mpPressureGeometry, WATER_PRESSURE);
-    result.insert(result.end(), water_pressure_dofs.begin(), water_pressure_dofs.end());
-
-    return result;
+    return Geo::DofUtilities::ExtractUPwDofsFromNodes(GetGeometry(), *mpPressureGeometry,
+                                                      GetGeometry().WorkingSpaceDimension());
 }
 
 const StressStatePolicy& SmallStrainUPwDiffOrderElement::GetStressStatePolicy() const

--- a/applications/GeoMechanicsApplication/custom_elements/small_strain_U_Pw_diff_order_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/small_strain_U_Pw_diff_order_element.cpp
@@ -1749,34 +1749,7 @@ void SmallStrainUPwDiffOrderElement::CalculateAndAddStiffnessMatrix(MatrixType& 
         rVariables.IntegrationCoefficient;
 
     // Distribute stiffness block matrix into the elemental matrix
-    this->AssembleUBlockMatrix(rLeftHandSideMatrix, StiffnessMatrix);
-
-    KRATOS_CATCH("")
-}
-
-void SmallStrainUPwDiffOrderElement::AssembleUBlockMatrix(Matrix& rLeftHandSideMatrix, const Matrix& StiffnessMatrix) const
-{
-    KRATOS_TRY
-
-    const GeometryType& rGeom     = GetGeometry();
-    const SizeType      Dim       = rGeom.WorkingSpaceDimension();
-    const SizeType      NumUNodes = rGeom.PointsNumber();
-    SizeType            Index_i, Index_j;
-
-    for (SizeType i = 0; i < NumUNodes; ++i) {
-        Index_i = i * Dim;
-
-        for (SizeType j = 0; j < NumUNodes; ++j) {
-            Index_j = j * Dim;
-
-            for (unsigned int idim = 0; idim < Dim; ++idim) {
-                for (unsigned int jdim = 0; jdim < Dim; ++jdim) {
-                    rLeftHandSideMatrix(Index_i + idim, Index_j + jdim) +=
-                        StiffnessMatrix(Index_i + idim, Index_j + jdim);
-                }
-            }
-        }
-    }
+    GeoElementUtilities::AssembleUBlockMatrix(rLeftHandSideMatrix, StiffnessMatrix);
 
     KRATOS_CATCH("")
 }

--- a/applications/GeoMechanicsApplication/custom_elements/small_strain_U_Pw_diff_order_element.hpp
+++ b/applications/GeoMechanicsApplication/custom_elements/small_strain_U_Pw_diff_order_element.hpp
@@ -289,8 +289,6 @@ protected:
 
     void AssignPressureToIntermediateNodes();
 
-    void AssembleUBlockMatrix(Matrix& rLeftHandSideMatrix, const Matrix& StiffnessMatrix) const;
-
     virtual Vector CalculateGreenLagrangeStrain(const Matrix& rDeformationGradient);
     virtual void   CalculateCauchyStrain(ElementVariables& rVariables);
     virtual void   CalculateStrain(ElementVariables& rVariables, unsigned int GPoint);

--- a/applications/GeoMechanicsApplication/custom_elements/transient_Pw_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/transient_Pw_element.cpp
@@ -546,7 +546,7 @@ void TransientPwElement<TDim, TNumNodes>::CalculateAndAddCompressibilityMatrix(M
     this->CalculateCompressibilityMatrix(rVariables.PMatrix, rVariables);
 
     // Distribute compressibility block matrix into the elemental matrix
-    GeoElementUtilities::AssemblePBlockMatrix<0, TNumNodes>(rLeftHandSideMatrix, rVariables.PMatrix);
+    GeoElementUtilities::AssemblePPBlockMatrix<0, TNumNodes>(rLeftHandSideMatrix, rVariables.PMatrix);
 
     KRATOS_CATCH("");
 }
@@ -561,7 +561,7 @@ void TransientPwElement<TDim, TNumNodes>::CalculateAndAddPermeabilityMatrix(Matr
     this->CalculatePermeabilityMatrix(rVariables.PDimMatrix, rVariables.PMatrix, rVariables);
 
     // Distribute permeability block matrix into the elemental matrix
-    GeoElementUtilities::AssemblePBlockMatrix<0, TNumNodes>(rLeftHandSideMatrix, rVariables.PMatrix);
+    GeoElementUtilities::AssemblePPBlockMatrix<0, TNumNodes>(rLeftHandSideMatrix, rVariables.PMatrix);
 
     KRATOS_CATCH("");
 }

--- a/applications/GeoMechanicsApplication/custom_elements/transient_Pw_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/transient_Pw_element.cpp
@@ -543,10 +543,10 @@ void TransientPwElement<TDim, TNumNodes>::CalculateAndAddCompressibilityMatrix(M
 {
     KRATOS_TRY;
 
-    this->CalculateCompressibilityMatrix(rVariables.PMatrix, rVariables);
+    this->CalculateCompressibilityMatrix(rVariables.PPMatrix, rVariables);
 
     // Distribute compressibility block matrix into the elemental matrix
-    rLeftHandSideMatrix += rVariables.PMatrix;
+    rLeftHandSideMatrix += rVariables.PPMatrix;
 
     KRATOS_CATCH("");
 }
@@ -558,10 +558,10 @@ void TransientPwElement<TDim, TNumNodes>::CalculateAndAddPermeabilityMatrix(Matr
 {
     KRATOS_TRY;
 
-    this->CalculatePermeabilityMatrix(rVariables.PDimMatrix, rVariables.PMatrix, rVariables);
+    this->CalculatePermeabilityMatrix(rVariables.PDimMatrix, rVariables.PPMatrix, rVariables);
 
     // Distribute permeability block matrix into the elemental matrix
-    rLeftHandSideMatrix += rVariables.PMatrix;
+    rLeftHandSideMatrix += rVariables.PPMatrix;
 
     KRATOS_CATCH("");
 }
@@ -588,7 +588,7 @@ void TransientPwElement<TDim, TNumNodes>::CalculateAndAddPermeabilityFlow(Vector
 {
     KRATOS_TRY;
 
-    this->CalculatePermeabilityFlow(rVariables.PDimMatrix, rVariables.PMatrix, rVariables.PVector, rVariables);
+    this->CalculatePermeabilityFlow(rVariables.PDimMatrix, rVariables.PPMatrix, rVariables.PVector, rVariables);
 
     // Distribute permeability block vector into elemental vector
     rRightHandSideVector += rVariables.PVector;
@@ -618,7 +618,7 @@ void TransientPwElement<TDim, TNumNodes>::CalculateAndAddCompressibilityFlow(Vec
 {
     KRATOS_TRY;
 
-    this->CalculateCompressibilityFlow(rVariables.PMatrix, rVariables.PVector, rVariables);
+    this->CalculateCompressibilityFlow(rVariables.PPMatrix, rVariables.PVector, rVariables);
 
     // Distribute compressibility block vector into elemental vector
     rRightHandSideVector += rVariables.PVector;

--- a/applications/GeoMechanicsApplication/custom_elements/transient_Pw_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/transient_Pw_element.cpp
@@ -591,7 +591,7 @@ void TransientPwElement<TDim, TNumNodes>::CalculateAndAddPermeabilityFlow(Vector
     this->CalculatePermeabilityFlow(rVariables.PDimMatrix, rVariables.PMatrix, rVariables.PVector, rVariables);
 
     // Distribute permeability block vector into elemental vector
-    GeoElementUtilities::AssemblePBlockVector<0, TNumNodes>(rRightHandSideVector, rVariables.PVector);
+    rRightHandSideVector += rVariables.PVector;
 
     KRATOS_CATCH("");
 }
@@ -606,7 +606,7 @@ void TransientPwElement<TDim, TNumNodes>::CalculateAndAddFluidBodyFlow(VectorTyp
     this->CalculateFluidBodyFlow(rVariables.PDimMatrix, rVariables.PVector, rVariables);
 
     // Distribute fluid body flow block vector into elemental vector
-    GeoElementUtilities::AssemblePBlockVector<0, TNumNodes>(rRightHandSideVector, rVariables.PVector);
+    rRightHandSideVector += rVariables.PVector;
 
     KRATOS_CATCH("");
 }
@@ -621,7 +621,7 @@ void TransientPwElement<TDim, TNumNodes>::CalculateAndAddCompressibilityFlow(Vec
     this->CalculateCompressibilityFlow(rVariables.PMatrix, rVariables.PVector, rVariables);
 
     // Distribute compressibility block vector into elemental vector
-    GeoElementUtilities::AssemblePBlockVector<0, TNumNodes>(rRightHandSideVector, rVariables.PVector);
+    rRightHandSideVector += rVariables.PVector;
 
     KRATOS_CATCH("");
 }

--- a/applications/GeoMechanicsApplication/custom_elements/transient_Pw_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/transient_Pw_element.cpp
@@ -546,7 +546,7 @@ void TransientPwElement<TDim, TNumNodes>::CalculateAndAddCompressibilityMatrix(M
     this->CalculateCompressibilityMatrix(rVariables.PMatrix, rVariables);
 
     // Distribute compressibility block matrix into the elemental matrix
-    GeoElementUtilities::AssemblePPBlockMatrix<0, TNumNodes>(rLeftHandSideMatrix, rVariables.PMatrix);
+    rLeftHandSideMatrix += rVariables.PMatrix;
 
     KRATOS_CATCH("");
 }
@@ -561,7 +561,7 @@ void TransientPwElement<TDim, TNumNodes>::CalculateAndAddPermeabilityMatrix(Matr
     this->CalculatePermeabilityMatrix(rVariables.PDimMatrix, rVariables.PMatrix, rVariables);
 
     // Distribute permeability block matrix into the elemental matrix
-    GeoElementUtilities::AssemblePPBlockMatrix<0, TNumNodes>(rLeftHandSideMatrix, rVariables.PMatrix);
+    rLeftHandSideMatrix += rVariables.PMatrix;
 
     KRATOS_CATCH("");
 }

--- a/applications/GeoMechanicsApplication/custom_elements/transient_Pw_interface_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/transient_Pw_interface_element.cpp
@@ -585,7 +585,7 @@ void TransientPwInterfaceElement<TDim, TNumNodes>::CalculateAndAddCompressibilit
         outer_prod(rVariables.Np, rVariables.Np) * rVariables.JointWidth * rVariables.IntegrationCoefficient;
 
     // Distribute compressibility block matrix into the elemental matrix
-    GeoElementUtilities::AssemblePBlockMatrix<0, TNumNodes>(rLeftHandSideMatrix, rVariables.PMatrix);
+    GeoElementUtilities::AssemblePPBlockMatrix<0, TNumNodes>(rLeftHandSideMatrix, rVariables.PMatrix);
 
     KRATOS_CATCH("")
 }
@@ -604,7 +604,7 @@ void TransientPwInterfaceElement<TDim, TNumNodes>::CalculateAndAddPermeabilityMa
                                   rVariables.JointWidth * rVariables.IntegrationCoefficient;
 
     // Distribute permeability block matrix into the elemental matrix
-    GeoElementUtilities::AssemblePBlockMatrix<0, TNumNodes>(rLeftHandSideMatrix, rVariables.PMatrix);
+    GeoElementUtilities::AssemblePPBlockMatrix<0, TNumNodes>(rLeftHandSideMatrix, rVariables.PMatrix);
 
     KRATOS_CATCH("")
 }

--- a/applications/GeoMechanicsApplication/custom_elements/transient_Pw_interface_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/transient_Pw_interface_element.cpp
@@ -638,7 +638,7 @@ void TransientPwInterfaceElement<TDim, TNumNodes>::CalculateAndAddCompressibilit
     noalias(rVariables.PVector) = -1.0 * prod(rVariables.PMatrix, rVariables.DtPressureVector);
 
     // Distribute compressibility block vector into elemental vector
-    GeoElementUtilities::AssemblePBlockVector<0, TNumNodes>(rRightHandSideVector, rVariables.PVector);
+    rRightHandSideVector += rVariables.PVector;
 
     KRATOS_CATCH("")
 }
@@ -659,7 +659,7 @@ void TransientPwInterfaceElement<TDim, TNumNodes>::CalculateAndAddPermeabilityFl
     noalias(rVariables.PVector) = -1.0 * prod(rVariables.PMatrix, rVariables.PressureVector);
 
     // Distribute permeability block vector into elemental vector
-    GeoElementUtilities::AssemblePBlockVector<0, TNumNodes>(rRightHandSideVector, rVariables.PVector);
+    rRightHandSideVector += rVariables.PVector;
 
     KRATOS_CATCH("")
 }
@@ -679,7 +679,7 @@ void TransientPwInterfaceElement<TDim, TNumNodes>::CalculateAndAddFluidBodyFlow(
                                   prod(rVariables.PDimMatrix, rVariables.BodyAcceleration);
 
     // Distribute fluid body flow block vector into elemental vector
-    GeoElementUtilities::AssemblePBlockVector<0, TNumNodes>(rRightHandSideVector, rVariables.PVector);
+    rRightHandSideVector += rVariables.PVector;
 
     KRATOS_CATCH("")
 }

--- a/applications/GeoMechanicsApplication/custom_elements/transient_Pw_interface_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/transient_Pw_interface_element.cpp
@@ -580,12 +580,12 @@ void TransientPwInterfaceElement<TDim, TNumNodes>::CalculateAndAddCompressibilit
 {
     KRATOS_TRY;
 
-    noalias(rVariables.PMatrix) =
+    noalias(rVariables.PPMatrix) =
         -PORE_PRESSURE_SIGN_FACTOR * rVariables.DtPressureCoefficient * rVariables.BiotModulusInverse *
         outer_prod(rVariables.Np, rVariables.Np) * rVariables.JointWidth * rVariables.IntegrationCoefficient;
 
     // Distribute compressibility block matrix into the elemental matrix
-    rLeftHandSideMatrix += rVariables.PMatrix;
+    rLeftHandSideMatrix += rVariables.PPMatrix;
 
     KRATOS_CATCH("")
 }
@@ -599,12 +599,12 @@ void TransientPwInterfaceElement<TDim, TNumNodes>::CalculateAndAddPermeabilityMa
     noalias(rVariables.PDimMatrix) =
         -PORE_PRESSURE_SIGN_FACTOR * prod(rVariables.GradNpT, rVariables.LocalPermeabilityMatrix);
 
-    noalias(rVariables.PMatrix) = rVariables.DynamicViscosityInverse * rVariables.RelativePermeability *
-                                  prod(rVariables.PDimMatrix, trans(rVariables.GradNpT)) *
-                                  rVariables.JointWidth * rVariables.IntegrationCoefficient;
+    noalias(rVariables.PPMatrix) = rVariables.DynamicViscosityInverse * rVariables.RelativePermeability *
+                                   prod(rVariables.PDimMatrix, trans(rVariables.GradNpT)) *
+                                   rVariables.JointWidth * rVariables.IntegrationCoefficient;
 
     // Distribute permeability block matrix into the elemental matrix
-    rLeftHandSideMatrix += rVariables.PMatrix;
+    rLeftHandSideMatrix += rVariables.PPMatrix;
 
     KRATOS_CATCH("")
 }
@@ -631,11 +631,11 @@ void TransientPwInterfaceElement<TDim, TNumNodes>::CalculateAndAddCompressibilit
 {
     KRATOS_TRY;
 
-    noalias(rVariables.PMatrix) = -PORE_PRESSURE_SIGN_FACTOR * rVariables.BiotModulusInverse *
-                                  outer_prod(rVariables.Np, rVariables.Np) * rVariables.JointWidth *
-                                  rVariables.IntegrationCoefficient;
+    noalias(rVariables.PPMatrix) = -PORE_PRESSURE_SIGN_FACTOR * rVariables.BiotModulusInverse *
+                                   outer_prod(rVariables.Np, rVariables.Np) *
+                                   rVariables.JointWidth * rVariables.IntegrationCoefficient;
 
-    noalias(rVariables.PVector) = -1.0 * prod(rVariables.PMatrix, rVariables.DtPressureVector);
+    noalias(rVariables.PVector) = -1.0 * prod(rVariables.PPMatrix, rVariables.DtPressureVector);
 
     // Distribute compressibility block vector into elemental vector
     rRightHandSideVector += rVariables.PVector;
@@ -651,12 +651,12 @@ void TransientPwInterfaceElement<TDim, TNumNodes>::CalculateAndAddPermeabilityFl
 
     noalias(rVariables.PDimMatrix) = prod(rVariables.GradNpT, rVariables.LocalPermeabilityMatrix);
 
-    noalias(rVariables.PMatrix) = -PORE_PRESSURE_SIGN_FACTOR * rVariables.DynamicViscosityInverse *
-                                  rVariables.RelativePermeability *
-                                  prod(rVariables.PDimMatrix, trans(rVariables.GradNpT)) *
-                                  rVariables.JointWidth * rVariables.IntegrationCoefficient;
+    noalias(rVariables.PPMatrix) = -PORE_PRESSURE_SIGN_FACTOR * rVariables.DynamicViscosityInverse *
+                                   rVariables.RelativePermeability *
+                                   prod(rVariables.PDimMatrix, trans(rVariables.GradNpT)) *
+                                   rVariables.JointWidth * rVariables.IntegrationCoefficient;
 
-    noalias(rVariables.PVector) = -1.0 * prod(rVariables.PMatrix, rVariables.PressureVector);
+    noalias(rVariables.PVector) = -1.0 * prod(rVariables.PPMatrix, rVariables.PressureVector);
 
     // Distribute permeability block vector into elemental vector
     rRightHandSideVector += rVariables.PVector;

--- a/applications/GeoMechanicsApplication/custom_elements/transient_Pw_interface_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/transient_Pw_interface_element.cpp
@@ -585,7 +585,7 @@ void TransientPwInterfaceElement<TDim, TNumNodes>::CalculateAndAddCompressibilit
         outer_prod(rVariables.Np, rVariables.Np) * rVariables.JointWidth * rVariables.IntegrationCoefficient;
 
     // Distribute compressibility block matrix into the elemental matrix
-    GeoElementUtilities::AssemblePPBlockMatrix<0, TNumNodes>(rLeftHandSideMatrix, rVariables.PMatrix);
+    rLeftHandSideMatrix += rVariables.PMatrix;
 
     KRATOS_CATCH("")
 }
@@ -604,7 +604,7 @@ void TransientPwInterfaceElement<TDim, TNumNodes>::CalculateAndAddPermeabilityMa
                                   rVariables.JointWidth * rVariables.IntegrationCoefficient;
 
     // Distribute permeability block matrix into the elemental matrix
-    GeoElementUtilities::AssemblePPBlockMatrix<0, TNumNodes>(rLeftHandSideMatrix, rVariables.PMatrix);
+    rLeftHandSideMatrix += rVariables.PMatrix;
 
     KRATOS_CATCH("")
 }

--- a/applications/GeoMechanicsApplication/custom_elements/updated_lagrangian_U_Pw_diff_order_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/updated_lagrangian_U_Pw_diff_order_element.cpp
@@ -134,12 +134,12 @@ void UpdatedLagrangianUPwDiffOrderElement::CalculateAndAddGeometricStiffnessMatr
         prod(rVariables.DNu_DX,
              rVariables.IntegrationCoefficient * Matrix(prod(StressTensor, trans(rVariables.DNu_DX)))); // to be optimized
 
-    Matrix UMatrix(NumUNodes * Dim, NumUNodes * Dim);
-    noalias(UMatrix) = ZeroMatrix(NumUNodes * Dim, NumUNodes * Dim);
-    MathUtils<double>::ExpandAndAddReducedMatrix(UMatrix, ReducedKgMatrix, Dim);
+    Matrix UUMatrix(NumUNodes * Dim, NumUNodes * Dim);
+    noalias(UUMatrix) = ZeroMatrix(NumUNodes * Dim, NumUNodes * Dim);
+    MathUtils<double>::ExpandAndAddReducedMatrix(UUMatrix, ReducedKgMatrix, Dim);
 
     // Distribute stiffness block matrix into the elemental matrix
-    GeoElementUtilities::AssembleUUBlockMatrix(rLeftHandSideMatrix, UMatrix);
+    GeoElementUtilities::AssembleUUBlockMatrix(rLeftHandSideMatrix, UUMatrix);
 
     KRATOS_CATCH("")
 }

--- a/applications/GeoMechanicsApplication/custom_elements/updated_lagrangian_U_Pw_diff_order_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/updated_lagrangian_U_Pw_diff_order_element.cpp
@@ -139,7 +139,7 @@ void UpdatedLagrangianUPwDiffOrderElement::CalculateAndAddGeometricStiffnessMatr
     MathUtils<double>::ExpandAndAddReducedMatrix(UMatrix, ReducedKgMatrix, Dim);
 
     // Distribute stiffness block matrix into the elemental matrix
-    this->AssembleUBlockMatrix(rLeftHandSideMatrix, UMatrix);
+    GeoElementUtilities::AssembleUBlockMatrix(rLeftHandSideMatrix, UMatrix);
 
     KRATOS_CATCH("")
 }

--- a/applications/GeoMechanicsApplication/custom_elements/updated_lagrangian_U_Pw_diff_order_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/updated_lagrangian_U_Pw_diff_order_element.cpp
@@ -139,7 +139,7 @@ void UpdatedLagrangianUPwDiffOrderElement::CalculateAndAddGeometricStiffnessMatr
     MathUtils<double>::ExpandAndAddReducedMatrix(UMatrix, ReducedKgMatrix, Dim);
 
     // Distribute stiffness block matrix into the elemental matrix
-    GeoElementUtilities::AssembleUBlockMatrix(rLeftHandSideMatrix, UMatrix);
+    GeoElementUtilities::AssembleUUBlockMatrix(rLeftHandSideMatrix, UMatrix);
 
     KRATOS_CATCH("")
 }

--- a/applications/GeoMechanicsApplication/custom_elements/updated_lagrangian_U_Pw_diff_order_element.hpp
+++ b/applications/GeoMechanicsApplication/custom_elements/updated_lagrangian_U_Pw_diff_order_element.hpp
@@ -67,7 +67,6 @@ public:
 
     /// The definition of the sizetype
     using SizeType = std::size_t;
-    using SmallStrainUPwDiffOrderElement::AssembleUBlockMatrix;
     using SmallStrainUPwDiffOrderElement::CalculateCauchyStrain;
     using SmallStrainUPwDiffOrderElement::CalculateDerivativesOnInitialConfiguration;
     using SmallStrainUPwDiffOrderElement::CalculateGreenLagrangeStrain;

--- a/applications/GeoMechanicsApplication/custom_utilities/condition_utilities.hpp
+++ b/applications/GeoMechanicsApplication/custom_utilities/condition_utilities.hpp
@@ -125,22 +125,6 @@ public:
     }
 
     //----------------------------------------------------------------------------------------
-    template< unsigned int TDim, unsigned int TNumNodes >
-    static inline void AssembleUBlockVector(Vector& rRightHandSideVector,
-                                            const array_1d<double, TDim*TNumNodes>& UBlockVector)
-    {
-        unsigned int Global_i, Local_i;
-
-        for (unsigned int i = 0; i < TNumNodes; ++i) {
-            Global_i = i * (TDim + 1);
-            Local_i  = i * TDim;
-            for (unsigned int idim = 0; idim < TDim; ++idim) {
-              rRightHandSideVector[Global_i + idim] += UBlockVector[Local_i + idim];
-            }
-        }
-    }
-
-    //----------------------------------------------------------------------------------------
     template< class TVectorType >
     static inline void AssemblePBlockVector(Vector& rRightHandSideVector,
                                             const TVectorType& PBlockVector,

--- a/applications/GeoMechanicsApplication/custom_utilities/condition_utilities.hpp
+++ b/applications/GeoMechanicsApplication/custom_utilities/condition_utilities.hpp
@@ -124,64 +124,6 @@ public:
         }
     }
 
-    //----------------------------------------------------------------------------------------
-    template< class TVectorType >
-    static inline void AssemblePBlockVector(Vector& rRightHandSideVector,
-                                            const TVectorType& PBlockVector,
-                                            const unsigned int& Dim,
-                                            const unsigned int& NumNodes)
-    {
-        unsigned int Global_i;
-
-        for (unsigned int i = 0; i < NumNodes; ++i) {
-            Global_i = i * (Dim + 1) + Dim;
-
-            rRightHandSideVector[Global_i] += PBlockVector[i];
-        }
-    }
-
-    //----------------------------------------------------------------------------------------
-    template< unsigned int TDim, unsigned int TNumNodes >
-    static inline void AssembleUPMatrix(Matrix& rLeftHandSideMatrix,
-                                        const BoundedMatrix<double,TDim*TNumNodes,TNumNodes>& UPBlockMatrix)
-    {
-        //Quadrilateral_3d_4
-        unsigned int Global_i, Global_j, Local_i;
-
-        for (unsigned int i = 0; i < TNumNodes; ++i) {
-            Global_i = i * (TDim + 1);
-            Local_i = i * TDim;
-
-            for (unsigned int j = 0; j < TNumNodes; ++j) {
-                Global_j = j * (TDim + 1) + TDim;
-                for (unsigned int idim = 0; idim < TDim; ++idim) {
-                   rLeftHandSideMatrix(Global_i+idim, Global_j) += UPBlockMatrix(Local_i+idim, j);
-                }
-            }
-        }
-    }
-
-    //----------------------------------------------------------------------------------------
-    template< unsigned int TDim, unsigned int TNumNodes >
-    static inline void AssemblePUMatrix(Matrix& rLeftHandSideMatrix,
-                                        const BoundedMatrix<double,TNumNodes,TDim*TNumNodes>& PUBlockMatrix)
-    {
-        //Quadrilateral_3d_4
-        unsigned int Global_i, Global_j, Local_j;
-
-        for (unsigned int i = 0; i < TNumNodes; ++i) {
-            Global_i = i * (TDim + 1) + TDim;
-
-            for (unsigned int j = 0; j < TNumNodes; ++j) {
-                Global_j = j * (TDim + 1);
-                Local_j = j * TDim;
-                for (unsigned int idim = 0; idim < TDim; ++idim) {
-                    rLeftHandSideMatrix(Global_i, Global_j+idim) += PUBlockMatrix(i, Local_j+idim);
-                }
-            }
-        }
-    }
-
     template <unsigned int TDim, unsigned int TNumNodes>
     static double CalculateIntegrationCoefficient(const Matrix& rJacobian, double Weight)
     {

--- a/applications/GeoMechanicsApplication/custom_utilities/dof_utilities.h
+++ b/applications/GeoMechanicsApplication/custom_utilities/dof_utilities.h
@@ -68,13 +68,16 @@ std::vector<Dof<double>*> ExtractUPwDofsFromNodes(const NodeRange& rNodes, std::
 }
 
 template <typename NodeRange1, typename NodeRange2>
-std::vector<Dof<double>*> ExtractUPwDofsFromNodes(const NodeRange2& rSecondOrderNodes, const NodeRange1& rFirstOrderNodes)
+std::vector<Dof<double>*> ExtractUPwDofsFromNodes(const NodeRange2& rSecondOrderNodes,
+                                                  const NodeRange1& rFirstOrderNodes,
+                                                  std::size_t       ModelDimension)
 {
     auto result = std::vector<Dof<double>*>{};
 
     for (const auto& r_node : rSecondOrderNodes) {
         result.push_back(r_node.pGetDof(DISPLACEMENT_X));
         result.push_back(r_node.pGetDof(DISPLACEMENT_Y));
+        if (ModelDimension == 3) result.push_back(nullptr);
     }
 
     ExtractDofsFromNodes(std::begin(rFirstOrderNodes), std::end(rFirstOrderNodes),

--- a/applications/GeoMechanicsApplication/custom_utilities/dof_utilities.h
+++ b/applications/GeoMechanicsApplication/custom_utilities/dof_utilities.h
@@ -15,6 +15,7 @@
 #include <algorithm>
 #include <vector>
 
+#include "geo_aliases.h"
 #include "geometries/geometry.h"
 #include "includes/dof.h"
 #include "includes/node.h"
@@ -64,11 +65,14 @@ std::vector<Dof<double>*> ExtractUPwDofsFromNodes(const NodeRange2& rSecondOrder
                                                   std::size_t       ModelDimension)
 {
     auto result = std::vector<Dof<double>*>{};
+    auto displacement_variables =
+        Geo::ConstVariableRefs{std::cref(DISPLACEMENT_X), std::cref(DISPLACEMENT_Y)};
+    if (ModelDimension == 3) displacement_variables.push_back(std::cref(DISPLACEMENT_Z));
 
     for (const auto& r_node : rSecondOrderNodes) {
-        result.push_back(r_node.pGetDof(DISPLACEMENT_X));
-        result.push_back(r_node.pGetDof(DISPLACEMENT_Y));
-        if (ModelDimension == 3) result.push_back(r_node.pGetDof(DISPLACEMENT_Z));
+        for (const auto& r_variable : displacement_variables) {
+            result.push_back(r_node.pGetDof(r_variable.get()));
+        }
     }
 
     ExtractDofsFromNodes(std::begin(rFirstOrderNodes), std::end(rFirstOrderNodes),

--- a/applications/GeoMechanicsApplication/custom_utilities/dof_utilities.h
+++ b/applications/GeoMechanicsApplication/custom_utilities/dof_utilities.h
@@ -77,7 +77,7 @@ std::vector<Dof<double>*> ExtractUPwDofsFromNodes(const NodeRange2& rSecondOrder
     for (const auto& r_node : rSecondOrderNodes) {
         result.push_back(r_node.pGetDof(DISPLACEMENT_X));
         result.push_back(r_node.pGetDof(DISPLACEMENT_Y));
-        if (ModelDimension == 3) result.push_back(nullptr);
+        if (ModelDimension == 3) result.push_back(result.front());
     }
 
     ExtractDofsFromNodes(std::begin(rFirstOrderNodes), std::end(rFirstOrderNodes),

--- a/applications/GeoMechanicsApplication/custom_utilities/dof_utilities.h
+++ b/applications/GeoMechanicsApplication/custom_utilities/dof_utilities.h
@@ -77,7 +77,7 @@ std::vector<Dof<double>*> ExtractUPwDofsFromNodes(const NodeRange2& rSecondOrder
     for (const auto& r_node : rSecondOrderNodes) {
         result.push_back(r_node.pGetDof(DISPLACEMENT_X));
         result.push_back(r_node.pGetDof(DISPLACEMENT_Y));
-        if (ModelDimension == 3) result.push_back(result.front());
+        if (ModelDimension == 3) result.push_back(r_node.pGetDof(DISPLACEMENT_Z));
     }
 
     ExtractDofsFromNodes(std::begin(rFirstOrderNodes), std::end(rFirstOrderNodes),

--- a/applications/GeoMechanicsApplication/custom_utilities/dof_utilities.h
+++ b/applications/GeoMechanicsApplication/custom_utilities/dof_utilities.h
@@ -18,6 +18,7 @@
 #include "geometries/geometry.h"
 #include "includes/dof.h"
 #include "includes/node.h"
+#include "includes/variables.h"
 
 namespace Kratos::Geo::DofUtilities
 {
@@ -44,7 +45,8 @@ std::vector<Dof<double>*> ExtractDofsFromNodes(const NodePtrRange& rNodePtrs, co
 template <typename NodeRange>
 std::vector<Dof<double>*> ExtractUPwDofsFromNodes(const NodeRange& rNodes)
 {
-    return std::vector<Dof<double>*>(std::distance(std::begin(rNodes), std::end(rNodes)) * 3, nullptr);
+    auto p_first_dof = rNodes[0].pGetDof(DISPLACEMENT_X);
+    return std::vector<Dof<double>*>(std::distance(std::begin(rNodes), std::end(rNodes)) * 3, p_first_dof);
 }
 
 Vector ExtractSolutionStepValues(const std::vector<Dof<double>*>& rDofs, int BufferIndex);

--- a/applications/GeoMechanicsApplication/custom_utilities/dof_utilities.h
+++ b/applications/GeoMechanicsApplication/custom_utilities/dof_utilities.h
@@ -41,6 +41,12 @@ std::vector<Dof<double>*> ExtractDofsFromNodes(const NodePtrRange& rNodePtrs, co
     return ExtractDofsFromNodes(std::begin(rNodePtrs), std::end(rNodePtrs), rDofVariable);
 }
 
+template <typename NodeRange>
+std::vector<Dof<double>*> ExtractUPwDofsFromNodes(const NodeRange& rNodes)
+{
+    return std::vector<Dof<double>*>(std::distance(std::begin(rNodes), std::end(rNodes)) * 3, nullptr);
+}
+
 Vector ExtractSolutionStepValues(const std::vector<Dof<double>*>& rDofs, int BufferIndex);
 Vector ExtractFirstTimeDerivatives(const std::vector<Dof<double>*>& rDofs, int BufferIndex);
 Vector ExtractSecondTimeDerivatives(const std::vector<Dof<double>*>& rDofs, int BufferIndex);

--- a/applications/GeoMechanicsApplication/custom_utilities/dof_utilities.h
+++ b/applications/GeoMechanicsApplication/custom_utilities/dof_utilities.h
@@ -38,19 +38,19 @@ OutputIt ExtractDofsFromNodes(InputIt                 NodeRangeBegin,
 }
 
 template <typename InputIt>
-std::vector<Dof<double>*> ExtractDofsFromNodes(InputIt                 NodePtrRangeBegin,
-                                               InputIt                 NodePtrRangeEnd,
+std::vector<Dof<double>*> ExtractDofsFromNodes(InputIt                 NodeRangeBegin,
+                                               InputIt                 NodeRangeEnd,
                                                const Variable<double>& rDofVariable)
 {
     auto result = std::vector<Dof<double>*>{};
-    ExtractDofsFromNodes(NodePtrRangeBegin, NodePtrRangeEnd, std::back_inserter(result), rDofVariable);
+    ExtractDofsFromNodes(NodeRangeBegin, NodeRangeEnd, std::back_inserter(result), rDofVariable);
     return result;
 }
 
-template <typename NodePtrRange>
-std::vector<Dof<double>*> ExtractDofsFromNodes(const NodePtrRange& rNodePtrs, const Variable<double>& rDofVariable)
+template <typename NodeRange>
+std::vector<Dof<double>*> ExtractDofsFromNodes(const NodeRange& rNodes, const Variable<double>& rDofVariable)
 {
-    return ExtractDofsFromNodes(std::begin(rNodePtrs), std::end(rNodePtrs), rDofVariable);
+    return ExtractDofsFromNodes(std::begin(rNodes), std::end(rNodes), rDofVariable);
 }
 
 template <typename NodeRange1, typename NodeRange2>

--- a/applications/GeoMechanicsApplication/custom_utilities/dof_utilities.h
+++ b/applications/GeoMechanicsApplication/custom_utilities/dof_utilities.h
@@ -67,6 +67,17 @@ std::vector<Dof<double>*> ExtractUPwDofsFromNodes(const NodeRange& rNodes, std::
     return result;
 }
 
+template <typename NodeRange1, typename NodeRange2>
+std::vector<Dof<double>*> ExtractUPwDofsFromNodes(const NodeRange2& rSecondOrderNodes, const NodeRange1& rFirstOrderNodes)
+{
+    const auto second_order_node_size =
+        std::distance(std::begin(rSecondOrderNodes), std::end(rSecondOrderNodes));
+    const auto first_order_node_size =
+        std::distance(std::begin(rFirstOrderNodes), std::end(rFirstOrderNodes));
+    auto result = std::vector<Dof<double>*>(second_order_node_size * 2 + first_order_node_size, nullptr);
+    return result;
+}
+
 Vector ExtractSolutionStepValues(const std::vector<Dof<double>*>& rDofs, int BufferIndex);
 Vector ExtractFirstTimeDerivatives(const std::vector<Dof<double>*>& rDofs, int BufferIndex);
 Vector ExtractSecondTimeDerivatives(const std::vector<Dof<double>*>& rDofs, int BufferIndex);

--- a/applications/GeoMechanicsApplication/custom_utilities/dof_utilities.h
+++ b/applications/GeoMechanicsApplication/custom_utilities/dof_utilities.h
@@ -64,9 +64,9 @@ std::vector<Dof<double>*> ExtractUPwDofsFromNodes(const DisplacementNodeRange&  
     if (ModelDimension == 3) displacement_variables.push_back(std::cref(DISPLACEMENT_Z));
 
     for (const auto& r_node : rDisplacementNodes) {
-        for (const auto& r_variable : displacement_variables) {
-            result.push_back(r_node.pGetDof(r_variable.get()));
-        }
+        std::transform(std::begin(displacement_variables), std::end(displacement_variables),
+                       std::back_inserter(result),
+                       [&r_node](const auto& r_variable) { return r_node.pGetDof(r_variable.get()); });
     }
 
     ExtractDofsFromNodes(std::begin(rWaterPressureNodes), std::end(rWaterPressureNodes),

--- a/applications/GeoMechanicsApplication/custom_utilities/dof_utilities.h
+++ b/applications/GeoMechanicsApplication/custom_utilities/dof_utilities.h
@@ -53,12 +53,13 @@ std::vector<Dof<double>*> ExtractDofsFromNodes(const NodePtrRange& rNodePtrs, co
 }
 
 template <typename NodeRange>
-std::vector<Dof<double>*> ExtractUPwDofsFromNodes(const NodeRange& rNodes)
+std::vector<Dof<double>*> ExtractUPwDofsFromNodes(const NodeRange& rNodes, std::size_t ModelDimension)
 {
     auto result = std::vector<Dof<double>*>{};
     for (auto& r_node : rNodes) {
         result.push_back(r_node.pGetDof(DISPLACEMENT_X));
         result.push_back(r_node.pGetDof(DISPLACEMENT_Y));
+        if (ModelDimension == 3) result.push_back(r_node.pGetDof(DISPLACEMENT_X));
     }
 
     ExtractDofsFromNodes(std::begin(rNodes), std::end(rNodes), std::back_inserter(result), WATER_PRESSURE);

--- a/applications/GeoMechanicsApplication/custom_utilities/dof_utilities.h
+++ b/applications/GeoMechanicsApplication/custom_utilities/dof_utilities.h
@@ -55,16 +55,7 @@ std::vector<Dof<double>*> ExtractDofsFromNodes(const NodePtrRange& rNodePtrs, co
 template <typename NodeRange>
 std::vector<Dof<double>*> ExtractUPwDofsFromNodes(const NodeRange& rNodes, std::size_t ModelDimension)
 {
-    auto result = std::vector<Dof<double>*>{};
-    for (auto& r_node : rNodes) {
-        result.push_back(r_node.pGetDof(DISPLACEMENT_X));
-        result.push_back(r_node.pGetDof(DISPLACEMENT_Y));
-        if (ModelDimension == 3) result.push_back(r_node.pGetDof(DISPLACEMENT_Z));
-    }
-
-    ExtractDofsFromNodes(std::begin(rNodes), std::end(rNodes), std::back_inserter(result), WATER_PRESSURE);
-
-    return result;
+    return ExtractUPwDofsFromNodes(rNodes, rNodes, ModelDimension);
 }
 
 template <typename NodeRange1, typename NodeRange2>

--- a/applications/GeoMechanicsApplication/custom_utilities/dof_utilities.h
+++ b/applications/GeoMechanicsApplication/custom_utilities/dof_utilities.h
@@ -45,8 +45,18 @@ std::vector<Dof<double>*> ExtractDofsFromNodes(const NodePtrRange& rNodePtrs, co
 template <typename NodeRange>
 std::vector<Dof<double>*> ExtractUPwDofsFromNodes(const NodeRange& rNodes)
 {
-    auto p_first_dof = rNodes[0].pGetDof(DISPLACEMENT_X);
-    return std::vector<Dof<double>*>(std::distance(std::begin(rNodes), std::end(rNodes)) * 3, p_first_dof);
+    auto result = std::vector<Dof<double>*>{};
+    for (auto& r_node : rNodes) {
+        result.push_back(r_node.pGetDof(DISPLACEMENT_X));
+        result.push_back(r_node.pGetDof(DISPLACEMENT_Y));
+    }
+
+    // Make sure that the result has the correct length and that it doesn't contain any `nullptr`s
+    while (result.size() != std::distance(std::begin(rNodes), std::end(rNodes)) * 3) {
+        result.push_back(result.front());
+    }
+
+    return result;
 }
 
 Vector ExtractSolutionStepValues(const std::vector<Dof<double>*>& rDofs, int BufferIndex);

--- a/applications/GeoMechanicsApplication/custom_utilities/dof_utilities.h
+++ b/applications/GeoMechanicsApplication/custom_utilities/dof_utilities.h
@@ -70,12 +70,21 @@ std::vector<Dof<double>*> ExtractUPwDofsFromNodes(const NodeRange& rNodes, std::
 template <typename NodeRange1, typename NodeRange2>
 std::vector<Dof<double>*> ExtractUPwDofsFromNodes(const NodeRange2& rSecondOrderNodes, const NodeRange1& rFirstOrderNodes)
 {
+    auto result = std::vector<Dof<double>*>{};
+
+    for (const auto& r_node : rSecondOrderNodes) {
+        result.push_back(r_node.pGetDof(DISPLACEMENT_X));
+        result.push_back(r_node.pGetDof(DISPLACEMENT_Y));
+    }
+
     const auto second_order_node_size =
         std::distance(std::begin(rSecondOrderNodes), std::end(rSecondOrderNodes));
     const auto first_order_node_size =
         std::distance(std::begin(rFirstOrderNodes), std::end(rFirstOrderNodes));
-    auto result = std::vector<Dof<double>*>(second_order_node_size * 2 + first_order_node_size,
-                                            rSecondOrderNodes[0].pGetDof(DISPLACEMENT_X));
+    while (result.size() < (second_order_node_size * 2 + first_order_node_size)) {
+        result.push_back(result.front());
+    }
+
     return result;
 }
 

--- a/applications/GeoMechanicsApplication/custom_utilities/dof_utilities.h
+++ b/applications/GeoMechanicsApplication/custom_utilities/dof_utilities.h
@@ -53,23 +53,23 @@ std::vector<Dof<double>*> ExtractDofsFromNodes(const NodeRange& rNodes, const Va
     return ExtractDofsFromNodes(std::begin(rNodes), std::end(rNodes), rDofVariable);
 }
 
-template <typename NodeRange1, typename NodeRange2>
-std::vector<Dof<double>*> ExtractUPwDofsFromNodes(const NodeRange2& rSecondOrderNodes,
-                                                  const NodeRange1& rFirstOrderNodes,
-                                                  std::size_t       ModelDimension)
+template <typename DisplacementNodeRange, typename WaterPressureNodeRange>
+std::vector<Dof<double>*> ExtractUPwDofsFromNodes(const DisplacementNodeRange&  rDisplacementNodes,
+                                                  const WaterPressureNodeRange& rWaterPressureNodes,
+                                                  std::size_t                   ModelDimension)
 {
     auto result = std::vector<Dof<double>*>{};
     auto displacement_variables =
         Geo::ConstVariableRefs{std::cref(DISPLACEMENT_X), std::cref(DISPLACEMENT_Y)};
     if (ModelDimension == 3) displacement_variables.push_back(std::cref(DISPLACEMENT_Z));
 
-    for (const auto& r_node : rSecondOrderNodes) {
+    for (const auto& r_node : rDisplacementNodes) {
         for (const auto& r_variable : displacement_variables) {
             result.push_back(r_node.pGetDof(r_variable.get()));
         }
     }
 
-    ExtractDofsFromNodes(std::begin(rFirstOrderNodes), std::end(rFirstOrderNodes),
+    ExtractDofsFromNodes(std::begin(rWaterPressureNodes), std::end(rWaterPressureNodes),
                          std::back_inserter(result), WATER_PRESSURE);
 
     return result;

--- a/applications/GeoMechanicsApplication/custom_utilities/dof_utilities.h
+++ b/applications/GeoMechanicsApplication/custom_utilities/dof_utilities.h
@@ -77,13 +77,8 @@ std::vector<Dof<double>*> ExtractUPwDofsFromNodes(const NodeRange2& rSecondOrder
         result.push_back(r_node.pGetDof(DISPLACEMENT_Y));
     }
 
-    const auto second_order_node_size =
-        std::distance(std::begin(rSecondOrderNodes), std::end(rSecondOrderNodes));
-    const auto first_order_node_size =
-        std::distance(std::begin(rFirstOrderNodes), std::end(rFirstOrderNodes));
-    while (result.size() < (second_order_node_size * 2 + first_order_node_size)) {
-        result.push_back(result.front());
-    }
+    ExtractDofsFromNodes(std::begin(rFirstOrderNodes), std::end(rFirstOrderNodes),
+                         std::back_inserter(result), WATER_PRESSURE);
 
     return result;
 }

--- a/applications/GeoMechanicsApplication/custom_utilities/dof_utilities.h
+++ b/applications/GeoMechanicsApplication/custom_utilities/dof_utilities.h
@@ -25,14 +25,24 @@ namespace Kratos::Geo::DofUtilities
 
 std::vector<std::size_t> ExtractEquationIdsFrom(const std::vector<Dof<double>*>& rDofs);
 
+template <typename InputIt, typename OutputIt>
+OutputIt ExtractDofsFromNodes(InputIt                 NodeRangeBegin,
+                              InputIt                 NodeRangeEnd,
+                              OutputIt                DofPtrRangeBegin,
+                              const Variable<double>& rDofVariable)
+{
+    return std::transform(NodeRangeBegin, NodeRangeEnd, DofPtrRangeBegin, [&rDofVariable](const auto& r_node) {
+        return r_node.pGetDof(rDofVariable);
+    });
+}
+
 template <typename InputIt>
 std::vector<Dof<double>*> ExtractDofsFromNodes(InputIt                 NodePtrRangeBegin,
                                                InputIt                 NodePtrRangeEnd,
                                                const Variable<double>& rDofVariable)
 {
     auto result = std::vector<Dof<double>*>{};
-    std::transform(NodePtrRangeBegin, NodePtrRangeEnd, std::back_inserter(result),
-                   [&rDofVariable](const auto& r_node) { return r_node.pGetDof(rDofVariable); });
+    ExtractDofsFromNodes(NodePtrRangeBegin, NodePtrRangeEnd, std::back_inserter(result), rDofVariable);
     return result;
 }
 
@@ -51,9 +61,7 @@ std::vector<Dof<double>*> ExtractUPwDofsFromNodes(const NodeRange& rNodes)
         result.push_back(r_node.pGetDof(DISPLACEMENT_Y));
     }
 
-    for (auto& r_node : rNodes) {
-        result.push_back(r_node.pGetDof(WATER_PRESSURE));
-    }
+    ExtractDofsFromNodes(std::begin(rNodes), std::end(rNodes), std::back_inserter(result), WATER_PRESSURE);
 
     return result;
 }

--- a/applications/GeoMechanicsApplication/custom_utilities/dof_utilities.h
+++ b/applications/GeoMechanicsApplication/custom_utilities/dof_utilities.h
@@ -53,12 +53,6 @@ std::vector<Dof<double>*> ExtractDofsFromNodes(const NodePtrRange& rNodePtrs, co
     return ExtractDofsFromNodes(std::begin(rNodePtrs), std::end(rNodePtrs), rDofVariable);
 }
 
-template <typename NodeRange>
-std::vector<Dof<double>*> ExtractUPwDofsFromNodes(const NodeRange& rNodes, std::size_t ModelDimension)
-{
-    return ExtractUPwDofsFromNodes(rNodes, rNodes, ModelDimension);
-}
-
 template <typename NodeRange1, typename NodeRange2>
 std::vector<Dof<double>*> ExtractUPwDofsFromNodes(const NodeRange2& rSecondOrderNodes,
                                                   const NodeRange1& rFirstOrderNodes,
@@ -79,6 +73,12 @@ std::vector<Dof<double>*> ExtractUPwDofsFromNodes(const NodeRange2& rSecondOrder
                          std::back_inserter(result), WATER_PRESSURE);
 
     return result;
+}
+
+template <typename NodeRange>
+std::vector<Dof<double>*> ExtractUPwDofsFromNodes(const NodeRange& rNodes, std::size_t ModelDimension)
+{
+    return ExtractUPwDofsFromNodes(rNodes, rNodes, ModelDimension);
 }
 
 Vector ExtractSolutionStepValues(const std::vector<Dof<double>*>& rDofs, int BufferIndex);

--- a/applications/GeoMechanicsApplication/custom_utilities/dof_utilities.h
+++ b/applications/GeoMechanicsApplication/custom_utilities/dof_utilities.h
@@ -51,9 +51,8 @@ std::vector<Dof<double>*> ExtractUPwDofsFromNodes(const NodeRange& rNodes)
         result.push_back(r_node.pGetDof(DISPLACEMENT_Y));
     }
 
-    // Make sure that the result has the correct length and that it doesn't contain any `nullptr`s
-    while (result.size() != std::distance(std::begin(rNodes), std::end(rNodes)) * 3) {
-        result.push_back(result.front());
+    for (auto& r_node : rNodes) {
+        result.push_back(r_node.pGetDof(WATER_PRESSURE));
     }
 
     return result;

--- a/applications/GeoMechanicsApplication/custom_utilities/dof_utilities.h
+++ b/applications/GeoMechanicsApplication/custom_utilities/dof_utilities.h
@@ -74,7 +74,8 @@ std::vector<Dof<double>*> ExtractUPwDofsFromNodes(const NodeRange2& rSecondOrder
         std::distance(std::begin(rSecondOrderNodes), std::end(rSecondOrderNodes));
     const auto first_order_node_size =
         std::distance(std::begin(rFirstOrderNodes), std::end(rFirstOrderNodes));
-    auto result = std::vector<Dof<double>*>(second_order_node_size * 2 + first_order_node_size, nullptr);
+    auto result = std::vector<Dof<double>*>(second_order_node_size * 2 + first_order_node_size,
+                                            rSecondOrderNodes[0].pGetDof(DISPLACEMENT_X));
     return result;
 }
 

--- a/applications/GeoMechanicsApplication/custom_utilities/dof_utilities.h
+++ b/applications/GeoMechanicsApplication/custom_utilities/dof_utilities.h
@@ -59,7 +59,7 @@ std::vector<Dof<double>*> ExtractUPwDofsFromNodes(const NodeRange& rNodes, std::
     for (auto& r_node : rNodes) {
         result.push_back(r_node.pGetDof(DISPLACEMENT_X));
         result.push_back(r_node.pGetDof(DISPLACEMENT_Y));
-        if (ModelDimension == 3) result.push_back(r_node.pGetDof(DISPLACEMENT_X));
+        if (ModelDimension == 3) result.push_back(r_node.pGetDof(DISPLACEMENT_Z));
     }
 
     ExtractDofsFromNodes(std::begin(rNodes), std::end(rNodes), std::back_inserter(result), WATER_PRESSURE);

--- a/applications/GeoMechanicsApplication/custom_utilities/element_utilities.hpp
+++ b/applications/GeoMechanicsApplication/custom_utilities/element_utilities.hpp
@@ -249,132 +249,67 @@ public:
         }
     }
 
-
-//----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    template< unsigned int TDim, unsigned int TNumNodes >
-    static inline void AssembleUBlockMatrix(Matrix &rLeftHandSideMatrix,
-                                            const BoundedMatrix<double,TDim*TNumNodes, TDim*TNumNodes> &UBlockMatrix)
+    template <typename MatrixType1, typename MatrixType2>
+    static inline void AssembleUBlockMatrix(MatrixType1& rLeftHandSideMatrix, const MatrixType2& rUBlockMatrix)
     {
-        for (unsigned int i = 0; i < TNumNodes; ++i) {
-            const unsigned int Global_i = i * (TDim + 1);
-            const unsigned int Local_i  = i * TDim;
-
-            for (unsigned int j = 0; j < TNumNodes; ++j) {
-                const unsigned int Global_j = j * (TDim + 1);
-                const unsigned int Local_j  = j * TDim;
-
-                for (unsigned int idim = 0; idim < TDim; ++idim) {
-                    for (unsigned int jdim = 0; jdim < TDim; ++jdim) {
-                        rLeftHandSideMatrix(Global_i+idim, Global_j+jdim) += UBlockMatrix(Local_i+idim, Local_j+jdim);
-                    }
-                }
+        for (auto i = std::size_t{0}; i < rUBlockMatrix.size1(); ++i) {
+            for (auto j = std::size_t{0}; j < rUBlockMatrix.size2(); ++j) {
+                rLeftHandSideMatrix(i, j) += rUBlockMatrix(i, j);
             }
         }
     }
 
-//----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    static inline void AssembleUBlockMatrix(Matrix &rLeftHandSideMatrix,
-                                            const Matrix &UBlockMatrix,
-                                            unsigned int TNumNodes,
-                                            unsigned int TDim)
-    {
-        for (unsigned int i = 0; i < TNumNodes; ++i) {
-            const unsigned int Global_i = i * (TDim + 1);
-            const unsigned int Local_i  = i * TDim;
-
-            for (unsigned int j = 0; j < TNumNodes; ++j) {
-                const unsigned int Global_j = j * (TDim + 1);
-                const unsigned int Local_j  = j * TDim;
-
-                for (unsigned int idim = 0; idim < TDim; ++idim) {
-                    for (unsigned int jdim = 0; jdim < TDim; ++jdim) {
-                        rLeftHandSideMatrix(Global_i+idim, Global_j+jdim) += UBlockMatrix(Local_i+idim, Local_j+jdim);
-                    }
-                }
-            }
-        }
-    }
-
-//----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    template< unsigned int TDim, unsigned int TNumNodes >
+    template <unsigned int TDim, unsigned int TNumNodes>
     static inline void AssembleUPBlockMatrix(Matrix& rLeftHandSideMatrix,
-                                             const BoundedMatrix<double,TDim*TNumNodes,TNumNodes>& UPBlockMatrix)
+                                             const BoundedMatrix<double, TDim * TNumNodes, TNumNodes>& rUPBlockMatrix)
     {
-        for (unsigned int i = 0; i < TNumNodes; ++i) {
-            const unsigned int Global_i = i * (TDim + 1);
-            const unsigned int Local_i = i * TDim;
-
-            for (unsigned int j = 0; j < TNumNodes; ++j) {
-                const unsigned int Global_j = j * (TDim + 1) + TDim;
-
-                for (unsigned int dim = 0; dim < TDim; ++dim) {
-                    rLeftHandSideMatrix(Global_i + dim, Global_j)  += UPBlockMatrix(Local_i + dim, j);
-                }
+        const auto offset = TNumNodes * TDim;
+        for (auto i = std::size_t{0}; i < rUPBlockMatrix.size1(); ++i) {
+            for (auto j = std::size_t{0}; j < rUPBlockMatrix.size2(); ++j) {
+                rLeftHandSideMatrix(i, j + offset) += rUPBlockMatrix(i, j);
             }
         }
     }
 
-//----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    template< unsigned int TDim, unsigned int TNumNodes >
+    template <unsigned int TDim, unsigned int TNumNodes>
     static inline void AssemblePUBlockMatrix(Matrix& rLeftHandSideMatrix,
-                                             const BoundedMatrix<double,TNumNodes,TNumNodes*TDim>& PUBlockMatrix)
+                                             const BoundedMatrix<double, TNumNodes, TNumNodes * TDim>& rPUBlockMatrix)
     {
-        for (unsigned int i = 0; i < TNumNodes; ++i) {
-            const unsigned int Global_i = i * (TDim + 1) + TDim;
-
-            for (unsigned int j = 0; j < TNumNodes; ++j) {
-                const unsigned int Global_j = j * (TDim + 1);
-                const unsigned int Local_j = j * TDim;
-
-                for (unsigned int dim = 0; dim < TDim; ++dim) {
-                    rLeftHandSideMatrix(Global_i, Global_j+dim) += PUBlockMatrix(i, Local_j+dim);
-                }
+        const auto offset = TNumNodes * TDim;
+        for (auto i = std::size_t{0}; i < rPUBlockMatrix.size1(); ++i) {
+            for (auto j = std::size_t{0}; j < rPUBlockMatrix.size2(); ++j) {
+                rLeftHandSideMatrix(i + offset, j) += rPUBlockMatrix(i, j);
             }
         }
     }
 
-//----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    template< unsigned int TDim, unsigned int TNumNodes >
+    template <unsigned int TDim, unsigned int TNumNodes>
     static inline void AssemblePBlockMatrix(Matrix& rLeftHandSideMatrix,
-                                            const BoundedMatrix<double,TNumNodes,TNumNodes> &PBlockMatrix)
+                                            const BoundedMatrix<double, TNumNodes, TNumNodes>& rPBlockMatrix)
     {
-        for (unsigned int i = 0; i < TNumNodes; ++i) {
-            const unsigned int Global_i = i * (TDim + 1) + TDim;
-
-            for (unsigned int j = 0; j < TNumNodes; ++j) {
-                const unsigned int Global_j = j * (TDim + 1) + TDim;
-
-                rLeftHandSideMatrix(Global_i,Global_j) += PBlockMatrix(i,j);
+        const auto offset = TNumNodes * TDim;
+        for (auto i = std::size_t{0}; i < rPBlockMatrix.size1(); ++i) {
+            for (auto j = std::size_t{0}; j < rPBlockMatrix.size2(); ++j) {
+                rLeftHandSideMatrix(i + offset, j + offset) += rPBlockMatrix(i, j);
             }
         }
     }
 
-//----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    template< unsigned int TDim, unsigned int TNumNodes >
+    template <unsigned int TDim, unsigned int TNumNodes>
     static inline void AssembleUBlockVector(Vector& rRightHandSideVector,
-                                            const array_1d<double,TDim*TNumNodes>& UBlockVector,
-                                            unsigned int OffsetDof = 1)
+                                            const array_1d<double, TDim * TNumNodes>& rUBlockVector)
     {
-        for (unsigned int i = 0; i < TNumNodes; ++i) {
-            const unsigned int Global_i = i * (TDim + OffsetDof);
-            const unsigned int Local_i  = i * TDim;
-
-            for (unsigned int dim = 0; dim < TDim; ++dim) {
-                rRightHandSideVector[Global_i + dim] += UBlockVector[Local_i + dim];
-            }
-        }
+        std::transform(rUBlockVector.begin(), rUBlockVector.end(), rRightHandSideVector.begin(),
+                       rRightHandSideVector.begin(), std::plus<double>{});
     }
 
-//----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    template< unsigned int TDim, unsigned int TNumNodes >
-    static inline void AssemblePBlockVector(Vector& rRightHandSideVector,
-                                            const array_1d<double, TNumNodes> &PBlockVector)
+    template <unsigned int TDim, unsigned int TNumNodes>
+    static inline void AssemblePBlockVector(Vector&                            rRightHandSideVector,
+                                            const array_1d<double, TNumNodes>& rPBlockVector)
     {
-        for (unsigned int i = 0; i < TNumNodes; ++i) {
-            const unsigned int Global_i = i * (TDim + 1) + TDim;
-
-            rRightHandSideVector[Global_i] += PBlockVector[i];
-        }
+        auto destination_begin = rRightHandSideVector.begin() + (TNumNodes * TDim);
+        std::transform(rPBlockVector.begin(), rPBlockVector.end(), destination_begin,
+                       destination_begin, std::plus<double>{});
     }
 
 //----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

--- a/applications/GeoMechanicsApplication/custom_utilities/element_utilities.hpp
+++ b/applications/GeoMechanicsApplication/custom_utilities/element_utilities.hpp
@@ -299,17 +299,16 @@ public:
     static inline void AssembleUBlockVector(Vector& rRightHandSideVector,
                                             const array_1d<double, TDim * TNumNodes>& rUBlockVector)
     {
-        std::transform(rUBlockVector.begin(), rUBlockVector.end(), rRightHandSideVector.begin(),
-                       rRightHandSideVector.begin(), std::plus<double>{});
+        constexpr auto offset = std::size_t{0};
+        AddVectorAtPosition(rUBlockVector, rRightHandSideVector, offset);
     }
 
     template <unsigned int TDim, unsigned int TNumNodes>
     static inline void AssemblePBlockVector(Vector&                            rRightHandSideVector,
                                             const array_1d<double, TNumNodes>& rPBlockVector)
     {
-        auto destination_begin = rRightHandSideVector.begin() + (TNumNodes * TDim);
-        std::transform(rPBlockVector.begin(), rPBlockVector.end(), destination_begin,
-                       destination_begin, std::plus<double>{});
+        constexpr auto offset = TNumNodes * TDim;
+        AddVectorAtPosition(rPBlockVector, rRightHandSideVector, offset);
     }
 
 //----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
@@ -630,6 +629,14 @@ public:
             }
         }
         return nodal_hydraulic_heads;
+    }
+
+private:
+    template <typename VectorType1, typename VectorType2>
+    static void AddVectorAtPosition(const VectorType1& rSourceVector, VectorType2& rDestinationVector, std::size_t Offset)
+    {
+        auto pos = rDestinationVector.begin() + Offset;
+        std::transform(rSourceVector.begin(), rSourceVector.end(), pos, pos, std::plus<double>{});
     }
 
 }; /* Class GeoElementUtilities*/

--- a/applications/GeoMechanicsApplication/custom_utilities/element_utilities.hpp
+++ b/applications/GeoMechanicsApplication/custom_utilities/element_utilities.hpp
@@ -616,8 +616,8 @@ private:
     template <typename VectorType1, typename VectorType2>
     static void AddVectorAtPosition(const VectorType1& rSourceVector, VectorType2& rDestinationVector, std::size_t Offset)
     {
-        auto pos = rDestinationVector.begin() + Offset;
-        std::transform(rSourceVector.begin(), rSourceVector.end(), pos, pos, std::plus<double>{});
+        auto pos = std::begin(rDestinationVector) + Offset;
+        std::transform(std::begin(rSourceVector), std::end(rSourceVector), pos, pos, std::plus<double>{});
     }
 
     template <typename MatrixType1, typename MatrixType2>

--- a/applications/GeoMechanicsApplication/custom_utilities/element_utilities.hpp
+++ b/applications/GeoMechanicsApplication/custom_utilities/element_utilities.hpp
@@ -224,53 +224,48 @@ public:
     }
 
     template <typename MatrixType1, typename MatrixType2>
-    static inline void AssembleUUBlockMatrix(MatrixType1& rLeftHandSideMatrix, const MatrixType2& rUBlockMatrix)
+    static inline void AssembleUUBlockMatrix(MatrixType1& rLeftHandSideMatrix, const MatrixType2& rUUBlockMatrix)
     {
         constexpr auto row_offset    = std::size_t{0};
         constexpr auto column_offset = row_offset;
-        AddMatrixAtPosition(rUBlockMatrix, rLeftHandSideMatrix, row_offset, column_offset);
+        AddMatrixAtPosition(rUUBlockMatrix, rLeftHandSideMatrix, row_offset, column_offset);
     }
 
-    template <unsigned int TDim, unsigned int TNumNodes>
-    static inline void AssembleUPBlockMatrix(Matrix& rLeftHandSideMatrix,
-                                             const BoundedMatrix<double, TDim * TNumNodes, TNumNodes>& rUPBlockMatrix)
+    template <typename MatrixType1, typename MatrixType2>
+    static inline void AssembleUPBlockMatrix(MatrixType1& rLeftHandSideMatrix, const MatrixType2& rUPBlockMatrix)
     {
         constexpr auto row_offset    = std::size_t{0};
-        constexpr auto column_offset = TNumNodes * TDim;
+        const auto     column_offset = rLeftHandSideMatrix.size2() - rUPBlockMatrix.size2();
         AddMatrixAtPosition(rUPBlockMatrix, rLeftHandSideMatrix, row_offset, column_offset);
     }
 
-    template <unsigned int TDim, unsigned int TNumNodes>
-    static inline void AssemblePUBlockMatrix(Matrix& rLeftHandSideMatrix,
-                                             const BoundedMatrix<double, TNumNodes, TNumNodes * TDim>& rPUBlockMatrix)
+    template <typename MatrixType1, typename MatrixType2>
+    static inline void AssemblePUBlockMatrix(MatrixType1& rLeftHandSideMatrix, const MatrixType2& rPUBlockMatrix)
     {
-        constexpr auto row_offset    = TNumNodes * TDim;
+        const auto     row_offset    = rLeftHandSideMatrix.size1() - rPUBlockMatrix.size1();
         constexpr auto column_offset = std::size_t{0};
         AddMatrixAtPosition(rPUBlockMatrix, rLeftHandSideMatrix, row_offset, column_offset);
     }
 
-    template <unsigned int TDim, unsigned int TNumNodes>
-    static inline void AssemblePPBlockMatrix(Matrix& rLeftHandSideMatrix,
-                                             const BoundedMatrix<double, TNumNodes, TNumNodes>& rPBlockMatrix)
+    template <typename MatrixType1, typename MatrixType2>
+    static inline void AssemblePPBlockMatrix(MatrixType1& rLeftHandSideMatrix, const MatrixType2& rPPBlockMatrix)
     {
-        constexpr auto row_offset    = TNumNodes * TDim;
-        constexpr auto column_offset = row_offset;
-        AddMatrixAtPosition(rPBlockMatrix, rLeftHandSideMatrix, row_offset, column_offset);
+        const auto row_offset    = rLeftHandSideMatrix.size1() - rPPBlockMatrix.size1();
+        const auto column_offset = row_offset;
+        AddMatrixAtPosition(rPPBlockMatrix, rLeftHandSideMatrix, row_offset, column_offset);
     }
 
-    template <unsigned int TDim, unsigned int TNumNodes>
-    static inline void AssembleUBlockVector(Vector& rRightHandSideVector,
-                                            const array_1d<double, TDim * TNumNodes>& rUBlockVector)
+    template <typename VectorType1, typename VectorType2>
+    static inline void AssembleUBlockVector(VectorType1& rRightHandSideVector, const VectorType2& rUBlockVector)
     {
         constexpr auto offset = std::size_t{0};
         AddVectorAtPosition(rUBlockVector, rRightHandSideVector, offset);
     }
 
-    template <unsigned int TDim, unsigned int TNumNodes>
-    static inline void AssemblePBlockVector(Vector&                            rRightHandSideVector,
-                                            const array_1d<double, TNumNodes>& rPBlockVector)
+    template <typename VectorType1, typename VectorType2>
+    static inline void AssemblePBlockVector(VectorType1& rRightHandSideVector, const VectorType2& rPBlockVector)
     {
-        constexpr auto offset = TNumNodes * TDim;
+        const auto offset = rRightHandSideVector.size() - rPBlockVector.size();
         AddVectorAtPosition(rPBlockVector, rRightHandSideVector, offset);
     }
 

--- a/applications/GeoMechanicsApplication/custom_utilities/element_utilities.hpp
+++ b/applications/GeoMechanicsApplication/custom_utilities/element_utilities.hpp
@@ -46,23 +46,6 @@ public:
 
 //----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     template< unsigned int TDim, unsigned int TNumNodes >
-    static inline void CalculateNuElementMatrix(BoundedMatrix<double, (TDim+1), TNumNodes*(TDim+1)>& rNut,
-                                                const Matrix& NContainer,
-                                                unsigned int GPoint)
-    {
-        const unsigned int offset = (TDim+1);
-
-        for (unsigned int i=0; i < TDim; ++i) {
-            unsigned int index = i - offset;
-            for (unsigned int j=0; j < TNumNodes; ++j) {
-                index += offset;
-                rNut(i, index) = NContainer(GPoint, j);
-            }
-        }
-    }
-
-//----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    template< unsigned int TDim, unsigned int TNumNodes >
     static inline void InterpolateVariableWithComponents(array_1d<double, TDim>& rVector,
                                                          const Matrix& NContainer,
                                                          const array_1d<double, TDim*TNumNodes>& VariableWithComponents,
@@ -230,9 +213,8 @@ public:
         }
     }
 
-//----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    static inline void AssembleDensityMatrix(Matrix &DensityMatrix,
-                                             double Density)
+    template <typename MatrixType>
+    static inline void AssembleDensityMatrix(MatrixType& DensityMatrix, double Density)
     {
         for (unsigned int idim = 0; idim < DensityMatrix.size1(); ++idim) {
             for (unsigned int jdim = 0; jdim < DensityMatrix.size2(); ++jdim) {

--- a/applications/GeoMechanicsApplication/custom_utilities/element_utilities.hpp
+++ b/applications/GeoMechanicsApplication/custom_utilities/element_utilities.hpp
@@ -14,9 +14,6 @@
 #if !defined(KRATOS_GEO_ELEMENT_UTILITIES )
 #define  KRATOS_GEO_ELEMENT_UTILITIES
 
-// System includes
-//#include <cmath>
-
 // Project includes
 #include "utilities/math_utils.h"
 #include "includes/element.h"
@@ -29,15 +26,10 @@ namespace Kratos
 
 class GeoElementUtilities
 {
-
-typedef std::size_t IndexType;
-
 public:
+    using IndexType    = std::size_t;
+    using GeometryType = Geometry<Node>;
 
-    typedef Node NodeType;
-    typedef Geometry<NodeType> GeometryType;
-
-//----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     template< unsigned int TDim, unsigned int TNumNodes >
     static inline void CalculateNuMatrix(BoundedMatrix<double,TDim,TDim*TNumNodes>& rNu,
                                          const Matrix& NContainer,

--- a/applications/GeoMechanicsApplication/custom_utilities/element_utilities.hpp
+++ b/applications/GeoMechanicsApplication/custom_utilities/element_utilities.hpp
@@ -242,7 +242,7 @@ public:
     }
 
     template <typename MatrixType1, typename MatrixType2>
-    static inline void AssembleUBlockMatrix(MatrixType1& rLeftHandSideMatrix, const MatrixType2& rUBlockMatrix)
+    static inline void AssembleUUBlockMatrix(MatrixType1& rLeftHandSideMatrix, const MatrixType2& rUBlockMatrix)
     {
         constexpr auto row_offset    = std::size_t{0};
         constexpr auto column_offset = row_offset;
@@ -268,8 +268,8 @@ public:
     }
 
     template <unsigned int TDim, unsigned int TNumNodes>
-    static inline void AssemblePBlockMatrix(Matrix& rLeftHandSideMatrix,
-                                            const BoundedMatrix<double, TNumNodes, TNumNodes>& rPBlockMatrix)
+    static inline void AssemblePPBlockMatrix(Matrix& rLeftHandSideMatrix,
+                                             const BoundedMatrix<double, TNumNodes, TNumNodes>& rPBlockMatrix)
     {
         constexpr auto row_offset    = TNumNodes * TDim;
         constexpr auto column_offset = row_offset;

--- a/applications/GeoMechanicsApplication/custom_utilities/element_utilities.hpp
+++ b/applications/GeoMechanicsApplication/custom_utilities/element_utilities.hpp
@@ -252,47 +252,36 @@ public:
     template <typename MatrixType1, typename MatrixType2>
     static inline void AssembleUBlockMatrix(MatrixType1& rLeftHandSideMatrix, const MatrixType2& rUBlockMatrix)
     {
-        for (auto i = std::size_t{0}; i < rUBlockMatrix.size1(); ++i) {
-            for (auto j = std::size_t{0}; j < rUBlockMatrix.size2(); ++j) {
-                rLeftHandSideMatrix(i, j) += rUBlockMatrix(i, j);
-            }
-        }
+        constexpr auto row_offset    = std::size_t{0};
+        constexpr auto column_offset = row_offset;
+        AddMatrixAtPosition(rUBlockMatrix, rLeftHandSideMatrix, row_offset, column_offset);
     }
 
     template <unsigned int TDim, unsigned int TNumNodes>
     static inline void AssembleUPBlockMatrix(Matrix& rLeftHandSideMatrix,
                                              const BoundedMatrix<double, TDim * TNumNodes, TNumNodes>& rUPBlockMatrix)
     {
-        const auto offset = TNumNodes * TDim;
-        for (auto i = std::size_t{0}; i < rUPBlockMatrix.size1(); ++i) {
-            for (auto j = std::size_t{0}; j < rUPBlockMatrix.size2(); ++j) {
-                rLeftHandSideMatrix(i, j + offset) += rUPBlockMatrix(i, j);
-            }
-        }
+        constexpr auto row_offset    = std::size_t{0};
+        constexpr auto column_offset = TNumNodes * TDim;
+        AddMatrixAtPosition(rUPBlockMatrix, rLeftHandSideMatrix, row_offset, column_offset);
     }
 
     template <unsigned int TDim, unsigned int TNumNodes>
     static inline void AssemblePUBlockMatrix(Matrix& rLeftHandSideMatrix,
                                              const BoundedMatrix<double, TNumNodes, TNumNodes * TDim>& rPUBlockMatrix)
     {
-        const auto offset = TNumNodes * TDim;
-        for (auto i = std::size_t{0}; i < rPUBlockMatrix.size1(); ++i) {
-            for (auto j = std::size_t{0}; j < rPUBlockMatrix.size2(); ++j) {
-                rLeftHandSideMatrix(i + offset, j) += rPUBlockMatrix(i, j);
-            }
-        }
+        constexpr auto row_offset    = TNumNodes * TDim;
+        constexpr auto column_offset = std::size_t{0};
+        AddMatrixAtPosition(rPUBlockMatrix, rLeftHandSideMatrix, row_offset, column_offset);
     }
 
     template <unsigned int TDim, unsigned int TNumNodes>
     static inline void AssemblePBlockMatrix(Matrix& rLeftHandSideMatrix,
                                             const BoundedMatrix<double, TNumNodes, TNumNodes>& rPBlockMatrix)
     {
-        const auto offset = TNumNodes * TDim;
-        for (auto i = std::size_t{0}; i < rPBlockMatrix.size1(); ++i) {
-            for (auto j = std::size_t{0}; j < rPBlockMatrix.size2(); ++j) {
-                rLeftHandSideMatrix(i + offset, j + offset) += rPBlockMatrix(i, j);
-            }
-        }
+        constexpr auto row_offset    = TNumNodes * TDim;
+        constexpr auto column_offset = row_offset;
+        AddMatrixAtPosition(rPBlockMatrix, rLeftHandSideMatrix, row_offset, column_offset);
     }
 
     template <unsigned int TDim, unsigned int TNumNodes>
@@ -637,6 +626,19 @@ private:
     {
         auto pos = rDestinationVector.begin() + Offset;
         std::transform(rSourceVector.begin(), rSourceVector.end(), pos, pos, std::plus<double>{});
+    }
+
+    template <typename MatrixType1, typename MatrixType2>
+    static void AddMatrixAtPosition(const MatrixType1& rSourceMatrix,
+                                    MatrixType2&       rDestinationMatrix,
+                                    std::size_t        RowOffset,
+                                    std::size_t        ColumnOffset)
+    {
+        for (auto i = std::size_t{0}; i < rSourceMatrix.size1(); ++i) {
+            for (auto j = std::size_t{0}; j < rSourceMatrix.size2(); ++j) {
+                rDestinationMatrix(i + RowOffset, j + ColumnOffset) += rSourceMatrix(i, j);
+            }
+        }
     }
 
 }; /* Class GeoElementUtilities*/

--- a/applications/GeoMechanicsApplication/custom_utilities/interface_element_utilities.hpp
+++ b/applications/GeoMechanicsApplication/custom_utilities/interface_element_utilities.hpp
@@ -94,49 +94,6 @@ public:
     }
 
     //----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    static inline void CalculateNuElementMatrix(BoundedMatrix<double,3,12>& rNut,
-                                                const Matrix& Ncontainer,
-                                                const unsigned int& GPoint)
-    {
-        //Quadrilateral_interface_2d_4
-        rNut(0,0) = -Ncontainer(GPoint,0); rNut(0,3) = -Ncontainer(GPoint,1);
-        rNut(1,1) = -Ncontainer(GPoint,0); rNut(1,4) = -Ncontainer(GPoint,1);
-
-        rNut(0,6) =  Ncontainer(GPoint,2); rNut(0,9)  = Ncontainer(GPoint,3);
-        rNut(1,7) =  Ncontainer(GPoint,2); rNut(1,10) = Ncontainer(GPoint,3);
-    }
-
-    //----------------------------------------------------------------------------------------
-    static inline void CalculateNuElementMatrix(BoundedMatrix<double,4,24>& rNut,
-                                                const Matrix& Ncontainer,
-                                                const unsigned int& GPoint)
-    {
-        //Prism_interface_3d_6
-        rNut(0,0) = -Ncontainer(GPoint,0); rNut(0,4) = -Ncontainer(GPoint,1); rNut(0,8)  = -Ncontainer(GPoint,2);
-        rNut(1,1) = -Ncontainer(GPoint,0); rNut(1,5) = -Ncontainer(GPoint,1); rNut(1,9)  = -Ncontainer(GPoint,2);
-        rNut(2,2) = -Ncontainer(GPoint,0); rNut(2,6) = -Ncontainer(GPoint,1); rNut(2,10) = -Ncontainer(GPoint,2);
-
-        rNut(0,12) = Ncontainer(GPoint,3); rNut(0,16) = Ncontainer(GPoint,4); rNut(0,20)  = Ncontainer(GPoint,5);
-        rNut(1,13) = Ncontainer(GPoint,3); rNut(1,17) = Ncontainer(GPoint,4); rNut(1,21)  = Ncontainer(GPoint,5);
-        rNut(2,14) = Ncontainer(GPoint,3); rNut(2,18) = Ncontainer(GPoint,4); rNut(2,22)  = Ncontainer(GPoint,5);
-    }
-
-    //----------------------------------------------------------------------------------------
-    static inline void CalculateNuElementMatrix(BoundedMatrix<double,4,32>& rNut,
-                                                const Matrix& Ncontainer,
-                                                const unsigned int& GPoint)
-    {
-        //Hexahedral_interface_3d_8
-        rNut(0,0) = -Ncontainer(GPoint,0); rNut(0,4) = -Ncontainer(GPoint,1); rNut(0,8)  = -Ncontainer(GPoint,2); rNut(0,12) = -Ncontainer(GPoint,3);
-        rNut(1,1) = -Ncontainer(GPoint,0); rNut(1,5) = -Ncontainer(GPoint,1); rNut(1,9)  = -Ncontainer(GPoint,2); rNut(1,13) = -Ncontainer(GPoint,3);
-        rNut(2,2) = -Ncontainer(GPoint,0); rNut(2,6) = -Ncontainer(GPoint,1); rNut(2,10) = -Ncontainer(GPoint,2); rNut(2,14) = -Ncontainer(GPoint,3);
-
-        rNut(0,16) = Ncontainer(GPoint,4); rNut(0,20) = Ncontainer(GPoint,5); rNut(0,24)  = Ncontainer(GPoint,6); rNut(0,28) =  Ncontainer(GPoint,7);
-        rNut(1,17) = Ncontainer(GPoint,4); rNut(1,21) = Ncontainer(GPoint,5); rNut(1,25)  = Ncontainer(GPoint,6); rNut(1,29) =  Ncontainer(GPoint,7);
-        rNut(2,18) = Ncontainer(GPoint,4); rNut(2,22) = Ncontainer(GPoint,5); rNut(2,26)  = Ncontainer(GPoint,6); rNut(2,30) =  Ncontainer(GPoint,7);
-    }
-
-    //----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     static inline void FillPermeabilityMatrix(BoundedMatrix<double,2,2>& rPermeabilityMatrix,
                                                    const double& JointWidth,
                                                    const double& Transversal_Permeability)
@@ -151,7 +108,7 @@ public:
                                                    const double& JointWidth,
                                                    const double& Transversal_Permeability)
     {
-        //Prism_interface_3d_6 & Hexahedral_interface_3d_8
+        //Prism_interface_3d_6 and Hexahedral_interface_3d_8
         rPermeabilityMatrix(0,0) = JointWidth*JointWidth/12.0;
         rPermeabilityMatrix(1,1) = JointWidth*JointWidth/12.0;
         rPermeabilityMatrix(2,2) = Transversal_Permeability;
@@ -168,7 +125,7 @@ public:
     //----------------------------------------------------------------------------------------
     static inline void CalculateVoigtVector(array_1d<double,3>& rVoigtVector)
     {
-        //Prism_interface_3d_6 & Hexahedral_interface_3d_8
+        //Prism_interface_3d_6 and Hexahedral_interface_3d_8
         rVoigtVector[0] = 0.0;
         rVoigtVector[1] = 0.0;
         rVoigtVector[2] = 1.0;
@@ -187,7 +144,7 @@ public:
     static inline void CalculateLinkPermeabilityMatrix(BoundedMatrix<double,3,3>& rPermeabilityMatrix,
                                                        const double& JointWidth)
     {
-        //Prism_interface_3d_6 & Hexahedral_interface_3d_8
+        //Prism_interface_3d_6 and Hexahedral_interface_3d_8
         rPermeabilityMatrix(0,0) = JointWidth*JointWidth/12.0;
         rPermeabilityMatrix(1,1) = JointWidth*JointWidth/12.0;
         rPermeabilityMatrix(2,2) = JointWidth*JointWidth/12.0;

--- a/applications/GeoMechanicsApplication/geo_aliases.h
+++ b/applications/GeoMechanicsApplication/geo_aliases.h
@@ -1,0 +1,25 @@
+// KRATOS___
+//     //   ) )
+//    //         ___      ___
+//   //  ____  //___) ) //   ) )
+//  //    / / //       //   / /
+// ((____/ / ((____   ((___/ /  MECHANICS
+//
+//  License:         geo_mechanics_application/license.txt
+//
+//  Main authors:    Anne van de Graaf
+//
+
+#pragma once
+
+#include <functional>
+#include <vector>
+
+#include "containers/variable.h"
+
+namespace Kratos::Geo
+{
+
+using ConstVariableRefs = std::vector<std::reference_wrapper<const Variable<double>>>;
+
+} // namespace Kratos::Geo

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/test_dof_utilities.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/test_dof_utilities.cpp
@@ -240,20 +240,15 @@ KRATOS_TEST_CASE_IN_SUITE(UDofsPrecedePwDofsWhenExtractingUPwDofsFromNondiffOrde
 
 KRATOS_TEST_CASE_IN_SUITE(UDofsPrecedePwDofsWhenExtractingUPwDofsFromDiffOrder2DElement, KratosGeoMechanicsFastSuite)
 {
-    auto       model = Model{};
-    const auto second_order_variables =
-        Geo::ConstVariableRefs{std::cref(DISPLACEMENT_X), std::cref(DISPLACEMENT_Y)};
-    const auto first_order_variables = Geo::ConstVariableRefs{std::cref(WATER_PRESSURE)};
-    auto&      r_model_part = ModelSetupUtilities::CreateModelPartWithASingle2D6NDiffOrderElement(
-        model, second_order_variables, first_order_variables);
+    auto model = Model{};
+    auto& r_model_part = ModelSetupUtilities::CreateModelPartWithASingle2D6NUPwDiffOrderElement(model);
 
     const auto second_order_nodes = r_model_part.Elements().front().GetGeometry();
     const auto first_order_nodes =
         Triangle2D3<Node>{second_order_nodes(0), second_order_nodes(1), second_order_nodes(2)};
     const auto dofs = Geo::DofUtilities::ExtractUPwDofsFromNodes(second_order_nodes, first_order_nodes);
 
-    KRATOS_EXPECT_EQ(dofs.size(), second_order_nodes.size() * second_order_variables.size() +
-                                      first_order_nodes.size() * first_order_variables.size());
+    KRATOS_EXPECT_EQ(dofs.size(), second_order_nodes.size() * 2 + first_order_nodes.size());
     ExpectDofsDontContainAnyNullptrs(dofs);
     ExpectDofsHaveThisVariable({dofs[0], dofs[2], dofs[4], dofs[6], dofs[8], dofs[10]}, DISPLACEMENT_X);
     ExpectDofsHaveThisVariable({dofs[1], dofs[3], dofs[5], dofs[7], dofs[9], dofs[11]}, DISPLACEMENT_Y);

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/test_dof_utilities.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/test_dof_utilities.cpp
@@ -258,6 +258,7 @@ KRATOS_TEST_CASE_IN_SUITE(UDofsPrecedePwDofsWhenExtractingUPwDofsFromDiffOrder2D
     ExpectDofsHaveThisVariable({dofs[0], dofs[2], dofs[4], dofs[6], dofs[8], dofs[10]}, DISPLACEMENT_X);
     ExpectDofsHaveThisVariable({dofs[1], dofs[3], dofs[5], dofs[7], dofs[9], dofs[11]}, DISPLACEMENT_Y);
     ExpectDofsHaveThisVariable({dofs.begin() + 12, dofs.end()}, WATER_PRESSURE);
+    ExpectDofsHaveThisNodeId({dofs[0], dofs[1], dofs[12]}, 1);
 }
 
 KRATOS_TEST_CASE_IN_SUITE(ExtractingValuesFromDofsYieldsNodalValues, KratosGeoMechanicsFastSuite)

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/test_dof_utilities.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/test_dof_utilities.cpp
@@ -281,6 +281,9 @@ KRATOS_TEST_CASE_IN_SUITE(UDofsPrecedePwDofsWhenExtractingUPwDofsFromDiffOrder3D
     ExpectDofsHaveThisVariable(
         {dofs[1], dofs[4], dofs[7], dofs[10], dofs[13], dofs[16], dofs[19], dofs[22], dofs[25], dofs[28]},
         DISPLACEMENT_Y);
+    ExpectDofsHaveThisVariable(
+        {dofs[2], dofs[5], dofs[8], dofs[11], dofs[14], dofs[17], dofs[20], dofs[23], dofs[26], dofs[29]},
+        DISPLACEMENT_Z);
 }
 
 KRATOS_TEST_CASE_IN_SUITE(ExtractingValuesFromDofsYieldsNodalValues, KratosGeoMechanicsFastSuite)

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/test_dof_utilities.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/test_dof_utilities.cpp
@@ -233,6 +233,10 @@ KRATOS_TEST_CASE_IN_SUITE(UDofsPrecedePwDofsWhenExtractingUPwDofsFromNondiffOrde
     KRATOS_EXPECT_TRUE(std::all_of(dofs_to_test.begin(), dofs_to_test.end(), [](const auto p_dof) {
         return p_dof->GetVariable() == DISPLACEMENT_Y;
     }))
+    dofs_to_test = std::vector<Dof<double>*>{dofs[2], dofs[5], dofs[8]};
+    KRATOS_EXPECT_TRUE(std::all_of(dofs_to_test.begin(), dofs_to_test.end(), [](const auto p_dof) {
+        return p_dof->GetVariable() == DISPLACEMENT_Z;
+    }))
 }
 
 KRATOS_TEST_CASE_IN_SUITE(ExtractingValuesFromDofsYieldsNodalValues, KratosGeoMechanicsFastSuite)

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/test_dof_utilities.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/test_dof_utilities.cpp
@@ -180,8 +180,9 @@ KRATOS_TEST_CASE_IN_SUITE(UDofsPrecedePwDofsWhenExtractingUPwDofsFromNondiffOrde
         std::cref(DISPLACEMENT_X), std::cref(DISPLACEMENT_Y), std::cref(WATER_PRESSURE)};
     auto& r_model_part = ModelSetupUtilities::CreateModelPartWithASingle2D3NElement(model, nodal_variables);
 
-    const auto dofs =
-        Geo::DofUtilities::ExtractUPwDofsFromNodes(r_model_part.Elements().front().GetGeometry());
+    const auto dofs = Geo::DofUtilities::ExtractUPwDofsFromNodes(
+        r_model_part.Elements().front().GetGeometry(),
+        r_model_part.Elements().front().GetGeometry().WorkingSpaceDimension());
 
     KRATOS_EXPECT_EQ(dofs.size(), r_model_part.NumberOfNodes() * nodal_variables.size());
     KRATOS_EXPECT_TRUE(
@@ -207,6 +208,21 @@ KRATOS_TEST_CASE_IN_SUITE(UDofsPrecedePwDofsWhenExtractingUPwDofsFromNondiffOrde
     dofs_to_test = std::vector<Dof<double>*>{dofs[4], dofs[5], dofs[8]};
     KRATOS_EXPECT_TRUE(std::all_of(dofs_to_test.begin(), dofs_to_test.end(),
                                    [](const auto p_dof) { return p_dof->GetId() == 3; }))
+}
+
+KRATOS_TEST_CASE_IN_SUITE(UDofsPrecedePwDofsWhenExtractingUPwDofsFromNondiffOrder3DElement, KratosGeoMechanicsFastSuite)
+{
+    auto       model = Model{};
+    const auto nodal_variables =
+        Geo::ConstVariableRefs{std::cref(DISPLACEMENT_X), std::cref(DISPLACEMENT_Y),
+                               std::cref(DISPLACEMENT_Z), std::cref(WATER_PRESSURE)};
+    auto& r_model_part = ModelSetupUtilities::CreateModelPartWithASingle3D4NElement(model, nodal_variables);
+
+    const auto dofs = Geo::DofUtilities::ExtractUPwDofsFromNodes(
+        r_model_part.Elements().front().GetGeometry(),
+        r_model_part.Elements().front().GetGeometry().WorkingSpaceDimension());
+
+    KRATOS_EXPECT_EQ(dofs.size(), r_model_part.NumberOfNodes() * nodal_variables.size());
 }
 
 KRATOS_TEST_CASE_IN_SUITE(ExtractingValuesFromDofsYieldsNodalValues, KratosGeoMechanicsFastSuite)

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/test_dof_utilities.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/test_dof_utilities.cpp
@@ -225,6 +225,10 @@ KRATOS_TEST_CASE_IN_SUITE(UDofsPrecedePwDofsWhenExtractingUPwDofsFromNondiffOrde
     KRATOS_EXPECT_EQ(dofs.size(), r_model_part.NumberOfNodes() * nodal_variables.size());
     KRATOS_EXPECT_TRUE(
         std::all_of(dofs.begin(), dofs.end(), [](const auto p_dof) { return p_dof != nullptr; }))
+    auto dofs_to_test = std::vector<Dof<double>*>{dofs[0], dofs[3], dofs[6]};
+    KRATOS_EXPECT_TRUE(std::all_of(dofs_to_test.begin(), dofs_to_test.end(), [](const auto p_dof) {
+        return p_dof->GetVariable() == DISPLACEMENT_X;
+    }))
 }
 
 KRATOS_TEST_CASE_IN_SUITE(ExtractingValuesFromDofsYieldsNodalValues, KratosGeoMechanicsFastSuite)

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/test_dof_utilities.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/test_dof_utilities.cpp
@@ -237,6 +237,10 @@ KRATOS_TEST_CASE_IN_SUITE(UDofsPrecedePwDofsWhenExtractingUPwDofsFromNondiffOrde
     KRATOS_EXPECT_TRUE(std::all_of(dofs_to_test.begin(), dofs_to_test.end(), [](const auto p_dof) {
         return p_dof->GetVariable() == DISPLACEMENT_Z;
     }))
+    dofs_to_test = std::vector<Dof<double>*>{dofs.begin() + 13, dofs.end()};
+    KRATOS_EXPECT_TRUE(std::all_of(dofs_to_test.begin(), dofs_to_test.end(), [](const auto p_dof) {
+        return p_dof->GetVariable() == WATER_PRESSURE;
+    }))
 }
 
 KRATOS_TEST_CASE_IN_SUITE(ExtractingValuesFromDofsYieldsNodalValues, KratosGeoMechanicsFastSuite)

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/test_dof_utilities.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/test_dof_utilities.cpp
@@ -259,6 +259,11 @@ KRATOS_TEST_CASE_IN_SUITE(UDofsPrecedePwDofsWhenExtractingUPwDofsFromDiffOrder2D
     ExpectDofsHaveThisVariable({dofs[1], dofs[3], dofs[5], dofs[7], dofs[9], dofs[11]}, DISPLACEMENT_Y);
     ExpectDofsHaveThisVariable({dofs.begin() + 12, dofs.end()}, WATER_PRESSURE);
     ExpectDofsHaveThisNodeId({dofs[0], dofs[1], dofs[12]}, 1);
+    ExpectDofsHaveThisNodeId({dofs[2], dofs[3], dofs[13]}, 2);
+    ExpectDofsHaveThisNodeId({dofs[4], dofs[5], dofs[14]}, 3);
+    ExpectDofsHaveThisNodeId({dofs[6], dofs[7]}, 4);
+    ExpectDofsHaveThisNodeId({dofs[8], dofs[9]}, 5);
+    ExpectDofsHaveThisNodeId({dofs[10], dofs[11]}, 6);
 }
 
 KRATOS_TEST_CASE_IN_SUITE(ExtractingValuesFromDofsYieldsNodalValues, KratosGeoMechanicsFastSuite)

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/test_dof_utilities.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/test_dof_utilities.cpp
@@ -197,6 +197,10 @@ KRATOS_TEST_CASE_IN_SUITE(UDofsPrecedePwDofsWhenExtractingUPwDofsFromNondiffOrde
     KRATOS_EXPECT_TRUE(std::all_of(dofs_to_test.begin(), dofs_to_test.end(), [](const auto p_dof) {
         return p_dof->GetVariable() == WATER_PRESSURE;
     }))
+    dofs_to_test = std::vector<Dof<double>*>{dofs[0], dofs[1], dofs[6]};
+    KRATOS_EXPECT_TRUE(std::all_of(dofs_to_test.begin(), dofs_to_test.end(), [](const Dof<double>* p_dof) {
+        return p_dof->GetId() == 1;
+    }))
 }
 
 KRATOS_TEST_CASE_IN_SUITE(ExtractingValuesFromDofsYieldsNodalValues, KratosGeoMechanicsFastSuite)

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/test_dof_utilities.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/test_dof_utilities.cpp
@@ -250,6 +250,9 @@ KRATOS_TEST_CASE_IN_SUITE(UDofsPrecedePwDofsWhenExtractingUPwDofsFromNondiffOrde
     dofs_to_test = std::vector<Dof<double>*>{dofs[6], dofs[7], dofs[8], dofs[14]};
     KRATOS_EXPECT_TRUE(std::all_of(dofs_to_test.begin(), dofs_to_test.end(),
                                    [](const auto p_dof) { return p_dof->GetId() == 3; }))
+    dofs_to_test = std::vector<Dof<double>*>{dofs[9], dofs[10], dofs[11], dofs[15]};
+    KRATOS_EXPECT_TRUE(std::all_of(dofs_to_test.begin(), dofs_to_test.end(),
+                                   [](const auto p_dof) { return p_dof->GetId() == 4; }))
 }
 
 KRATOS_TEST_CASE_IN_SUITE(ExtractingValuesFromDofsYieldsNodalValues, KratosGeoMechanicsFastSuite)

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/test_dof_utilities.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/test_dof_utilities.cpp
@@ -225,19 +225,19 @@ KRATOS_TEST_CASE_IN_SUITE(UDofsPrecedePwDofsWhenExtractingUPwDofsFromNondiffOrde
     KRATOS_EXPECT_EQ(dofs.size(), r_model_part.NumberOfNodes() * nodal_variables.size());
     KRATOS_EXPECT_TRUE(
         std::all_of(dofs.begin(), dofs.end(), [](const auto p_dof) { return p_dof != nullptr; }))
-    auto dofs_to_test = std::vector<Dof<double>*>{dofs[0], dofs[3], dofs[6]};
+    auto dofs_to_test = std::vector<Dof<double>*>{dofs[0], dofs[3], dofs[6], dofs[9]};
     KRATOS_EXPECT_TRUE(std::all_of(dofs_to_test.begin(), dofs_to_test.end(), [](const auto p_dof) {
         return p_dof->GetVariable() == DISPLACEMENT_X;
     }))
-    dofs_to_test = std::vector<Dof<double>*>{dofs[1], dofs[4], dofs[7]};
+    dofs_to_test = std::vector<Dof<double>*>{dofs[1], dofs[4], dofs[7], dofs[10]};
     KRATOS_EXPECT_TRUE(std::all_of(dofs_to_test.begin(), dofs_to_test.end(), [](const auto p_dof) {
         return p_dof->GetVariable() == DISPLACEMENT_Y;
     }))
-    dofs_to_test = std::vector<Dof<double>*>{dofs[2], dofs[5], dofs[8]};
+    dofs_to_test = std::vector<Dof<double>*>{dofs[2], dofs[5], dofs[8], dofs[11]};
     KRATOS_EXPECT_TRUE(std::all_of(dofs_to_test.begin(), dofs_to_test.end(), [](const auto p_dof) {
         return p_dof->GetVariable() == DISPLACEMENT_Z;
     }))
-    dofs_to_test = std::vector<Dof<double>*>{dofs.begin() + 13, dofs.end()};
+    dofs_to_test = std::vector<Dof<double>*>{dofs.begin() + 12, dofs.end()};
     KRATOS_EXPECT_TRUE(std::all_of(dofs_to_test.begin(), dofs_to_test.end(), [](const auto p_dof) {
         return p_dof->GetVariable() == WATER_PRESSURE;
     }))

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/test_dof_utilities.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/test_dof_utilities.cpp
@@ -183,6 +183,8 @@ KRATOS_TEST_CASE_IN_SUITE(UDofsPrecedePwDofsWhenExtractingUPwDofsFromNondiffOrde
 
     const auto dofs = Geo::DofUtilities::ExtractUPwDofsFromNodes(p_element->GetGeometry());
     KRATOS_EXPECT_EQ(dofs.size(), node_ids.size() * all_variables.size());
+    KRATOS_EXPECT_TRUE(
+        std::all_of(dofs.begin(), dofs.end(), [](const auto p_dof) { return p_dof != nullptr; }))
 }
 
 KRATOS_TEST_CASE_IN_SUITE(ExtractingValuesFromDofsYieldsNodalValues, KratosGeoMechanicsFastSuite)

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/test_dof_utilities.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/test_dof_utilities.cpp
@@ -284,6 +284,7 @@ KRATOS_TEST_CASE_IN_SUITE(UDofsPrecedePwDofsWhenExtractingUPwDofsFromDiffOrder3D
     ExpectDofsHaveThisVariable(
         {dofs[2], dofs[5], dofs[8], dofs[11], dofs[14], dofs[17], dofs[20], dofs[23], dofs[26], dofs[29]},
         DISPLACEMENT_Z);
+    ExpectDofsHaveThisVariable({dofs.begin() + 30, dofs.end()}, WATER_PRESSURE);
     ExpectDofsHaveThisNodeId({dofs[0], dofs[1], dofs[2], dofs[30]}, 1);
     ExpectDofsHaveThisNodeId({dofs[3], dofs[4], dofs[5], dofs[31]}, 2);
     ExpectDofsHaveThisNodeId({dofs[6], dofs[7], dofs[8], dofs[32]}, 3);

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/test_dof_utilities.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/test_dof_utilities.cpp
@@ -201,6 +201,10 @@ KRATOS_TEST_CASE_IN_SUITE(UDofsPrecedePwDofsWhenExtractingUPwDofsFromNondiffOrde
     KRATOS_EXPECT_TRUE(std::all_of(dofs_to_test.begin(), dofs_to_test.end(), [](const Dof<double>* p_dof) {
         return p_dof->GetId() == 1;
     }))
+    dofs_to_test = std::vector<Dof<double>*>{dofs[2], dofs[3], dofs[7]};
+    KRATOS_EXPECT_TRUE(std::all_of(dofs_to_test.begin(), dofs_to_test.end(), [](const Dof<double>* p_dof) {
+        return p_dof->GetId() == 2;
+    }))
 }
 
 KRATOS_TEST_CASE_IN_SUITE(ExtractingValuesFromDofsYieldsNodalValues, KratosGeoMechanicsFastSuite)

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/test_dof_utilities.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/test_dof_utilities.cpp
@@ -97,6 +97,13 @@ void SetNodalValues(ModelPart&                            rModelPart,
     }
 }
 
+void ExpectDofsHaveThisVariable(const std::vector<Dof<double>*>& rDofs, const Variable<double>& rExpectedVariable)
+{
+    KRATOS_EXPECT_TRUE(std::all_of(rDofs.begin(), rDofs.end(), [&rExpectedVariable](const auto p_dof) {
+        return p_dof->GetVariable() == rExpectedVariable;
+    }))
+}
+
 void ExpectDofsHaveThisNodeId(const std::vector<Dof<double>*>& rDofs, std::size_t ExpectedNodeId)
 {
     KRATOS_EXPECT_TRUE(std::all_of(rDofs.begin(), rDofs.end(), [ExpectedNodeId](const auto p_dof) {
@@ -194,18 +201,9 @@ KRATOS_TEST_CASE_IN_SUITE(UDofsPrecedePwDofsWhenExtractingUPwDofsFromNondiffOrde
     KRATOS_EXPECT_EQ(dofs.size(), r_model_part.NumberOfNodes() * nodal_variables.size());
     KRATOS_EXPECT_TRUE(
         std::all_of(dofs.begin(), dofs.end(), [](const auto p_dof) { return p_dof != nullptr; }))
-    auto dofs_to_test = std::vector<Dof<double>*>{dofs[0], dofs[2], dofs[4]};
-    KRATOS_EXPECT_TRUE(std::all_of(dofs_to_test.begin(), dofs_to_test.end(), [](const auto p_dof) {
-        return p_dof->GetVariable() == DISPLACEMENT_X;
-    }))
-    dofs_to_test = std::vector<Dof<double>*>{dofs[1], dofs[3], dofs[5]};
-    KRATOS_EXPECT_TRUE(std::all_of(dofs_to_test.begin(), dofs_to_test.end(), [](const auto p_dof) {
-        return p_dof->GetVariable() == DISPLACEMENT_Y;
-    }))
-    dofs_to_test = std::vector<Dof<double>*>{dofs.begin() + 6, dofs.end()};
-    KRATOS_EXPECT_TRUE(std::all_of(dofs_to_test.begin(), dofs_to_test.end(), [](const auto p_dof) {
-        return p_dof->GetVariable() == WATER_PRESSURE;
-    }))
+    ExpectDofsHaveThisVariable({dofs[0], dofs[2], dofs[4]}, DISPLACEMENT_X);
+    ExpectDofsHaveThisVariable({dofs[1], dofs[3], dofs[5]}, DISPLACEMENT_Y);
+    ExpectDofsHaveThisVariable({dofs.begin() + 6, dofs.end()}, WATER_PRESSURE);
     ExpectDofsHaveThisNodeId({dofs[0], dofs[1], dofs[6]}, 1);
     ExpectDofsHaveThisNodeId({dofs[2], dofs[3], dofs[7]}, 2);
     ExpectDofsHaveThisNodeId({dofs[4], dofs[5], dofs[8]}, 3);
@@ -226,22 +224,10 @@ KRATOS_TEST_CASE_IN_SUITE(UDofsPrecedePwDofsWhenExtractingUPwDofsFromNondiffOrde
     KRATOS_EXPECT_EQ(dofs.size(), r_model_part.NumberOfNodes() * nodal_variables.size());
     KRATOS_EXPECT_TRUE(
         std::all_of(dofs.begin(), dofs.end(), [](const auto p_dof) { return p_dof != nullptr; }))
-    auto dofs_to_test = std::vector<Dof<double>*>{dofs[0], dofs[3], dofs[6], dofs[9]};
-    KRATOS_EXPECT_TRUE(std::all_of(dofs_to_test.begin(), dofs_to_test.end(), [](const auto p_dof) {
-        return p_dof->GetVariable() == DISPLACEMENT_X;
-    }))
-    dofs_to_test = std::vector<Dof<double>*>{dofs[1], dofs[4], dofs[7], dofs[10]};
-    KRATOS_EXPECT_TRUE(std::all_of(dofs_to_test.begin(), dofs_to_test.end(), [](const auto p_dof) {
-        return p_dof->GetVariable() == DISPLACEMENT_Y;
-    }))
-    dofs_to_test = std::vector<Dof<double>*>{dofs[2], dofs[5], dofs[8], dofs[11]};
-    KRATOS_EXPECT_TRUE(std::all_of(dofs_to_test.begin(), dofs_to_test.end(), [](const auto p_dof) {
-        return p_dof->GetVariable() == DISPLACEMENT_Z;
-    }))
-    dofs_to_test = std::vector<Dof<double>*>{dofs.begin() + 12, dofs.end()};
-    KRATOS_EXPECT_TRUE(std::all_of(dofs_to_test.begin(), dofs_to_test.end(), [](const auto p_dof) {
-        return p_dof->GetVariable() == WATER_PRESSURE;
-    }))
+    ExpectDofsHaveThisVariable({dofs[0], dofs[3], dofs[6], dofs[9]}, DISPLACEMENT_X);
+    ExpectDofsHaveThisVariable({dofs[1], dofs[4], dofs[7], dofs[10]}, DISPLACEMENT_Y);
+    ExpectDofsHaveThisVariable({dofs[2], dofs[5], dofs[8], dofs[11]}, DISPLACEMENT_Z);
+    ExpectDofsHaveThisVariable({dofs.begin() + 12, dofs.end()}, WATER_PRESSURE);
     ExpectDofsHaveThisNodeId({dofs[0], dofs[1], dofs[2], dofs[12]}, 1);
     ExpectDofsHaveThisNodeId({dofs[3], dofs[4], dofs[5], dofs[13]}, 2);
     ExpectDofsHaveThisNodeId({dofs[6], dofs[7], dofs[8], dofs[14]}, 3);

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/test_dof_utilities.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/test_dof_utilities.cpp
@@ -241,6 +241,9 @@ KRATOS_TEST_CASE_IN_SUITE(UDofsPrecedePwDofsWhenExtractingUPwDofsFromNondiffOrde
     KRATOS_EXPECT_TRUE(std::all_of(dofs_to_test.begin(), dofs_to_test.end(), [](const auto p_dof) {
         return p_dof->GetVariable() == WATER_PRESSURE;
     }))
+    dofs_to_test = std::vector<Dof<double>*>{dofs[0], dofs[1], dofs[2], dofs[12]};
+    KRATOS_EXPECT_TRUE(std::all_of(dofs_to_test.begin(), dofs_to_test.end(),
+                                   [](const auto p_dof) { return p_dof->GetId() == 1; }))
 }
 
 KRATOS_TEST_CASE_IN_SUITE(ExtractingValuesFromDofsYieldsNodalValues, KratosGeoMechanicsFastSuite)

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/test_dof_utilities.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/test_dof_utilities.cpp
@@ -274,6 +274,7 @@ KRATOS_TEST_CASE_IN_SUITE(UDofsPrecedePwDofsWhenExtractingUPwDofsFromDiffOrder3D
         second_order_nodes, first_order_nodes, second_order_nodes.WorkingSpaceDimension());
 
     KRATOS_EXPECT_EQ(dofs.size(), second_order_nodes.size() * 3 + first_order_nodes.size());
+    ExpectDofsDontContainAnyNullptrs(dofs);
 }
 
 KRATOS_TEST_CASE_IN_SUITE(ExtractingValuesFromDofsYieldsNodalValues, KratosGeoMechanicsFastSuite)

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/test_dof_utilities.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/test_dof_utilities.cpp
@@ -256,6 +256,7 @@ KRATOS_TEST_CASE_IN_SUITE(UDofsPrecedePwDofsWhenExtractingUPwDofsFromDiffOrder2D
                                       first_order_nodes.size() * first_order_variables.size());
     ExpectDofsDontContainAnyNullptrs(dofs);
     ExpectDofsHaveThisVariable({dofs[0], dofs[2], dofs[4], dofs[6], dofs[8], dofs[10]}, DISPLACEMENT_X);
+    ExpectDofsHaveThisVariable({dofs[1], dofs[3], dofs[5], dofs[7], dofs[9], dofs[11]}, DISPLACEMENT_Y);
 }
 
 KRATOS_TEST_CASE_IN_SUITE(ExtractingValuesFromDofsYieldsNodalValues, KratosGeoMechanicsFastSuite)

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/test_dof_utilities.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/test_dof_utilities.cpp
@@ -223,6 +223,8 @@ KRATOS_TEST_CASE_IN_SUITE(UDofsPrecedePwDofsWhenExtractingUPwDofsFromNondiffOrde
         r_model_part.Elements().front().GetGeometry().WorkingSpaceDimension());
 
     KRATOS_EXPECT_EQ(dofs.size(), r_model_part.NumberOfNodes() * nodal_variables.size());
+    KRATOS_EXPECT_TRUE(
+        std::all_of(dofs.begin(), dofs.end(), [](const auto p_dof) { return p_dof != nullptr; }))
 }
 
 KRATOS_TEST_CASE_IN_SUITE(ExtractingValuesFromDofsYieldsNodalValues, KratosGeoMechanicsFastSuite)

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/test_dof_utilities.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/test_dof_utilities.cpp
@@ -16,6 +16,7 @@
 
 #include "containers/model.h"
 #include "custom_utilities/dof_utilities.h"
+#include "geo_aliases.h"
 #include "geo_mechanics_application_variables.h"
 #include "includes/element.h"
 #include "testing/testing.h"
@@ -25,9 +26,7 @@ namespace
 
 using namespace Kratos;
 
-using ConstVariableRefs = std::vector<std::reference_wrapper<const Variable<double>>>;
-
-ModelPart& CreateTestModelPart(Model& rModel, const ConstVariableRefs& rVariables)
+ModelPart& CreateTestModelPart(Model& rModel, const Geo::ConstVariableRefs& rVariables)
 {
     const auto buffer_size = std::size_t{2};
     auto&      r_result    = rModel.CreateModelPart("Dummy", buffer_size);
@@ -39,7 +38,7 @@ ModelPart& CreateTestModelPart(Model& rModel, const ConstVariableRefs& rVariable
 
 ModelPart& CreateTestModelPart(Model& rModel, const Variable<double>& rVariable)
 {
-    const auto variables = ConstVariableRefs{std::cref(rVariable)};
+    const auto variables = Geo::ConstVariableRefs{std::cref(rVariable)};
     return CreateTestModelPart(rModel, variables);
 }
 
@@ -50,8 +49,12 @@ Dof<double> MakeDofWithEquationId(Dof<double>::EquationIdType EquationId)
     return result;
 }
 
-[[maybe_unused]] intrusive_ptr<Node> AddNodeWithDofs(
-    ModelPart& rModelPart, ModelPart::IndexType NodeId, double x, double y, double z, const ConstVariableRefs& rVariables)
+[[maybe_unused]] intrusive_ptr<Node> AddNodeWithDofs(ModelPart&                    rModelPart,
+                                                     ModelPart::IndexType          NodeId,
+                                                     double                        x,
+                                                     double                        y,
+                                                     double                        z,
+                                                     const Geo::ConstVariableRefs& rVariables)
 {
     auto p_result = rModelPart.CreateNewNode(NodeId, x, y, z);
     for (const auto& r_variable : rVariables) {
@@ -63,11 +66,11 @@ Dof<double> MakeDofWithEquationId(Dof<double>::EquationIdType EquationId)
 [[maybe_unused]] intrusive_ptr<Node> AddNodeWithDof(
     ModelPart& rModelPart, ModelPart::IndexType NodeId, double x, double y, double z, const Variable<double>& rVariable)
 {
-    const auto variables = ConstVariableRefs{std::cref(rVariable)};
+    const auto variables = Geo::ConstVariableRefs{std::cref(rVariable)};
     return AddNodeWithDofs(rModelPart, NodeId, x, y, z, variables);
 }
 
-void AddThreeNodesWithDofs(ModelPart& rModelPart, const ConstVariableRefs& rVariables)
+void AddThreeNodesWithDofs(ModelPart& rModelPart, const Geo::ConstVariableRefs& rVariables)
 {
     AddNodeWithDofs(rModelPart, 1, 0.0, 0.0, 0.0, rVariables);
     AddNodeWithDofs(rModelPart, 2, 1.0, 0.0, 0.0, rVariables);
@@ -76,7 +79,7 @@ void AddThreeNodesWithDofs(ModelPart& rModelPart, const ConstVariableRefs& rVari
 
 void AddThreeNodesWithDofs(ModelPart& rModelPart, const Variable<double>& rVariable)
 {
-    const auto variables = ConstVariableRefs{std::cref(rVariable)};
+    const auto variables = Geo::ConstVariableRefs{std::cref(rVariable)};
     AddThreeNodesWithDofs(rModelPart, variables);
 }
 
@@ -172,7 +175,7 @@ KRATOS_TEST_CASE_IN_SUITE(VariableTypeAndNodeIDsMustMatchWhenExtractingDofsFromN
 KRATOS_TEST_CASE_IN_SUITE(UDofsPrecedePwDofsWhenExtractingUPwDofsFromNondiffOrder2DElement, KratosGeoMechanicsFastSuite)
 {
     auto       model         = Model{};
-    const auto all_variables = ConstVariableRefs{
+    const auto all_variables = Geo::ConstVariableRefs{
         std::cref(DISPLACEMENT_X), std::cref(DISPLACEMENT_Y), std::cref(WATER_PRESSURE)};
     auto& r_model_part = CreateTestModelPart(model, all_variables);
     AddThreeNodesWithDofs(r_model_part, all_variables);
@@ -242,7 +245,8 @@ KRATOS_TEST_CASE_IN_SUITE(ExtractingFirstDerivativeValuesFromDofsYieldsNodalFirs
 {
     const auto& r_variable              = DISPLACEMENT_X;
     const auto& r_first_time_derivative = VELOCITY_X;
-    const auto all_variables = ConstVariableRefs{std::cref(r_variable), std::cref(r_first_time_derivative)};
+    const auto  all_variables =
+        Geo::ConstVariableRefs{std::cref(r_variable), std::cref(r_first_time_derivative)};
 
     auto  model        = Model{};
     auto& r_model_part = CreateTestModelPart(model, all_variables);
@@ -277,7 +281,7 @@ KRATOS_TEST_CASE_IN_SUITE(ExtractingSecondDerivativeValuesFromDofsYieldsNodalSec
     const auto& r_variable               = DISPLACEMENT_X;
     const auto& r_first_time_derivative  = VELOCITY_X;
     const auto& r_second_time_derivative = ACCELERATION_X;
-    const auto  all_variables            = ConstVariableRefs{
+    const auto  all_variables            = Geo::ConstVariableRefs{
         std::cref(r_variable), std::cref(r_first_time_derivative), std::cref(r_second_time_derivative)};
 
     auto  model        = Model{};
@@ -371,7 +375,8 @@ KRATOS_TEST_CASE_IN_SUITE(ExtractingFirstDerivativesFromUPwDofsNotBeingPwYieldsN
 {
     const auto& r_variable              = DISPLACEMENT_X;
     const auto& r_first_time_derivative = VELOCITY_X;
-    const auto all_variables = ConstVariableRefs{std::cref(r_variable), std::cref(r_first_time_derivative)};
+    const auto  all_variables =
+        Geo::ConstVariableRefs{std::cref(r_variable), std::cref(r_first_time_derivative)};
 
     auto  model        = Model{};
     auto& r_model_part = CreateTestModelPart(model, all_variables);
@@ -404,7 +409,8 @@ KRATOS_TEST_CASE_IN_SUITE(ExtractingDPwDtValuesFromUPwDofsAlwaysYieldsZeroes, Kr
 {
     const auto& r_variable              = WATER_PRESSURE;
     const auto& r_first_time_derivative = DT_WATER_PRESSURE;
-    const auto all_variables = ConstVariableRefs{std::cref(r_variable), std::cref(r_first_time_derivative)};
+    const auto  all_variables =
+        Geo::ConstVariableRefs{std::cref(r_variable), std::cref(r_first_time_derivative)};
 
     auto  model        = Model{};
     auto& r_model_part = CreateTestModelPart(model, all_variables);
@@ -438,7 +444,7 @@ KRATOS_TEST_CASE_IN_SUITE(ExtractingSecondDerivativesFromUPwDofsNotBeingPwYields
     const auto& r_variable               = DISPLACEMENT_X;
     const auto& r_first_time_derivative  = VELOCITY_X;
     const auto& r_second_time_derivative = ACCELERATION_X;
-    const auto  all_variables            = ConstVariableRefs{
+    const auto  all_variables            = Geo::ConstVariableRefs{
         std::cref(r_variable), std::cref(r_first_time_derivative), std::cref(r_second_time_derivative)};
 
     auto  model        = Model{};
@@ -473,7 +479,8 @@ KRATOS_TEST_CASE_IN_SUITE(ExtractingD2PwDt2ValuesFromUPwDofsAlwaysYieldsZeroes, 
     const auto& r_variable              = WATER_PRESSURE;
     const auto& r_first_time_derivative = DT_WATER_PRESSURE;
     // There is no variable defined for the second time derivative of the water pressure
-    const auto all_variables = ConstVariableRefs{std::cref(r_variable), std::cref(r_first_time_derivative)};
+    const auto all_variables =
+        Geo::ConstVariableRefs{std::cref(r_variable), std::cref(r_first_time_derivative)};
 
     auto  model        = Model{};
     auto& r_model_part = CreateTestModelPart(model, all_variables);

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/test_dof_utilities.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/test_dof_utilities.cpp
@@ -205,6 +205,10 @@ KRATOS_TEST_CASE_IN_SUITE(UDofsPrecedePwDofsWhenExtractingUPwDofsFromNondiffOrde
     KRATOS_EXPECT_TRUE(std::all_of(dofs_to_test.begin(), dofs_to_test.end(), [](const Dof<double>* p_dof) {
         return p_dof->GetId() == 2;
     }))
+    dofs_to_test = std::vector<Dof<double>*>{dofs[4], dofs[5], dofs[8]};
+    KRATOS_EXPECT_TRUE(std::all_of(dofs_to_test.begin(), dofs_to_test.end(), [](const Dof<double>* p_dof) {
+        return p_dof->GetId() == 3;
+    }))
 }
 
 KRATOS_TEST_CASE_IN_SUITE(ExtractingValuesFromDofsYieldsNodalValues, KratosGeoMechanicsFastSuite)

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/test_dof_utilities.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/test_dof_utilities.cpp
@@ -229,6 +229,10 @@ KRATOS_TEST_CASE_IN_SUITE(UDofsPrecedePwDofsWhenExtractingUPwDofsFromNondiffOrde
     KRATOS_EXPECT_TRUE(std::all_of(dofs_to_test.begin(), dofs_to_test.end(), [](const auto p_dof) {
         return p_dof->GetVariable() == DISPLACEMENT_X;
     }))
+    dofs_to_test = std::vector<Dof<double>*>{dofs[1], dofs[4], dofs[7]};
+    KRATOS_EXPECT_TRUE(std::all_of(dofs_to_test.begin(), dofs_to_test.end(), [](const auto p_dof) {
+        return p_dof->GetVariable() == DISPLACEMENT_Y;
+    }))
 }
 
 KRATOS_TEST_CASE_IN_SUITE(ExtractingValuesFromDofsYieldsNodalValues, KratosGeoMechanicsFastSuite)

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/test_dof_utilities.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/test_dof_utilities.cpp
@@ -185,6 +185,10 @@ KRATOS_TEST_CASE_IN_SUITE(UDofsPrecedePwDofsWhenExtractingUPwDofsFromNondiffOrde
     KRATOS_EXPECT_EQ(dofs.size(), node_ids.size() * all_variables.size());
     KRATOS_EXPECT_TRUE(
         std::all_of(dofs.begin(), dofs.end(), [](const auto p_dof) { return p_dof != nullptr; }))
+    auto expected_dofs = std::vector<Dof<double>*>{dofs[0], dofs[2], dofs[4]};
+    KRATOS_EXPECT_TRUE(std::all_of(expected_dofs.begin(), expected_dofs.end(), [](const auto p_dof) {
+        return p_dof->GetVariable() == DISPLACEMENT_X;
+    }))
 }
 
 KRATOS_TEST_CASE_IN_SUITE(ExtractingValuesFromDofsYieldsNodalValues, KratosGeoMechanicsFastSuite)

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/test_dof_utilities.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/test_dof_utilities.cpp
@@ -200,9 +200,9 @@ KRATOS_TEST_CASE_IN_SUITE(UDofsPrecedePwDofsWhenExtractingUPwDofsFromNondiffOrde
         std::cref(DISPLACEMENT_X), std::cref(DISPLACEMENT_Y), std::cref(WATER_PRESSURE)};
     auto& r_model_part = ModelSetupUtilities::CreateModelPartWithASingle2D3NElement(model, nodal_variables);
 
-    const auto dofs = Geo::DofUtilities::ExtractUPwDofsFromNodes(
-        r_model_part.Elements().front().GetGeometry(),
-        r_model_part.Elements().front().GetGeometry().WorkingSpaceDimension());
+    const auto& r_geometry = r_model_part.Elements().front().GetGeometry();
+    const auto  dofs =
+        Geo::DofUtilities::ExtractUPwDofsFromNodes(r_geometry, r_geometry.WorkingSpaceDimension());
 
     KRATOS_EXPECT_EQ(dofs.size(), r_model_part.NumberOfNodes() * nodal_variables.size());
     ExpectDofsDontContainAnyNullptrs(dofs);
@@ -222,9 +222,9 @@ KRATOS_TEST_CASE_IN_SUITE(UDofsPrecedePwDofsWhenExtractingUPwDofsFromNondiffOrde
                                std::cref(DISPLACEMENT_Z), std::cref(WATER_PRESSURE)};
     auto& r_model_part = ModelSetupUtilities::CreateModelPartWithASingle3D4NElement(model, nodal_variables);
 
-    const auto dofs = Geo::DofUtilities::ExtractUPwDofsFromNodes(
-        r_model_part.Elements().front().GetGeometry(),
-        r_model_part.Elements().front().GetGeometry().WorkingSpaceDimension());
+    const auto& r_geometry = r_model_part.Elements().front().GetGeometry();
+    const auto  dofs =
+        Geo::DofUtilities::ExtractUPwDofsFromNodes(r_geometry, r_geometry.WorkingSpaceDimension());
 
     KRATOS_EXPECT_EQ(dofs.size(), r_model_part.NumberOfNodes() * nodal_variables.size());
     ExpectDofsDontContainAnyNullptrs(dofs);

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/test_dof_utilities.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/test_dof_utilities.cpp
@@ -97,6 +97,12 @@ void SetNodalValues(ModelPart&                            rModelPart,
     }
 }
 
+void ExpectDofsDontContainAnyNullptrs(const std::vector<Dof<double>*>& rDofs)
+{
+    KRATOS_EXPECT_TRUE(
+        std::all_of(rDofs.begin(), rDofs.end(), [](const auto p_dof) { return p_dof != nullptr; }))
+}
+
 void ExpectDofsHaveThisVariable(const std::vector<Dof<double>*>& rDofs, const Variable<double>& rExpectedVariable)
 {
     KRATOS_EXPECT_TRUE(std::all_of(rDofs.begin(), rDofs.end(), [&rExpectedVariable](const auto p_dof) {
@@ -199,8 +205,7 @@ KRATOS_TEST_CASE_IN_SUITE(UDofsPrecedePwDofsWhenExtractingUPwDofsFromNondiffOrde
         r_model_part.Elements().front().GetGeometry().WorkingSpaceDimension());
 
     KRATOS_EXPECT_EQ(dofs.size(), r_model_part.NumberOfNodes() * nodal_variables.size());
-    KRATOS_EXPECT_TRUE(
-        std::all_of(dofs.begin(), dofs.end(), [](const auto p_dof) { return p_dof != nullptr; }))
+    ExpectDofsDontContainAnyNullptrs(dofs);
     ExpectDofsHaveThisVariable({dofs[0], dofs[2], dofs[4]}, DISPLACEMENT_X);
     ExpectDofsHaveThisVariable({dofs[1], dofs[3], dofs[5]}, DISPLACEMENT_Y);
     ExpectDofsHaveThisVariable({dofs.begin() + 6, dofs.end()}, WATER_PRESSURE);
@@ -222,8 +227,7 @@ KRATOS_TEST_CASE_IN_SUITE(UDofsPrecedePwDofsWhenExtractingUPwDofsFromNondiffOrde
         r_model_part.Elements().front().GetGeometry().WorkingSpaceDimension());
 
     KRATOS_EXPECT_EQ(dofs.size(), r_model_part.NumberOfNodes() * nodal_variables.size());
-    KRATOS_EXPECT_TRUE(
-        std::all_of(dofs.begin(), dofs.end(), [](const auto p_dof) { return p_dof != nullptr; }))
+    ExpectDofsDontContainAnyNullptrs(dofs);
     ExpectDofsHaveThisVariable({dofs[0], dofs[3], dofs[6], dofs[9]}, DISPLACEMENT_X);
     ExpectDofsHaveThisVariable({dofs[1], dofs[4], dofs[7], dofs[10]}, DISPLACEMENT_Y);
     ExpectDofsHaveThisVariable({dofs[2], dofs[5], dofs[8], dofs[11]}, DISPLACEMENT_Z);

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/test_dof_utilities.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/test_dof_utilities.cpp
@@ -275,6 +275,12 @@ KRATOS_TEST_CASE_IN_SUITE(UDofsPrecedePwDofsWhenExtractingUPwDofsFromDiffOrder3D
 
     KRATOS_EXPECT_EQ(dofs.size(), second_order_nodes.size() * 3 + first_order_nodes.size());
     ExpectDofsDontContainAnyNullptrs(dofs);
+    ExpectDofsHaveThisVariable(
+        {dofs[0], dofs[3], dofs[6], dofs[9], dofs[12], dofs[15], dofs[18], dofs[21], dofs[24], dofs[27]},
+        DISPLACEMENT_X);
+    ExpectDofsHaveThisVariable(
+        {dofs[1], dofs[4], dofs[7], dofs[10], dofs[13], dofs[16], dofs[19], dofs[22], dofs[25], dofs[28]},
+        DISPLACEMENT_Y);
 }
 
 KRATOS_TEST_CASE_IN_SUITE(ExtractingValuesFromDofsYieldsNodalValues, KratosGeoMechanicsFastSuite)

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/test_dof_utilities.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/test_dof_utilities.cpp
@@ -254,6 +254,7 @@ KRATOS_TEST_CASE_IN_SUITE(UDofsPrecedePwDofsWhenExtractingUPwDofsFromDiffOrder2D
 
     KRATOS_EXPECT_EQ(dofs.size(), second_order_nodes.size() * second_order_variables.size() +
                                       first_order_nodes.size() * first_order_variables.size());
+    ExpectDofsDontContainAnyNullptrs(dofs);
 }
 
 KRATOS_TEST_CASE_IN_SUITE(ExtractingValuesFromDofsYieldsNodalValues, KratosGeoMechanicsFastSuite)

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/test_dof_utilities.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/test_dof_utilities.cpp
@@ -169,6 +169,22 @@ KRATOS_TEST_CASE_IN_SUITE(VariableTypeAndNodeIDsMustMatchWhenExtractingDofsFromN
     KRATOS_EXPECT_EQ(dofs[2]->GetId(), 3);
 }
 
+KRATOS_TEST_CASE_IN_SUITE(UDofsPrecedePwDofsWhenExtractingUPwDofsFromNondiffOrder2DElement, KratosGeoMechanicsFastSuite)
+{
+    auto       model         = Model{};
+    const auto all_variables = ConstVariableRefs{
+        std::cref(DISPLACEMENT_X), std::cref(DISPLACEMENT_Y), std::cref(WATER_PRESSURE)};
+    auto& r_model_part = CreateTestModelPart(model, all_variables);
+    AddThreeNodesWithDofs(r_model_part, all_variables);
+
+    const auto node_ids  = std::vector<ModelPart::IndexType>{1, 2, 3};
+    const auto p_element = r_model_part.CreateNewElement("UPwSmallStrainElement2D3N", 1, node_ids,
+                                                         r_model_part.CreateNewProperties(0));
+
+    const auto dofs = Geo::DofUtilities::ExtractUPwDofsFromNodes(p_element->GetGeometry());
+    KRATOS_EXPECT_EQ(dofs.size(), node_ids.size() * all_variables.size());
+}
+
 KRATOS_TEST_CASE_IN_SUITE(ExtractingValuesFromDofsYieldsNodalValues, KratosGeoMechanicsFastSuite)
 {
     auto        model        = Model{};

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/test_dof_utilities.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/test_dof_utilities.cpp
@@ -198,17 +198,14 @@ KRATOS_TEST_CASE_IN_SUITE(UDofsPrecedePwDofsWhenExtractingUPwDofsFromNondiffOrde
         return p_dof->GetVariable() == WATER_PRESSURE;
     }))
     dofs_to_test = std::vector<Dof<double>*>{dofs[0], dofs[1], dofs[6]};
-    KRATOS_EXPECT_TRUE(std::all_of(dofs_to_test.begin(), dofs_to_test.end(), [](const auto p_dof) {
-        return p_dof->GetId() == 1;
-    }))
+    KRATOS_EXPECT_TRUE(std::all_of(dofs_to_test.begin(), dofs_to_test.end(),
+                                   [](const auto p_dof) { return p_dof->GetId() == 1; }))
     dofs_to_test = std::vector<Dof<double>*>{dofs[2], dofs[3], dofs[7]};
-    KRATOS_EXPECT_TRUE(std::all_of(dofs_to_test.begin(), dofs_to_test.end(), [](const auto p_dof) {
-        return p_dof->GetId() == 2;
-    }))
+    KRATOS_EXPECT_TRUE(std::all_of(dofs_to_test.begin(), dofs_to_test.end(),
+                                   [](const auto p_dof) { return p_dof->GetId() == 2; }))
     dofs_to_test = std::vector<Dof<double>*>{dofs[4], dofs[5], dofs[8]};
-    KRATOS_EXPECT_TRUE(std::all_of(dofs_to_test.begin(), dofs_to_test.end(), [](const auto p_dof) {
-        return p_dof->GetId() == 3;
-    }))
+    KRATOS_EXPECT_TRUE(std::all_of(dofs_to_test.begin(), dofs_to_test.end(),
+                                   [](const auto p_dof) { return p_dof->GetId() == 3; }))
 }
 
 KRATOS_TEST_CASE_IN_SUITE(ExtractingValuesFromDofsYieldsNodalValues, KratosGeoMechanicsFastSuite)

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/test_dof_utilities.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/test_dof_utilities.cpp
@@ -255,6 +255,7 @@ KRATOS_TEST_CASE_IN_SUITE(UDofsPrecedePwDofsWhenExtractingUPwDofsFromDiffOrder2D
     KRATOS_EXPECT_EQ(dofs.size(), second_order_nodes.size() * second_order_variables.size() +
                                       first_order_nodes.size() * first_order_variables.size());
     ExpectDofsDontContainAnyNullptrs(dofs);
+    ExpectDofsHaveThisVariable({dofs[0], dofs[2], dofs[4], dofs[6], dofs[8], dofs[10]}, DISPLACEMENT_X);
 }
 
 KRATOS_TEST_CASE_IN_SUITE(ExtractingValuesFromDofsYieldsNodalValues, KratosGeoMechanicsFastSuite)

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/test_dof_utilities.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/test_dof_utilities.cpp
@@ -198,15 +198,15 @@ KRATOS_TEST_CASE_IN_SUITE(UDofsPrecedePwDofsWhenExtractingUPwDofsFromNondiffOrde
         return p_dof->GetVariable() == WATER_PRESSURE;
     }))
     dofs_to_test = std::vector<Dof<double>*>{dofs[0], dofs[1], dofs[6]};
-    KRATOS_EXPECT_TRUE(std::all_of(dofs_to_test.begin(), dofs_to_test.end(), [](const Dof<double>* p_dof) {
+    KRATOS_EXPECT_TRUE(std::all_of(dofs_to_test.begin(), dofs_to_test.end(), [](const auto p_dof) {
         return p_dof->GetId() == 1;
     }))
     dofs_to_test = std::vector<Dof<double>*>{dofs[2], dofs[3], dofs[7]};
-    KRATOS_EXPECT_TRUE(std::all_of(dofs_to_test.begin(), dofs_to_test.end(), [](const Dof<double>* p_dof) {
+    KRATOS_EXPECT_TRUE(std::all_of(dofs_to_test.begin(), dofs_to_test.end(), [](const auto p_dof) {
         return p_dof->GetId() == 2;
     }))
     dofs_to_test = std::vector<Dof<double>*>{dofs[4], dofs[5], dofs[8]};
-    KRATOS_EXPECT_TRUE(std::all_of(dofs_to_test.begin(), dofs_to_test.end(), [](const Dof<double>* p_dof) {
+    KRATOS_EXPECT_TRUE(std::all_of(dofs_to_test.begin(), dofs_to_test.end(), [](const auto p_dof) {
         return p_dof->GetId() == 3;
     }))
 }

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/test_dof_utilities.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/test_dof_utilities.cpp
@@ -244,6 +244,9 @@ KRATOS_TEST_CASE_IN_SUITE(UDofsPrecedePwDofsWhenExtractingUPwDofsFromNondiffOrde
     dofs_to_test = std::vector<Dof<double>*>{dofs[0], dofs[1], dofs[2], dofs[12]};
     KRATOS_EXPECT_TRUE(std::all_of(dofs_to_test.begin(), dofs_to_test.end(),
                                    [](const auto p_dof) { return p_dof->GetId() == 1; }))
+    dofs_to_test = std::vector<Dof<double>*>{dofs[3], dofs[4], dofs[5], dofs[13]};
+    KRATOS_EXPECT_TRUE(std::all_of(dofs_to_test.begin(), dofs_to_test.end(),
+                                   [](const auto p_dof) { return p_dof->GetId() == 2; }))
 }
 
 KRATOS_TEST_CASE_IN_SUITE(ExtractingValuesFromDofsYieldsNodalValues, KratosGeoMechanicsFastSuite)

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/test_dof_utilities.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/test_dof_utilities.cpp
@@ -19,6 +19,7 @@
 #include "geo_aliases.h"
 #include "geo_mechanics_application_variables.h"
 #include "includes/element.h"
+#include "test_utilities/model_setup_utilities.h"
 #include "testing/testing.h"
 
 namespace
@@ -174,18 +175,15 @@ KRATOS_TEST_CASE_IN_SUITE(VariableTypeAndNodeIDsMustMatchWhenExtractingDofsFromN
 
 KRATOS_TEST_CASE_IN_SUITE(UDofsPrecedePwDofsWhenExtractingUPwDofsFromNondiffOrder2DElement, KratosGeoMechanicsFastSuite)
 {
-    auto       model         = Model{};
-    const auto all_variables = Geo::ConstVariableRefs{
+    auto       model           = Model{};
+    const auto nodal_variables = Geo::ConstVariableRefs{
         std::cref(DISPLACEMENT_X), std::cref(DISPLACEMENT_Y), std::cref(WATER_PRESSURE)};
-    auto& r_model_part = CreateTestModelPart(model, all_variables);
-    AddThreeNodesWithDofs(r_model_part, all_variables);
-    const auto node_ids  = std::vector<ModelPart::IndexType>{1, 2, 3};
-    const auto p_element = r_model_part.CreateNewElement("UPwSmallStrainElement2D3N", 1, node_ids,
-                                                         r_model_part.CreateNewProperties(0));
+    auto& r_model_part = ModelSetupUtilities::CreateModelPartWithASingle2D3NElement(model, nodal_variables);
 
-    const auto dofs = Geo::DofUtilities::ExtractUPwDofsFromNodes(p_element->GetGeometry());
+    const auto dofs =
+        Geo::DofUtilities::ExtractUPwDofsFromNodes(r_model_part.Elements().front().GetGeometry());
 
-    KRATOS_EXPECT_EQ(dofs.size(), node_ids.size() * all_variables.size());
+    KRATOS_EXPECT_EQ(dofs.size(), r_model_part.NumberOfNodes() * nodal_variables.size());
     KRATOS_EXPECT_TRUE(
         std::all_of(dofs.begin(), dofs.end(), [](const auto p_dof) { return p_dof != nullptr; }))
     auto dofs_to_test = std::vector<Dof<double>*>{dofs[0], dofs[2], dofs[4]};

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/test_dof_utilities.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/test_dof_utilities.cpp
@@ -243,13 +243,13 @@ KRATOS_TEST_CASE_IN_SUITE(UDofsPrecedePwDofsWhenExtractingUPwDofsFromDiffOrder2D
     auto model = Model{};
     auto& r_model_part = ModelSetupUtilities::CreateModelPartWithASingle2D6NUPwDiffOrderElement(model);
 
-    const auto second_order_nodes = r_model_part.Elements().front().GetGeometry();
-    const auto first_order_nodes =
-        Triangle2D3<Node>{second_order_nodes(0), second_order_nodes(1), second_order_nodes(2)};
+    const auto displacement_nodes = r_model_part.Elements().front().GetGeometry();
+    const auto water_pressure_nodes =
+        Triangle2D3<Node>{displacement_nodes(0), displacement_nodes(1), displacement_nodes(2)};
     const auto dofs = Geo::DofUtilities::ExtractUPwDofsFromNodes(
-        second_order_nodes, first_order_nodes, second_order_nodes.WorkingSpaceDimension());
+        displacement_nodes, water_pressure_nodes, displacement_nodes.WorkingSpaceDimension());
 
-    KRATOS_EXPECT_EQ(dofs.size(), second_order_nodes.size() * 2 + first_order_nodes.size());
+    KRATOS_EXPECT_EQ(dofs.size(), displacement_nodes.size() * 2 + water_pressure_nodes.size());
     ExpectDofsDontContainAnyNullptrs(dofs);
     ExpectDofsHaveThisVariable({dofs[0], dofs[2], dofs[4], dofs[6], dofs[8], dofs[10]}, DISPLACEMENT_X);
     ExpectDofsHaveThisVariable({dofs[1], dofs[3], dofs[5], dofs[7], dofs[9], dofs[11]}, DISPLACEMENT_Y);

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/test_dof_utilities.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/test_dof_utilities.cpp
@@ -176,18 +176,22 @@ KRATOS_TEST_CASE_IN_SUITE(UDofsPrecedePwDofsWhenExtractingUPwDofsFromNondiffOrde
         std::cref(DISPLACEMENT_X), std::cref(DISPLACEMENT_Y), std::cref(WATER_PRESSURE)};
     auto& r_model_part = CreateTestModelPart(model, all_variables);
     AddThreeNodesWithDofs(r_model_part, all_variables);
-
     const auto node_ids  = std::vector<ModelPart::IndexType>{1, 2, 3};
     const auto p_element = r_model_part.CreateNewElement("UPwSmallStrainElement2D3N", 1, node_ids,
                                                          r_model_part.CreateNewProperties(0));
 
     const auto dofs = Geo::DofUtilities::ExtractUPwDofsFromNodes(p_element->GetGeometry());
+
     KRATOS_EXPECT_EQ(dofs.size(), node_ids.size() * all_variables.size());
     KRATOS_EXPECT_TRUE(
         std::all_of(dofs.begin(), dofs.end(), [](const auto p_dof) { return p_dof != nullptr; }))
-    auto expected_dofs = std::vector<Dof<double>*>{dofs[0], dofs[2], dofs[4]};
-    KRATOS_EXPECT_TRUE(std::all_of(expected_dofs.begin(), expected_dofs.end(), [](const auto p_dof) {
+    auto dofs_to_test = std::vector<Dof<double>*>{dofs[0], dofs[2], dofs[4]};
+    KRATOS_EXPECT_TRUE(std::all_of(dofs_to_test.begin(), dofs_to_test.end(), [](const auto p_dof) {
         return p_dof->GetVariable() == DISPLACEMENT_X;
+    }))
+    dofs_to_test = std::vector<Dof<double>*>{dofs[1], dofs[3], dofs[5]};
+    KRATOS_EXPECT_TRUE(std::all_of(dofs_to_test.begin(), dofs_to_test.end(), [](const auto p_dof) {
+        return p_dof->GetVariable() == DISPLACEMENT_Y;
     }))
 }
 

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/test_dof_utilities.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/test_dof_utilities.cpp
@@ -193,6 +193,10 @@ KRATOS_TEST_CASE_IN_SUITE(UDofsPrecedePwDofsWhenExtractingUPwDofsFromNondiffOrde
     KRATOS_EXPECT_TRUE(std::all_of(dofs_to_test.begin(), dofs_to_test.end(), [](const auto p_dof) {
         return p_dof->GetVariable() == DISPLACEMENT_Y;
     }))
+    dofs_to_test = std::vector<Dof<double>*>{dofs.begin() + 6, dofs.end()};
+    KRATOS_EXPECT_TRUE(std::all_of(dofs_to_test.begin(), dofs_to_test.end(), [](const auto p_dof) {
+        return p_dof->GetVariable() == WATER_PRESSURE;
+    }))
 }
 
 KRATOS_TEST_CASE_IN_SUITE(ExtractingValuesFromDofsYieldsNodalValues, KratosGeoMechanicsFastSuite)

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/test_dof_utilities.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/test_dof_utilities.cpp
@@ -247,6 +247,9 @@ KRATOS_TEST_CASE_IN_SUITE(UDofsPrecedePwDofsWhenExtractingUPwDofsFromNondiffOrde
     dofs_to_test = std::vector<Dof<double>*>{dofs[3], dofs[4], dofs[5], dofs[13]};
     KRATOS_EXPECT_TRUE(std::all_of(dofs_to_test.begin(), dofs_to_test.end(),
                                    [](const auto p_dof) { return p_dof->GetId() == 2; }))
+    dofs_to_test = std::vector<Dof<double>*>{dofs[6], dofs[7], dofs[8], dofs[14]};
+    KRATOS_EXPECT_TRUE(std::all_of(dofs_to_test.begin(), dofs_to_test.end(),
+                                   [](const auto p_dof) { return p_dof->GetId() == 3; }))
 }
 
 KRATOS_TEST_CASE_IN_SUITE(ExtractingValuesFromDofsYieldsNodalValues, KratosGeoMechanicsFastSuite)

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/test_dof_utilities.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/test_dof_utilities.cpp
@@ -246,7 +246,8 @@ KRATOS_TEST_CASE_IN_SUITE(UDofsPrecedePwDofsWhenExtractingUPwDofsFromDiffOrder2D
     const auto second_order_nodes = r_model_part.Elements().front().GetGeometry();
     const auto first_order_nodes =
         Triangle2D3<Node>{second_order_nodes(0), second_order_nodes(1), second_order_nodes(2)};
-    const auto dofs = Geo::DofUtilities::ExtractUPwDofsFromNodes(second_order_nodes, first_order_nodes);
+    const auto dofs = Geo::DofUtilities::ExtractUPwDofsFromNodes(
+        second_order_nodes, first_order_nodes, second_order_nodes.WorkingSpaceDimension());
 
     KRATOS_EXPECT_EQ(dofs.size(), second_order_nodes.size() * 2 + first_order_nodes.size());
     ExpectDofsDontContainAnyNullptrs(dofs);
@@ -259,6 +260,20 @@ KRATOS_TEST_CASE_IN_SUITE(UDofsPrecedePwDofsWhenExtractingUPwDofsFromDiffOrder2D
     ExpectDofsHaveThisNodeId({dofs[6], dofs[7]}, 4);
     ExpectDofsHaveThisNodeId({dofs[8], dofs[9]}, 5);
     ExpectDofsHaveThisNodeId({dofs[10], dofs[11]}, 6);
+}
+
+KRATOS_TEST_CASE_IN_SUITE(UDofsPrecedePwDofsWhenExtractingUPwDofsFromDiffOrder3DElement, KratosGeoMechanicsFastSuite)
+{
+    auto model = Model{};
+    auto& r_model_part = ModelSetupUtilities::CreateModelPartWithASingle3D10NUPwDiffOrderElement(model);
+
+    const auto second_order_nodes = r_model_part.Elements().front().GetGeometry();
+    const auto first_order_nodes  = Tetrahedra3D4<Node>{
+        second_order_nodes(0), second_order_nodes(1), second_order_nodes(2), second_order_nodes(3)};
+    const auto dofs = Geo::DofUtilities::ExtractUPwDofsFromNodes(
+        second_order_nodes, first_order_nodes, second_order_nodes.WorkingSpaceDimension());
+
+    KRATOS_EXPECT_EQ(dofs.size(), second_order_nodes.size() * 3 + first_order_nodes.size());
 }
 
 KRATOS_TEST_CASE_IN_SUITE(ExtractingValuesFromDofsYieldsNodalValues, KratosGeoMechanicsFastSuite)

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/test_dof_utilities.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/test_dof_utilities.cpp
@@ -238,6 +238,24 @@ KRATOS_TEST_CASE_IN_SUITE(UDofsPrecedePwDofsWhenExtractingUPwDofsFromNondiffOrde
     ExpectDofsHaveThisNodeId({dofs[9], dofs[10], dofs[11], dofs[15]}, 4);
 }
 
+KRATOS_TEST_CASE_IN_SUITE(UDofsPrecedePwDofsWhenExtractingUPwDofsFromDiffOrder2DElement, KratosGeoMechanicsFastSuite)
+{
+    auto       model = Model{};
+    const auto second_order_variables =
+        Geo::ConstVariableRefs{std::cref(DISPLACEMENT_X), std::cref(DISPLACEMENT_Y)};
+    const auto first_order_variables = Geo::ConstVariableRefs{std::cref(WATER_PRESSURE)};
+    auto&      r_model_part = ModelSetupUtilities::CreateModelPartWithASingle2D6NDiffOrderElement(
+        model, second_order_variables, first_order_variables);
+
+    const auto second_order_nodes = r_model_part.Elements().front().GetGeometry();
+    const auto first_order_nodes =
+        Triangle2D3<Node>{second_order_nodes(0), second_order_nodes(1), second_order_nodes(2)};
+    const auto dofs = Geo::DofUtilities::ExtractUPwDofsFromNodes(second_order_nodes, first_order_nodes);
+
+    KRATOS_EXPECT_EQ(dofs.size(), second_order_nodes.size() * second_order_variables.size() +
+                                      first_order_nodes.size() * first_order_variables.size());
+}
+
 KRATOS_TEST_CASE_IN_SUITE(ExtractingValuesFromDofsYieldsNodalValues, KratosGeoMechanicsFastSuite)
 {
     auto        model        = Model{};

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/test_dof_utilities.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/test_dof_utilities.cpp
@@ -97,6 +97,13 @@ void SetNodalValues(ModelPart&                            rModelPart,
     }
 }
 
+void ExpectDofsHaveThisNodeId(const std::vector<Dof<double>*>& rDofs, std::size_t ExpectedNodeId)
+{
+    KRATOS_EXPECT_TRUE(std::all_of(rDofs.begin(), rDofs.end(), [ExpectedNodeId](const auto p_dof) {
+        return p_dof->GetId() == ExpectedNodeId;
+    }))
+}
+
 } // namespace
 
 namespace Kratos::Testing
@@ -199,15 +206,9 @@ KRATOS_TEST_CASE_IN_SUITE(UDofsPrecedePwDofsWhenExtractingUPwDofsFromNondiffOrde
     KRATOS_EXPECT_TRUE(std::all_of(dofs_to_test.begin(), dofs_to_test.end(), [](const auto p_dof) {
         return p_dof->GetVariable() == WATER_PRESSURE;
     }))
-    dofs_to_test = std::vector<Dof<double>*>{dofs[0], dofs[1], dofs[6]};
-    KRATOS_EXPECT_TRUE(std::all_of(dofs_to_test.begin(), dofs_to_test.end(),
-                                   [](const auto p_dof) { return p_dof->GetId() == 1; }))
-    dofs_to_test = std::vector<Dof<double>*>{dofs[2], dofs[3], dofs[7]};
-    KRATOS_EXPECT_TRUE(std::all_of(dofs_to_test.begin(), dofs_to_test.end(),
-                                   [](const auto p_dof) { return p_dof->GetId() == 2; }))
-    dofs_to_test = std::vector<Dof<double>*>{dofs[4], dofs[5], dofs[8]};
-    KRATOS_EXPECT_TRUE(std::all_of(dofs_to_test.begin(), dofs_to_test.end(),
-                                   [](const auto p_dof) { return p_dof->GetId() == 3; }))
+    ExpectDofsHaveThisNodeId({dofs[0], dofs[1], dofs[6]}, 1);
+    ExpectDofsHaveThisNodeId({dofs[2], dofs[3], dofs[7]}, 2);
+    ExpectDofsHaveThisNodeId({dofs[4], dofs[5], dofs[8]}, 3);
 }
 
 KRATOS_TEST_CASE_IN_SUITE(UDofsPrecedePwDofsWhenExtractingUPwDofsFromNondiffOrder3DElement, KratosGeoMechanicsFastSuite)
@@ -241,18 +242,10 @@ KRATOS_TEST_CASE_IN_SUITE(UDofsPrecedePwDofsWhenExtractingUPwDofsFromNondiffOrde
     KRATOS_EXPECT_TRUE(std::all_of(dofs_to_test.begin(), dofs_to_test.end(), [](const auto p_dof) {
         return p_dof->GetVariable() == WATER_PRESSURE;
     }))
-    dofs_to_test = std::vector<Dof<double>*>{dofs[0], dofs[1], dofs[2], dofs[12]};
-    KRATOS_EXPECT_TRUE(std::all_of(dofs_to_test.begin(), dofs_to_test.end(),
-                                   [](const auto p_dof) { return p_dof->GetId() == 1; }))
-    dofs_to_test = std::vector<Dof<double>*>{dofs[3], dofs[4], dofs[5], dofs[13]};
-    KRATOS_EXPECT_TRUE(std::all_of(dofs_to_test.begin(), dofs_to_test.end(),
-                                   [](const auto p_dof) { return p_dof->GetId() == 2; }))
-    dofs_to_test = std::vector<Dof<double>*>{dofs[6], dofs[7], dofs[8], dofs[14]};
-    KRATOS_EXPECT_TRUE(std::all_of(dofs_to_test.begin(), dofs_to_test.end(),
-                                   [](const auto p_dof) { return p_dof->GetId() == 3; }))
-    dofs_to_test = std::vector<Dof<double>*>{dofs[9], dofs[10], dofs[11], dofs[15]};
-    KRATOS_EXPECT_TRUE(std::all_of(dofs_to_test.begin(), dofs_to_test.end(),
-                                   [](const auto p_dof) { return p_dof->GetId() == 4; }))
+    ExpectDofsHaveThisNodeId({dofs[0], dofs[1], dofs[2], dofs[12]}, 1);
+    ExpectDofsHaveThisNodeId({dofs[3], dofs[4], dofs[5], dofs[13]}, 2);
+    ExpectDofsHaveThisNodeId({dofs[6], dofs[7], dofs[8], dofs[14]}, 3);
+    ExpectDofsHaveThisNodeId({dofs[9], dofs[10], dofs[11], dofs[15]}, 4);
 }
 
 KRATOS_TEST_CASE_IN_SUITE(ExtractingValuesFromDofsYieldsNodalValues, KratosGeoMechanicsFastSuite)

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/test_dof_utilities.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/test_dof_utilities.cpp
@@ -284,6 +284,16 @@ KRATOS_TEST_CASE_IN_SUITE(UDofsPrecedePwDofsWhenExtractingUPwDofsFromDiffOrder3D
     ExpectDofsHaveThisVariable(
         {dofs[2], dofs[5], dofs[8], dofs[11], dofs[14], dofs[17], dofs[20], dofs[23], dofs[26], dofs[29]},
         DISPLACEMENT_Z);
+    ExpectDofsHaveThisNodeId({dofs[0], dofs[1], dofs[2], dofs[30]}, 1);
+    ExpectDofsHaveThisNodeId({dofs[3], dofs[4], dofs[5], dofs[31]}, 2);
+    ExpectDofsHaveThisNodeId({dofs[6], dofs[7], dofs[8], dofs[32]}, 3);
+    ExpectDofsHaveThisNodeId({dofs[9], dofs[10], dofs[11], dofs[33]}, 4);
+    ExpectDofsHaveThisNodeId({dofs[12], dofs[13], dofs[14]}, 5);
+    ExpectDofsHaveThisNodeId({dofs[15], dofs[16], dofs[17]}, 6);
+    ExpectDofsHaveThisNodeId({dofs[18], dofs[19], dofs[20]}, 7);
+    ExpectDofsHaveThisNodeId({dofs[21], dofs[22], dofs[23]}, 8);
+    ExpectDofsHaveThisNodeId({dofs[24], dofs[25], dofs[26]}, 9);
+    ExpectDofsHaveThisNodeId({dofs[27], dofs[28], dofs[29]}, 10);
 }
 
 KRATOS_TEST_CASE_IN_SUITE(ExtractingValuesFromDofsYieldsNodalValues, KratosGeoMechanicsFastSuite)

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/test_dof_utilities.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/test_dof_utilities.cpp
@@ -257,6 +257,7 @@ KRATOS_TEST_CASE_IN_SUITE(UDofsPrecedePwDofsWhenExtractingUPwDofsFromDiffOrder2D
     ExpectDofsDontContainAnyNullptrs(dofs);
     ExpectDofsHaveThisVariable({dofs[0], dofs[2], dofs[4], dofs[6], dofs[8], dofs[10]}, DISPLACEMENT_X);
     ExpectDofsHaveThisVariable({dofs[1], dofs[3], dofs[5], dofs[7], dofs[9], dofs[11]}, DISPLACEMENT_Y);
+    ExpectDofsHaveThisVariable({dofs.begin() + 12, dofs.end()}, WATER_PRESSURE);
 }
 
 KRATOS_TEST_CASE_IN_SUITE(ExtractingValuesFromDofsYieldsNodalValues, KratosGeoMechanicsFastSuite)

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/test_utilities/model_setup_utilities.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/test_utilities/model_setup_utilities.cpp
@@ -25,6 +25,15 @@ void AddNodalVariablesToModelPart(ModelPart& rModelPart, const Geo::ConstVariabl
     }
 }
 
+void CreateNewNodes(ModelPart& rModelPart, const std::vector<Point>& rPoints)
+{
+    auto NodeIndex = rModelPart.NumberOfNodes();
+    for (const auto& r_point : rPoints) {
+        ++NodeIndex;
+        rModelPart.CreateNewNode(NodeIndex, r_point.X(), r_point.Y(), r_point.Z());
+    }
+}
+
 template <typename InputIt>
 void AddDofsToNodes(InputIt NodeRangeBegin, InputIt NodeRangeEnd, const Geo::ConstVariableRefs& rNodalVariables)
 {
@@ -51,10 +60,7 @@ ModelPart& CreateModelPartWithASingle2D3NElement(Model& rModel, const Geo::Const
     ModelPart& result = rModel.CreateModelPart("Main");
     AddNodalVariablesToModelPart(result, rNodalVariables);
 
-    result.CreateNewNode(1, 0.0, 0.0, 0.0);
-    result.CreateNewNode(2, 1.0, 0.0, 0.0);
-    result.CreateNewNode(3, 1.0, 1.0, 0.0);
-
+    CreateNewNodes(result, {{0.0, 0.0, 0.0}, {1.0, 0.0, 0.0}, {1.0, 1.0, 0.0}});
     AddDofsToNodes(result.Nodes(), rNodalVariables);
 
     const std::vector<ModelPart::IndexType> node_ids{1, 2, 3};
@@ -68,11 +74,7 @@ ModelPart& CreateModelPartWithASingle3D4NElement(Model& rModel, const Geo::Const
     ModelPart& result = rModel.CreateModelPart("Main");
     AddNodalVariablesToModelPart(result, rNodalVariables);
 
-    result.CreateNewNode(1, 0.0, 0.0, 0.0);
-    result.CreateNewNode(2, 1.0, 0.0, 0.0);
-    result.CreateNewNode(3, 0.0, 1.0, 0.0);
-    result.CreateNewNode(4, 0.0, 0.0, 1.0);
-
+    CreateNewNodes(result, {{0.0, 0.0, 0.0}, {1.0, 0.0, 0.0}, {0.0, 1.0, 0.0}, {0.0, 0.0, 1.0}});
     AddDofsToNodes(result.Nodes(), rNodalVariables);
 
     const std::vector<ModelPart::IndexType> node_ids{1, 2, 3, 4};
@@ -90,12 +92,9 @@ ModelPart& CreateModelPartWithASingle2D6NUPwDiffOrderElement(Model& rModel)
     const auto first_order_variables = Geo::ConstVariableRefs{std::cref(WATER_PRESSURE)};
     AddNodalVariablesToModelPart(r_result, first_order_variables);
 
-    r_result.CreateNewNode(1, 0.0, 0.0, 0.0);
-    r_result.CreateNewNode(2, 1.0, 0.0, 0.0);
-    r_result.CreateNewNode(3, 0.0, 1.0, 0.0);
-    r_result.CreateNewNode(4, 0.5, 0.0, 0.0);
-    r_result.CreateNewNode(5, 0.5, 0.5, 0.0);
-    r_result.CreateNewNode(6, 0.0, 0.5, 0.0);
+    CreateNewNodes(
+        r_result,
+        {{0.0, 0.0, 0.0}, {1.0, 0.0, 0.0}, {0.0, 1.0, 0.0}, {0.5, 0.0, 0.0}, {0.5, 0.5, 0.0}, {0.0, 0.5, 0.0}});
 
     const auto nodes = r_result.Nodes();
     AddDofsToNodes(nodes, second_order_variables);

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/test_utilities/model_setup_utilities.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/test_utilities/model_setup_utilities.cpp
@@ -107,4 +107,35 @@ ModelPart& CreateModelPartWithASingle2D6NUPwDiffOrderElement(Model& rModel)
     return r_result;
 }
 
+ModelPart& CreateModelPartWithASingle3D10NUPwDiffOrderElement(Model& rModel)
+{
+    auto&      r_result               = rModel.CreateModelPart("Main");
+    const auto second_order_variables = Geo::ConstVariableRefs{
+        std::cref(DISPLACEMENT_X), std::cref(DISPLACEMENT_Y), std::cref(DISPLACEMENT_Z)};
+    AddNodalVariablesToModelPart(r_result, second_order_variables);
+    const auto first_order_variables = Geo::ConstVariableRefs{std::cref(WATER_PRESSURE)};
+    AddNodalVariablesToModelPart(r_result, first_order_variables);
+
+    CreateNewNodes(r_result, {{0.0, 0.0, 0.0},
+                              {1.0, 0.0, 0.0},
+                              {0.0, 1.0, 0.0},
+                              {0.0, 0.0, 1.0},
+                              {0.5, 0.0, 0.0},
+                              {0.5, 0.5, 0.0},
+                              {0.0, 0.5, 0.0},
+                              {0.0, 0.0, 0.5},
+                              {0.5, 0.0, 0.5},
+                              {0.0, 0.5, 0.5}});
+
+    const auto nodes = r_result.Nodes();
+    AddDofsToNodes(nodes, second_order_variables);
+    AddDofsToNodes(nodes.begin(), nodes.begin() + 4, first_order_variables);
+
+    const std::vector<ModelPart::IndexType> node_ids{1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
+    r_result.CreateNewElement("SmallStrainUPwDiffOrderElement3D10N", 1, node_ids,
+                              r_result.CreateNewProperties(0));
+
+    return r_result;
+}
+
 } // namespace Kratos::Testing::ModelSetupUtilities

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/test_utilities/model_setup_utilities.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/test_utilities/model_setup_utilities.cpp
@@ -18,13 +18,11 @@ namespace
 
 using namespace Kratos;
 
-ModelPart& CreateEmptyModelPart(Model& rModel, const Geo::ConstVariableRefs& rNodalVariables)
+void AddNodalVariablesToModelPart(ModelPart& rModelPart, const Geo::ConstVariableRefs& rNodalVariables)
 {
-    auto& r_result = rModel.CreateModelPart("Main");
     for (const auto& r_variable : rNodalVariables) {
-        r_result.AddNodalSolutionStepVariable(r_variable);
+        rModelPart.AddNodalSolutionStepVariable(r_variable.get());
     }
-    return r_result;
 }
 
 } // namespace
@@ -34,7 +32,8 @@ namespace Kratos::Testing::ModelSetupUtilities
 
 ModelPart& CreateModelPartWithASingle2D3NElement(Model& rModel, const Geo::ConstVariableRefs& rNodalVariables)
 {
-    ModelPart& result = CreateEmptyModelPart(rModel, rNodalVariables);
+    ModelPart& result = rModel.CreateModelPart("Main");
+    AddNodalVariablesToModelPart(result, rNodalVariables);
 
     result.CreateNewNode(1, 0.0, 0.0, 0.0);
     result.CreateNewNode(2, 1.0, 0.0, 0.0);
@@ -54,7 +53,8 @@ ModelPart& CreateModelPartWithASingle2D3NElement(Model& rModel, const Geo::Const
 
 ModelPart& CreateModelPartWithASingle3D4NElement(Model& rModel, const Geo::ConstVariableRefs& rNodalVariables)
 {
-    ModelPart& result = CreateEmptyModelPart(rModel, rNodalVariables);
+    ModelPart& result = rModel.CreateModelPart("Main");
+    AddNodalVariablesToModelPart(result, rNodalVariables);
 
     result.CreateNewNode(1, 0.0, 0.0, 0.0);
     result.CreateNewNode(2, 1.0, 0.0, 0.0);
@@ -79,10 +79,9 @@ ModelPart& CreateModelPartWithASingle2D6NUPwDiffOrderElement(Model& rModel)
         Geo::ConstVariableRefs{std::cref(DISPLACEMENT_X), std::cref(DISPLACEMENT_Y)};
     const auto first_order_variables = Geo::ConstVariableRefs{std::cref(WATER_PRESSURE)};
 
-    auto& r_result = CreateEmptyModelPart(rModel, second_order_variables);
-    for (const auto& r_variable : first_order_variables) {
-        r_result.AddNodalSolutionStepVariable(r_variable.get());
-    }
+    auto& r_result = rModel.CreateModelPart("Main");
+    AddNodalVariablesToModelPart(r_result, second_order_variables);
+    AddNodalVariablesToModelPart(r_result, first_order_variables);
 
     auto p_node1 = r_result.CreateNewNode(1, 0.0, 0.0, 0.0);
     auto p_node2 = r_result.CreateNewNode(2, 1.0, 0.0, 0.0);

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/test_utilities/model_setup_utilities.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/test_utilities/model_setup_utilities.cpp
@@ -13,15 +13,28 @@
 #include "containers/model.h"
 #include "includes/model_part.h"
 
+namespace
+{
+
+using namespace Kratos;
+
+ModelPart& CreateEmptyModelPart(Model& rModel, const Geo::ConstVariableRefs& rNodalVariables)
+{
+    auto& r_result = rModel.CreateModelPart("Main");
+    for (const auto& r_variable : rNodalVariables) {
+        r_result.AddNodalSolutionStepVariable(r_variable);
+    }
+    return r_result;
+}
+
+} // namespace
+
 namespace Kratos::Testing::ModelSetupUtilities
 {
 
 ModelPart& CreateModelPartWithASingle2D3NElement(Model& rModel, const Geo::ConstVariableRefs& rNodalVariables)
 {
-    ModelPart& result = rModel.CreateModelPart("Main");
-    for (const auto& r_variable : rNodalVariables) {
-        result.AddNodalSolutionStepVariable(r_variable);
-    }
+    ModelPart& result = CreateEmptyModelPart(rModel, rNodalVariables);
 
     result.CreateNewNode(1, 0.0, 0.0, 0.0);
     result.CreateNewNode(2, 1.0, 0.0, 0.0);
@@ -41,10 +54,7 @@ ModelPart& CreateModelPartWithASingle2D3NElement(Model& rModel, const Geo::Const
 
 ModelPart& CreateModelPartWithASingle3D4NElement(Model& rModel, const Geo::ConstVariableRefs& rNodalVariables)
 {
-    ModelPart& result = rModel.CreateModelPart("Main");
-    for (const auto& r_variable : rNodalVariables) {
-        result.AddNodalSolutionStepVariable(r_variable);
-    }
+    ModelPart& result = CreateEmptyModelPart(rModel, rNodalVariables);
 
     result.CreateNewNode(1, 0.0, 0.0, 0.0);
     result.CreateNewNode(2, 1.0, 0.0, 0.0);

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/test_utilities/model_setup_utilities.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/test_utilities/model_setup_utilities.cpp
@@ -73,10 +73,12 @@ ModelPart& CreateModelPartWithASingle3D4NElement(Model& rModel, const Geo::Const
     return result;
 }
 
-ModelPart& CreateModelPartWithASingle2D6NDiffOrderElement(Model& rModel,
-                                                          const Geo::ConstVariableRefs& rSecondOrderVariables,
-                                                          const Geo::ConstVariableRefs& rFirstOrderVariables)
+ModelPart& CreateModelPartWithASingle2D6NUPwDiffOrderElement(Model& rModel)
 {
+    const auto rSecondOrderVariables =
+        Geo::ConstVariableRefs{std::cref(DISPLACEMENT_X), std::cref(DISPLACEMENT_Y)};
+    const auto rFirstOrderVariables = Geo::ConstVariableRefs{std::cref(WATER_PRESSURE)};
+
     auto& r_result = CreateEmptyModelPart(rModel, rSecondOrderVariables);
     for (const auto& r_variable : rFirstOrderVariables) {
         r_result.AddNodalSolutionStepVariable(r_variable.get());
@@ -104,7 +106,8 @@ ModelPart& CreateModelPartWithASingle2D6NDiffOrderElement(Model& rModel,
     }
 
     const std::vector<ModelPart::IndexType> node_ids{1, 2, 3, 4, 5, 6};
-    r_result.CreateNewElement("SmallStrainUPwDiffOrderElement2D6N", 1, node_ids, r_result.CreateNewProperties(0));
+    r_result.CreateNewElement("SmallStrainUPwDiffOrderElement2D6N", 1, node_ids,
+                              r_result.CreateNewProperties(0));
 
     return r_result;
 }

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/test_utilities/model_setup_utilities.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/test_utilities/model_setup_utilities.cpp
@@ -75,12 +75,11 @@ ModelPart& CreateModelPartWithASingle3D4NElement(Model& rModel, const Geo::Const
 
 ModelPart& CreateModelPartWithASingle2D6NUPwDiffOrderElement(Model& rModel)
 {
+    auto&      r_result = rModel.CreateModelPart("Main");
     const auto second_order_variables =
         Geo::ConstVariableRefs{std::cref(DISPLACEMENT_X), std::cref(DISPLACEMENT_Y)};
-    const auto first_order_variables = Geo::ConstVariableRefs{std::cref(WATER_PRESSURE)};
-
-    auto& r_result = rModel.CreateModelPart("Main");
     AddNodalVariablesToModelPart(r_result, second_order_variables);
+    const auto first_order_variables = Geo::ConstVariableRefs{std::cref(WATER_PRESSURE)};
     AddNodalVariablesToModelPart(r_result, first_order_variables);
 
     auto p_node1 = r_result.CreateNewNode(1, 0.0, 0.0, 0.0);

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/test_utilities/model_setup_utilities.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/test_utilities/model_setup_utilities.cpp
@@ -39,14 +39,23 @@ ModelPart& CreateModelPartWithASingle2D3NElement(Model& rModel, const Geo::Const
     return result;
 }
 
-ModelPart& CreateModelPartWithASingle3D4NElement(Model& rModel)
+ModelPart& CreateModelPartWithASingle3D4NElement(Model& rModel, const Geo::ConstVariableRefs& rNodalVariables)
 {
     ModelPart& result = rModel.CreateModelPart("Main");
+    for (const auto& r_variable : rNodalVariables) {
+        result.AddNodalSolutionStepVariable(r_variable);
+    }
 
     result.CreateNewNode(1, 0.0, 0.0, 0.0);
     result.CreateNewNode(2, 1.0, 0.0, 0.0);
     result.CreateNewNode(3, 0.0, 1.0, 0.0);
     result.CreateNewNode(4, 0.0, 0.0, 1.0);
+
+    for (const auto& r_variable : rNodalVariables) {
+        for (auto& r_node : result.Nodes()) {
+            r_node.AddDof(r_variable.get());
+        }
+    }
 
     const std::vector<ModelPart::IndexType> node_ids{1, 2, 3, 4};
     result.CreateNewElement("UPwSmallStrainElement3D4N", 1, node_ids, result.CreateNewProperties(0));

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/test_utilities/model_setup_utilities.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/test_utilities/model_setup_utilities.cpp
@@ -10,19 +10,28 @@
 //  Main authors:    Richard Faasse
 //
 #include "model_setup_utilities.h"
-#include "includes/model_part.h"
 #include "containers/model.h"
+#include "includes/model_part.h"
 
 namespace Kratos::Testing::ModelSetupUtilities
 {
 
-ModelPart& CreateModelPartWithASingle2D3NElement(Model& rModel)
+ModelPart& CreateModelPartWithASingle2D3NElement(Model& rModel, const Geo::ConstVariableRefs& rNodalVariables)
 {
     ModelPart& result = rModel.CreateModelPart("Main");
+    for (const auto& r_variable : rNodalVariables) {
+        result.AddNodalSolutionStepVariable(r_variable);
+    }
 
     result.CreateNewNode(1, 0.0, 0.0, 0.0);
     result.CreateNewNode(2, 1.0, 0.0, 0.0);
     result.CreateNewNode(3, 1.0, 1.0, 0.0);
+
+    for (const auto& r_variable : rNodalVariables) {
+        for (auto& r_node : result.Nodes()) {
+            r_node.AddDof(r_variable.get());
+        }
+    }
 
     const std::vector<ModelPart::IndexType> node_ids{1, 2, 3};
     result.CreateNewElement("UPwSmallStrainElement2D3N", 1, node_ids, result.CreateNewProperties(0));
@@ -45,4 +54,4 @@ ModelPart& CreateModelPartWithASingle3D4NElement(Model& rModel)
     return result;
 }
 
-}
+} // namespace Kratos::Testing::ModelSetupUtilities

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/test_utilities/model_setup_utilities.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/test_utilities/model_setup_utilities.cpp
@@ -73,4 +73,40 @@ ModelPart& CreateModelPartWithASingle3D4NElement(Model& rModel, const Geo::Const
     return result;
 }
 
+ModelPart& CreateModelPartWithASingle2D6NDiffOrderElement(Model& rModel,
+                                                          const Geo::ConstVariableRefs& rSecondOrderVariables,
+                                                          const Geo::ConstVariableRefs& rFirstOrderVariables)
+{
+    auto& r_result = CreateEmptyModelPart(rModel, rSecondOrderVariables);
+    for (const auto& r_variable : rFirstOrderVariables) {
+        r_result.AddNodalSolutionStepVariable(r_variable.get());
+    }
+
+    auto p_node1 = r_result.CreateNewNode(1, 0.0, 0.0, 0.0);
+    auto p_node2 = r_result.CreateNewNode(2, 1.0, 0.0, 0.0);
+    auto p_node3 = r_result.CreateNewNode(3, 0.0, 1.0, 0.0);
+    auto p_node4 = r_result.CreateNewNode(4, 0.5, 0.0, 0.0);
+    auto p_node5 = r_result.CreateNewNode(5, 0.5, 0.5, 0.0);
+    auto p_node6 = r_result.CreateNewNode(6, 0.0, 0.5, 0.0);
+    auto nodes   = std::vector<Node*>{p_node1.get(), p_node2.get(), p_node3.get(),
+                                      p_node4.get(), p_node5.get(), p_node6.get()};
+
+    for (const auto& r_variable : rSecondOrderVariables) {
+        for (auto p_node : nodes) {
+            p_node->AddDof(r_variable.get());
+        }
+    }
+
+    for (const auto& r_variable : rFirstOrderVariables) {
+        for (auto it = nodes.begin(); it != nodes.begin() + 3; ++it) {
+            (*it)->AddDof(r_variable.get());
+        }
+    }
+
+    const std::vector<ModelPart::IndexType> node_ids{1, 2, 3, 4, 5, 6};
+    r_result.CreateNewElement("SmallStrainUPwDiffOrderElement2D6N", 1, node_ids, r_result.CreateNewProperties(0));
+
+    return r_result;
+}
+
 } // namespace Kratos::Testing::ModelSetupUtilities

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/test_utilities/model_setup_utilities.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/test_utilities/model_setup_utilities.cpp
@@ -75,12 +75,12 @@ ModelPart& CreateModelPartWithASingle3D4NElement(Model& rModel, const Geo::Const
 
 ModelPart& CreateModelPartWithASingle2D6NUPwDiffOrderElement(Model& rModel)
 {
-    const auto rSecondOrderVariables =
+    const auto second_order_variables =
         Geo::ConstVariableRefs{std::cref(DISPLACEMENT_X), std::cref(DISPLACEMENT_Y)};
-    const auto rFirstOrderVariables = Geo::ConstVariableRefs{std::cref(WATER_PRESSURE)};
+    const auto first_order_variables = Geo::ConstVariableRefs{std::cref(WATER_PRESSURE)};
 
-    auto& r_result = CreateEmptyModelPart(rModel, rSecondOrderVariables);
-    for (const auto& r_variable : rFirstOrderVariables) {
+    auto& r_result = CreateEmptyModelPart(rModel, second_order_variables);
+    for (const auto& r_variable : first_order_variables) {
         r_result.AddNodalSolutionStepVariable(r_variable.get());
     }
 
@@ -93,13 +93,13 @@ ModelPart& CreateModelPartWithASingle2D6NUPwDiffOrderElement(Model& rModel)
     auto nodes   = std::vector<Node*>{p_node1.get(), p_node2.get(), p_node3.get(),
                                       p_node4.get(), p_node5.get(), p_node6.get()};
 
-    for (const auto& r_variable : rSecondOrderVariables) {
+    for (const auto& r_variable : second_order_variables) {
         for (auto p_node : nodes) {
             p_node->AddDof(r_variable.get());
         }
     }
 
-    for (const auto& r_variable : rFirstOrderVariables) {
+    for (const auto& r_variable : first_order_variables) {
         for (auto it = nodes.begin(); it != nodes.begin() + 3; ++it) {
             (*it)->AddDof(r_variable.get());
         }

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/test_utilities/model_setup_utilities.h
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/test_utilities/model_setup_utilities.h
@@ -28,8 +28,6 @@ ModelPart& CreateModelPartWithASingle2D3NElement(Model& rModel,
 ModelPart& CreateModelPartWithASingle3D4NElement(Model& rModel,
                                                  const Geo::ConstVariableRefs& rNodalVariables = {});
 
-ModelPart& CreateModelPartWithASingle2D6NDiffOrderElement(Model& rModel,
-                                                          const Geo::ConstVariableRefs& rSecondOrderVariables = {},
-                                                          const Geo::ConstVariableRefs& rFirstOrderVariables = {});
+ModelPart& CreateModelPartWithASingle2D6NUPwDiffOrderElement(Model& rModel);
 
 } // namespace Kratos::Testing::ModelSetupUtilities

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/test_utilities/model_setup_utilities.h
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/test_utilities/model_setup_utilities.h
@@ -12,6 +12,8 @@
 
 #pragma once
 
+#include "geo_aliases.h"
+
 namespace Kratos
 {
 class Model;
@@ -21,7 +23,8 @@ class ModelPart;
 namespace Kratos::Testing::ModelSetupUtilities
 {
 
-ModelPart& CreateModelPartWithASingle2D3NElement(Model& rModel);
+ModelPart& CreateModelPartWithASingle2D3NElement(Model& rModel,
+                                                 const Geo::ConstVariableRefs& rNodalVariables = {});
 ModelPart& CreateModelPartWithASingle3D4NElement(Model& rModel);
 
-} // namespace Kratos::ModelSetupUtilities
+} // namespace Kratos::Testing::ModelSetupUtilities

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/test_utilities/model_setup_utilities.h
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/test_utilities/model_setup_utilities.h
@@ -25,6 +25,7 @@ namespace Kratos::Testing::ModelSetupUtilities
 
 ModelPart& CreateModelPartWithASingle2D3NElement(Model& rModel,
                                                  const Geo::ConstVariableRefs& rNodalVariables = {});
-ModelPart& CreateModelPartWithASingle3D4NElement(Model& rModel);
+ModelPart& CreateModelPartWithASingle3D4NElement(Model& rModel,
+                                                 const Geo::ConstVariableRefs& rNodalVariables = {});
 
 } // namespace Kratos::Testing::ModelSetupUtilities

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/test_utilities/model_setup_utilities.h
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/test_utilities/model_setup_utilities.h
@@ -28,4 +28,8 @@ ModelPart& CreateModelPartWithASingle2D3NElement(Model& rModel,
 ModelPart& CreateModelPartWithASingle3D4NElement(Model& rModel,
                                                  const Geo::ConstVariableRefs& rNodalVariables = {});
 
+ModelPart& CreateModelPartWithASingle2D6NDiffOrderElement(Model& rModel,
+                                                          const Geo::ConstVariableRefs& rSecondOrderVariables = {},
+                                                          const Geo::ConstVariableRefs& rFirstOrderVariables = {});
+
 } // namespace Kratos::Testing::ModelSetupUtilities

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/test_utilities/model_setup_utilities.h
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/test_utilities/model_setup_utilities.h
@@ -29,5 +29,6 @@ ModelPart& CreateModelPartWithASingle3D4NElement(Model& rModel,
                                                  const Geo::ConstVariableRefs& rNodalVariables = {});
 
 ModelPart& CreateModelPartWithASingle2D6NUPwDiffOrderElement(Model& rModel);
+ModelPart& CreateModelPartWithASingle3D10NUPwDiffOrderElement(Model& rModel);
 
 } // namespace Kratos::Testing::ModelSetupUtilities


### PR DESCRIPTION
**📝 Description**
This PR reorders the degrees of freedom (DOFs) of the non-diff order elements and conditions, such that they are consistent with the ordering applied to the diff order elements and conditions. In essence, this boils down to first enumerating all displacement DOFs, followed by enumerating the pore water pressure DOFs.

**🆕 Changelog**
Changes in this PR include:
- Added utility functions that extract all degrees of freedom of U-Pw elements given the element's nodes and its dimension. These new functions are now used by the diff order elements (and conditions) as well as the non-diff order ones.
- Removed several duplicated or unused (utility) functions.
- Renamed a few utility functions for assembling matrices to make clear which part of the partitioned matrices they consider.
- Re-implemented the utility functions that assemble matrices and vectors (to avoid lots of raw loops).
- Replaced the use of matrix/vector assemble functions where a dimension of 0 was supplied to force the position of addition. Instead, we now use the matrix/vector addition operators, which is much clearer and cleaner.
- Renamed a few function parameters and template type names to be more accurate.
- Added a header file for common (type) aliases.
- Fixed several (minor) code smells, including the removal of commented out code.
- Extended the utility functions for setting up test models. Also added a few helper functions for carrying out common checks in tests.
- Added documentation which describes how the degrees of freedom of the U-Pw elements have been ordered.