### PR TITLE
[Core] Exploit Unused Bits in `Dof`

### DIFF
--- a/kratos/includes/dof.h
+++ b/kratos/includes/dof.h
@@ -439,7 +439,6 @@ private:
     ///@{
 
     static const Variable<TDataType> msNone;
-    static constexpr int msIsFixedPosition = 63;
 
     ///@}
     ///@name Member Variables

--- a/kratos/includes/dof.h
+++ b/kratos/includes/dof.h
@@ -132,7 +132,8 @@ public:
             << "The Dof-Variable " << rThisVariable.Name() << " is not "
             << "in the list of variables" << std::endl;
 
-        mIndex = mpNodalData->GetSolutionStepData().pGetVariablesList()->AddDof(&rThisVariable);
+        [[maybe_unused]] const auto [dof_flags, p_nodal_data] = DofFlags::Decompose(mpNodalData);
+        mIndex = p_nodal_data->GetSolutionStepData().pGetVariablesList()->AddDof(&rThisVariable);
     }
 
     /** Constructor. This constructor takes the same input
@@ -175,7 +176,8 @@ public:
             << "The Reaction-Variable " << rThisReaction.Name() << " is not "
             << "in the list of variables" << std::endl;
 
-        mIndex = mpNodalData->GetSolutionStepData().pGetVariablesList()->AddDof(&rThisVariable, &rThisReaction);
+        [[maybe_unused]] const auto [dof_flags, p_nodal_data] = DofFlags::Decompose(mpNodalData);
+        mIndex = p_nodal_data->GetSolutionStepData().pGetVariablesList()->AddDof(&rThisVariable, &rThisReaction);
     }
 
     //This default constructor is needed for serializer
@@ -238,34 +240,40 @@ public:
 
     TDataType& GetSolutionStepValue(IndexType SolutionStepIndex = 0)
     {
-        return GetReference(GetVariable(), mpNodalData->GetSolutionStepData(), SolutionStepIndex, mVariableType);
+        [[maybe_unused]] const auto [dof_flags, p_nodal_data] = DofFlags::Decompose(mpNodalData);
+        return GetReference(GetVariable(), p_nodal_data->GetSolutionStepData(), SolutionStepIndex, mVariableType);
     }
 
     TDataType const& GetSolutionStepValue(IndexType SolutionStepIndex = 0) const
     {
-        return GetReference(GetVariable(), mpNodalData->GetSolutionStepData(), SolutionStepIndex, mVariableType);
+        [[maybe_unused]] const auto [dof_flags, p_nodal_data] = DofFlags::Decompose(mpNodalData);
+        return GetReference(GetVariable(), p_nodal_data->GetSolutionStepData(), SolutionStepIndex, mVariableType);
     }
 
     template<class TVariableType>
     typename TVariableType::Type& GetSolutionStepValue(const TVariableType& rThisVariable, IndexType SolutionStepIndex = 0)
     {
-        return mpNodalData->GetSolutionStepData().GetValue(rThisVariable, SolutionStepIndex);
+        [[maybe_unused]] const auto [dof_flags, p_nodal_data] = DofFlags::Decompose(mpNodalData);
+        return p_nodal_data->GetSolutionStepData().GetValue(rThisVariable, SolutionStepIndex);
     }
 
     template<class TVariableType>
     typename TVariableType::Type const& GetSolutionStepValue(const TVariableType& rThisVariable, IndexType SolutionStepIndex = 0) const
     {
-        return mpNodalData->GetSolutionStepData().GetValue(rThisVariable, SolutionStepIndex);
+        [[maybe_unused]] const auto [dof_flags, p_nodal_data] = DofFlags::Decompose(mpNodalData);
+        return p_nodal_data->GetSolutionStepData().GetValue(rThisVariable, SolutionStepIndex);
     }
 
     TDataType& GetSolutionStepReactionValue(IndexType SolutionStepIndex = 0)
     {
-        return GetReference(GetReaction(), mpNodalData->GetSolutionStepData(), SolutionStepIndex, mReactionType);
+        [[maybe_unused]] const auto [dof_flags, p_nodal_data] = DofFlags::Decompose(mpNodalData);
+        return GetReference(GetReaction(), p_nodal_data->GetSolutionStepData(), SolutionStepIndex, mReactionType);
     }
 
     TDataType const& GetSolutionStepReactionValue(IndexType SolutionStepIndex = 0) const
     {
-        return GetReference(GetReaction(), mpNodalData->GetSolutionStepData(), SolutionStepIndex, mReactionType);
+        [[maybe_unused]] const auto [dof_flags, p_nodal_data] = DofFlags::Decompose(mpNodalData);
+        return GetReference(GetReaction(), p_nodal_data->GetSolutionStepData(), SolutionStepIndex, mReactionType);
     }
 
     ///@}
@@ -274,32 +282,37 @@ public:
 
     IndexType Id() const
     {
-        return mpNodalData->GetId();
+        [[maybe_unused]] const auto [dof_flags, p_nodal_data] = DofFlags::Decompose(mpNodalData);
+        return p_nodal_data->GetId();
     }
 
     IndexType GetId() const
     {
-        return mpNodalData->GetId();
+        [[maybe_unused]] const auto [dof_flags, p_nodal_data] = DofFlags::Decompose(mpNodalData);
+        return p_nodal_data->GetId();
     }
 
     /** Returns variable assigned to this degree of freedom. */
     const VariableData& GetVariable() const
     {
-        return mpNodalData->GetSolutionStepData().GetVariablesList().GetDofVariable(mIndex);
+        [[maybe_unused]] const auto [dof_flags, p_nodal_data] = DofFlags::Decompose(mpNodalData);
+        return p_nodal_data->GetSolutionStepData().GetVariablesList().GetDofVariable(mIndex);
     }
 
     /** Returns reaction variable of this degree of freedom. */
     const VariableData& GetReaction() const
     {
-        auto p_reaction = mpNodalData->GetSolutionStepData().GetVariablesList().pGetDofReaction(mIndex);
+        [[maybe_unused]] const auto [dof_flags, p_nodal_data] = DofFlags::Decompose(mpNodalData);
+        auto p_reaction = p_nodal_data->GetSolutionStepData().GetVariablesList().pGetDofReaction(mIndex);
         return (p_reaction == nullptr) ? msNone : *p_reaction;
     }
 
     template<class TReactionType>
     void SetReaction(TReactionType const& rReaction)
     {
+        [[maybe_unused]] const auto [dof_flags, p_nodal_data] = DofFlags::Decompose(mpNodalData);
         mReactionType = DofTrait<TDataType, TReactionType>::Id;
-        mpNodalData->GetSolutionStepData().pGetVariablesList()->SetDofReaction(&rReaction, mIndex);
+        p_nodal_data->GetSolutionStepData().pGetVariablesList()->SetDofReaction(&rReaction, mIndex);
     }
 
     /** Return the Equation Id related to this degree eof freedom.
@@ -347,26 +360,50 @@ public:
         mIsActive = false;
     }
 
+    void Set(Flags flags)
+    {
+        KRATOS_TRY
+        auto [dof_flags, clean_pointer] = DofFlags::Decompose(mpNodalData);
+        dof_flags.Set(flags);
+        mpNodalData = dof_flags.Compose(clean_pointer);
+        KRATOS_CATCH("")
+    }
+
+    void Set(Flags flags, bool value)
+    {
+        KRATOS_TRY
+        auto [dof_flags, clean_pointer] = DofFlags::Decompose(mpNodalData);
+        value ? dof_flags.Set(flags) : dof_flags.Unset(flags);
+        mpNodalData = dof_flags.Compose(clean_pointer);
+        KRATOS_CATCH("")
+    }
+
     SolutionStepsDataContainerType* GetSolutionStepsData()
     {
-        return &(mpNodalData->GetSolutionStepData());
+        [[maybe_unused]] const auto [dof_flags, p_nodal_data] = DofFlags::Decompose(mpNodalData);
+        return &p_nodal_data->GetSolutionStepData();
     }
 
     void SetNodalData(NodalData* pNewNodalData)
     {
+        auto [dof_flags, p_nodal_data] = DofFlags::Decompose(mpNodalData);
         auto p_variable = &GetVariable();
-        auto p_reaction = mpNodalData->GetSolutionStepData().pGetVariablesList()->pGetDofReaction(mIndex);
-        mpNodalData = pNewNodalData;
+        auto p_reaction = p_nodal_data->GetSolutionStepData().pGetVariablesList()->pGetDofReaction(mIndex);
+        p_nodal_data = pNewNodalData;
+
         if(p_reaction != nullptr){
-            mIndex = mpNodalData->GetSolutionStepData().pGetVariablesList()->AddDof(p_variable, p_reaction);
+            mIndex = p_nodal_data->GetSolutionStepData().pGetVariablesList()->AddDof(p_variable, p_reaction);
         } else{
-            mIndex = mpNodalData->GetSolutionStepData().pGetVariablesList()->AddDof(p_variable);
+            mIndex = p_nodal_data->GetSolutionStepData().pGetVariablesList()->AddDof(p_variable);
         }
+
+        mpNodalData = dof_flags.Compose(p_nodal_data);
     }
 
     bool HasReaction() const
     {
-        return (mpNodalData->GetSolutionStepData().pGetVariablesList()->pGetDofReaction(mIndex) != nullptr);
+        [[maybe_unused]] const auto [dof_flags, p_nodal_data] = DofFlags::Decompose(mpNodalData);
+        return p_nodal_data->GetSolutionStepData().pGetVariablesList()->pGetDofReaction(mIndex) != nullptr;
     }
 
     ///@}
@@ -394,6 +431,14 @@ public:
     bool IsActive() const noexcept
     {
         return mIsActive;
+    }
+
+    bool Is(Flags flags) const
+    {
+        KRATOS_TRY
+        [[maybe_unused]] const auto [dof_flags, p_nodal_data] = DofFlags::Decompose(mpNodalData);
+        return dof_flags.Is(flags);
+        KRATOS_CATCH("")
     }
 
     ///@}
@@ -595,7 +640,7 @@ private:
     EquationIdType mEquationId : 48;
 
     /** A pointer to nodal data stored in node which is corresponded to this dof */
