### PR TITLE
[Core] Add standard JSON interface to ConnectivityPreserveModeler

### DIFF
--- a/kratos/includes/kratos_application.h
+++ b/kratos/includes/kratos_application.h
@@ -75,6 +75,7 @@
 #include "modeler/cad_tessellation_modeler.h"
 #include "modeler/serial_model_part_combinator_modeler.h"
 #include "modeler/combine_model_part_modeler.h"
+#include "modeler/connectivity_preserve_modeler.h"
 
 namespace Kratos {
 ///@name Kratos Classes
@@ -493,6 +494,7 @@ class KRATOS_API(KRATOS_CORE) KratosApplication {
 #endif
     const SerialModelPartCombinatorModeler mSerialModelPartCombinatorModeler;
     const CombineModelPartModeler mCombineModelPartModeler;
+    const ConnectivityPreserveModeler mConnectivityPreserveModeler;
 
     // Base constitutive law definition
     const ConstitutiveLaw mConstitutiveLaw;

--- a/kratos/modeler/connectivity_preserve_modeler.cpp
+++ b/kratos/modeler/connectivity_preserve_modeler.cpp
@@ -24,6 +24,20 @@ namespace Kratos
 
 // Public methods //////////////////////////////////////////////////////////////
 
+ConnectivityPreserveModeler::ConnectivityPreserveModeler(Model& rModel, Parameters Settings):
+    Modeler(Settings),
+    mpModel(&rModel)
+{
+    mParameters.ValidateAndAssignDefaults(GetDefaultParameters());
+}
+
+
+Modeler::Pointer ConnectivityPreserveModeler::Create(Model& rModel, const Parameters Settings) const
+{
+    return Kratos::make_shared<ConnectivityPreserveModeler>(rModel, Settings);
+}
+
+
 void ConnectivityPreserveModeler::GenerateModelPart(
     ModelPart& rOriginModelPart,
     ModelPart& rDestinationModelPart,
@@ -92,6 +106,55 @@ void ConnectivityPreserveModeler::GenerateModelPart(
 
     KRATOS_CATCH("");
 }
+
+
+void ConnectivityPreserveModeler::SetupModelPart()
+{
+    ModelPart& r_origin_model_part = mpModel->GetModelPart(mParameters["origin_model_part_name"].GetString());
+    ModelPart& r_destination_model_part = mpModel->GetModelPart(mParameters["destination_model_part_name"].GetString());
+    const std::string element_name = mParameters["reference_element"].GetString();
+    const std::string condition_name = mParameters["reference_condition"].GetString();
+
+    if (element_name != "") {
+        if (condition_name != "") {
+            GenerateModelPart(
+                r_origin_model_part,
+                r_destination_model_part,
+                KratosComponents<Element>::Get(element_name),
+                KratosComponents<Condition>::Get(condition_name));
+        } else {
+            GenerateModelPart(
+                r_origin_model_part,
+                r_destination_model_part,
+                KratosComponents<Element>::Get(element_name));
+        }
+    } else if (condition_name != "") {
+        GenerateModelPart(
+            r_origin_model_part,
+            r_destination_model_part,
+            KratosComponents<Condition>::Get(condition_name));
+    } else {
+        KRATOS_ERROR << "At least one of reference_element or reference_condition is required." << std::endl;
+    }
+}
+
+
+const Parameters ConnectivityPreserveModeler::GetDefaultParameters() const
+{
+    return Parameters(R"({
+        "origin_model_part_name": "undefined_origin_model_part_name",
+        "destination_model_part_name": "undefined_destination_model_part_name",
+        "reference_element": "",
+        "reference_condition": ""
+    })");
+}
+
+
+std::string ConnectivityPreserveModeler::Info() const
+{
+    return "ConnectivityPreserveModeler";
+}
+
 
 // Private methods /////////////////////////////////////////////////////////////
 void ConnectivityPreserveModeler::CheckVariableLists(ModelPart& rOriginModelPart, ModelPart& rDestinationModelPart) const

--- a/kratos/modeler/connectivity_preserve_modeler.cpp
+++ b/kratos/modeler/connectivity_preserve_modeler.cpp
@@ -142,10 +142,10 @@ void ConnectivityPreserveModeler::SetupModelPart()
 const Parameters ConnectivityPreserveModeler::GetDefaultParameters() const
 {
     return Parameters(R"({
-        "origin_model_part_name": "undefined_origin_model_part_name",
-        "destination_model_part_name": "undefined_destination_model_part_name",
-        "reference_element": "",
-        "reference_condition": ""
+        "origin_model_part_name"        : "undefined_origin_model_part_name",
+        "destination_model_part_name"   : "undefined_destination_model_part_name",
+        "reference_element"             : "",
+        "reference_condition"           : ""
     })");
 }
 

--- a/kratos/modeler/connectivity_preserve_modeler.cpp
+++ b/kratos/modeler/connectivity_preserve_modeler.cpp
@@ -111,7 +111,13 @@ void ConnectivityPreserveModeler::GenerateModelPart(
 void ConnectivityPreserveModeler::SetupModelPart()
 {
     ModelPart& r_origin_model_part = mpModel->GetModelPart(mParameters["origin_model_part_name"].GetString());
-    ModelPart& r_destination_model_part = mpModel->GetModelPart(mParameters["destination_model_part_name"].GetString());
+
+    const std::string destination_model_part_name = mParameters["destination_model_part_name"].GetString();
+    if (!mpModel->HasModelPart(destination_model_part_name)) {
+        mpModel->CreateModelPart(destination_model_part_name, r_origin_model_part.GetBufferSize());
+    }
+    ModelPart& r_destination_model_part = mpModel->GetModelPart(destination_model_part_name);
+
     const std::string element_name = mParameters["reference_element"].GetString();
     const std::string condition_name = mParameters["reference_condition"].GetString();
 

--- a/kratos/modeler/connectivity_preserve_modeler.h
+++ b/kratos/modeler/connectivity_preserve_modeler.h
@@ -131,9 +131,15 @@ public:
         const Condition& rReferenceCondition
     );
 
-
+    /// Generate a copy of rOriginModelPart in rDestinationModelPart.
+    /** This function fills rDestinationModelPart using data obtained from
+     *  rOriginModelPart. It is equivalent to one of the GenerateModelPart
+     *  functions, depending on whether an element and/or a condition
+     *  have been defined in the Parameters during construction.
+     */
     void SetupModelPart() override;
 
+    /// Defines the expected structure for the Parameters of this class.
     const Parameters GetDefaultParameters() const override;
 
     ///@}

--- a/kratos/modeler/connectivity_preserve_modeler.h
+++ b/kratos/modeler/connectivity_preserve_modeler.h
@@ -52,6 +52,9 @@ public:
     /// Default Constructor
     ConnectivityPreserveModeler() = default;
 
+    /// Factory Constructor
+    ConnectivityPreserveModeler(Model& rModeler, Parameters Settings);
+
     /// Copy constructor.
     ConnectivityPreserveModeler(ConnectivityPreserveModeler const& rOther) = delete;
 
@@ -68,6 +71,9 @@ public:
     ///@}
     ///@name Operations
     ///@{
+
+    /// Factory initialization
+    Modeler::Pointer Create(Model& rModel, const Parameters Settings) const override;
 
     /// Generate a copy of rOriginModelPart in rDestinationModelPart, using the given element and condtion types.
     /** This function fills rDestinationModelPart using data obtained from rOriginModelPart. The elements
@@ -125,6 +131,18 @@ public:
         const Condition& rReferenceCondition
     );
 
+
+    void SetupModelPart() override;
+
+    const Parameters GetDefaultParameters() const override;
+
+    ///@}
+    ///@name Input and output
+    ///@{
+
+    /// Turn back information as a string.
+    std::string Info() const override;
+
     ///@}
 
 private:
@@ -161,6 +179,12 @@ private:
         ModelPart& rOriginModelPart,
         ModelPart& rDestinationModelPart
     ) const;
+
+    ///@}
+    ///@name Private members
+    ///@{
+
+    Model* mpModel = nullptr;
 
     ///@}
 };

--- a/kratos/sources/kratos_application.cpp
+++ b/kratos/sources/kratos_application.cpp
@@ -215,6 +215,7 @@ void KratosApplication::RegisterKratosCore() {
 #endif
     KRATOS_REGISTER_MODELER("SerialModelPartCombinatorModeler", mSerialModelPartCombinatorModeler);
     KRATOS_REGISTER_MODELER("CombineModelPartModeler", mCombineModelPartModeler);
+    KRATOS_REGISTER_MODELER("ConnectivityPreserveModeler", mConnectivityPreserveModeler);
 
     // Register general geometries:
     // Point register:

--- a/kratos/tests/test_connectivity_preserve_modeler.py
+++ b/kratos/tests/test_connectivity_preserve_modeler.py
@@ -269,5 +269,23 @@ class TestConnectivityPreserveModeler(KratosUnittest.TestCase):
         self.assertEqual(len(model_part1.Conditions) , len(new_model_part.Conditions))
         self.assertEqual(len(model_part1.Elements) , len(new_model_part.Elements))
 
+        # In SetupModelPart, the destination model part can be created if it does not exist
+        self.assertFalse(current_model.HasModelPart("CreatedModelPart"))
+        modeler = KratosMultiphysics.ConnectivityPreserveModeler().Create(
+            current_model,
+            KratosMultiphysics.Parameters('''{
+                "origin_model_part_name": "Main",
+                "destination_model_part_name": "CreatedModelPart",
+                "reference_element": "Element2D3N",
+                "reference_condition": "LineCondition2D2N"
+            }''')
+        )
+        modeler.SetupModelPart()
+
+        created_model_part = current_model.GetModelPart("CreatedModelPart")
+        self.assertEqual(len(model_part1.Nodes) , len(created_model_part.Nodes))
+        self.assertEqual(len(model_part1.Conditions) , len(created_model_part.Conditions))
+        self.assertEqual(len(model_part1.Elements) , len(created_model_part.Elements))
+
 if __name__ == '__main__':
     KratosUnittest.main()

--- a/kratos/tests/test_connectivity_preserve_modeler.py
+++ b/kratos/tests/test_connectivity_preserve_modeler.py
@@ -229,5 +229,45 @@ class TestConnectivityPreserveModeler(KratosUnittest.TestCase):
         self.assertEqual(model_part_1.GetProperties()[1].GetValue(KratosMultiphysics.DENSITY), 2.0)
 
 
+    def test_setup_with_json_parameters(self):
+        current_model = KratosMultiphysics.Model()
+        model_part1 = current_model.CreateModelPart("Main")
+        model_part1.AddNodalSolutionStepVariable(KratosMultiphysics.DISTANCE)
+
+        model_part1.CreateNewNode(1,0.0,0.1,0.2)
+        model_part1.CreateNewNode(2,2.0,0.1,0.2)
+        model_part1.CreateNewNode(3,1.0,1.1,0.2)
+        model_part1.CreateNewNode(4,2.0,3.1,10.2)
+
+        sub1 = model_part1.CreateSubModelPart("sub1")
+        sub2 = model_part1.CreateSubModelPart("sub2")
+        subsub1 = sub1.CreateSubModelPart("subsub1")
+        subsub1.AddNodes([1,2])
+        sub2.AddNodes([3])
+
+        model_part1.CreateNewElement("Element2D3N", 1, [1,2,3], model_part1.GetProperties()[1])
+        model_part1.CreateNewElement("Element2D3N", 2, [1,2,4], model_part1.GetProperties()[1])
+
+        model_part1.CreateNewCondition("LineCondition2D2N", 2, [2,4], model_part1.GetProperties()[1])
+        sub1.AddConditions([2])
+
+        # Note: unlike other modes of operation, the json configuration requires both parts to be in the same Model
+        new_model_part = current_model.CreateModelPart("Other")
+
+        modeler = KratosMultiphysics.ConnectivityPreserveModeler().Create(
+            current_model,
+            KratosMultiphysics.Parameters('''{
+                "origin_model_part_name": "Main",
+                "destination_model_part_name": "Other",
+                "reference_element": "Element2D3N",
+                "reference_condition": "LineCondition2D2N"
+            }''')
+        )
+        modeler.SetupModelPart()
+
+        self.assertEqual(len(model_part1.Nodes) , len(new_model_part.Nodes))
+        self.assertEqual(len(model_part1.Conditions) , len(new_model_part.Conditions))
+        self.assertEqual(len(model_part1.Elements) , len(new_model_part.Elements))
+
 if __name__ == '__main__':
     KratosUnittest.main()


### PR DESCRIPTION
**📝 Description**
This PR makes it possible to set up and use the ConnectivityPreserveModeler through a JSON project parameters file. The destination model part is generated during the `SetupModelPart` phase of Modeler operation.

**🆕 Changelog**
- Implement `ConnectivityPreserveModeler::SetupModelPart` and auxiliary functions to instantiate the class through JSON settings.
- Register `ConnectivetyPreserveModeler`.
- Add test for the new flow.
