### PR TITLE
[Core] Fix condition creation in sub model part

### DIFF
--- a/kratos/sources/model_part.cpp
+++ b/kratos/sources/model_part.cpp
@@ -1514,6 +1514,7 @@ ModelPart::ConditionType::Pointer ModelPart::CreateNewCondition(std::string Cond
         ModelPart::PropertiesType::Pointer pProperties, ModelPart::IndexType ThisIndex)
 {
     KRATOS_TRY
+    
     if (IsSubModelPart()) {
         ConditionType::Pointer p_new_condition = mpParentModelPart->CreateNewCondition(ConditionName, Id, ConditionNodeIds, pProperties, ThisIndex);
         GetMesh(ThisIndex).AddCondition(p_new_condition);

--- a/kratos/sources/model_part.cpp
+++ b/kratos/sources/model_part.cpp
@@ -1514,6 +1514,12 @@ ModelPart::ConditionType::Pointer ModelPart::CreateNewCondition(std::string Cond
         ModelPart::PropertiesType::Pointer pProperties, ModelPart::IndexType ThisIndex)
 {
     KRATOS_TRY
+    if (IsSubModelPart()) {
+        ConditionType::Pointer p_new_condition = mpParentModelPart->CreateNewCondition(ConditionName, Id, ConditionNodeIds, pProperties, ThisIndex);
+        GetMesh(ThisIndex).AddCondition(p_new_condition);
+        return p_new_condition;
+    }
+
     Geometry< Node >::PointsArrayType pConditionNodes;
 
     for (unsigned int i = 0; i < ConditionNodeIds.size(); i++)


### PR DESCRIPTION
**📝 Description**
I have encountered a problem when trying to create a new condition with a vector of nodes. The current implementation assumes that the nodes belong to the model part, but this is not necessarily the case if it is a submodel part. For some reason, this was fixed for the elements but not for the conditions. I think it makes sense to do the same for both functions (see https://github.com/KratosMultiphysics/Kratos/blob/f6e7a3c2c529a6a8c9e782d628fe412633771220/kratos/sources/model_part.cpp#L980 )