### PR TITLE
New Rom Utility Functions

### DIFF
--- a/applications/RomApplication/custom_python/add_custom_utilities_to_python.cpp
+++ b/applications/RomApplication/custom_python/add_custom_utilities_to_python.cpp
@@ -50,7 +50,10 @@ void AddCustomUtilitiesToPython(pybind11::module& m)
         .def_static("SetHRomComputingModelPart", &RomAuxiliaryUtilities::SetHRomComputingModelPart)
         .def_static("SetHRomComputingModelPartWithNeighbours", &RomAuxiliaryUtilities::SetHRomComputingModelPartWithNeighbours)
         .def_static("SetHRomVolumetricVisualizationModelPart", &RomAuxiliaryUtilities::SetHRomVolumetricVisualizationModelPart)
-        .def_static("GetHRomConditionParentsIds", &RomAuxiliaryUtilities::GetHRomConditionParentsIds)
+        .def_static("GetHRomConditionParentsIds", [](ModelPart& rModelPart, const std::vector<IndexType>& rConditionIds) {
+                return RomAuxiliaryUtilities::GetHRomConditionParentsIds(rModelPart, rConditionIds);})
+        .def_static("GetHRomConditionParentsIds", [](const ModelPart& rModelPart, const std::map<std::string, std::map<IndexType, double>>& rHRomWeights) {
+                return RomAuxiliaryUtilities::GetHRomConditionParentsIds(rModelPart, rHRomWeights);})
         .def_static("GetNodalNeighbouringElementIdsNotInHRom", &RomAuxiliaryUtilities::GetNodalNeighbouringElementIdsNotInHRom)
         .def_static("GetNodalNeighbouringElementIds", &RomAuxiliaryUtilities::GetNodalNeighbouringElementIds)
         .def_static("GetConditionIdsNotInHRomModelPart", &RomAuxiliaryUtilities::GetConditionIdsNotInHRomModelPart)

--- a/applications/RomApplication/custom_python/add_custom_utilities_to_python.cpp
+++ b/applications/RomApplication/custom_python/add_custom_utilities_to_python.cpp
@@ -55,7 +55,11 @@ void AddCustomUtilitiesToPython(pybind11::module& m)
         .def_static("GetHRomConditionParentsIds", [](const ModelPart& rModelPart, const std::map<std::string, std::map<IndexType, double>>& rHRomWeights) {
                 return RomAuxiliaryUtilities::GetHRomConditionParentsIds(rModelPart, rHRomWeights);})
         .def_static("GetNodalNeighbouringElementIdsNotInHRom", &RomAuxiliaryUtilities::GetNodalNeighbouringElementIdsNotInHRom)
-        .def_static("GetNodalNeighbouringElementIds", &RomAuxiliaryUtilities::GetNodalNeighbouringElementIds)
+        .def_static("GetNodalNeighbouringElementIds", [](Kratos::ModelPart& rModelPart, Kratos::ModelPart& rGivenModelPart) {
+                return Kratos::RomAuxiliaryUtilities::GetNodalNeighbouringElementIds(rModelPart, rGivenModelPart);})
+        .def_static("GetNodalNeighbouringElementIds", [](Kratos::ModelPart& rModelPart, const std::vector<Kratos::IndexType>& rNodeIds, bool retrieveSingleNeighbour) {
+                return Kratos::RomAuxiliaryUtilities::GetNodalNeighbouringElementIds(rModelPart, rNodeIds, retrieveSingleNeighbour);})
+        .def_static("GetNodalNeighbouringConditionIds", &RomAuxiliaryUtilities::GetNodalNeighbouringConditionIds)
         .def_static("GetConditionIdsNotInHRomModelPart", &RomAuxiliaryUtilities::GetConditionIdsNotInHRomModelPart)
         .def_static("GetElementIdsNotInHRomModelPart", &RomAuxiliaryUtilities::GetElementIdsNotInHRomModelPart)
         .def_static("GetHRomMinimumConditionsIds", &RomAuxiliaryUtilities::GetHRomMinimumConditionsIds)

