### PR TITLE
[Core] Add Process for MPC Visualization

### DIFF
--- a/kratos/processes/multipoint_constraint_to_element_process.cpp
+++ b/kratos/processes/multipoint_constraint_to_element_process.cpp
@@ -222,9 +222,7 @@ MultipointConstraintToElementProcess::MultipointConstraintToElementProcess(Model
 
 
 /// Required by PIMPL
-MultipointConstraintToElementProcess::~MultipointConstraintToElementProcess()
-{
-}
+MultipointConstraintToElementProcess::~MultipointConstraintToElementProcess() = default;
 
 
 // Make sure every MPC is associated with an element

--- a/kratos/processes/multipoint_constraint_to_element_process.cpp
+++ b/kratos/processes/multipoint_constraint_to_element_process.cpp
@@ -1,0 +1,335 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
+//
+//  Main authors:    Máté Kelemen
+//
+
+// Core includes
+#include "processes/multipoint_constraint_to_element_process.h" // MultipointConstraintToElementProcess
+#include "containers/model.h" // Model
+#include "includes/model_part.h" // ModelPart
+#include "includes/master_slave_constraint.h" // MasterSlaveConstraint
+#include "includes/element.h" // Element
+#include "includes/kratos_components.h" // KratosComponents
+#include "includes/key_hash.h" // HashCombine
+#include "includes/variables.h" // SCALAR_LAGRANGE_MULTIPLIER
+#include "utilities/interval_utility.h" // IntervalUtility
+
+// System includes
+#include <unordered_map> // unordered_map
+#include <unordered_set> // unordered_set
+#include <optional> // optional
+
+
+namespace Kratos {
+
+
+namespace {
+
+
+/// @brief Find the largest @ref Element ID in a @ref ModelPart.
+Element::IndexType GetLargestElementId(const ModelPart& rModelPart)
+{
+    // IDs are 1-based
+    Element::IndexType output = 1;
+
+    // Elements are stored in an ordered container, sorted by their IDs,
+    // so the last element in the container should have the largest ID.
+    if (!rModelPart.Elements().empty()) {
+        output = rModelPart.Elements().back().Id();
+    }
+
+    const DataCommunicator& r_mpi = rModelPart.GetCommunicator().GetDataCommunicator();
+    return r_mpi.MaxAll(output);
+}
+
+
+/// @brief Pair of integers with commutative hash and equality comparison.
+template <class TIndex>
+struct SymmetricIdPair
+{
+    using value_type = TIndex;
+
+    using first_type = value_type;
+
+    using second_type = value_type;
+
+    struct hash
+    {
+        std::size_t operator()(SymmetricIdPair Instance) const noexcept
+        {
+            value_type min = std::min(Instance.first, Instance.second);
+            const value_type max = std::max(Instance.first, Instance.second);
+            HashCombine(min, max); // <== mutates min
+            return min;
+        }
+    }; // struct hash
+
+    friend bool operator==(SymmetricIdPair Left, SymmetricIdPair Right) noexcept
+    {
+        return (Left.first == Right.first && Left.second == Right.second)
+            || (Left.first == Right.second && Left.second == Right.first);
+    }
+
+    first_type first;
+
+    second_type second;
+};
+
+
+/// @brief Pair of symmetric ID pairs.
+/// @note This pair is NOT symmetric, but the subpairs are.
+template <class TFirst, class TSecond>
+struct NestedIdPair
+{
+    using first_type = SymmetricIdPair<TFirst>;
+
+    using second_type = SymmetricIdPair<TSecond>;
+
+    struct hash
+    {
+        std::size_t operator()(NestedIdPair Instance) const noexcept
+        {
+            auto first_hash = typename first_type::hash()(Instance.first);
+            const auto second_hash = typename second_type::hash()(Instance.second);
+            HashCombine(first_hash, second_hash); // <== mutates first_hash
+            return first_hash;
+        }
+    }; // struct hash
+
+    friend bool operator==(NestedIdPair Left, NestedIdPair Right) noexcept
+    {
+        return Left.first == Right.first && Left.second == Right.second;
+    }
+
+    first_type first;
+
+    second_type second;
+};
+
+
+void EnsureNode(ModelPart& rOutputModelPart, const Node& rInputNode)
+{
+    const auto it_node = rOutputModelPart.Nodes().find(rInputNode.Id());
+    if (it_node == rOutputModelPart.Nodes().end()) {
+        rOutputModelPart.CreateNewNode(rInputNode.Id(),
+                                       rInputNode.X0(),
+                                       rInputNode.Y0(),
+                                       rInputNode.Z0());
+    }
+}
+
+
+Element& ConstructMPCElement(ModelPart& rOutputModelPart,
+                             std::pair<const Node*,const Node*> Nodes,
+                             Element::IndexType Id,
+                             const Properties::Pointer& rpProperties)
+{
+    // The node pointers might not be in the output model part (usually they aren't)
+    // so they must be constructed if they haven't been already.
+    EnsureNode(rOutputModelPart, *Nodes.first);
+    EnsureNode(rOutputModelPart, *Nodes.second);
+
+    Element::Pointer p_element = rOutputModelPart.CreateNewElement("Element2D2N",
+                                                                   Id,
+                                                                   std::vector<Node::IndexType> {Nodes.first->Id(), Nodes.second->Id()},
+                                                                   rpProperties);
+    return *p_element;
+}
+
+
+} // anonymous namespace
+
+
+struct MultipointConstraintToElementProcess::Impl
+{
+    std::optional<ModelPart*> mpInputModelPart;
+
+    std::optional<ModelPart*> mpOutputModelPart;
+
+    std::optional<IntervalUtility> mInterval;
+
+    /// Map associating each constrained variable pair with a sub model part
+    /// in the output model part, as well as a pair of pointers to the actual
+    /// static variables.
+    std::unordered_map<
+        SymmetricIdPair<Variable<double>::KeyType>,
+        ModelPart*,
+        SymmetricIdPair<Variable<double>::KeyType>::hash
+    > mSubModelPartMap;
+
+    /// Map associating an @ref MasterSlaveConstraint "MPC" and an element
+    /// with each pair of nodes and variables.
+    std::unordered_map<
+        NestedIdPair<Node::IndexType,Variable<double>::KeyType>,
+        std::pair<
+            Element::IndexType,
+            MasterSlaveConstraint::IndexType
+        >,
+        NestedIdPair<Node::IndexType,Variable<double>::KeyType>::hash
+    > mConstraintMap;
+}; // struct MultipointConstraintToElementProcess::Impl
+
+
+MultipointConstraintToElementProcess::MultipointConstraintToElementProcess() noexcept
+    : mpImpl(new Impl)
+{
+}
+
+
+MultipointConstraintToElementProcess::MultipointConstraintToElementProcess(Model& rModel,
+                                                                           Parameters Settings)
+    : MultipointConstraintToElementProcess()
+{
+    KRATOS_TRY
+
+    Settings.ValidateAndAssignDefaults(this->GetDefaultParameters());
+    mpImpl->mpInputModelPart = &rModel.GetModelPart(Settings["input_model_part_name"].Get<std::string>());
+    mpImpl->mInterval = IntervalUtility(Settings);
+
+    const std::string output_model_part_name = Settings["output_model_part_name"].Get<std::string>();
+    if (rModel.HasModelPart(output_model_part_name)) {
+        mpImpl->mpOutputModelPart = &rModel.GetModelPart(output_model_part_name);
+    } else {
+        mpImpl->mpOutputModelPart = &rModel.CreateModelPart(output_model_part_name);
+        if (mpImpl->mpOutputModelPart.value()->GetRootModelPart().rProperties().empty()) {
+            mpImpl->mpOutputModelPart.value()->GetRootModelPart().CreateNewProperties(1);
+        }
+    }
+
+    KRATOS_CATCH("")
+}
+
+
+/// Required by PIMPL
+MultipointConstraintToElementProcess::~MultipointConstraintToElementProcess()
+{
+}
+
+
+// Make sure every MPC is associated with an element
+// AND every element represents at least one MPC.
+// Each MPC is represented by a scalar variable in an
+// element.
+void MultipointConstraintToElementProcess::Execute()
+{
+    KRATOS_TRY
+
+    ModelPart& r_input_model_part = *mpImpl->mpInputModelPart.value();
+    auto& r_constraints = r_input_model_part.MasterSlaveConstraints();
+    ModelPart& r_output_model_part = *mpImpl->mpOutputModelPart.value();
+
+    // @todo make sure that issuing new element IDs is MPI-safe and reasonably efficient (@matekelemen)
+    Element::IndexType next_element_id = GetLargestElementId(r_output_model_part.GetRootModelPart()) + 1;
+    KRATOS_ERROR_IF(r_output_model_part.GetRootModelPart().rProperties().empty());
+    Properties::Pointer p_element_properties = *r_input_model_part.GetRootModelPart().rProperties().ptr_begin();
+
+    // First, remove elements that are no longer related to any MPC.
+    for (auto it_entry=mpImpl->mConstraintMap.begin(); it_entry!=mpImpl->mConstraintMap.end(); ++it_entry) {
+        const Element::IndexType element_id = it_entry->second.first;
+        const MasterSlaveConstraint::IndexType constraint_id = it_entry->second.second;
+        if (r_constraints.find(constraint_id) == r_constraints.end()) {
+            r_output_model_part.RemoveElement(element_id);
+            mpImpl->mConstraintMap.erase(it_entry); // <== don't worry, iterators don't get invalidated in std::unordered_map
+        }
+    } // for r_entry in mConstraintMap
+
+    // Now create new elements for each MPC that doesn't already have one.
+    for (const MasterSlaveConstraint& r_constraint : r_input_model_part.MasterSlaveConstraints()) {
+        MasterSlaveConstraint::MatrixType scales;
+        MasterSlaveConstraint::VectorType offsets;
+        r_constraint.GetLocalSystem(scales, offsets, r_input_model_part.GetProcessInfo());
+
+        const auto& r_slaves = r_constraint.GetSlaveDofsVector();
+        const auto& r_masters = r_constraint.GetMasterDofsVector();
+        for (std::size_t i_slave=0ul; i_slave<r_slaves.size(); ++i_slave) {
+            for (std::size_t i_master=0ul; i_master<r_masters.size(); ++i_master) {
+                const double scale = scales(i_slave, i_master);
+                if (scale) {
+
+                    const Dof<double>& r_slave = *r_constraint.GetSlaveDofsVector()[i_slave];
+                    const Dof<double>& r_master = *r_constraint.GetMasterDofsVector()[i_master];
+                    SymmetricIdPair<Node::IndexType> node_id_pair {r_slave.GetId(), r_master.GetId()};
+                    SymmetricIdPair<Variable<double>::KeyType> variable_id_pair {r_slave.GetVariable().SourceKey(),
+                                                                                 r_master.GetVariable().SourceKey()};
+                    NestedIdPair<Node::IndexType,Variable<double>::KeyType> mpc_id {node_id_pair, variable_id_pair};
+
+                    // Get or create the element related to this MPC
+                    auto it_mpc = mpImpl->mConstraintMap.find(mpc_id);
+                    if (it_mpc == mpImpl->mConstraintMap.end()) {
+                        auto it_sub_model_part = mpImpl->mSubModelPartMap.find(variable_id_pair);
+
+                        // Get or create the sub model part related to the pair of constrained variables
+                        if (it_sub_model_part == mpImpl->mSubModelPartMap.end()) {
+                            const std::string slave_variable_name = r_slave.GetVariable().Name();
+                            const std::string master_variable_name = r_master.GetVariable().Name();
+                            const std::string sub_model_part_name = std::min(slave_variable_name, master_variable_name)
+                                                                    + "_" +
+                                                                    std::max(slave_variable_name, master_variable_name);
+                            ModelPart& r_sub_model_part = r_output_model_part.CreateSubModelPart(sub_model_part_name);
+                            it_sub_model_part = mpImpl->mSubModelPartMap.emplace(variable_id_pair, &r_sub_model_part).first;
+                        }
+
+                        const auto it_slave_node = r_input_model_part.Nodes().find(r_slave.Id());
+                        const auto it_master_node = r_input_model_part.Nodes().find(r_master.Id());
+                        KRATOS_ERROR_IF(it_slave_node == r_input_model_part.Nodes().end());
+                        KRATOS_ERROR_IF(it_master_node == r_input_model_part.Nodes().end());
+                        ModelPart& r_output_sub_model_part = *it_sub_model_part->second;
+                        Element& r_element = ConstructMPCElement(r_output_sub_model_part,
+                                                                 {&*it_slave_node, &*it_master_node},
+                                                                 next_element_id++,
+                                                                 p_element_properties);
+                        it_mpc = mpImpl->mConstraintMap.emplace(mpc_id, std::make_pair(r_element.Id(), r_constraint.Id())).first;
+                    } // if constraint is new
+
+                    // Set the scale of the constraint
+                    const Element::IndexType element_id = it_mpc->second.first;
+                    const auto it_element = r_output_model_part.Elements().find(element_id);
+                    KRATOS_ERROR_IF(it_element == r_output_model_part.Elements().end());
+                    Element& r_element = *it_element;
+                    r_element.SetValue(SCALAR_LAGRANGE_MULTIPLIER, scale);
+                } // if scale
+            } // for p_slave in constraint.Slaves
+        } // for p_master in constraint.Masters
+    } // for r_constraint in r_input_model_part.MasterSlaveConstraints
+
+    KRATOS_CATCH("")
+}
+
+
+void MultipointConstraintToElementProcess::ExecuteInitialize()
+{
+    KRATOS_TRY
+    this->Execute();
+    KRATOS_CATCH("")
+}
+
+
+void MultipointConstraintToElementProcess::ExecuteInitializeSolutionStep()
+{
+    KRATOS_TRY
+    const double current_time = mpImpl->mpInputModelPart.value()->GetProcessInfo()[TIME];
+    if (mpImpl->mInterval.value().IsInInterval(current_time)) {
+        this->Execute();
+    }
+    KRATOS_CATCH("")
+}
+
+
+const Parameters MultipointConstraintToElementProcess::GetDefaultParameters() const
+{
+    return Parameters(R"({
+        "input_model_part_name" : "",
+        "output_model_part_name" : "",
+        "interval" : [0.0, "End"]
+    })");
+}
+
+
+} // namespace Kratos

