### PR TITLE
[GeoMechanicsApplication] Made several member function signatures consistent

### DIFF
--- a/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_FIC_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_FIC_element.cpp
@@ -408,8 +408,8 @@ template <unsigned int TDim, unsigned int TNumNodes>
 void UPwSmallStrainFICElement<TDim, TNumNodes>::CalculateAll(MatrixType& rLeftHandSideMatrix,
                                                              VectorType& rRightHandSideVector,
                                                              const ProcessInfo& CurrentProcessInfo,
-                                                             const bool CalculateStiffnessMatrixFlag,
-                                                             const bool CalculateResidualVectorFlag)
+                                                             bool CalculateStiffnessMatrixFlag,
+                                                             bool CalculateResidualVectorFlag)
 {
     KRATOS_TRY
 

--- a/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_FIC_element.hpp
+++ b/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_FIC_element.hpp
@@ -166,8 +166,8 @@ protected:
     void CalculateAll(MatrixType&        rLeftHandSideMatrix,
                       VectorType&        rRightHandSideVector,
                       const ProcessInfo& CurrentProcessInfo,
-                      const bool         CalculateStiffnessMatrixFlag,
-                      const bool         CalculateResidualVectorFlag) override;
+                      bool               CalculateStiffnessMatrixFlag,
+                      bool               CalculateResidualVectorFlag) override;
 
     void InitializeFICElementVariables(FICElementVariables& rFICVariables,
                                        const GeometryType::ShapeFunctionsGradientsType& DN_DXContainer,

--- a/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_interface_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_interface_element.cpp
@@ -1291,8 +1291,8 @@ template <unsigned int TDim, unsigned int TNumNodes>
 void UPwSmallStrainInterfaceElement<TDim, TNumNodes>::CalculateAll(MatrixType& rLeftHandSideMatrix,
                                                                    VectorType& rRightHandSideVector,
                                                                    const ProcessInfo& CurrentProcessInfo,
-                                                                   const bool CalculateStiffnessMatrixFlag,
-                                                                   const bool CalculateResidualVectorFlag)
+                                                                   bool CalculateStiffnessMatrixFlag,
+                                                                   bool CalculateResidualVectorFlag)
 {
     KRATOS_TRY
 

--- a/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_interface_element.hpp
+++ b/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_interface_element.hpp
@@ -210,8 +210,8 @@ protected:
     void CalculateAll(MatrixType&        rLeftHandSideMatrix,
                       VectorType&        rRightHandSideVector,
                       const ProcessInfo& CurrentProcessInfo,
-                      const bool         CalculateStiffnessMatrixFlag,
-                      const bool         CalculateResidualVectorFlag) override;
+                      bool               CalculateStiffnessMatrixFlag,
+                      bool               CalculateResidualVectorFlag) override;
 
     virtual void InitializeElementVariables(InterfaceElementVariables& rVariables,
                                             const GeometryType&        Geom,

--- a/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_link_interface_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_link_interface_element.cpp
@@ -288,8 +288,8 @@ template <unsigned int TDim, unsigned int TNumNodes>
 void UPwSmallStrainLinkInterfaceElement<TDim, TNumNodes>::CalculateAll(MatrixType& rLeftHandSideMatrix,
                                                                        VectorType& rRightHandSideVector,
                                                                        const ProcessInfo& CurrentProcessInfo,
-                                                                       const bool CalculateStiffnessMatrixFlag,
-                                                                       const bool CalculateResidualVectorFlag)
+                                                                       bool CalculateStiffnessMatrixFlag,
+                                                                       bool CalculateResidualVectorFlag)
 {
     KRATOS_TRY
 

--- a/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_link_interface_element.hpp
+++ b/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_link_interface_element.hpp
@@ -117,8 +117,8 @@ protected:
     void CalculateAll(MatrixType&        rLeftHandSideMatrix,
                       VectorType&        rRightHandSideVector,
                       const ProcessInfo& CurrentProcessInfo,
-                      const bool         CalculateStiffnessMatrixFlag,
-                      const bool         CalculateResidualVectorFlag) override;
+                      bool               CalculateStiffnessMatrixFlag,
+                      bool               CalculateResidualVectorFlag) override;
 
     //----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 

