### PR TITLE
[GeoMechanicsApplication] Added a missing `#include` in a unit test file

### DIFF
--- a/applications/GeoMechanicsApplication/tests/cpp_tests/test_math_utilities.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/test_math_utilities.cpp
@@ -11,6 +11,7 @@
 //
 
 #include "custom_utilities/math_utilities.h"
+#include "includes/checks.h"
 #include "testing/testing.h"
 
 namespace Kratos::Testing
@@ -23,7 +24,7 @@ KRATOS_TEST_CASE_IN_SUITE(CalculateDeterminants_ReturnsCorrectResults, KratosGeo
     const std::vector<double> results = GeoMechanicsMathUtilities::CalculateDeterminants(matrices);
 
     const std::vector<double> expected_results = {3.0, 0.0, 8.0};
-    KRATOS_CHECK_VECTOR_NEAR(results, expected_results, 1.0e-12);
+    KRATOS_CHECK_VECTOR_NEAR(results, expected_results, 1.0e-12)
 }
 
 KRATOS_TEST_CASE_IN_SUITE(CalculateDeterminants_ReturnsEmptyVectorForEmptyInput, KratosGeoMechanicsFastSuite)


### PR DESCRIPTION
**📝 Description**
Due to the missing `#include` of `includes/checks.h`, compilation of `test_math_utilities.cpp` failed when using a non-unity build. It was unable to find macro `KRATOS_CHECK_VECTOR_NEAR`.

Also removed a redundant semicolon (yielding an empty statement).