### PR TITLE
[Gitignore] Adding IDX to the Gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,6 +80,7 @@ kratos/scripts/wheels/README.md
 
 # Most used editor files
 *.vscode
+*.idx
 remote_*.md
 
 /compile_commands.json


### PR DESCRIPTION
**📝 Description**

I have been granted access to [Google IDX](https://idx.google.com) and in order to avoid conflicts ith the editor I am updating the `.gitgnore` file.

**🆕 Changelog**

- [Adding **IDX** to the Gitignore file](https://github.com/KratosMultiphysics/Kratos/commit/b2fa9fbc0ad5c7effc35d91ccd07223e4367b82f)
