### PR TITLE
[GeoMechanicsApplication] Inlined member functions `SetRetentionParameters`

### DIFF
--- a/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_element.cpp
@@ -1705,18 +1705,7 @@ void UPwSmallStrainElement<TDim, TNumNodes>::SetConstitutiveParameters(ElementVa
 }
 
 template <unsigned int TDim, unsigned int TNumNodes>
-void UPwSmallStrainElement<TDim, TNumNodes>::SetRetentionParameters(const ElementVariables& rVariables,
-                                                                    RetentionLaw::Parameters& rRetentionParameters)
-{
-    KRATOS_TRY
-
-    rRetentionParameters.SetFluidPressure(rVariables.FluidPressure);
-
-    KRATOS_CATCH("")
-}
-
-template <unsigned int TDim, unsigned int TNumNodes>
-double UPwSmallStrainElement<TDim, TNumNodes>::CalculateFluidPressure(const ElementVariables& rVariables)
+double UPwSmallStrainElement<TDim, TNumNodes>::CalculateFluidPressure(const ElementVariables& rVariables) const
 {
     KRATOS_TRY
 
@@ -1733,7 +1722,7 @@ void UPwSmallStrainElement<TDim, TNumNodes>::CalculateRetentionResponse(ElementV
     KRATOS_TRY
 
     rVariables.FluidPressure = CalculateFluidPressure(rVariables);
-    SetRetentionParameters(rVariables, rRetentionParameters);
+    rRetentionParameters.SetFluidPressure(rVariables.FluidPressure);
 
     rVariables.DegreeOfSaturation = mRetentionLawVector[GPoint]->CalculateSaturation(rRetentionParameters);
     rVariables.DerivativeOfSaturation =

--- a/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_element.hpp
+++ b/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_element.hpp
@@ -222,8 +222,6 @@ protected:
 
     void SetConstitutiveParameters(ElementVariables& rVariables, ConstitutiveLaw::Parameters& rConstitutiveParameters);
 
-    void SetRetentionParameters(const ElementVariables& rVariables, RetentionLaw::Parameters& rRetentionParameters);
-
     virtual void CalculateKinematics(ElementVariables& rVariables, unsigned int PointNumber);
 
     void InitializeBiotCoefficients(ElementVariables& rVariables, bool hasBiotCoefficient = false);
@@ -288,7 +286,7 @@ protected:
     void InitializeNodalVolumeAccelerationVariables(ElementVariables& rVariables);
 
     void   InitializeProperties(ElementVariables& rVariables);
-    double CalculateFluidPressure(const ElementVariables& rVariables);
+    [[nodiscard]] double CalculateFluidPressure(const ElementVariables& rVariables) const;
     std::vector<array_1d<double, TDim>> CalculateFluidFluxes(const std::vector<double>& rPermeabilityUpdateFactors,
                                                              const ProcessInfo& rCurrentProcessInfo);
 

--- a/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_interface_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_interface_element.cpp
@@ -601,7 +601,7 @@ void UPwSmallStrainInterfaceElement<TDim, TNumNodes>::CalculateOnIntegrationPoin
         // Loop over integration points
         for (unsigned int GPoint = 0; GPoint < NumGPoints; ++GPoint) {
             Variables.FluidPressure = CalculateFluidPressure(Variables);
-            SetRetentionParameters(Variables, RetentionParameters);
+            RetentionParameters.SetFluidPressure(Variables.FluidPressure);
 
             if (rVariable == DEGREE_OF_SATURATION)
                 GPValues[GPoint] = mRetentionLawVector[GPoint]->CalculateSaturation(RetentionParameters);
@@ -2093,18 +2093,7 @@ void UPwSmallStrainInterfaceElement<TDim, TNumNodes>::CalculateAndAddFluidBodyFl
 }
 
 template <unsigned int TDim, unsigned int TNumNodes>
-void UPwSmallStrainInterfaceElement<TDim, TNumNodes>::SetRetentionParameters(
-    const InterfaceElementVariables& rVariables, RetentionLaw::Parameters& rRetentionParameters)
-{
-    KRATOS_TRY
-
-    rRetentionParameters.SetFluidPressure(rVariables.FluidPressure);
-
-    KRATOS_CATCH("")
-}
-
-template <unsigned int TDim, unsigned int TNumNodes>
-double UPwSmallStrainInterfaceElement<TDim, TNumNodes>::CalculateFluidPressure(const InterfaceElementVariables& rVariables)
+double UPwSmallStrainInterfaceElement<TDim, TNumNodes>::CalculateFluidPressure(const InterfaceElementVariables& rVariables) const
 {
     KRATOS_TRY
 
@@ -2120,7 +2109,7 @@ void UPwSmallStrainInterfaceElement<TDim, TNumNodes>::CalculateRetentionResponse
     KRATOS_TRY
 
     rVariables.FluidPressure = CalculateFluidPressure(rVariables);
-    SetRetentionParameters(rVariables, rRetentionParameters);
+    rRetentionParameters.SetFluidPressure(rVariables.FluidPressure);
 
     rVariables.DegreeOfSaturation = mRetentionLawVector[GPoint]->CalculateSaturation(rRetentionParameters);
     rVariables.DerivativeOfSaturation =

--- a/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_interface_element.hpp
+++ b/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_interface_element.hpp
@@ -281,10 +281,7 @@ protected:
     template <class TValueType>
     void InterpolateOutputValues(std::vector<TValueType>& rOutput, const std::vector<TValueType>& GPValues);
 
-    void SetRetentionParameters(const InterfaceElementVariables& rVariables,
-                                RetentionLaw::Parameters&        rRetentionParameters);
-
-    double CalculateFluidPressure(const InterfaceElementVariables& rVariables);
+    [[nodiscard]] double CalculateFluidPressure(const InterfaceElementVariables& rVariables) const;
 
     double CalculateBulkModulus(const Matrix& ConstitutiveMatrix);
 

--- a/applications/GeoMechanicsApplication/custom_elements/small_strain_U_Pw_diff_order_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/small_strain_U_Pw_diff_order_element.cpp
@@ -910,7 +910,7 @@ void SmallStrainUPwDiffOrderElement::CalculateOnIntegrationPoints(const Variable
             this->CalculateKinematics(Variables, GPoint);
 
             Variables.FluidPressure = CalculateFluidPressure(Variables);
-            SetRetentionParameters(Variables, RetentionParameters);
+            RetentionParameters.SetFluidPressure(Variables.FluidPressure);
 
             if (rVariable == DEGREE_OF_SATURATION)
                 rOutput[GPoint] = mRetentionLawVector[GPoint]->CalculateSaturation(RetentionParameters);
@@ -1011,8 +1011,8 @@ void SmallStrainUPwDiffOrderElement::CalculateOnIntegrationPoints(const Variable
                     BodyAcceleration[idim] += Variables.Nu[i] * Variables.BodyAcceleration[Index++];
             }
 
-            CalculateFluidPressure(Variables);
-            SetRetentionParameters(Variables, RetentionParameters);
+            Variables.FluidPressure = CalculateFluidPressure(Variables);
+            RetentionParameters.SetFluidPressure(Variables.FluidPressure);
 
             const double RelativePermeability =
                 mRetentionLawVector[GPoint]->CalculateRelativePermeability(RetentionParameters);
@@ -2089,16 +2089,6 @@ double SmallStrainUPwDiffOrderElement::CalculateFluidPressure(const ElementVaria
     KRATOS_CATCH("")
 }
 
-void SmallStrainUPwDiffOrderElement::SetRetentionParameters(const ElementVariables& rVariables,
-                                                            RetentionLaw::Parameters& rRetentionParameters) const
-{
-    KRATOS_TRY
-
-    rRetentionParameters.SetFluidPressure(rVariables.FluidPressure);
-
-    KRATOS_CATCH("")
-}
-
 void SmallStrainUPwDiffOrderElement::CalculateRetentionResponse(ElementVariables& rVariables,
                                                                 RetentionLaw::Parameters& rRetentionParameters,
                                                                 unsigned int GPoint)
@@ -2106,7 +2096,7 @@ void SmallStrainUPwDiffOrderElement::CalculateRetentionResponse(ElementVariables
     KRATOS_TRY
 
     rVariables.FluidPressure = CalculateFluidPressure(rVariables);
-    SetRetentionParameters(rVariables, rRetentionParameters);
+    rRetentionParameters.SetFluidPressure(rVariables.FluidPressure);
 
     rVariables.DegreeOfSaturation = mRetentionLawVector[GPoint]->CalculateSaturation(rRetentionParameters);
     rVariables.DerivativeOfSaturation =

--- a/applications/GeoMechanicsApplication/custom_elements/small_strain_U_Pw_diff_order_element.hpp
+++ b/applications/GeoMechanicsApplication/custom_elements/small_strain_U_Pw_diff_order_element.hpp
@@ -302,10 +302,7 @@ protected:
 
     Matrix CalculateDeformationGradient(unsigned int GPoint) const;
 
-    double CalculateFluidPressure(const ElementVariables& rVariables) const;
-
-    void SetRetentionParameters(const ElementVariables&   rVariables,
-                                RetentionLaw::Parameters& rRetentionParameters) const;
+    [[nodiscard]] double CalculateFluidPressure(const ElementVariables& rVariables) const;
 
     void CalculateRetentionResponse(ElementVariables&         rVariables,
                                     RetentionLaw::Parameters& rRetentionParameters,


### PR DESCRIPTION
**📝 Description**
These member functions only set the fluid pressure (taken from the `ElementVariables` data structure) that is kept by the retention law parameters. This simple action does not need another level of indirection.

**🆕 Changelog**
Other changes include:
- It was found that in one location the fluid pressure was calculated, but its result was not stored. Now it is.
- Marked a few member functions `[[nodiscard]]`, to trigger warnings when the returned result is discarded.
- A few more member functions have been made `const`.
