### PR TITLE
Fix Memory Leak in LSPG ROM Builder and Solver by Ensuring Vector Zeroing

### DIFF
--- a/applications/RomApplication/custom_strategies/global_rom_builder_and_solver.h
+++ b/applications/RomApplication/custom_strategies/global_rom_builder_and_solver.h
@@ -379,10 +379,14 @@ public:
             r_Dx.resize(BaseBuilderAndSolverType::GetEquationSystemSize(), false);
         }
 
+        // TSparseSpace::SetToZero(r_Dx);
+
         TSystemVectorType& r_b = *pb;
         if (r_b.size() != BaseBuilderAndSolverType::GetEquationSystemSize()) {
             r_b.resize(BaseBuilderAndSolverType::GetEquationSystemSize(), false);
         }
+
+        // TSparseSpace::SetToZero(r_b);
 
         KRATOS_CATCH("")
     }

--- a/applications/RomApplication/custom_strategies/global_rom_builder_and_solver.h
+++ b/applications/RomApplication/custom_strategies/global_rom_builder_and_solver.h
@@ -379,14 +379,14 @@ public:
             r_Dx.resize(BaseBuilderAndSolverType::GetEquationSystemSize(), false);
         }
 
-        // TSparseSpace::SetToZero(r_Dx);
+        TSparseSpace::SetToZero(r_Dx);
 
         TSystemVectorType& r_b = *pb;
         if (r_b.size() != BaseBuilderAndSolverType::GetEquationSystemSize()) {
             r_b.resize(BaseBuilderAndSolverType::GetEquationSystemSize(), false);
         }
 
-        // TSparseSpace::SetToZero(r_b);
+        TSparseSpace::SetToZero(r_b);
 
         KRATOS_CATCH("")
     }