--- a/applications/GeoMechanicsApplication/custom_elements/U_Pw_updated_lagrangian_FIC_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/U_Pw_updated_lagrangian_FIC_element.cpp
@@ -44,8 +44,8 @@ template <unsigned int TDim, unsigned int TNumNodes>
 void UPwUpdatedLagrangianFICElement<TDim, TNumNodes>::CalculateAll(MatrixType& rLeftHandSideMatrix,
                                                                    VectorType& rRightHandSideVector,
                                                                    const ProcessInfo& rCurrentProcessInfo,
-                                                                   const bool CalculateStiffnessMatrixFlag,
-                                                                   const bool CalculateResidualVectorFlag)
+                                                                   bool CalculateStiffnessMatrixFlag,
+                                                                   bool CalculateResidualVectorFlag)
 {
     KRATOS_TRY;
 

--- a/applications/GeoMechanicsApplication/custom_elements/U_Pw_updated_lagrangian_FIC_element.hpp
+++ b/applications/GeoMechanicsApplication/custom_elements/U_Pw_updated_lagrangian_FIC_element.hpp
@@ -221,8 +221,8 @@ protected:
     void CalculateAll(MatrixType&        rLeftHandSideMatrix,
                       VectorType&        rRightHandSideVector,
                       const ProcessInfo& rCurrentProcessInfo,
-                      const bool         CalculateStiffnessMatrixFlag,
-                      const bool         CalculateResidualVectorFlag) override;
+                      bool               CalculateStiffnessMatrixFlag,
+                      bool               CalculateResidualVectorFlag) override;
 
     ///@}
     ///@name Protected Operations

--- a/applications/GeoMechanicsApplication/custom_elements/U_Pw_updated_lagrangian_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/U_Pw_updated_lagrangian_element.cpp
@@ -59,8 +59,8 @@ template <unsigned int TDim, unsigned int TNumNodes>
 void UPwUpdatedLagrangianElement<TDim, TNumNodes>::CalculateAll(MatrixType& rLeftHandSideMatrix,
                                                                 VectorType& rRightHandSideVector,
                                                                 const ProcessInfo& rCurrentProcessInfo,
-                                                                const bool CalculateStiffnessMatrixFlag,
-                                                                const bool CalculateResidualVectorFlag)
+                                                                bool CalculateStiffnessMatrixFlag,
+                                                                bool CalculateResidualVectorFlag)
 {
     KRATOS_TRY;
 

--- a/applications/GeoMechanicsApplication/custom_elements/U_Pw_updated_lagrangian_element.hpp
+++ b/applications/GeoMechanicsApplication/custom_elements/U_Pw_updated_lagrangian_element.hpp
@@ -222,8 +222,8 @@ protected:
     void CalculateAll(MatrixType&        rLeftHandSideMatrix,
                       VectorType&        rRightHandSideVector,
                       const ProcessInfo& rCurrentProcessInfo,
-                      const bool         CalculateStiffnessMatrixFlag,
-                      const bool         CalculateResidualVectorFlag) override;
+                      bool               CalculateStiffnessMatrixFlag,
+                      bool               CalculateResidualVectorFlag) override;
 
     ///@}
     ///@name Protected Operations

--- a/applications/GeoMechanicsApplication/custom_elements/steady_state_Pw_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/steady_state_Pw_element.cpp
@@ -137,8 +137,8 @@ template <unsigned int TDim, unsigned int TNumNodes>
 void SteadyStatePwElement<TDim, TNumNodes>::CalculateAll(MatrixType&        rLeftHandSideMatrix,
                                                          VectorType&        rRightHandSideVector,
                                                          const ProcessInfo& rCurrentProcessInfo,
-                                                         const bool CalculateStiffnessMatrixFlag,
-                                                         const bool CalculateResidualVectorFlag)
+                                                         bool CalculateStiffnessMatrixFlag,
+                                                         bool CalculateResidualVectorFlag)
 {
     KRATOS_TRY
 

--- a/applications/GeoMechanicsApplication/custom_elements/steady_state_Pw_element.hpp
+++ b/applications/GeoMechanicsApplication/custom_elements/steady_state_Pw_element.hpp
@@ -119,8 +119,8 @@ protected:
     void CalculateAll(MatrixType&        rLeftHandSideMatrix,
                       VectorType&        rRightHandSideVector,
                       const ProcessInfo& CurrentProcessInfo,
-                      const bool         CalculateStiffnessMatrixFlag,
-                      const bool         CalculateResidualVectorFlag) override;
+                      bool               CalculateStiffnessMatrixFlag,
+                      bool               CalculateResidualVectorFlag) override;
 
     void CalculateAndAddLHS(MatrixType& rLeftHandSideMatrix, ElementVariables& rVariables) override;
 

