### PR TITLE
[GeoMechanicsApplication] Add cross-sectional area to the Pw line element

### DIFF
--- a/applications/GeoMechanicsApplication/custom_elements/transient_Pw_line_element.h
+++ b/applications/GeoMechanicsApplication/custom_elements/transient_Pw_line_element.h
@@ -207,13 +207,13 @@ private:
 
     Vector CalculateIntegrationCoefficients(const Vector& rDetJContainer) const
     {
+        const auto& r_properties = GetProperties();
         const auto& r_integration_points = GetGeometry().IntegrationPoints(GetIntegrationMethod());
 
         auto result = Vector{r_integration_points.size()};
         std::transform(r_integration_points.begin(), r_integration_points.end(), rDetJContainer.begin(),
-                       result.begin(), [](const auto& rIntegrationPoint, const auto& rDetJ) {
-                           return rIntegrationPoint.Weight() * rDetJ;
-                       });
+                       result.begin(), [&r_properties](const auto& rIntegrationPoint, const auto& rDetJ) {
+                           return rIntegrationPoint.Weight() * rDetJ * r_properties[CROSS_AREA]; });
         return result;
     }
 

--- a/applications/GeoMechanicsApplication/tests/test_pressure_line_element/Common/MaterialParameters2D.json
+++ b/applications/GeoMechanicsApplication/tests/test_pressure_line_element/Common/MaterialParameters2D.json
@@ -20,7 +20,8 @@
         "BIOT_COEFFICIENT"                 : 1.000000e+00,
         "RETENTION_LAW"                    : "SaturatedLaw",
         "SATURATED_SATURATION"             : 1.000000e+00,
-        "RESIDUAL_SATURATION"              : 0.000000e+00
+        "RESIDUAL_SATURATION"              : 0.000000e+00,
+        "CROSS_AREA"                       : 1.0
       },
       "Tables": { 
       }

--- a/applications/GeoMechanicsApplication/tests/test_pressure_line_element/Common/MaterialParameters3D.json
+++ b/applications/GeoMechanicsApplication/tests/test_pressure_line_element/Common/MaterialParameters3D.json
@@ -19,7 +19,8 @@
         "DYNAMIC_VISCOSITY"                : 1.000000e-03,
         "BIOT_COEFFICIENT"                 : 1.000000e+00,
         "RETENTION_LAW"                    : "SaturatedLaw",
-        "SATURATED_SATURATION"             : 1.000000e+00
+        "SATURATED_SATURATION"             : 1.000000e+00,
+        "CROSS_AREA"                       : 1.0
       },
       "Tables": { 
       }


### PR DESCRIPTION
**📝 Description**
The Pw line element has to be extended to include the sectional area. All terms in the pressure equation has to be multiplied with the sectional area. In principle, it does not make change in the results for an isolated 1D line element. The effect will appear when the 1D line element gets combined with 2D element, for example, when a well or pipe inside the soil gets simulated. The matrices of this 1D element will be superposined with the 2D elements in the main matrix.

**🆕 Changelog**
- Added cross sectional area to pw line element
- Added "CROSS_AREA" to material properties