-    NodalData* mpNodalData;
+    typename DofFlags::template DirtyPointer<NodalData> mpNodalData;
 
     ///@}
     ///@name Private Operators

--- a/kratos/includes/dof.h
+++ b/kratos/includes/dof.h
@@ -485,9 +485,9 @@ public:
 private:
     /// @brief 3-bit-wide bit array that hides its data in the 3 least significant bits of a pointer.
     /// @details List of supported flags:
-    ///          - @ref MASTER
-    ///          - @ref SLAVE
-    ///          - there is space for one extra flag to support.
+    ///          - @ref MASTER                                      (0b001)
+    ///          - @ref SLAVE                                       (0b010)
+    ///          - there is space for one extra flag to support.    (0b100)
     class DofFlags
     {
     private:
@@ -520,12 +520,6 @@ private:
 
             T* mPointer;
         };
-
-        /// @brief Counterpart of the @ref MASTER @ref Flags "flag".
-        static constexpr DofFlags Master = 0b001;
-
-        /// @brief Counterpart of the @ref SLAVE @ref Flags "flag".
-        static constexpr DofFlags Slave = 0b010;
 
         //constexpr static DofFlags LAST_SUPPORTED_FLAG_GOES_HERE = 0b100;
 


### PR DESCRIPTION
This PR addresses #11916 and adds a restricted set of flags to `Dof`, but unlike #12196, it does not increase its size. The price to pay for it is fewer flags and more complex code.

##

https://github.com/KratosMultiphysics/Kratos/blob/7bf35edc43614e310b5365b8254b6eb3e7761d0c/kratos/includes/dof.h#L439-L452

In total, 4 extra bits can be used in `Dof` without increasing its size:
- the bit size of `Dof` was `1 + 4 + 4 + 6 + 48 + 64 = 127`, which means that one extra bit `mIsActive` could be squeezed into the list of member variables.
- `NodalData` has an alignment requirement of 8 bytes. This means that any valid pointer to a `NodalData` instance must be a multiple of 8 (2³). As a result, the lowest 8 bits of any `NodalData*` **is always 000** and we can exploit this fact to hide 3 bits of some other information (such as 3 flags) there.