--- a/kratos/processes/multipoint_constraint_to_element_process.cpp
+++ b/kratos/processes/multipoint_constraint_to_element_process.cpp
@@ -198,6 +198,14 @@ MultipointConstraintToElementProcess::MultipointConstraintToElementProcess(Model
         mpImpl->mpOutputModelPart = &rModel.GetModelPart(output_model_part_name);
     } else {
         mpImpl->mpOutputModelPart = &rModel.CreateModelPart(output_model_part_name);
+
+        // Link the input model part's process info. This is necessary to ensure that
+        // the interval control works properly (TIME and STEP get updated). This is
+        // essential if the user provides an output model part that's outside the tree
+        // of the input model part.
+        mpImpl->mpOutputModelPart.value()->SetProcessInfo(mpImpl->mpInputModelPart.value()->pGetProcessInfo());
+
+        // Make sure the output model part has properties; it will be used for constructing elements.
         if (mpImpl->mpOutputModelPart.value()->GetRootModelPart().rProperties().empty()) {
             mpImpl->mpOutputModelPart.value()->GetRootModelPart().CreateNewProperties(1);
         }
@@ -216,7 +224,7 @@ MultipointConstraintToElementProcess::~MultipointConstraintToElementProcess()
 // Make sure every MPC is associated with an element
 // AND every element represents at least one MPC.
 // Each MPC is represented by a scalar variable in an
-// element.
+// element (SCALAR_LAGRANGE_MULTIPLIER).
 void MultipointConstraintToElementProcess::Execute()
 {
     KRATOS_TRY

--- a/kratos/processes/multipoint_constraint_to_element_process.cpp
+++ b/kratos/processes/multipoint_constraint_to_element_process.cpp
@@ -133,8 +133,9 @@ struct MultipointConstraintToElementProcess::Impl
             output = rModelPart.Elements().back().Id();
         }
 
+        // Max reduce across MPI ranks
         const DataCommunicator& r_mpi = rModelPart.GetCommunicator().GetDataCommunicator();
-        return r_mpi.MaxAll(output);
+        return static_cast<Element::IndexType>(r_mpi.MaxAll(static_cast<long unsigned int>(output))); // <== explicit casts for MSVC
     }
 
 