--- a/applications/GeoMechanicsApplication/custom_elements/steady_state_Pw_interface_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/steady_state_Pw_interface_element.cpp
@@ -116,8 +116,8 @@ template <unsigned int TDim, unsigned int TNumNodes>
 void SteadyStatePwInterfaceElement<TDim, TNumNodes>::CalculateAll(MatrixType& rLeftHandSideMatrix,
                                                                   VectorType& rRightHandSideVector,
                                                                   const ProcessInfo& CurrentProcessInfo,
-                                                                  const bool CalculateStiffnessMatrixFlag,
-                                                                  const bool CalculateResidualVectorFlag)
+                                                                  bool CalculateStiffnessMatrixFlag,
+                                                                  bool CalculateResidualVectorFlag)
 {
     KRATOS_TRY
 

--- a/applications/GeoMechanicsApplication/custom_elements/steady_state_Pw_interface_element.hpp
+++ b/applications/GeoMechanicsApplication/custom_elements/steady_state_Pw_interface_element.hpp
@@ -104,8 +104,8 @@ protected:
     void CalculateAll(MatrixType&        rLeftHandSideMatrix,
                       VectorType&        rRightHandSideVector,
                       const ProcessInfo& CurrentProcessInfo,
-                      const bool         CalculateStiffnessMatrixFlag,
-                      const bool         CalculateResidualVectorFlag) override;
+                      bool               CalculateStiffnessMatrixFlag,
+                      bool               CalculateResidualVectorFlag) override;
 
     void CalculateAndAddLHS(MatrixType& rLeftHandSideMatrix, InterfaceElementVariables& rVariables) override;
 

--- a/applications/GeoMechanicsApplication/custom_elements/steady_state_Pw_piping_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/steady_state_Pw_piping_element.cpp
@@ -179,8 +179,8 @@ template <unsigned int TDim, unsigned int TNumNodes>
 void SteadyStatePwPipingElement<TDim, TNumNodes>::CalculateAll(MatrixType& rLeftHandSideMatrix,
                                                                VectorType& rRightHandSideVector,
                                                                const ProcessInfo& CurrentProcessInfo,
-                                                               const bool CalculateStiffnessMatrixFlag,
-                                                               const bool CalculateResidualVectorFlag)
+                                                               bool CalculateStiffnessMatrixFlag,
+                                                               bool CalculateResidualVectorFlag)
 {
     KRATOS_TRY
     // Previous definitions

--- a/applications/GeoMechanicsApplication/custom_elements/steady_state_Pw_piping_element.hpp
+++ b/applications/GeoMechanicsApplication/custom_elements/steady_state_Pw_piping_element.hpp
@@ -114,8 +114,8 @@ protected:
     void CalculateAll(MatrixType&        rLeftHandSideMatrix,
                       VectorType&        rRightHandSideVector,
                       const ProcessInfo& CurrentProcessInfo,
-                      const bool         CalculateStiffnessMatrixFlag,
-                      const bool         CalculateResidualVectorFlag) override;
+                      bool               CalculateStiffnessMatrixFlag,
+                      bool               CalculateResidualVectorFlag) override;
 
     using BaseType::CalculateOnIntegrationPoints;
     void CalculateOnIntegrationPoints(const Variable<bool>& rVariable,

--- a/applications/GeoMechanicsApplication/custom_elements/transient_Pw_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/transient_Pw_element.cpp
@@ -424,8 +424,8 @@ template <unsigned int TDim, unsigned int TNumNodes>
 void TransientPwElement<TDim, TNumNodes>::CalculateAll(MatrixType&        rLeftHandSideMatrix,
                                                        VectorType&        rRightHandSideVector,
                                                        const ProcessInfo& rCurrentProcessInfo,
-                                                       const bool CalculateStiffnessMatrixFlag,
-                                                       const bool CalculateResidualVectorFlag)
+                                                       bool CalculateStiffnessMatrixFlag,
+                                                       bool CalculateResidualVectorFlag)
 {
     KRATOS_TRY
 

--- a/applications/GeoMechanicsApplication/custom_elements/transient_Pw_element.hpp
+++ b/applications/GeoMechanicsApplication/custom_elements/transient_Pw_element.hpp
@@ -156,8 +156,8 @@ protected:
     void CalculateAll(MatrixType&        rLeftHandSideMatrix,
                       VectorType&        rRightHandSideVector,
                       const ProcessInfo& CurrentProcessInfo,
-                      const bool         CalculateStiffnessMatrixFlag,
-                      const bool         CalculateResidualVectorFlag) override;
+                      bool               CalculateStiffnessMatrixFlag,
+                      bool               CalculateResidualVectorFlag) override;
 
     void InitializeElementVariables(ElementVariables& rVariables, const ProcessInfo& CurrentProcessInfo) override;
 

