### PR TITLE
[Core] Fix Average Element size calculator for 2D9N

### DIFF
--- a/kratos/tests/cpp_tests/utilities/test_element_size_calculator.cpp
+++ b/kratos/tests/cpp_tests/utilities/test_element_size_calculator.cpp
@@ -92,6 +92,29 @@ namespace Kratos
             KRATOS_EXPECT_NEAR(average_size, std::pow(0.25, 1.0 / 3.0), TOLERANCE); //
         }
 
+        KRATOS_TEST_CASE_IN_SUITE(TriangleSize, KratosCoreFastSuite)
+        {
+            Geometry<NodeType>::PointsArrayType nodes_2d_3;
+            nodes_2d_3.push_back(NodeType::Pointer(new NodeType(1, 0.0, 0.0, 0.0)));
+            nodes_2d_3.push_back(NodeType::Pointer(new NodeType(2, 2.0, 0.0, 0.0)));
+            nodes_2d_3.push_back(NodeType::Pointer(new NodeType(3, 0.0, 2.0, 0.0)));
+            auto p_triangle_2d3 = GeometryType::Pointer(new Triangle2D3<NodeType>(nodes_2d_3));
+            const double minimum_size_2d3 = ElementSizeCalculator<2, 3>::MinimumElementSize(*p_triangle_2d3);
+            const double average_size_2d3 = ElementSizeCalculator<2, 3>::AverageElementSize(*p_triangle_2d3);
+            KRATOS_EXPECT_NEAR(minimum_size_2d3, std::pow(2.0, 0.5), TOLERANCE);
+            KRATOS_EXPECT_NEAR(average_size_2d3, std::pow(2.0, 0.5), TOLERANCE);
+
+            Geometry<NodeType>::PointsArrayType nodes_2d_6(nodes_2d_3.ptr_begin(), nodes_2d_3.ptr_end());
+            nodes_2d_6.push_back(NodeType::Pointer(new NodeType(4, 0.5, 0.0, 0.0)));
+            nodes_2d_6.push_back(NodeType::Pointer(new NodeType(5, 0.5, 0.5, 0.0)));
+            nodes_2d_6.push_back(NodeType::Pointer(new NodeType(6, 0.0, 0.5, 0.0)));
+            auto p_triangle_2d6 = GeometryType::Pointer(new Triangle2D6<NodeType>(nodes_2d_6));
+            const double minimum_size_2d6 = ElementSizeCalculator<2, 6>::MinimumElementSize(*p_triangle_2d6);
+            const double average_size_2d6 = ElementSizeCalculator<2, 6>::AverageElementSize(*p_triangle_2d6);
+            KRATOS_EXPECT_NEAR(minimum_size_2d6, std::pow(2.0, 0.5), TOLERANCE);
+            KRATOS_EXPECT_NEAR(average_size_2d6, std::pow(2.0, 0.5), TOLERANCE);
+        }
+
         KRATOS_TEST_CASE_IN_SUITE(Triangle2D3MinimumElementSizeDerivatives, KratosCoreFastSuite)
         {
             Geometry<NodeType>::PointsArrayType nodes;
@@ -144,6 +167,32 @@ namespace Kratos
             RunElementSizeCalculatorDerivativesTest(
                 *p_geometry, ElementSizeCalculator<2, 6>::AverageElementSize,
                 ElementSizeCalculator<2, 6>::AverageElementSizeDerivative, 1e-8, 1e-7);
+        }
+
+        KRATOS_TEST_CASE_IN_SUITE(QuadrilateralSize, KratosCoreFastSuite)
+        {
+            Geometry<NodeType>::PointsArrayType nodes_2d_4;
+            nodes_2d_4.push_back(NodeType::Pointer(new NodeType(1, 0.0, 0.0, 0.0)));
+            nodes_2d_4.push_back(NodeType::Pointer(new NodeType(2, 2.0, 0.0, 0.0)));
+            nodes_2d_4.push_back(NodeType::Pointer(new NodeType(3, 2.0, 2.0, 0.0)));
+            nodes_2d_4.push_back(NodeType::Pointer(new NodeType(4, 0.0, 2.0, 0.0)));
+            auto p_quadrilateral_2d4 = GeometryType::Pointer(new Quadrilateral2D4<NodeType>(nodes_2d_4));
+            const double minimum_size_2d4 = ElementSizeCalculator<2, 4>::MinimumElementSize(*p_quadrilateral_2d4);
+            const double average_size_2d4 = ElementSizeCalculator<2, 4>::AverageElementSize(*p_quadrilateral_2d4);
+            KRATOS_EXPECT_NEAR(minimum_size_2d4, 2.0, TOLERANCE);
+            KRATOS_EXPECT_NEAR(average_size_2d4, 2.0, TOLERANCE);
+
+            Geometry<NodeType>::PointsArrayType nodes_2d_9(nodes_2d_4.ptr_begin(), nodes_2d_4.ptr_end());
+            nodes_2d_9.push_back(NodeType::Pointer(new NodeType(5, 1.0, 0.0, 0.0)));
+            nodes_2d_9.push_back(NodeType::Pointer(new NodeType(6, 2.0, 1.0, 0.0)));
+            nodes_2d_9.push_back(NodeType::Pointer(new NodeType(7, 1.0, 2.0, 0.0)));
+            nodes_2d_9.push_back(NodeType::Pointer(new NodeType(8, 0.0, 1.0, 0.0)));
+            nodes_2d_9.push_back(NodeType::Pointer(new NodeType(9, 1.0, 1.0, 0.0)));
+            auto p_quadrilateral_2d9 = GeometryType::Pointer(new Quadrilateral2D9<NodeType>(nodes_2d_9));
+            const double minimum_size_2d9 = ElementSizeCalculator<2, 9>::MinimumElementSize(*p_quadrilateral_2d9);
+            const double average_size_2d9 = ElementSizeCalculator<2, 9>::AverageElementSize(*p_quadrilateral_2d9);
+            KRATOS_EXPECT_NEAR(minimum_size_2d9, 2.0, TOLERANCE);
+            KRATOS_EXPECT_NEAR(average_size_2d9, 2.0, TOLERANCE);
         }
 
         KRATOS_TEST_CASE_IN_SUITE(Quadrilateral2D4MinimumElementSizeDerivatives, KratosCoreFastSuite)
