### PR TITLE
[RomApp] Separate Basis Generation and File Writing Processes

### DIFF
--- a/applications/RomApplication/python_scripts/petrov_galerkin_training_utility.py
+++ b/applications/RomApplication/python_scripts/petrov_galerkin_training_utility.py
@@ -101,8 +101,8 @@ class PetrovGalerkinTrainingUtility(object):
 
     def CalculateAndSaveBasis(self, snapshots_matrix = None):
         # Calculate the new basis and save
-        snapshots_basis = self.__CalculateResidualBasis(snapshots_matrix)
-        self.__AppendNewBasisToRomParameters(snapshots_basis)
+        snapshots_basis = self._CalculateResidualBasis(snapshots_matrix)
+        self._AppendNewBasisToRomParameters(snapshots_basis)
 
 
     @classmethod
@@ -118,7 +118,7 @@ class PetrovGalerkinTrainingUtility(object):
         }""")
         return default_settings
 
-    def __CalculateResidualBasis(self, snapshots_matrix):
+    def _CalculateResidualBasis(self, snapshots_matrix):
         if snapshots_matrix is None:
             snapshots_matrix = self._GetSnapshotsMatrix()
         u_left,s_left,_,_ = RandomizedSingularValueDecomposition(COMPUTE_V=False).Calculate(
@@ -135,7 +135,7 @@ class PetrovGalerkinTrainingUtility(object):
 
         return u
 
-    def __AppendNewBasisToRomParameters(self, u):
+    def _AppendNewBasisToRomParameters(self, u):
         petrov_galerkin_number_of_rom_dofs= np.shape(u)[1]
         n_nodal_unknowns = len(self.rom_settings["nodal_unknowns"].GetStringArray())
         petrov_galerkin_nodal_modes = {}

--- a/applications/RomApplication/python_scripts/petrov_galerkin_training_utility.py
+++ b/applications/RomApplication/python_scripts/petrov_galerkin_training_utility.py
@@ -161,11 +161,6 @@ class PetrovGalerkinTrainingUtility(object):
 
         if self.echo_level > 0 : KratosMultiphysics.Logger.PrintInfo("PetrovGalerkinTrainingUtility","\'RomParameters.json\' file updated with HROM weights.")
 
-    def __GetPrettyFloat(self, number):
-        float_format = "{:.12f}"
-        pretty_number = float(float_format.format(number))
-        return pretty_number
-
     def __GetGalerkinBasis(self):
         if self.rom_format == "json":
             with open(self.rom_basis_output_folder / self.rom_basis_output_name.with_suffix(".json"), 'r') as f:
@@ -195,10 +190,3 @@ class PetrovGalerkinTrainingUtility(object):
             snapshots_matrix = np.c_[snapshots_matrix,self.time_step_snapshots_matrix_container[0]]
         return snapshots_matrix
 
-
-    @classmethod
-    def __OrthogonalProjector(self, A, B):
-        # A - B @(B.T @ A)
-        BtA = B.T@A
-        A -= B @ BtA
-        return A

--- a/applications/RomApplication/python_scripts/rom_manager.py
+++ b/applications/RomApplication/python_scripts/rom_manager.py
@@ -245,7 +245,8 @@ class RomManager(object):
                     BasisOutputProcess = process
             SnapshotsMatrix.append(BasisOutputProcess._GetSnapshotsMatrix()) #TODO add a CustomMethod() as a standard method in the Analysis Stage to retrive some solution
         SnapshotsMatrix = np.block(SnapshotsMatrix)
-        BasisOutputProcess._PrintRomBasis(SnapshotsMatrix) #Calling the RomOutput Process for creating the RomParameter.json
+        u = BasisOutputProcess._ComputeSVD(SnapshotsMatrix)
+        BasisOutputProcess._PrintRomBasis(u) #Calling the RomOutput Process for creating the RomParameter.json
 
         return SnapshotsMatrix
 


### PR DESCRIPTION
**📝 Description**
This PR aims to split file generation/updating from the computation of the computationally expensive SVD, ensuring efficiency and scalability.  
As part of our ongoing efforts to optimize our architecture, we plan to introduce a database that manages RightBasis and LeftBasis in future Prs. When the database is in place, only the file updating will be launched if the bases already exist.


**🆕 Changelog**
- Implemented splitting in CalculateRomBasisOutputProcess of SVD and files writting.
- Made  some methods non-private in PetrovGalerkinTrainingUtility to facilitate calls from RomManager.
- Removed unused methods in PetrovGalerkinTrainingUtility.
- Modified RomManager to accommodate the split generation of the left basis and the writting of the files.