--- a/applications/GeoMechanicsApplication/custom_elements/transient_Pw_interface_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/transient_Pw_interface_element.cpp
@@ -441,8 +441,8 @@ template <unsigned int TDim, unsigned int TNumNodes>
 void TransientPwInterfaceElement<TDim, TNumNodes>::CalculateAll(MatrixType& rLeftHandSideMatrix,
                                                                 VectorType& rRightHandSideVector,
                                                                 const ProcessInfo& CurrentProcessInfo,
-                                                                const bool CalculateStiffnessMatrixFlag,
-                                                                const bool CalculateResidualVectorFlag)
+                                                                bool CalculateStiffnessMatrixFlag,
+                                                                bool CalculateResidualVectorFlag)
 {
     KRATOS_TRY
 

--- a/applications/GeoMechanicsApplication/custom_elements/transient_Pw_interface_element.hpp
+++ b/applications/GeoMechanicsApplication/custom_elements/transient_Pw_interface_element.hpp
@@ -137,8 +137,8 @@ protected:
     void CalculateAll(MatrixType&        rLeftHandSideMatrix,
                       VectorType&        rRightHandSideVector,
                       const ProcessInfo& CurrentProcessInfo,
-                      const bool         CalculateStiffnessMatrixFlag,
-                      const bool         CalculateResidualVectorFlag) override;
+                      bool               CalculateStiffnessMatrixFlag,
+                      bool               CalculateResidualVectorFlag) override;
 
     void InitializeElementVariables(InterfaceElementVariables& rVariables,
                                     const GeometryType&        Geom,

--- a/applications/GeoMechanicsApplication/custom_elements/updated_lagrangian_U_Pw_diff_order_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/updated_lagrangian_U_Pw_diff_order_element.cpp
@@ -41,8 +41,8 @@ Element::Pointer UpdatedLagrangianUPwDiffOrderElement::Create(IndexType         
 void UpdatedLagrangianUPwDiffOrderElement::CalculateAll(MatrixType&        rLeftHandSideMatrix,
                                                         VectorType&        rRightHandSideVector,
                                                         const ProcessInfo& rCurrentProcessInfo,
-                                                        const bool CalculateStiffnessMatrixFlag,
-                                                        const bool CalculateResidualVectorFlag)
+                                                        bool CalculateStiffnessMatrixFlag,
+                                                        bool CalculateResidualVectorFlag)
 {
     KRATOS_TRY
 

--- a/applications/GeoMechanicsApplication/custom_elements/updated_lagrangian_U_Pw_diff_order_element.hpp
+++ b/applications/GeoMechanicsApplication/custom_elements/updated_lagrangian_U_Pw_diff_order_element.hpp
@@ -209,8 +209,8 @@ protected:
     void CalculateAll(MatrixType&        rLeftHandSideMatrix,
                       VectorType&        rRightHandSideVector,
                       const ProcessInfo& rCurrentProcessInfo,
-                      const bool         CalculateStiffnessMatrixFlag,
-                      const bool         CalculateResidualVectorFlag) override;
+                      bool               CalculateStiffnessMatrixFlag,
+                      bool               CalculateResidualVectorFlag) override;
 
     void CalculateAndAddGeometricStiffnessMatrix(MatrixType&       rLeftHandSideMatrix,
                                                  ElementVariables& rVariables,


### PR DESCRIPTION
**📝 Description**
Member function parameters that are passed by value should not be declared `const`. See ["Con.1: By default, make objects immutable"](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Rconst-immutable) of the C++ Core Guidelines (under section "Exceptions").

**🆕 Changelog**
Removed `const` from several member function parameters that are passed by value.
