### PR TITLE
[Core] Making aplications deregistrable V3

### DIFF
--- a/kratos/includes/define.h
+++ b/kratos/includes/define.h
@@ -696,10 +696,12 @@ catch(...) { Block KRATOS_THROW_ERROR(std::runtime_error, "Unknown error", MoreI
 #ifdef KRATOS_REGISTER_GEOMETRY
 #undef KRATOS_REGISTER_GEOMETRY
 #endif
-#define KRATOS_REGISTER_GEOMETRY(name, reference) \
-    KratosComponents<Geometry<Node>>::Add(name, reference); \
-    if(!Registry::HasItem("geometries."+Registry::GetCurrentSource()+"."+name)){                                              \
-        Registry::AddItem<RegistryItem>("geometries."+Registry::GetCurrentSource()+"."+name);                           \
+#define KRATOS_REGISTER_GEOMETRY(name, reference)                                                                   \
+    KratosComponents<Geometry<Node>>::Add(name, reference);                                                         \
+    if(!Registry::HasItem("geometries."+Registry::GetCurrentSource()+"."+name) &&                                   \
+       !Registry::HasItem("components."+std::string(name))){                                                                     \
+        Registry::AddItem<RegistryItem>("geometries."+Registry::GetCurrentSource()+"."+name);                       \
+        Registry::AddItem<RegistryItem>("components."+std::string(name));                                                        \
     }                                                                                                               \
     Serializer::Register(name, reference);
 
@@ -708,8 +710,10 @@ catch(...) { Block KRATOS_THROW_ERROR(std::runtime_error, "Unknown error", MoreI
 #endif
 #define KRATOS_REGISTER_ELEMENT(name, reference)                                                                    \
     KratosComponents<Element>::Add(name, reference);                                                                \
-    if(!Registry::HasItem("elements."+Registry::GetCurrentSource()+"."+name)){                                              \
-        Registry::AddItem<RegistryItem>("elements."+Registry::GetCurrentSource()+"."+name);                           \
+    if(!Registry::HasItem("elements."+Registry::GetCurrentSource()+"."+name) &&                                     \
+       !Registry::HasItem("components."+std::string(name))){                                                                    \
+        Registry::AddItem<RegistryItem>("elements."+Registry::GetCurrentSource()+"."+name);                         \
+        Registry::AddItem<RegistryItem>("components."+std::string(name));                                                        \
     }                                                                                                               \
     Serializer::Register(name, reference);
 
@@ -718,8 +722,10 @@ catch(...) { Block KRATOS_THROW_ERROR(std::runtime_error, "Unknown error", MoreI
 #endif
 #define KRATOS_REGISTER_CONDITION(name, reference)                                                                  \
     KratosComponents<Condition>::Add(name, reference);                                                              \
-    if(!Registry::HasItem("conditions."+Registry::GetCurrentSource()+"."+name)){                                            \
+    if(!Registry::HasItem("conditions."+Registry::GetCurrentSource()+"."+name) &&                                   \
+       !Registry::HasItem("components."+std::string(name))){                                                                     \
         Registry::AddItem<RegistryItem>("conditions."+Registry::GetCurrentSource()+"."+name);                       \
+        Registry::AddItem<RegistryItem>("components."+std::string(name));                                                        \
     }                                                                                                               \
     Serializer::Register(name, reference);
 
@@ -728,8 +734,10 @@ catch(...) { Block KRATOS_THROW_ERROR(std::runtime_error, "Unknown error", MoreI
 #endif
 #define KRATOS_REGISTER_CONSTRAINT(name, reference)                                                                 \
     KratosComponents<MasterSlaveConstraint>::Add(name, reference);                                                  \
-    if(!Registry::HasItem("constraints."+Registry::GetCurrentSource()+"."+name)){                                    \
-        Registry::AddItem<RegistryItem>("constraints."+Registry::GetCurrentSource()+"."+name);   \
+    if(!Registry::HasItem("constraints."+Registry::GetCurrentSource()+"."+name) &&                                  \
+       !Registry::HasItem("components."+std::string(name))){                                                                     \
+        Registry::AddItem<RegistryItem>("constraints."+Registry::GetCurrentSource()+"."+name);                      \
+        Registry::AddItem<RegistryItem>("components."+std::string(name));                                                        \
     }                                                                                                               \
     Serializer::Register(name, reference);
 
@@ -738,8 +746,10 @@ catch(...) { Block KRATOS_THROW_ERROR(std::runtime_error, "Unknown error", MoreI
 #endif
 #define KRATOS_REGISTER_MODELER(name, reference)                                                                    \
     KratosComponents<Modeler>::Add(name, reference);                                                                \
-    if(!Registry::HasItem("modelers."+Registry::GetCurrentSource()+"."+name)){                                       \
-        Registry::AddItem<RegistryItem>("modelers."+Registry::GetCurrentSource()+"."+name);                    \
+    if(!Registry::HasItem("modelers."+Registry::GetCurrentSource()+"."+name) &&                                     \
+       !Registry::HasItem("components."+std::string(name))){                                                                     \
+        Registry::AddItem<RegistryItem>("modelers."+Registry::GetCurrentSource()+"."+name);                         \
+        Registry::AddItem<RegistryItem>("components."+std::string(name));                                                        \
     }                                                                                                               \
     Serializer::Register(name, reference);
 
@@ -748,8 +758,10 @@ catch(...) { Block KRATOS_THROW_ERROR(std::runtime_error, "Unknown error", MoreI
 #endif
 #define KRATOS_REGISTER_CONSTITUTIVE_LAW(name, reference)                                                           \
     KratosComponents<ConstitutiveLaw>::Add(name, reference);                                                        \
-    if(!Registry::HasItem("constitutive_laws."+Registry::GetCurrentSource()+"."+name)){                              \
-        Registry::AddItem<RegistryItem>("constitutive_laws."+Registry::GetCurrentSource()+"."+name);   \
+    if(!Registry::HasItem("constitutive_laws."+Registry::GetCurrentSource()+"."+name) &&                            \
+       !Registry::HasItem("components."+std::string(name))){                                                                     \
+        Registry::AddItem<RegistryItem>("constitutive_laws."+Registry::GetCurrentSource()+"."+name);                \
+        Registry::AddItem<RegistryItem>("components."+std::string(name));                                                        \
     }                                                                                                               \
     Serializer::Register(name, reference);
 

--- a/kratos/includes/define.h
+++ b/kratos/includes/define.h
@@ -703,36 +703,51 @@ catch(...) { Block KRATOS_THROW_ERROR(std::runtime_error, "Unknown error", MoreI
 #ifdef KRATOS_REGISTER_ELEMENT
 #undef KRATOS_REGISTER_ELEMENT
 #endif
-#define KRATOS_REGISTER_ELEMENT(name, reference) \
-    KratosComponents<Element >::Add(name, reference); \
+#define KRATOS_REGISTER_ELEMENT(name, reference)                                                                    \
+    KratosComponents<Element>::Add(name, reference);                                                                \
+    if(!Registry::HasItem("elements."+Registry::GetCurrentSource()+"."+name)){                                              \
+        Registry::AddItem<RegistryItem>("elements."+Registry::GetCurrentSource()+"."+name);                           \
+    }                                                                                                               \
     Serializer::Register(name, reference);
 
 #ifdef KRATOS_REGISTER_CONDITION
 #undef KRATOS_REGISTER_CONDITION
 #endif
-#define KRATOS_REGISTER_CONDITION(name, reference) \
-    KratosComponents<Condition >::Add(name, reference); \
+#define KRATOS_REGISTER_CONDITION(name, reference)                                                                  \
+    KratosComponents<Condition>::Add(name, reference);                                                              \
+    if(!Registry::HasItem("conditions."+Registry::GetCurrentSource()+"."+name)){                                            \
+        Registry::AddItem<RegistryItem>("conditions."+Registry::GetCurrentSource()+"."+name);                       \
+    }                                                                                                               \
     Serializer::Register(name, reference);
 
 #ifdef KRATOS_REGISTER_CONSTRAINT
 #undef KRATOS_REGISTER_CONSTRAINT
 #endif
-#define KRATOS_REGISTER_CONSTRAINT(name, reference) \
-    KratosComponents<MasterSlaveConstraint >::Add(name, reference); \
+#define KRATOS_REGISTER_CONSTRAINT(name, reference)                                                                 \
+    KratosComponents<MasterSlaveConstraint>::Add(name, reference);                                                  \
+    if(!Registry::HasItem("constraints."+Registry::GetCurrentSource()+"."+name)){                                    \
+        Registry::AddItem<RegistryItem>("constraints."+Registry::GetCurrentSource()+"."+name);   \
+    }                                                                                                               \
     Serializer::Register(name, reference);
 
 #ifdef KRATOS_REGISTER_MODELER
 #undef KRATOS_REGISTER_MODELER
 #endif
-#define KRATOS_REGISTER_MODELER(name, reference) \
-    KratosComponents<Modeler>::Add(name, reference); \
+#define KRATOS_REGISTER_MODELER(name, reference)                                                                    \
+    KratosComponents<Modeler>::Add(name, reference);                                                                \
+    if(!Registry::HasItem("modelers."+Registry::GetCurrentSource()+"."+name)){                                       \
+        Registry::AddItem<RegistryItem>("modelers."+Registry::GetCurrentSource()+"."+name);                    \
+    }                                                                                                               \
     Serializer::Register(name, reference);
 
 #ifdef KRATOS_REGISTER_CONSTITUTIVE_LAW
 #undef KRATOS_REGISTER_CONSTITUTIVE_LAW
 #endif
-#define KRATOS_REGISTER_CONSTITUTIVE_LAW(name, reference) \
-    KratosComponents<ConstitutiveLaw >::Add(name, reference); \
+#define KRATOS_REGISTER_CONSTITUTIVE_LAW(name, reference)                                                           \
+    KratosComponents<ConstitutiveLaw>::Add(name, reference);                                                        \
+    if(!Registry::HasItem("constitutive_laws."+Registry::GetCurrentSource()+"."+name)){                              \
+        Registry::AddItem<RegistryItem>("constitutive_laws."+Registry::GetCurrentSource()+"."+name);   \
+    }                                                                                                               \
     Serializer::Register(name, reference);
 
 #define KRATOS_DEPRECATED [[deprecated]]

--- a/kratos/includes/define.h
+++ b/kratos/includes/define.h
@@ -698,6 +698,9 @@ catch(...) { Block KRATOS_THROW_ERROR(std::runtime_error, "Unknown error", MoreI
 #endif
 #define KRATOS_REGISTER_GEOMETRY(name, reference) \
     KratosComponents<Geometry<Node>>::Add(name, reference); \
+    if(!Registry::HasItem("geometries."+Registry::GetCurrentSource()+"."+name)){                                              \
+        Registry::AddItem<RegistryItem>("geometries."+Registry::GetCurrentSource()+"."+name);                           \
+    }                                                                                                               \
     Serializer::Register(name, reference);
 
 #ifdef KRATOS_REGISTER_ELEMENT

--- a/kratos/includes/kratos_application.h
+++ b/kratos/includes/kratos_application.h
@@ -131,8 +131,8 @@ class KRATOS_API(KRATOS_CORE) KratosApplication {
     virtual ~KratosApplication() 
     {
         // This must be commented until tests have been fixed.
-        DeregisterCommonComponents();
-        DeregisterApplication();
+        // DeregisterCommonComponents();
+        // DeregisterApplication();
     }
 
     ///@}

--- a/kratos/includes/kratos_application.h
+++ b/kratos/includes/kratos_application.h
@@ -128,7 +128,12 @@ class KRATOS_API(KRATOS_CORE) KratosApplication {
           mpModelers(rOther.mpModelers) {}
 
     /// Destructor.
-    virtual ~KratosApplication() {}
+    virtual ~KratosApplication() 
+    {
+        // This must be commented until tests have been fixed.
+        DeregisterCommonComponents();
+        DeregisterApplication();
+    }
 
     ///@}
     ///@name Operations
@@ -140,6 +145,25 @@ class KRATOS_API(KRATOS_CORE) KratosApplication {
     }
 
     void RegisterKratosCore();
+
+    /**
+     * @brief This method is used to unregister common components of the application.
+     * @details This method is used to unregister common components of the application. 
+     * The list of unregistered components are the ones exposed in the common KratosComponents interface:
+     * - Geometries
+     * - Elements
+     * - Conditions
+     * - MasterSlaveConstraints
+     * - Modelers
+     * - ConstitutiveLaws
+     */
+    void DeregisterCommonComponents();
+
+    /**
+     * @brief This method is used to unregister specific application components.
+     * @details This method is used to unregister specific application components.
+     */
+    virtual void DeregisterApplication();
 
     ///////////////////////////////////////////////////////////////////
     void RegisterVariables();  // This contains the whole list of common variables in the Kratos Core

--- a/kratos/includes/kratos_application.h
+++ b/kratos/includes/kratos_application.h
@@ -146,6 +146,9 @@ class KRATOS_API(KRATOS_CORE) KratosApplication {
 
     void RegisterKratosCore();
 
+    template<class TDeregisterComponentFType>
+    void DeregisterComponent(std::string const & rComponentName, TDeregisterComponentFType && remove_detail);
+
     /**
      * @brief This method is used to unregister common components of the application.
      * @details This method is used to unregister common components of the application. 

--- a/kratos/includes/kratos_application.h
+++ b/kratos/includes/kratos_application.h
@@ -146,8 +146,8 @@ class KRATOS_API(KRATOS_CORE) KratosApplication {
 
     void RegisterKratosCore();
 
-    template<class TDeregisterComponentFType>
-    void DeregisterComponent(std::string const & rComponentName, TDeregisterComponentFType && remove_detail);
+    template<class TComponentsContainer>
+    void DeregisterComponent(std::string const & rComponentName);
 
     /**
      * @brief This method is used to unregister common components of the application.

--- a/kratos/includes/registry.h
+++ b/kratos/includes/registry.h
@@ -151,6 +151,18 @@ public:
 
     static void RemoveItem(std::string const& ItemName);
 
+    /** Sets the current source of the registry
+     *  This function is used to keep track of which application is adding items to the registry
+     *  @param rCurrentSource The current source of the registry
+    */
+    static void SetCurrentSource(std::string const & rCurrentSource);
+
+    /** Gets the current source of the registry
+     *  This function is used to keep track of which application is adding items to the registry
+     *  @param return The current source of the registry
+    */
+    static std::string GetCurrentSource();
+
     ///@}
     ///@name Inquiry
     ///@{
@@ -189,6 +201,7 @@ private:
     ///@{
 
         static RegistryItem* mspRootRegistryItem;
+        static std::string   mCurrentSource;
 
     ///@}
     ///@name Member Variables

--- a/kratos/includes/registry.h
+++ b/kratos/includes/registry.h
@@ -201,7 +201,6 @@ private:
     ///@{
 
         static RegistryItem* mspRootRegistryItem;
-        static std::string   mCurrentSource;
 
     ///@}
     ///@name Member Variables

--- a/kratos/includes/registry_item.h
+++ b/kratos/includes/registry_item.h
@@ -306,7 +306,11 @@ private:
     ///@{
 
     std::string mName;
+#if defined (__GNUC__) && __GNUC__ <= 8 && __GNUC_MINOR__ <= 3
+    boost::any mpValue;
+#else
     std::any mpValue;
+#endif
     std::string (RegistryItem::*mGetValueStringMethod)() const;
 
     ///@}

--- a/kratos/includes/registry_item.h
+++ b/kratos/includes/registry_item.h
@@ -18,7 +18,12 @@
 #include <string>
 #include <iostream>
 #include <unordered_map>
-#include <any>
+
+#if defined (__GNUC__) && __GNUC__ <= 8 && __GNUC_MINOR__ <= 3
+    #include <boost/any.hpp>
+#else
+    #include <any>
+#endif 
 
 // External includes
 
@@ -243,7 +248,11 @@ public:
     {
         KRATOS_TRY
 
+#if defined (__GNUC__) && __GNUC__ <= 8 && __GNUC_MINOR__ <= 3
+        return *(boost::any_cast<std::shared_ptr<TDataType>>(mpValue));
+#else
         return *(std::any_cast<std::shared_ptr<TDataType>>(mpValue));
+#endif
 
         KRATOS_CATCH("");
     }
@@ -253,7 +262,11 @@ public:
     {
         KRATOS_TRY
 
+#if defined (__GNUC__) && __GNUC__ <= 8 && __GNUC_MINOR__ <= 3
+        return *std::dynamic_pointer_cast<TCastType>(boost::any_cast<std::shared_ptr<TDataType>>(mpValue));
+#else
         return *std::dynamic_pointer_cast<TCastType>(std::any_cast<std::shared_ptr<TDataType>>(mpValue));
+#endif
 
         KRATOS_CATCH("");
     }

--- a/kratos/sources/kratos_application.cpp
+++ b/kratos/sources/kratos_application.cpp
@@ -312,7 +312,7 @@ void KratosApplication::DeregisterComponent(std::string const & rComponentName) 
     // Remove only if the application has this type of components registered
     if (Registry::HasItem(path)) {
 
-        // Generate a temporal list with all the keys to avoid invalidating the iterator (Convert this intro a transform range when C++20 is available)
+        // Generate a temporal list with all the keys to avoid invalidating the iterator (Convert this into a transform range when C++20 is available)
         std::vector<std::string> keys;
         std::transform(Registry::GetItem(path).cbegin(), Registry::GetItem(path).cend(), std::back_inserter(keys), [](auto & key){return std::string(key.first);});
 

--- a/kratos/sources/kratos_application.cpp
+++ b/kratos/sources/kratos_application.cpp
@@ -347,43 +347,6 @@ void KratosApplication::DeregisterCommonComponents()
 {
     KRATOS_INFO("") << "Deregistering " << mApplicationName << std::endl;
 
-    // auto deregister_detail = [&](std::string const & rComponentName, auto remove_detail) {
-    //     auto path = std::string(rComponentName)+"."+mApplicationName;
-
-    //     // Remove only if the application has this type of components registered
-    //     if (Registry::HasItem(path)) {
-
-    //         // Generate a temporal list with all the keys to avoid invalidating the iterator (Convert this intro a transform range when C++20 is available)
-    //         std::vector<std::string> keys;
-    //         std::transform(Registry::GetItem(path).cbegin(), Registry::GetItem(path).cend(), std::back_inserter(keys), [](auto & key){return std::string(key.first);});
-
-    //         for (auto & key : keys) {
-    //             auto cmpt_key = "components."+key;
-    //             auto type_key = path+"."+key;
-
-    //             // Remove from KratosComponents
-    //             remove_detail(key);
-
-    //             // Remove from registry general component list
-    //             if (Registry::HasItem(cmpt_key)) {
-    //                 Registry::RemoveItem(cmpt_key);
-    //             } else {
-    //                 KRATOS_ERROR << "Trying ro remove: " << cmpt_key << " which was not found in registry" << std::endl;
-    //             }
-
-    //             // Remove from registry component typed list
-    //             if (Registry::HasItem(type_key)) {
-    //                 Registry::RemoveItem(type_key);
-    //             } else {
-    //                 KRATOS_ERROR << "Trying ro remove: " << type_key << " which was not found in registry" << std::endl;
-    //             }
-    //         }
-
-    //         // Finally, remove the entry all together
-    //         Registry::RemoveItem(path);
-    //     }
-    // };
-
     DeregisterComponent<Geometry<Node>>("geometries");
     DeregisterComponent<Element>("elements");
     DeregisterComponent<Condition>("conditions");

--- a/kratos/sources/kratos_application.cpp
+++ b/kratos/sources/kratos_application.cpp
@@ -305,8 +305,8 @@ void KratosApplication::RegisterKratosCore() {
     KRATOS_REGISTER_CONSTITUTIVE_LAW("ConstitutiveLaw", mConstitutiveLaw);
 }
 
-template<class TDeregisterComponentFType>
-void KratosApplication::DeregisterComponent(std::string const & rComponentName, TDeregisterComponentFType && remove_detail) {
+template<class TComponentsContainer>
+void KratosApplication::DeregisterComponent(std::string const & rComponentName) {
     auto path = std::string(rComponentName)+"."+mApplicationName;
 
     // Remove only if the application has this type of components registered
@@ -321,7 +321,7 @@ void KratosApplication::DeregisterComponent(std::string const & rComponentName, 
             auto type_key = path+"."+key;
 
             // Remove from KratosComponents
-            remove_detail(key);
+            KratosComponents<TComponentsContainer>::Remove(key);
 
             // Remove from registry general component list
             if (Registry::HasItem(cmpt_key)) {
@@ -384,12 +384,12 @@ void KratosApplication::DeregisterCommonComponents()
     //     }
     // };
 
-    DeregisterComponent("geometries", [](std::string const & key){ KratosComponents<Geometry<Node>>::Remove(key);});
-    DeregisterComponent("elements", [](std::string const & key){ KratosComponents<Element>::Remove(key);});
-    DeregisterComponent("conditions", [](std::string const & key){ KratosComponents<Condition>::Remove(key);});
-    DeregisterComponent("constraints", [](std::string const & key){ KratosComponents<MasterSlaveConstraint>::Remove(key);});
-    DeregisterComponent("modelers", [](std::string const & key){ KratosComponents<Modeler>::Remove(key);});
-    DeregisterComponent("constitutive_laws", [](std::string const & key){ KratosComponents<ConstitutiveLaw>::Remove(key);});
+    DeregisterComponent<Geometry<Node>>("geometries");
+    DeregisterComponent<Element>("elements");
+    DeregisterComponent<Condition>("conditions");
+    DeregisterComponent<MasterSlaveConstraint>("constraints");
+    DeregisterComponent<Modeler>("modelers");
+    DeregisterComponent<ConstitutiveLaw>("constitutive_laws");
 }
 
 void KratosApplication::DeregisterApplication() {

--- a/kratos/sources/kratos_application.cpp
+++ b/kratos/sources/kratos_application.cpp
@@ -311,10 +311,17 @@ void KratosApplication::DeregisterCommonComponents()
 
     auto deregister_detail = [&](std::string const & rComponentName, auto remove_detail) {
         auto path = std::string(rComponentName)+"."+mApplicationName;
-        std::cout << "Deregistering " << path << " components" << std::endl;
         for (auto & key : Registry::GetItem(path)) {
             std::cout << "\t" << key.first << std::endl;
+            
+            // Remove from components
             remove_detail(key.first);
+
+            // Remove from registry component typed list
+            Registry::RemoveItem(path);
+
+            // Remove from registry general component list
+            Registry::RemoveItem("components."+key.first);
         }
     };
 

--- a/kratos/sources/kratos_application.cpp
+++ b/kratos/sources/kratos_application.cpp
@@ -312,30 +312,37 @@ void KratosApplication::DeregisterCommonComponents()
     auto deregister_detail = [&](std::string const & rComponentName, auto remove_detail) {
         auto path = std::string(rComponentName)+"."+mApplicationName;
 
-        // Generate a temporal list with all the keys to avoid invalidating the iterator (Convert this intro a transform range when C++20 is available)
-        std::vector<std::string> keys;
-        std::transform(Registry::GetItem(path).cbegin(), Registry::GetItem(path).cend(), std::back_inserter(keys), [](auto & key){return std::string(key.first);});
+        // Remove only if the application has this type of components registered
+        if (Registry::HasItem(path)) {
 
-        for (auto & key : keys) {
-            auto cmpt_key = "components."+key;
-            auto type_key = path+"."+key;
+            // Generate a temporal list with all the keys to avoid invalidating the iterator (Convert this intro a transform range when C++20 is available)
+            std::vector<std::string> keys;
+            std::transform(Registry::GetItem(path).cbegin(), Registry::GetItem(path).cend(), std::back_inserter(keys), [](auto & key){return std::string(key.first);});
 
-            // Remove from KratosComponents
-            remove_detail(key);
+            for (auto & key : keys) {
+                auto cmpt_key = "components."+key;
+                auto type_key = path+"."+key;
 
-            // Remove from registry general component list
-            if(Registry::HasItem(cmpt_key)) {
-                Registry::RemoveItem(cmpt_key);
-            } else {
-                KRATOS_ERROR << "Trying ro remove: " << cmpt_key << " which was not found in registry" << std::endl;
+                // Remove from KratosComponents
+                remove_detail(key);
+
+                // Remove from registry general component list
+                if (Registry::HasItem(cmpt_key)) {
+                    Registry::RemoveItem(cmpt_key);
+                } else {
+                    KRATOS_ERROR << "Trying ro remove: " << cmpt_key << " which was not found in registry" << std::endl;
+                }
+
+                // Remove from registry component typed list
+                if (Registry::HasItem(type_key)) {
+                    Registry::RemoveItem(type_key);
+                } else {
+                    KRATOS_ERROR << "Trying ro remove: " << type_key << " which was not found in registry" << std::endl;
+                }
             }
 
-            // Remove from registry component typed list
-            if(Registry::HasItem(type_key)) {
-                Registry::RemoveItem(type_key);
-            } else {
-                KRATOS_ERROR << "Trying ro remove: " << type_key << " which was not found in registry" << std::endl;
-            }
+            // Finally, remove the entry all together
+            Registry::RemoveItem(path);
         }
     };
 

--- a/kratos/sources/registry.cpp
+++ b/kratos/sources/registry.cpp
@@ -83,45 +83,25 @@ namespace
     void Registry::SetCurrentSource(std::string const & rCurrentSource)
     {
         // If context key not present, create it
-        if(!Registry::HasItem("CurrentContext")){
-           Registry::AddItem<RegistryItem>("CurrentContext");
+        if (Registry::HasItem("CurrentContext")){
+            Registry::RemoveItem("CurrentContext");
         }
 
-        auto & entry = Registry::GetItem("CurrentContext");
+        // It is needed to create a std::string explicitly copying the '"CurrentContext"+rCurrentSource' to avoid casting problems
+        // involing std::any_cast to a reference type which key references a string that may not be alive when invoked.
+        std::string context_key = std::string("CurrentContext" + rCurrentSource);
 
-        // Generate a temporal list with all the keys to avoid invalidating the iterator (Convert this intro a transform range when C++20 is available)
-        std::vector<std::string> keys;
-        std::transform(entry.cbegin(), entry.cend(), std::back_inserter(keys), [](auto & key){return std::string(key.first);});
-
-        for (auto sub_key: keys) {
-            entry.RemoveItem(sub_key);
-        }
-
-        Registry::AddItem<RegistryItem>("CurrentContext."+rCurrentSource);
+        Registry::AddItem<RegistryItem>(context_key);
     }
 
     std::string Registry::GetCurrentSource()
     {
-        using namespace std::literals;
-
         // If context key not present, create it
-        if(!Registry::HasItem("CurrentContext")){
-            Registry::AddItem<RegistryItem>("CurrentContext");
-        }
-
-        auto & entry = Registry::GetItem("CurrentContext");
-
-        // If no context set, set the default one
-        if(entry.size() == 0){
+        if (!Registry::HasItem("CurrentContext")){
             Registry::AddItem<RegistryItem>("CurrentContext.KratosMultiphysics");
         }
 
-        // If more than one context set, throw an error
-        if(entry.size() > 1){
-            KRATOS_ERROR << "More than one context set in the registry" << std::endl;
-        }
-
-        return entry.begin()->first;
+        return Registry::GetItem("CurrentContext").begin()->first;
     }
 
     std::size_t Registry::size()

--- a/kratos/sources/registry.cpp
+++ b/kratos/sources/registry.cpp
@@ -89,7 +89,7 @@ namespace
 
         // It is needed to create a std::string explicitly copying the '"CurrentContext"+rCurrentSource' to avoid casting problems
         // involing std::any_cast to a reference type which key references a string that may not be alive when invoked.
-        std::string context_key = std::string("CurrentContext" + rCurrentSource);
+        std::string context_key = std::string("CurrentContext." + rCurrentSource);
 
         Registry::AddItem<RegistryItem>(context_key);
     }

--- a/kratos/sources/registry.cpp
+++ b/kratos/sources/registry.cpp
@@ -28,6 +28,7 @@ namespace
 }
 
     RegistryItem* Registry::mspRootRegistryItem = nullptr;
+    std::string   Registry::mCurrentSource = "all";
 
     RegistryItem& Registry::GetItem(std::string const& rItemFullName)
     {
@@ -78,6 +79,16 @@ namespace
         else{
             KRATOS_ERROR << "The item \"" << rItemFullName << "\" is not found in the registry. The item \"" << p_current_item->Name() << "\" does not have \"" << r_item_name << "\"" << std::endl;
         }
+    }
+
+    void Registry::SetCurrentSource(std::string const & rCurrentSource)
+    {
+        mCurrentSource = rCurrentSource;
+    }
+
+    std::string Registry::GetCurrentSource()
+    {
+        return mCurrentSource;
     }
 
     std::size_t Registry::size()

--- a/kratos/sources/registry.cpp
+++ b/kratos/sources/registry.cpp
@@ -28,7 +28,6 @@ namespace
 }
 
     RegistryItem* Registry::mspRootRegistryItem = nullptr;
-    std::string   Registry::mCurrentSource = "all";
 
     RegistryItem& Registry::GetItem(std::string const& rItemFullName)
     {

--- a/kratos/sources/registry.cpp
+++ b/kratos/sources/registry.cpp
@@ -83,12 +83,37 @@ namespace
 
     void Registry::SetCurrentSource(std::string const & rCurrentSource)
     {
-        mCurrentSource = rCurrentSource;
+        // If context key not present, create it
+        if(!Registry::HasItem("CurrentContext")){
+           Registry::AddItem<RegistryItem>("CurrentContext");
+        }
+
+        auto & entry = Registry::GetItem("CurrentContext");
+
+        if (entry.HasItem("value")) {
+            entry.RemoveItem("value");
+        }
+
+        entry.AddItem<std::string>("value", rCurrentSource);
     }
 
     std::string Registry::GetCurrentSource()
     {
-        return mCurrentSource;
+        using namespace std::literals;
+
+        // If context key not present, create it
+        if(!Registry::HasItem("CurrentContext")){
+            Registry::AddItem<RegistryItem>("CurrentContext");
+        }
+
+        auto & entry = Registry::GetItem("CurrentContext");
+
+        // If no context set, set the default one
+        if (!entry.HasItem("value")) {
+            entry.AddItem<std::string>("value", std::string("KratosMultiphysics"));
+        }
+
+        return Registry::GetItem("CurrentContext.value").GetValue<std::string>();
     }
 
     std::size_t Registry::size()

--- a/kratos/sources/registry_item.cpp
+++ b/kratos/sources/registry_item.cpp
@@ -23,13 +23,21 @@ namespace Kratos
     RegistryItem::SubRegistryItemType& RegistryItem::GetSubRegistryItemMap()
     {
         KRATOS_ERROR_IF(HasValue()) << "Item " << Name() << " has value and cannot be iterated." << std::endl;
+#if defined (__GNUC__) && __GNUC__ <= 8 && __GNUC_MINOR__ <= 3
+        return *(boost::any_cast<SubRegistryItemPointerType>(mpValue));
+#else
         return *(std::any_cast<SubRegistryItemPointerType>(mpValue));
+#endif
     }
 
     RegistryItem::SubRegistryItemType& RegistryItem::GetSubRegistryItemMap() const
     {
         KRATOS_ERROR_IF(HasValue()) << "Item " << Name() << " has value and cannot be iterated." << std::endl;
+#if defined (__GNUC__) && __GNUC__ <= 8 && __GNUC_MINOR__ <= 3
+        return *(boost::any_cast<SubRegistryItemPointerType>(mpValue));
+#else
         return *(std::any_cast<SubRegistryItemPointerType>(mpValue));
+#endif
     }
 
     RegistryItem::SubRegistryItemType::iterator RegistryItem::begin()


### PR DESCRIPTION
**📝 Description**
Third version of attempting to make applications deregistrable.

Applied the comments of @philbucher @pooyan-dadvand and @jcotela (and @loumalouomega :heart: )

### OVERVIEW

- Registry now has a Setter/Getter to know who is using the register macros
- Register macros add things to the registry 
- At application we check if the registry key for the different components exist for the given app, if not is created
- At destruction we iterate over all the keys under the current application and delete it from the components.

Currently only the name of the component is stored, subject to change to a reference in the future, but I tried to keep the PR super small.

### TODO

- [ ] Add preconditioners
- [ ] Consistenly renaming all Unregister to Deregister
- [x] Cleanup Debug Strings

Changes for the IGA and name consistency will come in separate PR if you like this one.
