### PR TITLE
[RomApp] Skipping LSPG B&S cpp test

### DIFF
--- a/applications/RomApplication/tests/cpp_tests/test_lspg_rom_builder_and_solver.cpp
+++ b/applications/RomApplication/tests/cpp_tests/test_lspg_rom_builder_and_solver.cpp
@@ -204,6 +204,8 @@ KRATOS_TEST_CASE_IN_SUITE(LeastSquaresPetrovGalerkinROMBuilderAndSolver, RomAppl
     const auto dx = BuildAndSolve(model_part, p_scheme, romBnS);
     const auto& dq = model_part.GetValue(ROM_SOLUTION_INCREMENT);
 
+    KRATOS_SKIP_TEST << "this test is failing randomly in Windows. We will skip it until we find the error" << std::endl;
+
     KRATOS_EXPECT_NEAR(model_part.ElementsBegin()->GetValue(HROM_WEIGHT), 1, 1e-8);
     KRATOS_EXPECT_EQ(romBnS.GetEquationSystemSize(), 3);
 


### PR DESCRIPTION
**📝 Description**
The cpp test for the LSPG B&S was failing randomly in the Windows CI. 

This PR will skip the test until we find the error

**🆕 Changelog**
- Added a KRATOS_SKIP_TEST on test_lspg_rom_builder_and_solver.cpp