@@ -206,6 +255,33 @@ namespace Kratos
             RunElementSizeCalculatorDerivativesTest(
                 *p_geometry, ElementSizeCalculator<2, 9>::AverageElementSize,
                 ElementSizeCalculator<2, 9>::AverageElementSizeDerivative, 1e-8, 1e-7);
+        }
+
+        KRATOS_TEST_CASE_IN_SUITE(TetrahedraSize, KratosCoreFastSuite)
+        {
+            Geometry<NodeType>::PointsArrayType nodes_3d_4;
+            nodes_3d_4.push_back(NodeType::Pointer(new NodeType(1, 0.0, 0.0, 0.0)));
+            nodes_3d_4.push_back(NodeType::Pointer(new NodeType(2, 2.0, 0.0, 0.0)));
+            nodes_3d_4.push_back(NodeType::Pointer(new NodeType(3, 2.0, 2.0, 0.0)));
+            nodes_3d_4.push_back(NodeType::Pointer(new NodeType(4, 1.0, 1.0, 2.0)));
+            auto p_tetrahedra_3d4 = GeometryType::Pointer(new Tetrahedra3D4<NodeType>(nodes_3d_4));
+            const double minimum_size_3d4 = ElementSizeCalculator<3, 4>::MinimumElementSize(*p_tetrahedra_3d4);
+            const double average_size_3d4 = ElementSizeCalculator<3, 4>::AverageElementSize(*p_tetrahedra_3d4);
+            KRATOS_EXPECT_NEAR(minimum_size_3d4, std::pow(2.0, 0.5), TOLERANCE);
+            KRATOS_EXPECT_NEAR(average_size_3d4, std::pow(2.0 * 2.0 / 3.0, 1.0 / 3.0), TOLERANCE);
+
+            Geometry<NodeType>::PointsArrayType nodes_3d_10(nodes_3d_4.ptr_begin(), nodes_3d_4.ptr_end());
+            nodes_3d_10.push_back(NodeType::Pointer(new NodeType(5, 1.0, 0.0, 0.0)));
+            nodes_3d_10.push_back(NodeType::Pointer(new NodeType(6, 2.0, 1.0, 0.0)));
+            nodes_3d_10.push_back(NodeType::Pointer(new NodeType(7, 1.0, 1.0, 0.0)));
+            nodes_3d_10.push_back(NodeType::Pointer(new NodeType(8, 0.5, 0.5, 1.0)));
+            nodes_3d_10.push_back(NodeType::Pointer(new NodeType(9, 1.5, 0.5, 1.0)));
+            nodes_3d_10.push_back(NodeType::Pointer(new NodeType(10, 1.5, 1.5, 1.0)));
+            auto p_tetrahedra_3d10 = GeometryType::Pointer(new Tetrahedra3D10<NodeType>(nodes_3d_10));
+            const double minimum_size_3d10 = ElementSizeCalculator<3, 10>::MinimumElementSize(*p_tetrahedra_3d10);
+            const double average_size_3d10 = ElementSizeCalculator<3, 10>::AverageElementSize(*p_tetrahedra_3d10);
+            KRATOS_EXPECT_NEAR(minimum_size_3d10, std::pow(2.0, 0.5), TOLERANCE);
+            KRATOS_EXPECT_NEAR(average_size_3d10, std::pow(2.0 * 2.0 / 3.0, 1.0 / 3.0), TOLERANCE);
         }
 
         KRATOS_TEST_CASE_IN_SUITE(Tetrahedra3D4MinimumElementSizeDerivatives, KratosCoreFastSuite)
