### PR TITLE
Kratos rom nonconverged projected residuals

### DIFF
--- a/applications/RomApplication/custom_python/add_custom_strategies_to_python.cpp
+++ b/applications/RomApplication/custom_python/add_custom_strategies_to_python.cpp
@@ -71,6 +71,7 @@ void  AddCustomStrategiesToPython(pybind11::module& m)
 
     py::class_<GlobalROMBuilderAndSolverType, typename GlobalROMBuilderAndSolverType::Pointer, ResidualBasedBlockBuilderAndSolverType>(m, "GlobalROMBuilderAndSolver")
         .def(py::init< LinearSolverType::Pointer, Parameters>() )
+        .def("GetNonConvergedProjectedResiduals", &GlobalROMBuilderAndSolverType::GetNonConvergedProjectedResiduals)
         ;
 
     typedef LeastSquaresPetrovGalerkinROMBuilderAndSolver<SparseSpaceType, LocalSpaceType, LinearSolverType> LeastSquaresPetrovGalerkinROMBuilderAndSolverType;

--- a/applications/RomApplication/custom_strategies/global_petrov_galerkin_rom_builder_and_solver.h
+++ b/applications/RomApplication/custom_strategies/global_petrov_galerkin_rom_builder_and_solver.h
@@ -193,7 +193,9 @@ public:
         KRATOS_CATCH("");
     }
 
