### PR TITLE
[HDF5] Instantiate `HDF5::File::HasDataType`

### DIFF
--- a/applications/HDF5Application/custom_io/hdf5_file.cpp
+++ b/applications/HDF5Application/custom_io/hdf5_file.cpp
@@ -1091,6 +1091,9 @@ void File::ReadDataSetImpl(
 }
 
 // template instantiations
+template KRATOS_API(HDF5_APPLICATION) bool File::HasDataType<int>(const std::string&) const;
+template KRATOS_API(HDF5_APPLICATION) bool File::HasDataType<double>(const std::string&) const;
+
 #ifndef KRATOS_HDF5_FILE_DATA_SET_METHOD_INSTANTIATION
 #define KRATOS_HDF5_FILE_DATA_SET_METHOD_INSTANTIATION(...)                                                                                                                                     \
     template KRATOS_API(HDF5_APPLICATION) void File::WriteDataSetImpl<__VA_ARGS__, File::DataTransferMode::Collective>(const std::string&, const __VA_ARGS__&, WriteInfo&);                     \


### PR DESCRIPTION
`HDF5::File::HasDataType` is a member function template, which is defined in a source file. However, it's never instantiated for the two types it can be used for (`int`, `double`), which leads to the linker crapping out when someone tries using it from outside the HDF5App.

This PR adds instantiations for
- `HDF5::File::HasDataType<int>`
- `HDF5::File::HasDataType<double>`