--- a/kratos/processes/multipoint_constraint_to_element_process.h
+++ b/kratos/processes/multipoint_constraint_to_element_process.h
@@ -29,6 +29,7 @@ namespace Kratos {
  *           {
  *              "input_model_part_name" : "",
  *              "output_model_part_name" : "",
+ *              "output_variable" : "CONSTRAINT_SCALE_FACTOR",
  *              "interval" : [0.0, "End"]
  *           }
  *           @endcode
@@ -39,9 +40,9 @@ namespace Kratos {
  *
  *  @param input_model_part_name full name of the model part to scane multipoint constraints in.
  *  @param output_model_part_name full name of the model part to generate elements in. It is created if it does not exist yet.
+ *  @param output_variable name of the element variable to write the scale of the constraints to.
  *  @param interval time interval to manage the generated elements in.
  *
- *  @note The coefficient of the relationships is stored in elements' @a SCALAR_LAGRANGE_MULTIPLIER variable.
  *  @note This process requires exclusive access to its output @ref ModelPart, which it will manage while active.
  *        Elements are added and deleted to reflect active @ref MasterSlaveConstraint "multipoint constraints".
  *  @todo This process would be better off generating @ref Geometry "geometries", but no output process writes those yet @matekelemen.

--- a/kratos/processes/multipoint_constraint_to_element_process.h
+++ b/kratos/processes/multipoint_constraint_to_element_process.h
@@ -38,14 +38,14 @@ namespace Kratos {
  *           if @a output_model_part_name is @a root and a multipoint constraint relates @a DISPLACEMENT_X to @a PRESSURE,
  *           then @ref Element2D2N "Element2D2Ns" will be constructed in the @a root.DISPLACEMENT_X_PRESSURE sub model part.
  *
- *  @param input_model_part_name full name of the model part to scane multipoint constraints in.
+ *  @param input_model_part_name full name of the model part to scan multipoint constraints in.
  *  @param output_model_part_name full name of the model part to generate elements in. It is created if it does not exist yet.
  *  @param output_variable name of the element variable to write the scale of the constraints to.
- *  @param interval time interval to manage the generated elements in.
+ *  @param interval time interval in which this process is active.
  *
  *  @note This process requires exclusive access to its output @ref ModelPart, which it will manage while active.
  *        Elements are added and deleted to reflect active @ref MasterSlaveConstraint "multipoint constraints".
- *  @todo This process would be better off generating @ref Geometry "geometries", but no output process writes those yet @matekelemen.
+ *  @todo This process would be better off generating @ref Geometry "geometries", but no output process writes them yet @matekelemen.
  *
  *  @ingroup KratosCore
  */

--- a/kratos/processes/multipoint_constraint_to_element_process.h
+++ b/kratos/processes/multipoint_constraint_to_element_process.h
@@ -13,8 +13,11 @@
 #pragma once
 
 // Core includes
-#include "includes/define.h"
-#include "processes/process.h"
+#include "includes/define.h" // KRATOS_API, KRATOS_CLASS_POINTER_DEFINITION
+#include "processes/process.h" // Process, Model, Parameters
+
+// System includes
+#include <memory> // unique_ptr
 
 
 namespace Kratos {
@@ -24,15 +27,28 @@ namespace Kratos {
  *  @details Default parameters:
  *           @code
  *           {
- *              "model_part_name" : "",
+ *              "input_model_part_name" : "",
+ *              "output_model_part_name" : "",
  *              "interval" : [0.0, "End"]
  *           }
  *           @endcode
- *  @note This process requires exclusive access to its @ref ModelPart, which it will manage while active.
+ *           Multipoint constraints act on pairs of @ref Dof "DoFs", not on @ref Node "nodes", so elements are further
+ *           partitioned into sub model parts, based on the pair of @ref Variable "variables" they constrain. For example,
+ *           if @a output_model_part_name is @a root and a multipoint constraint relates @a DISPLACEMENT_X to @a PRESSURE,
+ *           then @ref Element2D2N "Element2D2Ns" will be constructed in the @a root.DISPLACEMENT_X_PRESSURE sub model part.
+ *
+ *  @param input_model_part_name full name of the model part to scane multipoint constraints in.
+ *  @param output_model_part_name full name of the model part to generate elements in. It is created if it does not exist yet.
+ *  @param interval time interval to manage the generated elements in.
+ *
+ *  @note The coefficient of the relationships is stored in elements' @a SCALAR_LAGRANGE_MULTIPLIER variable.
+ *  @note This process requires exclusive access to its output @ref ModelPart, which it will manage while active.
  *        Elements are added and deleted to reflect active @ref MasterSlaveConstraint "multipoint constraints".
+ *  @todo This process would be better off generating @ref Geometry "geometries", but no output process writes those yet @matekelemen.
+ *
  *  @ingroup KratosCore
  */
-class KRATOS_API(KRATOS_CORE) MultipointConstraintToElementProcess : public Process
+class KRATOS_API(KRATOS_CORE) MultipointConstraintToElementProcess final : public Process
 {
 public:
     KRATOS_CLASS_POINTER_DEFINITION(MultipointConstraintToElementProcess);

--- a/kratos/processes/multipoint_constraint_to_element_process.h
+++ b/kratos/processes/multipoint_constraint_to_element_process.h
@@ -1,0 +1,60 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
+//
+//  Main authors:    Máté Kelemen
+//
+
+#pragma once
+
+// Core includes
+#include "includes/define.h"
+#include "processes/process.h"
+
+
+namespace Kratos {
+
+
+/** @brief Utility process that generates elements from @ref MasterSlaveConstraint "multipoint constraints" for visualization purposes.
+ *  @details Default parameters:
+ *           @code
+ *           {
+ *              "model_part_name" : "",
+ *              "interval" : [0.0, "End"]
+ *           }
+ *           @endcode
+ *  @note This process requires exclusive access to its @ref ModelPart, which it will manage while active.
+ *        Elements are added and deleted to reflect active @ref MasterSlaveConstraint "multipoint constraints".
+ *  @ingroup KratosCore
+ */
+class KRATOS_API(KRATOS_CORE) MultipointConstraintToElementProcess : public Process
+{
+public:
+    KRATOS_CLASS_POINTER_DEFINITION(MultipointConstraintToElementProcess);
+
+    MultipointConstraintToElementProcess() noexcept;
+
+    MultipointConstraintToElementProcess(Model& rModel, Parameters Settings);
+
+    ~MultipointConstraintToElementProcess() override;
+
+    void Execute() override;
+
+    void ExecuteInitialize() override;
+
+    void ExecuteInitializeSolutionStep() override;
+
+    const Parameters GetDefaultParameters() const override;
+
+private:
+    struct Impl;
+    std::unique_ptr<Impl> mpImpl;
+}; // class MultipointConstraintToElementProcess
+
+
+} // namespace Kratos

--- a/kratos/python/add_processes_to_python.cpp
+++ b/kratos/python/add_processes_to_python.cpp
@@ -72,6 +72,7 @@
 #include "processes/generic_find_elements_neighbours_process.h"
 #include "processes/check_same_modelpart_using_skin_distance_process.h"
 #include "processes/calculate_nodal_distance_to_skin_process.h"
+#include "processes/multipoint_constraint_to_element_process.h"
 
 #include "spaces/ublas_space.h"
 #include "linear_solvers/linear_solver.h"
@@ -505,7 +506,7 @@ void  AddProcessesToPython(pybind11::module& m)
         .def(py::init<ModelPart&, ModelPart&, Parameters>())
     ;
 
-    py::class_<ApplyRayCastingInterfaceRecognitionProcess<2>, 
+    py::class_<ApplyRayCastingInterfaceRecognitionProcess<2>,
       ApplyRayCastingInterfaceRecognitionProcess<2>::Pointer, Process>
       (m,"ApplyRayCastingInterfaceRecognitionProcess2D")
         .def(py::init<Model&, Parameters>())
@@ -689,6 +690,10 @@ void  AddProcessesToPython(pybind11::module& m)
     ;
 
     py::class_<CalculateNodalDistanceToSkinProcess, CalculateNodalDistanceToSkinProcess::Pointer, Process> (m, "CalculateNodalDistanceToSkinProcess")
+    .def(py::init<Model&, Parameters>())
+    ;
+
+    py::class_<MultipointConstraintToElementProcess, MultipointConstraintToElementProcess::Pointer, Process> (m, "MultipointConstraintToElementProcess")
     .def(py::init<Model&, Parameters>())
     ;
 }

--- a/kratos/python_scripts/multipoint_constraint_to_element_process.py
+++ b/kratos/python_scripts/multipoint_constraint_to_element_process.py
@@ -1,0 +1,7 @@
+import KratosMultiphysics
+
+MultipointConstraintToElementProcess = KratosMultiphysics.MultipointConstraintToElementProcess
+
+def Factory(parameters: KratosMultiphysics.Parameters,
+            model: KratosMultiphysics.Model) -> MultipointConstraintToElementProcess:
+    return MultipointConstraintToElementProcess(model, parameters["Parameters"])


### PR DESCRIPTION
Add a process that generates `Element2D2N`s from `MasterSlaveConstraint`s. These elements can then be written to files with any other output process.

*The input and output model parts are controlled by the user and can belong to completely separate trees, so the interference of the generated elements with the solver can be prevented.*

![trebuchet_arm_mpc](https://github.com/KratosMultiphysics/Kratos/assets/44344022/cdb2b2ee-eb63-4ea5-886d-376d105f5d0a)

FYI @sunethwarna 