-    void InitializeRomResidualsUtility(ModelPart& rModelPart, typename TSchemeType::Pointer pScheme) {
+    void InitializeRomResidualsUtility(ModelPart& rModelPart,
+        typename TSchemeType::Pointer pScheme)
+    {
         // Initialize Rom Residuals Utility
         if (BaseType::mStoreNonConvergedProjectedResiduals) {
             Parameters ResidualsUtilityParameters;

--- a/applications/RomApplication/custom_strategies/global_petrov_galerkin_rom_builder_and_solver.h
+++ b/applications/RomApplication/custom_strategies/global_petrov_galerkin_rom_builder_and_solver.h
@@ -143,6 +143,71 @@ public:
     ///@name Operations
     ///@{
 
+    void SetUpDofSet(
+        typename TSchemeType::Pointer pScheme,
+        ModelPart &rModelPart) override
+    {
+        KRATOS_TRY;
+
+        KRATOS_INFO_IF("GlobalPetrovGalerkinROMBuilderAndSolver", (this->GetEchoLevel() > 1)) << "Setting up the dofs" << std::endl;
+        KRATOS_INFO_IF("GlobalPetrovGalerkinROMBuilderAndSolver", (this->GetEchoLevel() > 2)) << "Number of threads" << ParallelUtilities::GetNumThreads() << "\n" << std::endl;
+        KRATOS_INFO_IF("GlobalPetrovGalerkinROMBuilderAndSolver", (this->GetEchoLevel() > 2)) << "Initializing element loop" << std::endl;
+
+        // Get model part data
+        if (BaseType::mHromWeightsInitialized == false) {
+            BaseType::InitializeHROMWeights(rModelPart);
+        }
+
+        auto dof_queue = BaseType::ExtractDofSet(pScheme, rModelPart);
+
+        // Fill a sorted auxiliary array of with the DOFs set
+        KRATOS_INFO_IF("GlobalPetrovGalerkinROMBuilderAndSolver", (this->GetEchoLevel() > 2)) << "Initializing ordered array filling\n" << std::endl;
+        auto dof_array = BaseType::SortAndRemoveDuplicateDofs(dof_queue);
+
+        // Update base builder and solver DOFs array and set corresponding flag
+        BaseBuilderAndSolverType::GetDofSet().swap(dof_array);
+        BaseBuilderAndSolverType::SetDofSetIsInitializedFlag(true);
+
+        // Function to initialize RomResidualsUtility
+        InitializeRomResidualsUtility(rModelPart, pScheme);
+
+        // Throw an exception if there are no DOFs involved in the analysis
+        KRATOS_ERROR_IF(BaseBuilderAndSolverType::GetDofSet().size() == 0) << "No degrees of freedom!" << std::endl;
+        KRATOS_INFO_IF("GlobalPetrovGalerkinROMBuilderAndSolver", (this->GetEchoLevel() > 2)) << "Number of degrees of freedom:" << BaseBuilderAndSolverType::GetDofSet().size() << std::endl;
+        KRATOS_INFO_IF("GlobalPetrovGalerkinROMBuilderAndSolver", (this->GetEchoLevel() > 2)) << "Finished setting up the dofs" << std::endl;
+
+#ifdef KRATOS_DEBUG
+        // If reactions are to be calculated, we check if all the dofs have reactions defined
+        if (BaseBuilderAndSolverType::GetCalculateReactionsFlag())
+        {
+            for (const auto& r_dof: BaseBuilderAndSolverType::GetDofSet())
+            {
+                KRATOS_ERROR_IF_NOT(r_dof.HasReaction())
+                    << "Reaction variable not set for the following :\n"
+                    << "Node : " << r_dof.Id() << '\n'
+                    << "Dof  : " << r_dof      << '\n'
+                    << "Not possible to calculate reactions." << std::endl;
+            }
+        }
+#endif
+        KRATOS_CATCH("");
+    }
+
+    void InitializeRomResidualsUtility(ModelPart& rModelPart, typename TSchemeType::Pointer pScheme) {
+        // Initialize Rom Residuals Utility
+        if (BaseType::mStoreNonConvergedProjectedResiduals) {
+            Parameters ResidualsUtilityParameters;
+            int number_of_rom_dofs = static_cast<int>(BaseType::GetNumberOfROMModes());  // Convert size_t to int if necessary
+            int petrov_galerkin_number_of_rom_dofs = static_cast<int>(mNumberOfPetrovGalerkinRomModes);  // Convert size_t to int if necessary
+            ResidualsUtilityParameters.AddEmptyValue("number_of_rom_dofs").SetInt(number_of_rom_dofs);
+            ResidualsUtilityParameters.AddEmptyValue("petrov_galerkin_number_of_rom_dofs").SetInt(petrov_galerkin_number_of_rom_dofs);
+            ResidualsUtilityParameters.AddStringArray("nodal_unknowns", BaseType::mNodalUnknowns);
+
+            BaseType::mRomResidualsUtility = std::make_unique<RomResidualsUtility>(rModelPart, ResidualsUtilityParameters, pScheme);
+
+        }
+    }
+
     /**
      * Builds and projects the reduced system of equations
      */
@@ -220,6 +285,27 @@ public:
         // Compute the matrix multiplication
         mEigenRomA = eigen_mPsiGlobal.transpose() * eigen_rA_times_mPhiGlobal; //TODO: Make it in parallel.
         mEigenRomB = eigen_mPsiGlobal.transpose() * eigen_rb; //TODO: Make it in parallel.
+
+        // Store (append) Non-Converged Projected Residuals (HROM training)
+        if (BaseType::mStoreNonConvergedProjectedResiduals) {
+            StoreAndAppendNonConvergedProjectedResiduals();
+        }
+
+        KRATOS_CATCH("")
+    }
+
+    void StoreAndAppendNonConvergedProjectedResiduals() {
+        KRATOS_TRY
+
+        Matrix current_non_converged_projected_residual = BaseType::mRomResidualsUtility->GetProjectedResidualsOntoPsi();
+
+        if (BaseType::mNonConvergedProjectedResiduals.size1() == 0 && BaseType::mNonConvergedProjectedResiduals.size2() == 0) {
+            // Initialize the matrix with the first set of data
+            BaseType::mNonConvergedProjectedResiduals = current_non_converged_projected_residual;
+        } else {
+            // Append the new data horizontally
+            BaseType::AppendMatrixHorizontally(BaseType::mNonConvergedProjectedResiduals, current_non_converged_projected_residual);
+        }
 
         KRATOS_CATCH("")
     }

--- a/applications/RomApplication/custom_strategies/global_rom_builder_and_solver.h
+++ b/applications/RomApplication/custom_strategies/global_rom_builder_and_solver.h
@@ -806,6 +806,11 @@ protected:
         mEigenRomA = eigen_mPhiGlobal.transpose() * eigen_rA_times_mPhiGlobal; //TODO: Make it in parallel.
         mEigenRomB = eigen_mPhiGlobal.transpose() * eigen_rb; //TODO: Make it in parallel.
 
+        // Store (append) Non-Converged Projected Residuals (HROM training)
+        if (mStoreNonConvergedProjectedResiduals) {
+            StoreAndAppendNonConvergedProjectedResiduals();
+        }
+
         KRATOS_CATCH("")
     }
 
@@ -821,18 +826,6 @@ protected:
         KRATOS_TRY
 
         RomSystemVectorType dxrom(GetNumberOfROMModes());
-
-        // Store (append) Non-Converged Projected Residuals
-        if (mStoreNonConvergedProjectedResiduals) {
-            Matrix current_non_converged_projected_residual = mRomResidualsUtility->GetProjectedResidualsOntoPhi();
-            if (mNonConvergedProjectedResiduals.size1() == 0 && mNonConvergedProjectedResiduals.size2() == 0) {
-                // Initialize the matrix with the first set of data
-                mNonConvergedProjectedResiduals = current_non_converged_projected_residual;
-            } else {
-                // Append the new data horizontally
-                AppendMatrixHorizontally(mNonConvergedProjectedResiduals, current_non_converged_projected_residual);
-            }
-        }
 
         const auto solving_timer = BuiltinTimer();
 
@@ -851,6 +844,22 @@ protected:
         const auto backward_projection_timer = BuiltinTimer();
         ProjectToFineBasis(dxrom, rModelPart, rDx);
         KRATOS_INFO_IF("GlobalROMBuilderAndSolver", (this->GetEchoLevel() > 0)) << "Project to fine basis time: " << backward_projection_timer.ElapsedSeconds() << std::endl;
+
+        KRATOS_CATCH("")
+    }
+
+    void StoreAndAppendNonConvergedProjectedResiduals() {
+        KRATOS_TRY
+
+        Matrix current_non_converged_projected_residual = mRomResidualsUtility->GetProjectedResidualsOntoPhi();
+
+        if (mNonConvergedProjectedResiduals.size1() == 0 && mNonConvergedProjectedResiduals.size2() == 0) {
+            // Initialize the matrix with the first set of data
+            mNonConvergedProjectedResiduals = current_non_converged_projected_residual;
+        } else {
+            // Append the new data horizontally
+            AppendMatrixHorizontally(mNonConvergedProjectedResiduals, current_non_converged_projected_residual);
+        }
 
         KRATOS_CATCH("")
     }