--- a/applications/RomApplication/custom_utilities/rom_auxiliary_utilities.cpp
+++ b/applications/RomApplication/custom_utilities/rom_auxiliary_utilities.cpp
@@ -516,7 +516,7 @@ std::vector<IndexType> RomAuxiliaryUtilities::GetHRomConditionParentsIds(
         // Add the neighbour elements to new_element_ids_set
         for (size_t i = 0; i < r_neigh_elements.size(); ++i) {
             const auto& r_elem = r_neigh_elements[i];
-            parent_ids_set.insert(r_elem.Id() - 1);
+            parent_ids_set.insert(r_elem.Id() - 1); //FIXME: FIX THE + 1 --> WE NEED TO WRITE REAL IDS IN THE WEIGHTS!!
             break;
         }
     }
@@ -570,7 +570,7 @@ std::vector<IndexType> RomAuxiliaryUtilities::GetNodalNeighbouringElementIds(
         // Add the neighbour elements to new_element_ids_set
         for (size_t i = 0; i < r_neigh.size(); ++i) {
             const auto& r_elem = r_neigh[i];
-            new_element_ids_set.insert(r_elem.Id() - 1);
+            new_element_ids_set.insert(r_elem.Id() - 1); //FIXME: FIX THE + 1 --> WE NEED TO WRITE REAL IDS IN THE WEIGHTS!!
         }
     }
 