--- a/applications/RomApplication/tests/cpp_tests/test_lspg_rom_builder_and_solver.cpp
+++ b/applications/RomApplication/tests/cpp_tests/test_lspg_rom_builder_and_solver.cpp
@@ -204,8 +204,6 @@ KRATOS_TEST_CASE_IN_SUITE(LeastSquaresPetrovGalerkinROMBuilderAndSolver, RomAppl
     const auto dx = BuildAndSolve(model_part, p_scheme, romBnS);
     const auto& dq = model_part.GetValue(ROM_SOLUTION_INCREMENT);
 
-    // KRATOS_SKIP_TEST << "this test is failing randomly in Windows. We will skip it until we find the error" << std::endl;
-
     KRATOS_EXPECT_NEAR(model_part.ElementsBegin()->GetValue(HROM_WEIGHT), 1, 1e-8);
     KRATOS_EXPECT_EQ(romBnS.GetEquationSystemSize(), 3);
 

--- a/applications/RomApplication/tests/cpp_tests/test_lspg_rom_builder_and_solver.cpp
+++ b/applications/RomApplication/tests/cpp_tests/test_lspg_rom_builder_and_solver.cpp
@@ -186,38 +186,37 @@ KRATOS_TEST_CASE_IN_SUITE(LeastSquaresPetrovGalerkinROMBuilderAndSolver, RomAppl
 {
     using namespace LeastSquaresPetrovGalerkinROMBuilderAndSolverTestingInternal;
 
-    for (int i=0; i<1000; i++){
-        Model model{};
-        ModelPart& model_part = FillModel(model);
+    Model model{};
+    ModelPart& model_part = FillModel(model);
 
-        Parameters parameters(R"(
-        {
-            "name" : "rom_builder_and_solver",
-            "nodal_unknowns" : ["TEMPERATURE"],
-            "number_of_rom_dofs" : 2
-        }
-        )");
-
-        auto plinear_solver = std::make_shared<LinearSolverType>();
-        SchemeType::Pointer p_scheme = std::make_shared<ResidualBasedIncrementalUpdateStaticSchemeType>();
-        auto romBnS = LeastSquaresPetrovGalerkinROMBuilderAndSolverType(plinear_solver, parameters);
-
-        const auto dx = BuildAndSolve(model_part, p_scheme, romBnS);
-        const auto& dq = model_part.GetValue(ROM_SOLUTION_INCREMENT);
-
-        // KRATOS_SKIP_TEST << "this test is failing randomly in Windows. We will skip it until we find the error" << std::endl;
-
-        KRATOS_EXPECT_NEAR(model_part.ElementsBegin()->GetValue(HROM_WEIGHT), 1, 1e-8);
-        KRATOS_EXPECT_EQ(romBnS.GetEquationSystemSize(), 3);
-
-        KRATOS_EXPECT_NEAR(dq(0), 1.0 , 1e-8);
-        KRATOS_EXPECT_NEAR(dq(1), 0.5 , 1e-8);
-
-        // Testing free dofs
-        KRATOS_EXPECT_EQ(dx.size(), 3);
-        KRATOS_EXPECT_NEAR(dx(1), 1.5 , 1e-8);
-        KRATOS_EXPECT_NEAR(dx(2), 2.0 , 1e-8);
+    Parameters parameters(R"(
+    {
+        "name" : "rom_builder_and_solver",
+        "nodal_unknowns" : ["TEMPERATURE"],
+        "number_of_rom_dofs" : 2
     }
+    )");
+
+    auto plinear_solver = std::make_shared<LinearSolverType>();
+    SchemeType::Pointer p_scheme = std::make_shared<ResidualBasedIncrementalUpdateStaticSchemeType>();
+    auto romBnS = LeastSquaresPetrovGalerkinROMBuilderAndSolverType(plinear_solver, parameters);
+
+    const auto dx = BuildAndSolve(model_part, p_scheme, romBnS);
+    const auto& dq = model_part.GetValue(ROM_SOLUTION_INCREMENT);
+
+    // KRATOS_SKIP_TEST << "this test is failing randomly in Windows. We will skip it until we find the error" << std::endl;
+
+    KRATOS_EXPECT_NEAR(model_part.ElementsBegin()->GetValue(HROM_WEIGHT), 1, 1e-8);
+    KRATOS_EXPECT_EQ(romBnS.GetEquationSystemSize(), 3);
+
+    KRATOS_EXPECT_NEAR(dq(0), 1.0 , 1e-8);
+    KRATOS_EXPECT_NEAR(dq(1), 0.5 , 1e-8);
+
+    // Testing free dofs
+    KRATOS_EXPECT_EQ(dx.size(), 3);
+    KRATOS_EXPECT_NEAR(dx(1), 1.5 , 1e-8);
+    KRATOS_EXPECT_NEAR(dx(2), 2.0 , 1e-8);
+
 }
 
 }

--- a/applications/RomApplication/tests/cpp_tests/test_lspg_rom_builder_and_solver.cpp
+++ b/applications/RomApplication/tests/cpp_tests/test_lspg_rom_builder_and_solver.cpp
@@ -186,36 +186,38 @@ KRATOS_TEST_CASE_IN_SUITE(LeastSquaresPetrovGalerkinROMBuilderAndSolver, RomAppl
 {
     using namespace LeastSquaresPetrovGalerkinROMBuilderAndSolverTestingInternal;
 
-    Model model{};
-    ModelPart& model_part = FillModel(model);
+    for (int i=0; i<1000; i++){
+        Model model{};
+        ModelPart& model_part = FillModel(model);
 
-    Parameters parameters(R"(
-    {
-        "name" : "rom_builder_and_solver",
-        "nodal_unknowns" : ["TEMPERATURE"],
-        "number_of_rom_dofs" : 2
+        Parameters parameters(R"(
+        {
+            "name" : "rom_builder_and_solver",
+            "nodal_unknowns" : ["TEMPERATURE"],
+            "number_of_rom_dofs" : 2
+        }
+        )");
+
+        auto plinear_solver = std::make_shared<LinearSolverType>();
+        SchemeType::Pointer p_scheme = std::make_shared<ResidualBasedIncrementalUpdateStaticSchemeType>();
+        auto romBnS = LeastSquaresPetrovGalerkinROMBuilderAndSolverType(plinear_solver, parameters);
+
+        const auto dx = BuildAndSolve(model_part, p_scheme, romBnS);
+        const auto& dq = model_part.GetValue(ROM_SOLUTION_INCREMENT);
+
+        // KRATOS_SKIP_TEST << "this test is failing randomly in Windows. We will skip it until we find the error" << std::endl;
+
+        KRATOS_EXPECT_NEAR(model_part.ElementsBegin()->GetValue(HROM_WEIGHT), 1, 1e-8);
+        KRATOS_EXPECT_EQ(romBnS.GetEquationSystemSize(), 3);
+
+        KRATOS_EXPECT_NEAR(dq(0), 1.0 , 1e-8);
+        KRATOS_EXPECT_NEAR(dq(1), 0.5 , 1e-8);
+
+        // Testing free dofs
+        KRATOS_EXPECT_EQ(dx.size(), 3);
+        KRATOS_EXPECT_NEAR(dx(1), 1.5 , 1e-8);
+        KRATOS_EXPECT_NEAR(dx(2), 2.0 , 1e-8);
     }
-    )");
-
-    auto plinear_solver = std::make_shared<LinearSolverType>();
-    SchemeType::Pointer p_scheme = std::make_shared<ResidualBasedIncrementalUpdateStaticSchemeType>();
-    auto romBnS = LeastSquaresPetrovGalerkinROMBuilderAndSolverType(plinear_solver, parameters);
-
-    const auto dx = BuildAndSolve(model_part, p_scheme, romBnS);
-    const auto& dq = model_part.GetValue(ROM_SOLUTION_INCREMENT);
-
-    KRATOS_SKIP_TEST << "this test is failing randomly in Windows. We will skip it until we find the error" << std::endl;
-
-    KRATOS_EXPECT_NEAR(model_part.ElementsBegin()->GetValue(HROM_WEIGHT), 1, 1e-8);
-    KRATOS_EXPECT_EQ(romBnS.GetEquationSystemSize(), 3);
-
-    KRATOS_EXPECT_NEAR(dq(0), 1.0 , 1e-8);
-    KRATOS_EXPECT_NEAR(dq(1), 0.5 , 1e-8);
-
-    // Testing free dofs
-    KRATOS_EXPECT_EQ(dx.size(), 3);
-    KRATOS_EXPECT_NEAR(dx(1), 1.5 , 1e-8);
-    KRATOS_EXPECT_NEAR(dx(2), 2.0 , 1e-8);
 }
 
 }


### PR DESCRIPTION
## Description

This PR resolves an issue with improper initialization found in the LSPG ROM builder and solver test (the bug was in the `global_rom_builder_and_solver.h`). The problem was due to vectors not being zeroed out after resizing, leading to uninitialized floating point values, which could affect the accuracy and reliability of computations.