--- a/applications/RomApplication/custom_strategies/global_rom_builder_and_solver.h
+++ b/applications/RomApplication/custom_strategies/global_rom_builder_and_solver.h
@@ -402,6 +402,10 @@ public:
         KRATOS_CATCH("")
     }
 
+    const Kratos::Matrix& GetNonConvergedProjectedResiduals() {
+        return mNonConvergedProjectedResiduals;
+    }
+
     Parameters GetDefaultParameters() const override
     {
         Parameters default_parameters = Parameters(R"(

--- a/applications/RomApplication/custom_strategies/lspg_rom_builder_and_solver.h
+++ b/applications/RomApplication/custom_strategies/lspg_rom_builder_and_solver.h
@@ -397,17 +397,17 @@ public:
     }
 
     // Function to convert Eigen matrix to Kratos matrix
-    Kratos::Matrix ConvertEigenToKratos(const EigenDynamicMatrix& eigenMatrix) {
-        std::size_t rows = eigenMatrix.rows();
-        std::size_t cols = eigenMatrix.cols();
-        Kratos::Matrix kratosMatrix(rows, cols);
+    Kratos::Matrix ConvertEigenToKratos(const EigenDynamicMatrix& rEigenMatrix) {
+        std::size_t rows = rEigenMatrix.rows();
+        std::size_t cols = rEigenMatrix.cols();
+        Kratos::Matrix kratos_matrix(rows, cols);
 
         for (std::size_t i = 0; i < rows; ++i) {
             for (std::size_t j = 0; j < cols; ++j) {
-                kratosMatrix(i, j) = eigenMatrix(i, j);
+                kratos_matrix(i, j) = rEigenMatrix(i, j);
             }
         }
-        return kratosMatrix;
+        return kratos_matrix;
     }
 
     void WriteReactionDataToMatrixMarket(

--- a/applications/RomApplication/custom_strategies/lspg_rom_builder_and_solver.h
+++ b/applications/RomApplication/custom_strategies/lspg_rom_builder_and_solver.h
@@ -172,6 +172,9 @@ public:
         BaseType::GetDofSet().swap(dof_array);
         BaseType::SetDofSetIsInitializedFlag(true);
 
+        // Initialize Rom Residuals Utility
+        BaseType::InitializeRomResidualsUtility(rModelPart, pScheme);
+
         // Throw an exception if there are no DOFs involved in the analysis
         KRATOS_ERROR_IF(BaseType::GetDofSet().size() == 0) << "No degrees of freedom!" << std::endl;
         KRATOS_INFO_IF("GlobalLeastSquaresPetrovGalerkinROMBuilderAndSolver", (BaseType::GetEchoLevel() > 2)) << "Number of degrees of freedom:" << BaseType::GetDofSet().size() << std::endl;
@@ -448,7 +451,7 @@ public:
             }
         }
 
-
+        // FIXME: This if is not doing anything as they both solve using a QR decomposition. Change this.
         if (mSolvingTechnique == "normal_equations"){
             BaseType::SolveROM(rModelPart, mEigenRomA, mEigenRomB, Dx);
         }

--- a/applications/RomApplication/python_scripts/hrom_training_utility.py
+++ b/applications/RomApplication/python_scripts/hrom_training_utility.py
@@ -166,9 +166,6 @@ class HRomTrainingUtility(object):
         if self.echo_level > 0 : KratosMultiphysics.Logger.PrintInfo("HRomTrainingUtility","Generating matrix of projected residuals.")
         if (self.projection_strategy=="galerkin"):
                 res_mat = self.__rom_residuals_utility.GetProjectedResidualsOntoPhi()
-                if self.store_non_converged_projected_residuals:
-                    ncp_res_mat = np.array(self.solver._GetBuilderAndSolver().GetNonConvergedProjectedResiduals())
-                    res_mat = np.hstack((res_mat, ncp_res_mat))
         elif (self.projection_strategy=="lspg"):
                 jacobian_phi_product = self.GetJacobianPhiMultiplication(computing_model_part)
                 res_mat = self.__rom_residuals_utility.GetProjectedResidualsOntoJPhi(jacobian_phi_product)
@@ -177,6 +174,12 @@ class HRomTrainingUtility(object):
         else:
             err_msg = f"Projection strategy \'{self.projection_strategy}\' for HROM is not supported."
             raise Exception(err_msg)
+
+        # Append non converged projected residuals
+        if self.store_non_converged_projected_residuals:
+            ncp_res_mat = np.array(self.solver._GetBuilderAndSolver().GetNonConvergedProjectedResiduals())
+            res_mat = np.hstack((res_mat, ncp_res_mat))
+            print(res_mat.shape)
 
         np_res_mat = np.array(res_mat, copy=False)
         self.time_step_residual_matrix_container.append(np_res_mat)

--- a/applications/RomApplication/python_scripts/hrom_training_utility.py
+++ b/applications/RomApplication/python_scripts/hrom_training_utility.py
@@ -48,6 +48,7 @@ class HRomTrainingUtility(object):
         self.include_condition_parents = settings["include_condition_parents"].GetBool()
         self.num_of_right_rom_dofs = self.rom_settings["number_of_rom_dofs"].GetInt()
         self.constraint_sum_weights =  settings["constraint_sum_weights"].GetBool()
+        self.store_non_converged_projected_residuals = settings["store_non_converged_projected_residuals"].GetBool()
 
         # Retrieve list of model parts from settings
         self.include_conditions_model_parts_list = settings["include_conditions_model_parts_list"].GetStringArray()
@@ -283,7 +284,8 @@ class HRomTrainingUtility(object):
             "include_nodal_neighbouring_elements_model_parts_list":[],
             "include_minimum_condition": false,
             "include_condition_parents": false,
-            "constraint_sum_weights": true
+            "constraint_sum_weights": true,
+            "store_non_converged_projected_residuals": false
         }""")
         return default_settings
 

--- a/applications/RomApplication/python_scripts/hrom_training_utility.py
+++ b/applications/RomApplication/python_scripts/hrom_training_utility.py
@@ -166,6 +166,9 @@ class HRomTrainingUtility(object):
         if self.echo_level > 0 : KratosMultiphysics.Logger.PrintInfo("HRomTrainingUtility","Generating matrix of projected residuals.")
         if (self.projection_strategy=="galerkin"):
                 res_mat = self.__rom_residuals_utility.GetProjectedResidualsOntoPhi()
+                if self.store_non_converged_projected_residuals:
+                    ncp_res_mat = np.array(self.solver._GetBuilderAndSolver().GetNonConvergedProjectedResiduals())
+                    res_mat = np.hstack((res_mat, ncp_res_mat))
         elif (self.projection_strategy=="lspg"):
                 jacobian_phi_product = self.GetJacobianPhiMultiplication(computing_model_part)
                 res_mat = self.__rom_residuals_utility.GetProjectedResidualsOntoJPhi(jacobian_phi_product)

--- a/applications/RomApplication/python_scripts/hrom_training_utility.py
+++ b/applications/RomApplication/python_scripts/hrom_training_utility.py
@@ -179,7 +179,6 @@ class HRomTrainingUtility(object):
         if self.store_non_converged_projected_residuals:
             ncp_res_mat = np.array(self.solver._GetBuilderAndSolver().GetNonConvergedProjectedResiduals())
             res_mat = np.hstack((res_mat, ncp_res_mat))
-            print(res_mat.shape)
 
         np_res_mat = np.array(res_mat, copy=False)
         self.time_step_residual_matrix_container.append(np_res_mat)

--- a/applications/RomApplication/python_scripts/new_python_solvers_wrapper_rom.py
+++ b/applications/RomApplication/python_scripts/new_python_solvers_wrapper_rom.py
@@ -51,16 +51,24 @@ def CreateSolverByParameters(model, solver_settings, parallelism, analysis_stage
     # Note that an auxiliary Kratos model is also created to avoid creating the main_model_part in the prototype class instance
     #TODO: We could do the same exercise as we do in the stage (module_name to ClassName equal to ModuleName if we standarize the solver names)
     aux_solver_settings = solver_settings.Clone()
-    aux_solver_settings.RemoveValue("rom_settings")
-    aux_solver_settings.RemoveValue("projection_strategy")
-    aux_solver_settings.RemoveValue("assembling_strategy")
-    aux_solver_settings.RemoveValue("monotonicity_preserving")
+    # List of settings keys to remove
+    keys_to_remove = [
+        "rom_settings", "projection_strategy", "assembling_strategy", "monotonicity_preserving"
+    ]
+
+    # Use the utility function to remove multiple settings
+    RemoveSettings(aux_solver_settings, keys_to_remove)
     aux_base_solver_instance = solvers_wrapper_module.CreateSolverByParameters(KratosMultiphysics.Model(), aux_solver_settings, parallelism)
 
     # Create the ROM solver from the base solver
     rom_solver_instance = rom_solver.CreateSolver(type(aux_base_solver_instance), model, solver_settings)
 
     return rom_solver_instance
+
+def RemoveSettings(settings, keys_to_remove):
+    for key in keys_to_remove:
+        if settings.Has(key):
+            settings.RemoveValue(key)
 
 def CreateSolver(model, custom_settings):
 

--- a/applications/RomApplication/python_scripts/rom_analysis.py
+++ b/applications/RomApplication/python_scripts/rom_analysis.py
@@ -95,7 +95,7 @@ def CreateRomAnalysisInstance(cls, global_model, parameters):
             self.project_parameters["solver_settings"].AddString("assembling_strategy",self.assembling_strategy)
 
             # Add HROM Settings (e.g. hrom_settings)
-            self.project_parameters["solver_settings"]["rom_settings"]["rom_bns_settings"].AddBool("store_non_converged_projected_residuals", self.rom_parameters["hrom_train"]["store_non_converged_projected_residuals"].GetBool()) if self.rom_parameters["store_non_converged_projected_residuals"].Has("store_non_converged_projected_residuals") else False
+            self.project_parameters["solver_settings"]["rom_settings"]["rom_bns_settings"].AddBool("store_non_converged_projected_residuals", self.rom_parameters["hrom_settings"]["store_non_converged_projected_residuals"].GetBool()) if self.rom_parameters["hrom_settings"].Has("store_non_converged_projected_residuals") else False
 
             # Create the ROM solver
             return new_python_solvers_wrapper_rom.CreateSolver(

--- a/applications/RomApplication/python_scripts/rom_analysis.py
+++ b/applications/RomApplication/python_scripts/rom_analysis.py
@@ -94,6 +94,9 @@ def CreateRomAnalysisInstance(cls, global_model, parameters):
             self.assembling_strategy = self.rom_parameters["assembling_strategy"].GetString() if self.rom_parameters.Has("assembling_strategy") else "global"
             self.project_parameters["solver_settings"].AddString("assembling_strategy",self.assembling_strategy)
 
+            # Add HROM Settings (e.g. hrom_settings)
+            self.project_parameters["solver_settings"]["rom_settings"]["rom_bns_settings"].AddBool("store_non_converged_projected_residuals", self.rom_parameters["hrom_train"]["store_non_converged_projected_residuals"].GetBool()) if self.rom_parameters["store_non_converged_projected_residuals"].Has("store_non_converged_projected_residuals") else False
+
             # Create the ROM solver
             return new_python_solvers_wrapper_rom.CreateSolver(
                 self.model,

--- a/applications/RomApplication/python_scripts/rom_analysis.py
+++ b/applications/RomApplication/python_scripts/rom_analysis.py
@@ -94,8 +94,13 @@ def CreateRomAnalysisInstance(cls, global_model, parameters):
             self.assembling_strategy = self.rom_parameters["assembling_strategy"].GetString() if self.rom_parameters.Has("assembling_strategy") else "global"
             self.project_parameters["solver_settings"].AddString("assembling_strategy",self.assembling_strategy)
 
-            # Add HROM Settings (e.g. hrom_settings)
-            self.project_parameters["solver_settings"]["rom_settings"]["rom_bns_settings"].AddBool("store_non_converged_projected_residuals", self.rom_parameters["hrom_settings"]["store_non_converged_projected_residuals"].GetBool()) if self.rom_parameters["hrom_settings"].Has("store_non_converged_projected_residuals") else False
+            # Retrieve the value for 'store_non_converged_projected_residuals' if it exists, otherwise default to False
+            store_non_converged_projected_residuals = \
+                self.rom_parameters["hrom_settings"]["store_non_converged_projected_residuals"].GetBool() \
+                if self.rom_parameters["hrom_settings"].Has("store_non_converged_projected_residuals") else False
+
+            # Add the retrieved or default value to the project parameters
+            self.project_parameters["solver_settings"]["rom_settings"]["rom_bns_settings"].AddBool("store_non_converged_projected_residuals", store_non_converged_projected_residuals)
 
             # Create the ROM solver
             return new_python_solvers_wrapper_rom.CreateSolver(

--- a/applications/RomApplication/python_scripts/rom_solver.py
+++ b/applications/RomApplication/python_scripts/rom_solver.py
@@ -25,7 +25,9 @@ def CreateSolver(cls, model, custom_settings):
                 "rom_settings": {
                     "nodal_unknowns": [],
                     "number_of_rom_dofs": 0,
-                    "rom_bns_settings": {}
+                    "rom_bns_settings": {
+                        "store_non_converged_projected_residuals": false
+                    }
                 }
             }""")
             default_settings.AddMissingParameters(super().GetDefaultParameters())