@@ -300,6 +376,51 @@ namespace Kratos
             RunElementSizeCalculatorDerivativesTest(
                 *p_geometry, ElementSizeCalculator<3, 6>::AverageElementSize,
                 ElementSizeCalculator<3, 6>::AverageElementSizeDerivative, 1e-8, 1e-7);
+        }
+
+        KRATOS_TEST_CASE_IN_SUITE(HexahedraSize, KratosCoreFastSuite)
+        {
+            Geometry<NodeType>::PointsArrayType nodes_3d_8;
+            nodes_3d_8.push_back(NodeType::Pointer(new NodeType(1, 0.0, 0.0, 0.0)));
+            nodes_3d_8.push_back(NodeType::Pointer(new NodeType(2, 2.0, 0.0, 0.0)));
+            nodes_3d_8.push_back(NodeType::Pointer(new NodeType(3, 2.0, 2.0, 0.0)));
+            nodes_3d_8.push_back(NodeType::Pointer(new NodeType(4, 0.0, 2.0, 0.0)));
+            nodes_3d_8.push_back(NodeType::Pointer(new NodeType(5, 0.0, 0.0, 2.0)));
+            nodes_3d_8.push_back(NodeType::Pointer(new NodeType(6, 2.0, 0.0, 2.0)));
+            nodes_3d_8.push_back(NodeType::Pointer(new NodeType(7, 2.0, 2.0, 2.0)));
+            nodes_3d_8.push_back(NodeType::Pointer(new NodeType(8, 0.0, 2.0, 2.0)));
+            auto p_hexahedra_3d8 = GeometryType::Pointer(new Hexahedra3D8<NodeType>(nodes_3d_8));
+            const double minimum_size_3d8 = ElementSizeCalculator<3, 8>::MinimumElementSize(*p_hexahedra_3d8);
+            const double average_size_3d8 = ElementSizeCalculator<3, 8>::AverageElementSize(*p_hexahedra_3d8);
+            KRATOS_EXPECT_NEAR(minimum_size_3d8, 2.0, TOLERANCE);
+            KRATOS_EXPECT_NEAR(average_size_3d8, 2.0, TOLERANCE);
+
+            Geometry<NodeType>::PointsArrayType nodes_3d_27(nodes_3d_8.ptr_begin(), nodes_3d_8.ptr_end());
+            nodes_3d_27.push_back(NodeType::Pointer(new NodeType(9, 1.0, 0.0, 0.0)));
+            nodes_3d_27.push_back(NodeType::Pointer(new NodeType(10, 2.0, 1.0, 0.0)));
+            nodes_3d_27.push_back(NodeType::Pointer(new NodeType(11, 1.0, 2.0, 0.0)));
+            nodes_3d_27.push_back(NodeType::Pointer(new NodeType(12, 0.0, 1.0, 0.0)));
+            nodes_3d_27.push_back(NodeType::Pointer(new NodeType(13, 0.0, 0.0, 1.0)));
+            nodes_3d_27.push_back(NodeType::Pointer(new NodeType(14, 2.0, 0.0, 1.0)));
+            nodes_3d_27.push_back(NodeType::Pointer(new NodeType(15, 2.0, 2.0, 1.0)));
+            nodes_3d_27.push_back(NodeType::Pointer(new NodeType(16, 0.0, 2.0, 1.0)));
+            nodes_3d_27.push_back(NodeType::Pointer(new NodeType(17, 1.0, 0.0, 2.0)));
+            nodes_3d_27.push_back(NodeType::Pointer(new NodeType(18, 2.0, 1.0, 2.0)));
+            nodes_3d_27.push_back(NodeType::Pointer(new NodeType(19, 1.0, 2.0, 2.0)));
+            nodes_3d_27.push_back(NodeType::Pointer(new NodeType(20, 0.0, 1.0, 2.0)));
+            nodes_3d_27.push_back(NodeType::Pointer(new NodeType(21, 1.0, 1.0, 0.0)));
+            nodes_3d_27.push_back(NodeType::Pointer(new NodeType(22, 1.0, 0.0, 1.0)));
+            nodes_3d_27.push_back(NodeType::Pointer(new NodeType(23, 2.0, 1.0, 1.0)));
+            nodes_3d_27.push_back(NodeType::Pointer(new NodeType(24, 1.0, 2.0, 1.0)));
+            nodes_3d_27.push_back(NodeType::Pointer(new NodeType(25, 0.0, 1.0, 1.0)));
+            nodes_3d_27.push_back(NodeType::Pointer(new NodeType(26, 1.0, 1.0, 2.0)));
+            nodes_3d_27.push_back(NodeType::Pointer(new NodeType(27, 1.0, 1.0, 1.0)));
+
+            auto p_hexahedra_3d27 = GeometryType::Pointer(new Hexahedra3D27<NodeType>(nodes_3d_27));
+            const double minimum_size_3d27 = ElementSizeCalculator<3, 27>::MinimumElementSize(*p_hexahedra_3d27);
+            const double average_size_3d27 = ElementSizeCalculator<3, 27>::AverageElementSize(*p_hexahedra_3d27);
+            KRATOS_EXPECT_NEAR(minimum_size_3d27, 2.0, TOLERANCE);
+            KRATOS_EXPECT_NEAR(average_size_3d27, 2.0, TOLERANCE);
         }
 
         KRATOS_TEST_CASE_IN_SUITE(Hexahedra3D8MinimumElementSizeDerivatives, KratosCoreFastSuite)

