### PR TITLE
[GeoMechanicsApplication] Fixed the bug related to shape-function-gradients for thermal line el…

### DIFF
--- a/applications/GeoMechanicsApplication/custom_elements/transient_thermal_element.h
+++ b/applications/GeoMechanicsApplication/custom_elements/transient_thermal_element.h
@@ -71,6 +71,9 @@ public:
         GeometryType::ShapeFunctionsGradientsType dN_dX_container;
         Vector                                    det_J_container;
 
+        // ShapreFunctionsIntegrationsPointsGradients does not allow for the line element in 2D/3D configuration
+        // and will produce errors. To circumvent this, the dN_dX_container is separately computed with correct
+        // dimensions for the line element.
         if (GetGeometry().LocalSpaceDimension() == 1) {
             GetGeometry().DeterminantOfJacobian(det_J_container, this->GetIntegrationMethod());
             dN_dX_container = GetGeometry().ShapeFunctionsLocalGradients(this->GetIntegrationMethod());

--- a/applications/GeoMechanicsApplication/custom_elements/transient_thermal_element.h
+++ b/applications/GeoMechanicsApplication/custom_elements/transient_thermal_element.h
@@ -74,6 +74,8 @@ public:
         if (GetGeometry().LocalSpaceDimension() == 1) {
             GetGeometry().DeterminantOfJacobian(det_J_container, this->GetIntegrationMethod());
             dN_dX_container = GetGeometry().ShapeFunctionsLocalGradients(this->GetIntegrationMethod());
+            std::transform(dN_dX_container.begin(), dN_dX_container.end(), det_J_container.begin(),
+                           dN_dX_container.begin(), std::divides<>());
         } 
         else {
             GetGeometry().ShapeFunctionsIntegrationPointsGradients(dN_dX_container, det_J_container,


### PR DESCRIPTION
📝 Description
There is a bug detected in the calculation of shape function gradients for line thermal element. The shape fuction gradient is calculated based on the local coordinates. Later it has to be multiplied by the inverse of the Jacobian in order to be projected to the global coordinates. However, a such multiplication is missing.

🆕 Changelog

Added a statement to divide the shape-function-gradients to the determinant of Jacobian. In 1D, this is equvalent to multiplication with inverse Jacobian