### PR TITLE
Optimize Node Processing in ROM Basis Setting

### DIFF
--- a/applications/RomApplication/python_scripts/rom_analysis.py
+++ b/applications/RomApplication/python_scripts/rom_analysis.py
@@ -168,24 +168,44 @@ def CreateRomAnalysisInstance(cls, global_model, parameters):
                         node.SetValue(KratosROM.ROM_LEFT_BASIS, aux)
 
             elif self.rom_parameters["rom_format"].GetString() == "numpy":
-                # Set the nodal ROM basis
+
+                # Load node IDs and right modes
                 node_ids = np.load(self.rom_basis_output_folder / "NodeIds.npy")
                 right_modes = np.load(self.rom_basis_output_folder / "RightBasisMatrix.npy")
-                if right_modes.ndim ==1: #check if matrix contains a single mode (a 1D numpy array)
-                    right_modes.reshape(-1,1)
-                right_modes = right_modes[:,:rom_dofs]
-                if (self.solving_strategy == "petrov_galerkin"):
+
+                # Ensure right_modes is a 2D array
+                if right_modes.ndim == 1:
+                    right_modes = right_modes.reshape(-1, 1)
+
+                # Trim right_modes based on ROM degrees of freedom (DOFs)
+                right_modes = right_modes[:, :rom_dofs]
+
+                # Handle left modes for Petrov-Galerkin strategy
+                if self.solving_strategy == "petrov_galerkin":
                     petrov_galerkin_rom_dofs = self.project_parameters["solver_settings"]["rom_settings"]["petrov_galerkin_number_of_rom_dofs"].GetInt()
                     left_modes = np.load(self.rom_basis_output_folder / "LeftBasisMatrix.npy")
-                    if left_modes.ndim ==1:
-                        left_modes.reshape(-1,1)
-                    left_modes = left_modes[:,:petrov_galerkin_rom_dofs]
 
+                    # Ensure left_modes is a 2D array
+                    if left_modes.ndim == 1:
+                        left_modes = left_modes.reshape(-1, 1)
+
+                    # Trim left_modes based on Petrov-Galerkin ROM DOFs
+                    left_modes = left_modes[:, :petrov_galerkin_rom_dofs]
+
+                # Preprocess to create a mapping from node ID to index
+                node_id_to_index = {nid: idx for idx, nid in enumerate(node_ids)}
+
+                # Loop over each node in computing_model_part
                 for node in computing_model_part.Nodes:
-                    offset = np.where(node_ids == node.Id)[0][0]*nodal_dofs
-                    node.SetValue(KratosROM.ROM_BASIS, KratosMultiphysics.Matrix(right_modes[offset:offset+nodal_dofs, :])) # ROM basis
-                    if (self.solving_strategy == "petrov_galerkin"):
-                        node.SetValue(KratosROM.ROM_LEFT_BASIS, KratosMultiphysics.Matrix(left_modes[offset:offset+nodal_dofs, :])) # ROM basis
+                    index = node_id_to_index[node.Id]
+                    offset = index * nodal_dofs
+
+                    # Set ROM basis for the node
+                    node.SetValue(KratosROM.ROM_BASIS, KratosMultiphysics.Matrix(right_modes[offset:offset + nodal_dofs, :]))
+
+                    # Set Petrov-Galerkin ROM basis if applicable
+                    if self.solving_strategy == "petrov_galerkin":
+                        node.SetValue(KratosROM.ROM_LEFT_BASIS, KratosMultiphysics.Matrix(left_modes[offset:offset + nodal_dofs, :]))
 
             # Check for HROM stages
             if self.train_hrom:


### PR DESCRIPTION
### Description

This PR introduces performance optimizations to the node processing logic in `rom_analysis.py`, specifically for setting the Reduced Order Model (ROM) basis. The original implementation, which iterated over all nodes using `np.where` within a loop, was suboptimal for large datasets.

### Changes

#### File Modified
- `rom_analysis.py`

#### Key Modifications
- Implemented a preprocessing step to create a dictionary (`node_id_to_index`), mapping each node ID to its index in the `node_ids` array. This optimizes the retrieval of node indices during the main processing loop.
- Updated the loop over nodes to leverage the `node_id_to_index` mapping for efficient index lookup, thereby reducing computational overhead.

### Benefits

- **Performance Improvement**: Significant reduction in computation time, especially beneficial for large models with numerous nodes.

### Additional Notes

- The changes maintain the existing functionality while greatly enhancing performance, particularly in large-scale applications.
- Care was taken to ensure compatibility with the rest of the `rom_analysis.py` module.

