### PR TITLE
[Core] Adding max radius search coefficient in `GeometricalObjectsBins` for `SearchNearest`

### DIFF
--- a/kratos/spatial_containers/geometrical_objects_bins.cpp
+++ b/kratos/spatial_containers/geometrical_objects_bins.cpp
@@ -150,7 +150,7 @@ GeometricalObjectsBins::ResultType GeometricalObjectsBins::SearchNearest(
     ResultType current_result;
 
     const array_1d<double, 3> box_size = mBoundingBox.GetMaxPoint() - mBoundingBox.GetMinPoint();
-    const double max_radius= (*std::max_element(box_size.begin(), box_size.end())) * MaxRadiusCoefficient; //  TODO: Must be added in the MPI utils as well
+    const double max_radius= (*std::max_element(box_size.begin(), box_size.end())) * MaxRadiusCoefficient;
 
     return SearchNearestInRadius(rPoint, max_radius);
 }

--- a/kratos/spatial_containers/geometrical_objects_bins.cpp
+++ b/kratos/spatial_containers/geometrical_objects_bins.cpp
@@ -142,12 +142,15 @@ GeometricalObjectsBins::ResultType GeometricalObjectsBins::SearchNearestInRadius
 /***********************************************************************************/
 /***********************************************************************************/
 
-GeometricalObjectsBins::ResultType GeometricalObjectsBins::SearchNearest(const PointType& rPoint)
+GeometricalObjectsBins::ResultType GeometricalObjectsBins::SearchNearest(
+    const PointType& rPoint,
+    const double MaxRadiusCoefficient
+    )
 {
     ResultType current_result;
 
     const array_1d<double, 3> box_size = mBoundingBox.GetMaxPoint() - mBoundingBox.GetMinPoint();
-    const double max_radius= *std::max_element(box_size.begin(), box_size.end());
+    const double max_radius= (*std::max_element(box_size.begin(), box_size.end())) * MaxRadiusCoefficient; //  TODO: Must be added in the MPI utils as well
 
     return SearchNearestInRadius(rPoint, max_radius);
 }

--- a/kratos/spatial_containers/geometrical_objects_bins.h
+++ b/kratos/spatial_containers/geometrical_objects_bins.h
@@ -227,9 +227,13 @@ public:
      * @details If there are more than one object in the same minimum distance only one is returned
      * Result contains a flag is the object has been found or not.
      * @param rPoint The point to be checked
+     * @param MaxRadiusCoefficient The coefficient to increase the max radius computed considering BB
      * @return ResultType The result of the search
-    */
-    ResultType SearchNearest(const PointType& rPoint);
+     */
+    ResultType SearchNearest(
+        const PointType& rPoint,
+        const double MaxRadiusCoefficient = 1.0
+        );
 
     /**
      * @brief This method takes a point and finds the nearest object to it (iterative version).


### PR DESCRIPTION
**📝 Description**

I found that in some corner cases where geometry exactly on the BB you can get empty result in search nearest (literally a corner case). With this coefficient it is possible to resize the BB max radius.

**🆕 Changelog**

- [Adding max radius search coefficient in `GeometricalObjectsBins` for `SearchNearest`](https://github.com/KratosMultiphysics/Kratos/commit/1c76b58c9bba2082ce747eb66b5bc3d923342042)