### PR TITLE
[Core] IntersectonUtilities - use epsilon in ComputePlaneLineIntersection

### DIFF
--- a/kratos/utilities/intersection_utilities.h
+++ b/kratos/utilities/intersection_utilities.h
@@ -740,9 +740,9 @@ public:
 
         // Compute the intersection point and check if it is inside the bounds of the segment
         const double r = a / b;
-        if (r < 0.0){
+        if (r < 0.0 - epsilon){
             return 0;    // Intersection point lies outside the bounds of the segment
-        } else if (r > 1.0) {
+        } else if (r > 1.0 + epsilon) {
             return 0;    // Intersection point lies outside the bounds of the segment
         }
         rIntersectionPoint = rLinePoint1 + r * line_dir;


### PR DESCRIPTION
We had a case in our QA suite in @KratosMultiphysics/altair that was failing randomly even when running with only 1 core. After some investigation I found that the problem came from an intersection of a line with a plane was very close to zero, making the result change a little in every run.

I also found that this function was not using an epsilon tolerance for this check even if it was already being defined. I added it so we make sure that all values of "r" between [0, 1.0] are considered as "intersected".