### PR TITLE
[GeoMechanicsApplication] Fix bug in calculation of shape-function-gradients in Pw line element

### DIFF
--- a/applications/GeoMechanicsApplication/custom_elements/transient_Pw_line_element.h
+++ b/applications/GeoMechanicsApplication/custom_elements/transient_Pw_line_element.h
@@ -71,6 +71,7 @@ public:
         Vector det_J_container;
         GetGeometry().DeterminantOfJacobian(det_J_container, this->GetIntegrationMethod());
         GeometryType::ShapeFunctionsGradientsType dN_dX_container = GetGeometry().ShapeFunctionsLocalGradients(this->GetIntegrationMethod());
+        std::transform(dN_dX_container.begin(), dN_dX_container.end(), det_J_container.begin(), dN_dX_container.begin(), std::divides<>());
         const Matrix& r_N_container = GetGeometry().ShapeFunctionsValues(GetIntegrationMethod());
 
         const auto integration_coefficients = CalculateIntegrationCoefficients(det_J_container);
@@ -359,6 +360,8 @@ private:
                 body_acceleration, rNContainer, volume_acceleration, integration_point_index);
 
             array_1d<double, TDim> tangent_vector = column(J_container[integration_point_index], 0);
+            tangent_vector /= norm_2(tangent_vector);
+
             array_1d<double, 1> projected_gravity = ZeroVector(1);
             projected_gravity(0) = MathUtils<double>::Dot(tangent_vector, body_acceleration);
             const auto N = Vector{row(rNContainer, integration_point_index)};

--- a/applications/GeoMechanicsApplication/tests/test_pressure_line_element/test_oblique_line_element2D2N/ProjectParameters.json
+++ b/applications/GeoMechanicsApplication/tests/test_pressure_line_element/test_oblique_line_element2D2N/ProjectParameters.json
@@ -63,11 +63,8 @@
     "line_search_tolerance"              : 0.5,
     "rotation_dofs"                      : true,
     "linear_solver_settings" : {
-      "solver_type"                      : "bicgstab",
-      "tolerance"                        : 1.0e-6,
-      "max_iteration"                    : 1000,
-      "scaling"                          : true,
-      "preconditioner_type"              : "ilu0"
+      "solver_type":   "LinearSolversApplication.sparse_lu",
+      "scaling":       true
     },
     "problem_domain_sub_model_part_list" : ["filter"],
     "processes_sub_model_part_list"      : ["Start","Gravity","top"],

--- a/applications/GeoMechanicsApplication/tests/test_pressure_line_element/test_oblique_line_element3D2N/ProjectParameters.json
+++ b/applications/GeoMechanicsApplication/tests/test_pressure_line_element/test_oblique_line_element3D2N/ProjectParameters.json
@@ -63,11 +63,8 @@
     "line_search_tolerance"              : 0.5,
     "rotation_dofs"                      : true,
     "linear_solver_settings" : {
-      "solver_type"                      : "bicgstab",
-      "tolerance"                        : 1.0e-6,
-      "max_iteration"                    : 1000,
-      "scaling"                          : true,
-      "preconditioner_type"              : "ilu0"
+      "solver_type":   "LinearSolversApplication.sparse_lu",
+      "scaling":       true
     },
     "problem_domain_sub_model_part_list" : ["filter"],
     "processes_sub_model_part_list"      : ["Start","Gravity","top"],


### PR DESCRIPTION
**📝 Description**
Similar to https://github.com/KratosMultiphysics/Kratos/pull/12347 (PR for thermal element), there is a bug detected in the calculation of shape function gradients for Pw line element. The shape fuction gradient is calculated based on the local coordinates. Later it has to be multiplied by the inverse of the Jacobian in order to be projected to the global coordinates. However, a such multiplication is missing.

**🆕 Changelog**
- Fixed bug
- Modified 2 test cases
