### PR TITLE
[GeoMechanicsApplication] Removed a redundant `override`

### DIFF
--- a/applications/GeoMechanicsApplication/custom_elements/U_Pw_updated_lagrangian_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/U_Pw_updated_lagrangian_element.cpp
@@ -42,21 +42,6 @@ Element::Pointer UPwUpdatedLagrangianElement<TDim, TNumNodes>::Create(IndexType 
 
 //----------------------------------------------------------------------------------------
 template <unsigned int TDim, unsigned int TNumNodes>
-int UPwUpdatedLagrangianElement<TDim, TNumNodes>::Check(const ProcessInfo& rCurrentProcessInfo) const
-{
-    KRATOS_TRY
-
-    // Base class checks for positive area and Id > 0
-    // Verify generic variables
-    int ierr = UPwSmallStrainElement<TDim, TNumNodes>::Check(rCurrentProcessInfo);
-
-    return ierr;
-
-    KRATOS_CATCH("");
-}
-
-//----------------------------------------------------------------------------------------
-template <unsigned int TDim, unsigned int TNumNodes>
 void UPwUpdatedLagrangianElement<TDim, TNumNodes>::CalculateAll(MatrixType& rLeftHandSideMatrix,
                                                                 VectorType& rRightHandSideVector,
                                                                 const ProcessInfo& rCurrentProcessInfo,

--- a/applications/GeoMechanicsApplication/custom_elements/U_Pw_updated_lagrangian_element.hpp
+++ b/applications/GeoMechanicsApplication/custom_elements/U_Pw_updated_lagrangian_element.hpp
@@ -119,8 +119,6 @@ public:
 
     ~UPwUpdatedLagrangianElement() = default;
 
-    int Check(const ProcessInfo& rCurrentProcessInfo) const override;
-
     /**
      * @brief Creates a new element
      * @param NewId The Id of the new created element


### PR DESCRIPTION
**📝 Description**
Removed an overridden function that simply forwarded the request to its base class. Since that is the default behavior when no `override` is provided, it's better to remove the redundant implementation.
