### PR TITLE
Making the for_each catch definition consistent with KRATOS_NO_TRY_CATCH

### DIFF
--- a/kratos/utilities/parallel_utilities.h
+++ b/kratos/utilities/parallel_utilities.h
@@ -40,17 +40,21 @@
 
 #define KRATOS_PREPARE_CATCH_THREAD_EXCEPTION std::stringstream err_stream;
 
-#define KRATOS_CATCH_THREAD_EXCEPTION \
-} catch(Exception& e) { \
-    KRATOS_CRITICAL_SECTION \
-    err_stream << "Thread #" << i << " caught exception: " << e.what(); \
-} catch(std::exception& e) { \
-    KRATOS_CRITICAL_SECTION \
-    err_stream << "Thread #" << i << " caught exception: " << e.what(); \
-} catch(...) { \
-    KRATOS_CRITICAL_SECTION \
-    err_stream << "Thread #" << i << " caught unknown exception:"; \
-}
+#ifndef KRATOS_NO_TRY_CATCH
+    #define KRATOS_CATCH_THREAD_EXCEPTION \
+    } catch(Exception& e) { \
+        KRATOS_CRITICAL_SECTION \
+        err_stream << "Thread #" << i << " caught exception: " << e.what(); \
+    } catch(std::exception& e) { \
+        KRATOS_CRITICAL_SECTION \
+        err_stream << "Thread #" << i << " caught exception: " << e.what(); \
+    } catch(...) { \
+        KRATOS_CRITICAL_SECTION \
+        err_stream << "Thread #" << i << " caught unknown exception:"; \
+    }
+#else
+    #define KRATOS_CATCH_THREAD_EXCEPTION {}
+#endif
 
 #define KRATOS_CHECK_AND_THROW_THREAD_EXCEPTION \
 const std::string& err_msg = err_stream.str(); \


### PR DESCRIPTION
**📝 Description**
Since `KRATOS_TRY` definition is conditional `KRATOS_CATCH_THREAD_EXCEPTION` must have the same switch. 

Would be good that in the future we keep the block macros in the same file.