--- a/applications/RomApplication/tests/cpp_tests/test_lspg_rom_builder_and_solver.cpp
+++ b/applications/RomApplication/tests/cpp_tests/test_lspg_rom_builder_and_solver.cpp
@@ -193,7 +193,14 @@ KRATOS_TEST_CASE_IN_SUITE(LeastSquaresPetrovGalerkinROMBuilderAndSolver, RomAppl
     {
         "name" : "rom_builder_and_solver",
         "nodal_unknowns" : ["TEMPERATURE"],
-        "number_of_rom_dofs" : 2
+        "number_of_rom_dofs" : 2,
+        "rom_bns_settings" : {
+            "store_non_converged_projected_residuals": false,
+            "monotonicity_preserving": false,
+            "train_petrov_galerkin": false,
+            "solving_technique" : "normal_equations",
+            "basis_strategy" : "residuals"
+        }
     }
     )");
 


### PR DESCRIPTION
## Overview
This PR introduces enhancements to allow the inclusion of non-converged projected residuals for HROM training. This information is vital for ECMs to utilize details from the nonlinear iterations. Modifications have been made to the Global ROM Builder and Solver classes. Further enhancements for elemental ROM builder and solvers will be covered in a subsequent PR to maintain clarity and brevity in this submission.

## Changes Made

