### PR TITLE
[FastPR][Core] Minor hotfix in VTU output process

### DIFF
--- a/kratos/python_scripts/vtu_output_process.py
+++ b/kratos/python_scripts/vtu_output_process.py
@@ -89,7 +89,7 @@ class VtuOutputProcess(Kratos.OutputProcess):
         current_suffix = self.__controller.GetCurrentControlValue()
 
         for vtu_output in self.vtu_output_ios:
-            vtu_output.PrintOutput(str(self.output_path / vtu_output.GetModelPart().FullName()) + "_" + current_suffix)
+            vtu_output.PrintOutput(f"{self.output_path / vtu_output.GetModelPart().FullName()}_{current_suffix}")
 
         self.__controller.Update()
 


### PR DESCRIPTION
**📝 Description**
I got an error complaining of the `current_suffix` type, which is not string. By using f-strings this is readily fixed.