--- a/kratos/utilities/element_size_calculator.cpp
+++ b/kratos/utilities/element_size_calculator.cpp
@@ -867,6 +867,7 @@ double ElementSizeCalculator<2,4>::AverageElementSizeDerivative(
 template<>
 double ElementSizeCalculator<2,9>::AverageElementSize(const Geometry<Node >& rGeometry)
 {
+    // this is to compensate for the missing 2.0 in the geometry length computation.
     return rGeometry.Length() * 2.0;
 }
 

--- a/kratos/utilities/element_size_calculator.cpp
+++ b/kratos/utilities/element_size_calculator.cpp
@@ -867,7 +867,7 @@ double ElementSizeCalculator<2,4>::AverageElementSizeDerivative(
 template<>
 double ElementSizeCalculator<2,9>::AverageElementSize(const Geometry<Node >& rGeometry)
 {
-    return rGeometry.Length();
+    return rGeometry.Length() * 2.0;
 }
 
 template<>
@@ -893,9 +893,9 @@ double ElementSizeCalculator<2,9>::AverageElementSizeDerivative(
     const auto detJ = MathUtils<double>::Det2(jacobian);
 
     if (detJ > 0.0) {
-        return 0.5 * detJ_derivative / (std::sqrt(detJ));
+        return detJ_derivative / (std::sqrt(detJ));
     } else if (detJ < 0.0) {
-        return -0.5 * detJ_derivative / (std::sqrt(-detJ));
+        return -detJ_derivative / (std::sqrt(-detJ));
     } else {
         return 0.0;
     }


### PR DESCRIPTION
**📝 Description**
As mentioned in the title, this corrects the average length calculation of the `Quad2D9N` to be consistent with the linear computation.

closes #12300 

**🆕 Changelog**
- Fixes average legth computation of `Quad2D9N`
