### PR TITLE
Add missing KRATOS_API

### DIFF
--- a/kratos/modeler/coloring/voxel_mesher_coloring.h
+++ b/kratos/modeler/coloring/voxel_mesher_coloring.h
@@ -26,7 +26,7 @@
 
 namespace Kratos {
 
-class VoxelMesherColoring {
+class KRATOS_API(KRATOS_CORE) VoxelMesherColoring {
 
     VoxelMeshGeneratorModeler& mrModeler;
     Parameters mParameters;

--- a/kratos/modeler/entity_generation/voxel_mesher_entity_generation.h
+++ b/kratos/modeler/entity_generation/voxel_mesher_entity_generation.h
@@ -24,7 +24,7 @@
 
 namespace Kratos {
 
-class VoxelMesherEntityGeneration {
+class KRATOS_API(KRATOS_CORE) VoxelMesherEntityGeneration {
 
     VoxelMeshGeneratorModeler& mrModeler;
     Parameters mParameters;

--- a/kratos/modeler/key_plane_generation/key_plane_generation.h
+++ b/kratos/modeler/key_plane_generation/key_plane_generation.h
@@ -22,7 +22,7 @@
 
 namespace Kratos {
 
-class VoxelMesherKeyPlaneGeneration {
+class KRATOS_API(KRATOS_CORE) VoxelMesherKeyPlaneGeneration {
 
     VoxelMeshGeneratorModeler& mrModeler;
     Parameters mParameters;

--- a/kratos/modeler/operation/voxel_mesher_operation.h
+++ b/kratos/modeler/operation/voxel_mesher_operation.h
@@ -24,7 +24,7 @@
 
 namespace Kratos {
 
-class VoxelMesherOperation {
+class KRATOS_API(KRATOS_CORE) VoxelMesherOperation {
 
     VoxelMeshGeneratorModeler& mrModeler;
     Parameters mParameters;


### PR DESCRIPTION
**📝 Description**
In https://github.com/KratosMultiphysics/Kratos/pull/12297 I forgot to add KRATOS_API declarations for the base classes of the VoxelMeshGeneratorModeler components (key plane generators, coloring, entity generators, operations). I need these to make sure that these classes are visible in the library in order to derive them in other applications.

**🆕 Changelog**
- Added KRATOS_API declarations to base Voxel Mesh Generator Modeler component classes.