- **Python Exports**:
  - `applications/RomApplication/custom_python/add_custom_strategies_to_python.cpp`: Exported `GetNonConvergedProjectedResiduals` to Python to facilitate access from Python scripts.

- **Global ROM Builder and Solver**:
  - `applications/RomApplication/custom_strategies/global_rom_builder_and_solver.h`: Implemented `InitializeRomResidualsUtility` for initialization with right ROM basis information. Added `StoreAndAppendNonConvergedProjectedResiduals` function to handle residuals using `RomResidualsUtility->GetProjectedResidualsOntoPhi()` and included `AppendMatrixHorizontally` for dynamic matrix appending across nonlinear iterations.

- **LSPG ROM Builder and Solver**:
  - `applications/RomApplication/custom_strategies/lspg_rom_builder_and_solver.h`: Integrated `StoreAndAppendNonConvergedProjectedResiduals` with `RomResidualsUtility->GetProjectedResidualsOntoJPhi()`. Added `ConvertEigenToKratos` to convert Eigen matrices to Kratos format for compatibility.

- **Global Petrov-Galerkin ROM Builder and Solver**:
  - `applications/RomApplication/custom_strategies/global_petrov_galerkin_rom_builder_and_solver.h`: Overridden `SetUpDofSet` to initialize `RomResidualsUtility` with Petrov-Galerkin specific settings. Added `InitializeRomResidualsUtility` and `StoreAndAppendNonConvergedProjectedResiduals`, which uses `RomResidualsUtility->GetProjectedResidualsOntoPsi()` for storing residuals.


- **Python Scripts**:
  - `applications/RomApplication/python_scripts/hrom_training_utility.py`: Updated to retrieve non-converged projected residuals from the C++ B&S.
  - `applications/RomApplication/python_scripts/rom_analysis.py` and `applications/RomApplication/python_scripts/rom_solver.py`: Updated settings to support the new features.


