### PR TITLE
[StructuralMechanicsApplication] Fix `reponse` typo ➡️ `response`

### DIFF
--- a/applications/StructuralMechanicsApplication/custom_elements/base_solid_element.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/base_solid_element.cpp
@@ -839,7 +839,7 @@ void BaseSolidElement::CalculateOnIntegrationPoints(
                     // Compute element kinematics B, F, DN_DX ...
                     CalculateKinematicVariables(this_kinematic_variables, point_number, this->GetIntegrationMethod());
 
-                    // Compute material reponse
+                    // Compute material response
                     CalculateConstitutiveVariables(this_kinematic_variables, this_constitutive_variables, Values, point_number, integration_points, GetStressMeasure(), false);
 
                     double integration_weight = GetIntegrationWeight(integration_points, point_number, detJ[point_number]);
@@ -899,7 +899,7 @@ void BaseSolidElement::CalculateOnIntegrationPoints(
             for (IndexType point_number = 0; point_number < number_of_integration_points; ++point_number) {
                 // Compute element kinematics B, F, DN_DX ...
                 CalculateKinematicVariables(this_kinematic_variables, point_number, this->GetIntegrationMethod());
-                // Compute material reponse, not encessary to rotate since it's an invariant
+                // Compute material response, not encessary to rotate since it's an invariant
                 CalculateConstitutiveVariables(this_kinematic_variables, this_constitutive_variables, Values, point_number, integration_points, GetStressMeasure(), false);
 
                 // Compute VM stress
@@ -1049,10 +1049,10 @@ void BaseSolidElement::CalculateOnIntegrationPoints(
                 CalculateKinematicVariables(this_kinematic_variables, point_number, this->GetIntegrationMethod());
                 //call the constitutive law to update material variables
                 if( rVariable == CAUCHY_STRESS_VECTOR) {
-                    // Compute material reponse
+                    // Compute material response
                     CalculateConstitutiveVariables(this_kinematic_variables, this_constitutive_variables, Values, point_number, integration_points, ConstitutiveLaw::StressMeasure_Cauchy, is_rotated);
                 } else {
-                    // Compute material reponse
+                    // Compute material response
                     CalculateConstitutiveVariables(this_kinematic_variables, this_constitutive_variables, Values, point_number, integration_points,ConstitutiveLaw::StressMeasure_PK2, is_rotated);
                 }
 
@@ -1093,7 +1093,7 @@ void BaseSolidElement::CalculateOnIntegrationPoints(
             for ( IndexType point_number = 0; point_number < number_of_integration_points; ++point_number ) {
                 // Compute element kinematics B, F, DN_DX ...
                 CalculateKinematicVariables(this_kinematic_variables, point_number, this->GetIntegrationMethod());
-                // Compute material reponse
+                // Compute material response
                 CalculateConstitutiveVariables(this_kinematic_variables, this_constitutive_variables, Values, point_number, integration_points, this_stress_measure, false);
 
                 if (strain_size == 4) { // Axysimmetric
@@ -1220,7 +1220,7 @@ void BaseSolidElement::CalculateOnIntegrationPoints(
                 // Compute element kinematics B, F, DN_DX ...
                 CalculateKinematicVariables(this_kinematic_variables, point_number, this->GetIntegrationMethod());
 
-                // Compute material reponse
+                // Compute material response
                 CalculateConstitutiveVariables(this_kinematic_variables, this_constitutive_variables, Values, point_number, integration_points, GetStressMeasure(), is_rotated);
 
                 if( rOutput[point_number].size2() != this_constitutive_variables.D.size2() )

--- a/applications/StructuralMechanicsApplication/custom_elements/base_solid_element.h
+++ b/applications/StructuralMechanicsApplication/custom_elements/base_solid_element.h
@@ -1051,7 +1051,7 @@ private:
             // Compute element kinematics B, F, DN_DX ...
             this->CalculateKinematicVariables(this_kinematic_variables, point_number, this->GetIntegrationMethod());
 
-            // Compute material reponse
+            // Compute material response
             this->SetConstitutiveVariables(this_kinematic_variables, this_constitutive_variables, Values, point_number, integration_points);
 
             // rotate to local axes strain/F

--- a/applications/StructuralMechanicsApplication/custom_elements/small_displacement.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/small_displacement.cpp
@@ -166,7 +166,7 @@ void SmallDisplacement::CalculateAll(
         // Compute element kinematics B, F, DN_DX ...
         CalculateKinematicVariables(this_kinematic_variables, point_number, this->GetIntegrationMethod());
 
-        // Compute material reponse
+        // Compute material response
         CalculateConstitutiveVariables(this_kinematic_variables, this_constitutive_variables, Values, point_number, integration_points, GetStressMeasure(), is_rotated);
 
         // Calculating weights for integration on the reference configuration

--- a/applications/StructuralMechanicsApplication/custom_elements/small_displacement_bbar.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/small_displacement_bbar.cpp
@@ -150,7 +150,7 @@ void SmallDisplacementBbar::CalculateAll(
         // Compute element kinematics B, F, DN_DX ...
         CalculateKinematicVariablesBbar(this_kinematic_variables, point_number, integration_points);
 
-        // Compute material reponse
+        // Compute material response
         CalculateConstitutiveVariables(this_kinematic_variables, this_constitutive_variables,
                                        Values, point_number, integration_points,
                                        GetStressMeasure(), is_rotated);
@@ -546,7 +546,7 @@ void SmallDisplacementBbar::CalculateOnIntegrationPoints(
             // Compute element kinematics B, F, DN_DX ...
             CalculateKinematicVariablesBbar(this_kinematic_variables, point_number, integration_points);
 
-            // Compute material reponse
+            // Compute material response
             SetConstitutiveVariables(this_kinematic_variables, this_constitutive_variables,
                                            Values, point_number, integration_points);
 
@@ -583,7 +583,7 @@ void SmallDisplacementBbar::CalculateOnIntegrationPoints(
         for(IndexType point_number = 0; point_number < integration_points.size(); point_number++) {
             // Compute element kinematics B, F, DN_DX ...
             CalculateKinematicVariablesBbar(this_kinematic_variables, point_number, integration_points);
-            // Compute material reponse
+            // Compute material response
             CalculateConstitutiveVariables(this_kinematic_variables, this_constitutive_variables,
                                            Values, point_number, integration_points,
                                            GetStressMeasure(), false);
@@ -664,7 +664,7 @@ void SmallDisplacementBbar::CalculateOnIntegrationPoints(
             CalculateKinematicVariablesBbar(this_kinematic_variables, point_number, integration_points);
             //call the constitutive law to update material variables
             if( rVariable == CAUCHY_STRESS_VECTOR) {
-                // Compute material reponse
+                // Compute material response
                 CalculateConstitutiveVariables(this_kinematic_variables,
                                                this_constitutive_variables,
                                                Values,
@@ -673,7 +673,7 @@ void SmallDisplacementBbar::CalculateOnIntegrationPoints(
                                                ConstitutiveLaw::StressMeasure_Cauchy, is_rotated);
             }
             else {
-                // Compute material reponse
+                // Compute material response
                 CalculateConstitutiveVariables(this_kinematic_variables,
                                                this_constitutive_variables,
                                                Values,
@@ -720,7 +720,7 @@ void SmallDisplacementBbar::CalculateOnIntegrationPoints(
         for ( IndexType point_number = 0; point_number < integration_points.size(); point_number++ ) {
             // Compute element kinematics B, F, DN_DX ...
             CalculateKinematicVariablesBbar(this_kinematic_variables, point_number, integration_points);
-            // Compute material reponse
+            // Compute material response
             CalculateConstitutiveVariables(this_kinematic_variables, this_constitutive_variables,
                                            Values, point_number, integration_points, this_stress_measure, false);
 
@@ -811,7 +811,7 @@ void SmallDisplacementBbar::CalculateOnIntegrationPoints(
         for(IndexType point_number = 0; point_number < mConstitutiveLawVector.size(); point_number++) {
             // Compute element kinematics B, F, DN_DX ...
             CalculateKinematicVariablesBbar(this_kinematic_variables, point_number, integration_points);
-            // Compute material reponse
+            // Compute material response
             CalculateConstitutiveVariables(this_kinematic_variables, this_constitutive_variables,
                                            Values, point_number, integration_points,
                                            GetStressMeasure(), is_rotated);
@@ -843,7 +843,7 @@ void SmallDisplacementBbar::CalculateOnIntegrationPoints(
         for(IndexType point_number = 0; point_number < mConstitutiveLawVector.size(); point_number++ ) {
             // Compute element kinematics B, F, DN_DX ...
             CalculateKinematicVariablesBbar(this_kinematic_variables, point_number, integration_points);
-            // Compute material reponse
+            // Compute material response
             CalculateConstitutiveVariables(this_kinematic_variables, this_constitutive_variables,
                                            Values, point_number, integration_points,
                                            GetStressMeasure(), false);

--- a/applications/StructuralMechanicsApplication/custom_elements/small_displacement_mixed_volumetric_strain_element.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/small_displacement_mixed_volumetric_strain_element.cpp
@@ -1122,10 +1122,10 @@ void SmallDisplacementMixedVolumetricStrainElement::CalculateOnIntegrationPoints
 
             // Call the constitutive law to update material variables
             if( rVariable == CAUCHY_STRESS_VECTOR) {
-                // Compute material reponse
+                // Compute material response
                 CalculateConstitutiveVariables(kinematic_variables, constitutive_variables, cons_law_values, i_gauss, r_integration_points, ConstitutiveLaw::StressMeasure_Cauchy);
             } else {
-                // Compute material reponse
+                // Compute material response
                 CalculateConstitutiveVariables(kinematic_variables, constitutive_variables, cons_law_values, i_gauss, r_integration_points, ConstitutiveLaw::StressMeasure_PK2);
             }
 

--- a/applications/StructuralMechanicsApplication/custom_elements/total_lagrangian.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/total_lagrangian.cpp
@@ -218,7 +218,7 @@ void TotalLagrangian::CalculateAll(
         // Compute element kinematics B, F, DN_DX ...
         this->CalculateKinematicVariables(this_kinematic_variables, point_number, this->GetIntegrationMethod());
 
-        // Compute material reponse
+        // Compute material response
         this->CalculateConstitutiveVariables(this_kinematic_variables, this_constitutive_variables, Values, point_number, integration_points, this->GetStressMeasure(), is_rotated);
 
         // Calculating weights for integration on the reference configuration

--- a/applications/StructuralMechanicsApplication/custom_elements/total_lagrangian_mixed_volumetric_strain_element.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/total_lagrangian_mixed_volumetric_strain_element.cpp
@@ -7036,7 +7036,7 @@ void TotalLagrangianMixedVolumetricStrainElement<TDim>::CalculateOnIntegrationPo
             // Calculate kinematics
             CalculateKinematicVariables(kinematic_variables, i_gauss, GetIntegrationMethod());
 
-            // Compute material reponse
+            // Compute material response
             CalculateConstitutiveVariables(kinematic_variables, constitutive_variables, cons_law_values, i_gauss, r_integration_points, ConstitutiveLaw::StressMeasure_PK2);
 
             // Calculate and save Von-Mises equivalent stress
@@ -7092,10 +7092,10 @@ void TotalLagrangianMixedVolumetricStrainElement<TDim>::CalculateOnIntegrationPo
 
             // Call the constitutive law to update material variables
             if( rVariable == CAUCHY_STRESS_VECTOR) {
-                // Compute material reponse
+                // Compute material response
                 CalculateConstitutiveVariables(kinematic_variables, constitutive_variables, cons_law_values, i_gauss, r_integration_points, ConstitutiveLaw::StressMeasure_Cauchy);
             } else {
-                // Compute material reponse
+                // Compute material response
                 CalculateConstitutiveVariables(kinematic_variables, constitutive_variables, cons_law_values, i_gauss, r_integration_points, ConstitutiveLaw::StressMeasure_PK2);
             }
 

--- a/applications/StructuralMechanicsApplication/custom_elements/total_lagrangian_q1p0_mixed_element.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/total_lagrangian_q1p0_mixed_element.cpp
@@ -179,7 +179,7 @@ void TotalLagrangianQ1P0MixedElement::CalculateAll(
         // Compute element kinematics B, F, DN_DX ...
         this->CalculateKinematicVariables(this_kinematic_variables, point_number, this->GetIntegrationMethod());
 
-        // Compute material reponse
+        // Compute material response
         this->CalculateConstitutiveVariables(this_kinematic_variables, this_constitutive_variables, Values, point_number, integration_points, this->GetStressMeasure(), false);
 
         const Matrix& r_C = prod(trans(this_kinematic_variables.F), this_kinematic_variables.F);

--- a/applications/StructuralMechanicsApplication/custom_elements/updated_lagrangian.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/updated_lagrangian.cpp
@@ -264,7 +264,7 @@ void UpdatedLagrangian::CalculateAll(
         // Compute element kinematics B, F, DN_DX ...
         this->CalculateKinematicVariables(this_kinematic_variables, point_number, this->GetIntegrationMethod());
 
-        // Compute material reponse
+        // Compute material response
         this->CalculateConstitutiveVariables(this_kinematic_variables, this_constitutive_variables, Values, point_number, integration_points, this->GetStressMeasure(), is_rotated);
 
         // Calculating weights for integration on the reference configuration

--- a/applications/StructuralMechanicsApplication/python_scripts/symbolic_generation/total_lagrangian_mixed_volumetric_strain_element/total_lagrangian_mixed_volumetric_strain_element_template.cpp
+++ b/applications/StructuralMechanicsApplication/python_scripts/symbolic_generation/total_lagrangian_mixed_volumetric_strain_element/total_lagrangian_mixed_volumetric_strain_element_template.cpp
@@ -1114,7 +1114,7 @@ void TotalLagrangianMixedVolumetricStrainElement<TDim>::CalculateOnIntegrationPo
             // Calculate kinematics
             CalculateKinematicVariables(kinematic_variables, i_gauss, GetIntegrationMethod());
 
-            // Compute material reponse
+            // Compute material response
             CalculateConstitutiveVariables(kinematic_variables, constitutive_variables, cons_law_values, i_gauss, r_integration_points, ConstitutiveLaw::StressMeasure_PK2);
 
             // Calculate and save Von-Mises equivalent stress
@@ -1170,10 +1170,10 @@ void TotalLagrangianMixedVolumetricStrainElement<TDim>::CalculateOnIntegrationPo
 
             // Call the constitutive law to update material variables
             if( rVariable == CAUCHY_STRESS_VECTOR) {
-                // Compute material reponse
+                // Compute material response
                 CalculateConstitutiveVariables(kinematic_variables, constitutive_variables, cons_law_values, i_gauss, r_integration_points, ConstitutiveLaw::StressMeasure_Cauchy);
             } else {
-                // Compute material reponse
+                // Compute material response
                 CalculateConstitutiveVariables(kinematic_variables, constitutive_variables, cons_law_values, i_gauss, r_integration_points, ConstitutiveLaw::StressMeasure_PK2);
             }
 


### PR DESCRIPTION
**📝 Description**

Fix `reponse` typo ➡️ `response`.

**🆕 Changelog**

-  [Fix `reponse` typo ➡️ `response`](https://github.com/KratosMultiphysics/Kratos/commit/060d4fc2e7898993d7e82314af5ef3bd43300b4d)