@@ -600,7 +600,7 @@ std::vector<IndexType> RomAuxiliaryUtilities::GetNodalNeighbouringElementIds(
         // Add the neighbour elements to new_element_ids_set
         for (size_t i = 0; i < r_neigh_elements.size(); ++i) {
             const auto& r_elem = r_neigh_elements[i];
-            new_entity_ids_set.insert(r_elem.Id() - 1);
+            new_entity_ids_set.insert(r_elem.Id() - 1); //FIXME: FIX THE + 1 --> WE NEED TO WRITE REAL IDS IN THE WEIGHTS!!
             if (RetrieveSingleNeighbour) {
                 break; // Break if only one neighbour should be retrieved
             }
@@ -633,7 +633,7 @@ std::vector<IndexType> RomAuxiliaryUtilities::GetNodalNeighbouringConditionIds(
         // Add the neighbour elements to new_element_ids_set
         for (size_t i = 0; i < r_neigh_elements.size(); ++i) {
             const auto& r_cond = r_neigh_elements[i];
-            new_condition_ids_set.insert(r_cond.Id() - 1);
+            new_condition_ids_set.insert(r_cond.Id() - 1); //FIXME: FIX THE + 1 --> WE NEED TO WRITE REAL IDS IN THE WEIGHTS!!
             if (RetrieveSingleNeighbour) {
                 break; // Break if only one neighbour should be retrieved
             }
@@ -657,8 +657,8 @@ std::vector<IndexType> RomAuxiliaryUtilities::GetElementIdsNotInHRomModelPart(
         IndexType element_id = r_elem.Id();
 
         // Check if the element is already added
-        if (r_elem_weights.find(element_id - 1) == r_elem_weights.end()) {
-            new_element_ids.push_back(element_id - 1);
+        if (r_elem_weights.find(element_id - 1) == r_elem_weights.end()) { //FIXME: FIX THE + 1 --> WE NEED TO WRITE REAL IDS IN THE WEIGHTS!!
+            new_element_ids.push_back(element_id - 1); //FIXME: FIX THE + 1 --> WE NEED TO WRITE REAL IDS IN THE WEIGHTS!!
         }
     }
 
@@ -677,8 +677,8 @@ std::vector<IndexType> RomAuxiliaryUtilities::GetConditionIdsNotInHRomModelPart(
         IndexType condition_id = r_cond.Id();
 
         // Check if the condition is already added
-        if (r_cond_weights.find(condition_id - 1) == r_cond_weights.end()) {
-            new_condition_ids.push_back(condition_id - 1);
+        if (r_cond_weights.find(condition_id - 1) == r_cond_weights.end()) { //FIXME: FIX THE + 1 --> WE NEED TO WRITE REAL IDS IN THE WEIGHTS!!
+            new_condition_ids.push_back(condition_id - 1); //FIXME: FIX THE + 1 --> WE NEED TO WRITE REAL IDS IN THE WEIGHTS!!
         }
     }
 
@@ -691,7 +691,7 @@ std::vector<IndexType> RomAuxiliaryUtilities::GetElementIdsInModelPart(
     std::vector<IndexType> element_ids;
 
     for (const auto& r_elem : rModelPart.Elements()) {
-        element_ids.push_back(r_elem.Id() - 1);
+        element_ids.push_back(r_elem.Id() - 1); //FIXME: FIX THE + 1 --> WE NEED TO WRITE REAL IDS IN THE WEIGHTS!!
     }
     return element_ids;
 }
@@ -702,7 +702,7 @@ std::vector<IndexType> RomAuxiliaryUtilities::GetConditionIdsInModelPart(
     std::vector<IndexType> condition_ids;
 
     for (const auto& r_cond : rModelPart.Conditions()) {
-        condition_ids.push_back(r_cond.Id() - 1);
+        condition_ids.push_back(r_cond.Id() - 1); //FIXME: FIX THE + 1 --> WE NEED TO WRITE REAL IDS IN THE WEIGHTS!!
     }
     return condition_ids;
 }
@@ -765,7 +765,7 @@ void RomAuxiliaryUtilities::RecursiveHRomMinimumConditionIds(
 
         // If minimum condition is missing, add the first condition as minimum one
         if (!has_minimum_condition) {
-            rMinimumConditionsIds.push_back(rModelPart.ConditionsBegin()->Id() - 1); //FIXME: FIX THE - 1
+            rMinimumConditionsIds.push_back(rModelPart.ConditionsBegin()->Id() - 1); //FIXME: FIX THE + 1
         }
 
         // Recursively check the current modelpart submodelparts

--- a/applications/RomApplication/custom_utilities/rom_auxiliary_utilities.cpp
+++ b/applications/RomApplication/custom_utilities/rom_auxiliary_utilities.cpp
@@ -580,6 +580,72 @@ std::vector<IndexType> RomAuxiliaryUtilities::GetNodalNeighbouringElementIds(
     return new_element_ids;
 }
 
+std::vector<IndexType> RomAuxiliaryUtilities::GetNodalNeighbouringElementIds(
+    ModelPart& rModelPart,
+    const std::vector<IndexType>& rNodeIds,
+    bool RetrieveSingleNeighbour)
+{
+    std::unordered_set<IndexType> new_entity_ids_set;
+
+    // Execute process to find neighboring entities
+    FindGlobalNodalEntityNeighboursProcess<ModelPart::ElementsContainerType> find_nodal_elements_neighbours_process(rModelPart);
+    find_nodal_elements_neighbours_process.Execute();
+
+    // Iterate over the given node IDs
+    for (const auto nodeId : rNodeIds) {
+        auto& r_node = rModelPart.GetNode(nodeId);
+
+        // Add neighboring elements' IDs to the set
+        const auto& r_neigh_elements = r_node.GetValue(NEIGHBOUR_ELEMENTS);
+        // Add the neighbour elements to new_element_ids_set
+        for (size_t i = 0; i < r_neigh_elements.size(); ++i) {
+            const auto& r_elem = r_neigh_elements[i];
+            new_entity_ids_set.insert(r_elem.Id() - 1);
+            if (RetrieveSingleNeighbour) {
+                break; // Break if only one neighbour should be retrieved
+            }
+        }
+    }
+
+    // Convert the unordered_set to a vector
+    std::vector<IndexType> new_element_ids(new_entity_ids_set.begin(), new_entity_ids_set.end());
+
+    return new_element_ids;
+}
+
+std::vector<IndexType> RomAuxiliaryUtilities::GetNodalNeighbouringConditionIds(
+    ModelPart& rModelPart,
+    const std::vector<IndexType>& rNodeIds,
+    bool RetrieveSingleNeighbour)
+{
+    std::unordered_set<IndexType> new_condition_ids_set;
+
+    // Execute process to find neighboring entities
+    FindGlobalNodalEntityNeighboursProcess<ModelPart::ConditionsContainerType> find_nodal_conditions_neighbours_process(rModelPart);
+    find_nodal_conditions_neighbours_process.Execute();
+
+    // Iterate over the given node IDs
+    for (const auto nodeId : rNodeIds) {
+        auto& r_node = rModelPart.GetNode(nodeId);
+
+        // Add neighboring elements' IDs to the set
+        const auto& r_neigh_elements = r_node.GetValue(NEIGHBOUR_CONDITIONS);
+        // Add the neighbour elements to new_element_ids_set
+        for (size_t i = 0; i < r_neigh_elements.size(); ++i) {
+            const auto& r_cond = r_neigh_elements[i];
+            new_condition_ids_set.insert(r_cond.Id() - 1);
+            if (RetrieveSingleNeighbour) {
+                break; // Break if only one neighbour should be retrieved
+            }
+        }
+    }
+
+    // Convert the unordered_set to a vector
+    std::vector<IndexType> new_condition_ids(new_condition_ids_set.begin(), new_condition_ids_set.end());
+
+    return new_condition_ids;
+}
+
 std::vector<IndexType> RomAuxiliaryUtilities::GetElementIdsNotInHRomModelPart(
     const ModelPart& rModelPartWithElementsToInclude,
     std::map<std::string, std::map<IndexType, double>>& rHRomWeights)

--- a/applications/RomApplication/custom_utilities/rom_auxiliary_utilities.h
+++ b/applications/RomApplication/custom_utilities/rom_auxiliary_utilities.h
@@ -126,6 +126,21 @@ public:
         const ModelPart& rModelPart,
         const std::map<std::string, std::map<IndexType, double>>& rHRomWeights);
 
+
+    /**
+     * @brief Finds the parent elements for specified condition IDs and decrements their IDs for zero-based indexing.
+     * This version executes a process to compute nodal element neighbours for the entire model part, ensuring
+     * that each condition's neighbours are up-to-date before retrieving parent element IDs.
+     *
+     * @param rModelPart Model part from which to find parent elements, which may be modified due to neighbour computation.
+     * @param rConditionIds A vector containing condition IDs for which parents will be identified.
+     * @return std::vector<IndexType> List of unique element IDs decremented by one (for zero-based indexing), corresponding to the parent elements.
+     */
+    static std::vector<IndexType> GetHRomConditionParentsIds(
+        ModelPart& rModelPart,
+        const std::vector<IndexType>& rConditionIds);
+
+
     /**
      * @brief Retrieve the decremented (-1 to account for numpy indexing) IDs of elements neighboring nodes in a given sub-model part but not present in HRom weights.
      *
@@ -266,20 +281,20 @@ public:
         const std::unordered_map<Kratos::VariableData::KeyType, Matrix::size_type>& rVarToRowMapping);
 
     /**
-     * @brief Obtain the JPhi elemental matrix for a particular element. 
+     * @brief Obtain the JPhi elemental matrix for a particular element.
      * JPhi represents the projection of the Jacobian onto the ROM_BASIS.
      * @param rJPhiElemental The matrix to store the result in. Must have the appropriate size already.
      * @param rDofs The set of degrees of freedom (DoFs) of the element.
      * @param rJPhi The JPhi matrix, from which rows are extracted according to the equation ID of each DoF.
-     * 
-     * This function loops over all the DoFs for the given element. For each DoF, it uses its equation ID to extract a 
+     *
+     * This function loops over all the DoFs for the given element. For each DoF, it uses its equation ID to extract a
      * corresponding row from the rJPhi matrix, which is then stored in the corresponding row of rJPhiElemental.
      */
     static void GetJPhiElemental(
         Matrix &rJPhiElemental,
         const Element::DofsVectorType& rDofs,
         const Matrix &rJPhi);
-        
+
     ///@}
 
     private:

--- a/applications/RomApplication/custom_utilities/rom_auxiliary_utilities.h
+++ b/applications/RomApplication/custom_utilities/rom_auxiliary_utilities.h
@@ -178,6 +178,58 @@ public:
         ModelPart& rGivenModelPart);
 
     /**
+     * @brief Retrieve the IDs of elements neighboring specified nodes in a given model part.
+     *
+     * This function iterates over a list of node IDs and collects the IDs of elements that
+     * neighbor these nodes. The neighboring elements are determined using the 'NEIGHBOUR_ELEMENTS'
+     * values attached to each node. The function ensures that each element ID
+     * is unique, thus avoiding duplicates in the returned vector. It's important to note
+     * that this function assumes that the 'NEIGHBOUR_ELEMENTS' values are already
+     * computed for the nodes in the model part. The boolean flag 'RetrieveSingleNeighbour' indicates whether to retrieve
+     * all neighboring elements or only a single neighbor per node.
+     *
+     * The function is particularly useful in scenarios where it's necessary to find all elements
+     * that are directly connected to a certain subset of nodes within a model part. This can be essential in
+     * ROM (Reduced Order Modelling) applications or any other application requiring localized information around
+     * a set of nodes.
+     *
+     * @param rModelPart The model part which contains all the elements.
+     * @param rNodeIds A vector of node IDs for which neighboring elements should be fetched.
+     * @param RetrieveSingleNeighbour Indicates whether to retrieve all neighbors or only a single neighbor per node.
+     * @return std::vector<IndexType> A list of unique IDs of neighboring elements.
+     */
+    static std::vector<IndexType> GetNodalNeighbouringElementIds(
+        ModelPart& rModelPart,
+        const std::vector<IndexType>& rNodeIds,
+        bool RetrieveSingleNeighbour);
+
+    /**
+     * @brief Retrieve the IDs of conditions neighboring specified nodes in a given model part.
+     *
+     * This function iterates over a list of node IDs and collects the IDs of conditions that
+     * neighbor these nodes. The neighboring conditions are determined using the 'NEIGHBOUR_CONDITIONS'
+     * values attached to each node. The function ensures that each condition ID
+     * is unique, thus avoiding duplicates in the returned vector. It's important to note
+     * that this function assumes that the 'NEIGHBOUR_CONDITIONS' values are already
+     * computed for the nodes in the model part. The boolean flag 'retrieveSingleNeighbour' indicates whether to retrieve
+     * all neighboring conditions or only a single neighbor per node.
+     *
+     * The function is particularly useful in scenarios where it's necessary to find all conditions
+     * that are directly connected to a certain subset of nodes within a model part. This can be essential in
+     * ROM (Reduced Order Modelling) applications or any other application requiring localized information around
+     * a set of nodes.
+     *
+     * @param rModelPart The model part which contains all the conditions.
+     * @param rNodeIds A vector of node IDs for which neighboring conditions should be fetched.
+     * @param retrieveSingleNeighbour Indicates whether to retrieve all neighbors or only a single neighbor per node.
+     * @return std::vector<IndexType> A list of unique IDs of neighboring conditions.
+     */
+    static std::vector<IndexType> GetNodalNeighbouringConditionIds(
+        ModelPart& rModelPart,
+        const std::vector<IndexType>& rNodeIds,
+        bool retrieveSingleNeighbour);
+
+    /**
      * @brief Identifies condition decremented (-1 to account for numpy indexing) IDs from a given ModelPart that are not in the HROM weights
      * This function iterates through the conditions in the provided ModelPart, checks if their IDs exist in the HROM weights,
      * and includes them in a list if they are missing. The decremented (-1 to account for numpy indexing) IDs of the absent conditions are returned.


### PR DESCRIPTION
## PR Description

This PR introduces a set of new utility functions to the `RomAuxiliaryUtilities` class.

### Description
1. **GetHRomConditionParentsIds**
   - **Purpose**: Retrieves the parent elements of specified conditions, vital for constructing reduced order models where maintaining the parent element of a selected condition is necessary. This extension allows for fetching parent elements for any list of condition ids, whereas previously this was only possible for a map containing the original HROM conditions and elements weights.

2. **GetNodalNeighbouringElementIds**
   - **Purpose**: Fetches element IDs neighboring specified nodes. This extension allows for fetching neighboring elements for any list of nodes, whereas previously this was only possible for elements within a given model part.

3. **GetNodalNeighbouringConditionIds**
   - **Purpose**: Functions similarly to the `GetNodalNeighbouringElementIds` but targets conditions adjacent to given nodes.

These utilities were particularly valuable for cosimulation scenarios where the transfer on the interface becomes a challenge.
