### PR TITLE
[GeoMechanicsApplication] extract stiffness matrix utility

### DIFF
--- a/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_element.cpp
@@ -868,17 +868,19 @@ void UPwSmallStrainElement<TDim, TNumNodes>::CalculateMaterialStiffnessMatrix(Ma
     this->CalculateAnyOfMaterialResponse(deformation_gradients, ConstitutiveParameters,
                                          Variables.NContainer, Variables.DN_DXContainer,
                                          strain_vectors, mStressVector, constitutive_matrices);
+    const auto integration_coefficients =
+        this->CalculateIntegrationCoefficients(IntegrationPoints, Variables.detJContainer);
 
     for (unsigned int GPoint = 0; GPoint < NumGPoints; ++GPoint) {
-        this->CalculateKinematics(Variables, GPoint);
+        // this->CalculateKinematics(Variables, GPoint);
         Variables.B                  = b_matrices[GPoint];
         Variables.F                  = deformation_gradients[GPoint];
         Variables.StrainVector       = strain_vectors[GPoint];
         Variables.ConstitutiveMatrix = constitutive_matrices[GPoint];
 
         // Compute weighting coefficient for integration
-        Variables.IntegrationCoefficient =
-            this->CalculateIntegrationCoefficient(IntegrationPoints[GPoint], Variables.detJ);
+        Variables.IntegrationCoefficient = integration_coefficients[GPoint];
+        // this->CalculateIntegrationCoefficient(IntegrationPoints[GPoint], Variables.detJ);
 
         // Compute stiffness matrix
         this->CalculateAndAddStiffnessMatrix(rStiffnessMatrix, Variables);

--- a/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_element.cpp
@@ -851,7 +851,6 @@ void UPwSmallStrainElement<TDim, TNumNodes>::CalculateMaterialStiffnessMatrix(Ma
     const GeometryType&                             rGeom = this->GetGeometry();
     const GeometryType::IntegrationPointsArrayType& IntegrationPoints =
         rGeom.IntegrationPoints(mThisIntegrationMethod);
-    const IndexType NumGPoints = IntegrationPoints.size();
 
     // Constitutive Law parameters
     ConstitutiveLaw::Parameters ConstitutiveParameters(rGeom, rProp, rCurrentProcessInfo);

--- a/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_element.cpp
@@ -1234,7 +1234,7 @@ void UPwSmallStrainElement<TDim, TNumNodes>::CalculateAndAddStiffnessMatrix(Matr
 {
     KRATOS_TRY
 
-    Matrix stiffness_matrix = GeoEquationOfMotionUtilities::CalculateStiffnessMatrixGPoint(
+    const auto stiffness_matrix = GeoEquationOfMotionUtilities::CalculateStiffnessMatrixGPoint(
         rVariables.B, rVariables.ConstitutiveMatrix, rVariables.IntegrationCoefficient);
     GeoElementUtilities::AssembleUUBlockMatrix(rLeftHandSideMatrix, stiffness_matrix);
 
@@ -1332,7 +1332,6 @@ void UPwSmallStrainElement<TDim, TNumNodes>::CalculateAndAddStiffnessForce(Vecto
     noalias(rVariables.UVector) =
         -1.0 * prod(trans(rVariables.B), mStressVector[GPoint]) * rVariables.IntegrationCoefficient;
 
-    // Distribute stiffness block vector into elemental vector
     GeoElementUtilities::AssembleUBlockVector(rRightHandSideVector, rVariables.UVector);
 
     KRATOS_CATCH("")

--- a/applications/GeoMechanicsApplication/custom_elements/small_strain_U_Pw_diff_order_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/small_strain_U_Pw_diff_order_element.cpp
@@ -1717,10 +1717,9 @@ void SmallStrainUPwDiffOrderElement::CalculateAndAddStiffnessMatrix(MatrixType& 
 {
     KRATOS_TRY
 
-    Matrix stiffness_matrix = GeoEquationOfMotionUtilities::CalculateStiffnessMatrixGPoint(
+    const auto stiffness_matrix = GeoEquationOfMotionUtilities::CalculateStiffnessMatrixGPoint(
         rVariables.B, rVariables.ConstitutiveMatrix, rVariables.IntegrationCoefficient);
 
-    // Distribute stiffness block matrix into the elemental matrix
     GeoElementUtilities::AssembleUUBlockMatrix(rLeftHandSideMatrix, stiffness_matrix);
 
     KRATOS_CATCH("")

--- a/applications/GeoMechanicsApplication/custom_elements/small_strain_U_Pw_diff_order_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/small_strain_U_Pw_diff_order_element.cpp
@@ -1346,7 +1346,12 @@ void SmallStrainUPwDiffOrderElement::CalculateMaterialStiffnessMatrix(MatrixType
     const auto integration_coefficients =
         CalculateIntegrationCoefficients(IntegrationPoints, Variables.detJuContainer);
 
-    for (unsigned int GPoint = 0; GPoint < IntegrationPoints.size(); ++GPoint) {
+    const auto stiffness_matrix = GeoEquationOfMotionUtilities::CalculateStiffnessMatrix(
+        b_matrices, constitutive_matrices, integration_coefficients);
+
+    GeoElementUtilities::AssembleUUBlockMatrix(rStiffnessMatrix, stiffness_matrix);
+
+    /*for (unsigned int GPoint = 0; GPoint < IntegrationPoints.size(); ++GPoint) {
         // compute element kinematics (Np, gradNpT, |J|, B, strains)
         // this->CalculateKinematics(Variables, GPoint);
         Variables.B = b_matrices[GPoint];
@@ -1361,7 +1366,7 @@ void SmallStrainUPwDiffOrderElement::CalculateMaterialStiffnessMatrix(MatrixType
 
         // Contributions of material stiffness to the left hand side
         this->CalculateAndAddStiffnessMatrix(rStiffnessMatrix, Variables);
-    }
+    }*/
 
     KRATOS_CATCH("")
 }
@@ -1729,12 +1734,11 @@ void SmallStrainUPwDiffOrderElement::CalculateAndAddStiffnessMatrix(MatrixType& 
 {
     KRATOS_TRY
 
-    Matrix StiffnessMatrix =
-        prod(trans(rVariables.B), Matrix(prod(rVariables.ConstitutiveMatrix, rVariables.B))) *
-        rVariables.IntegrationCoefficient;
+    Matrix stiffness_matrix = GeoEquationOfMotionUtilities::CalculateStiffnessMatrixGPoint(
+        rVariables.B, rVariables.ConstitutiveMatrix, rVariables.IntegrationCoefficient);
 
     // Distribute stiffness block matrix into the elemental matrix
-    GeoElementUtilities::AssembleUUBlockMatrix(rLeftHandSideMatrix, StiffnessMatrix);
+    GeoElementUtilities::AssembleUUBlockMatrix(rLeftHandSideMatrix, stiffness_matrix);
 
     KRATOS_CATCH("")
 }

--- a/applications/GeoMechanicsApplication/custom_elements/small_strain_U_Pw_diff_order_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/small_strain_U_Pw_diff_order_element.cpp
@@ -1343,10 +1343,12 @@ void SmallStrainUPwDiffOrderElement::CalculateMaterialStiffnessMatrix(MatrixType
     this->CalculateAnyOfMaterialResponse(deformation_gradients, ConstitutiveParameters,
                                          Variables.NuContainer, Variables.DNu_DXContainer,
                                          strain_vectors, mStressVector, constitutive_matrices);
+    const auto integration_coefficients =
+        CalculateIntegrationCoefficients(IntegrationPoints, Variables.detJuContainer);
 
     for (unsigned int GPoint = 0; GPoint < IntegrationPoints.size(); ++GPoint) {
         // compute element kinematics (Np, gradNpT, |J|, B, strains)
-        this->CalculateKinematics(Variables, GPoint);
+        // this->CalculateKinematics(Variables, GPoint);
         Variables.B = b_matrices[GPoint];
 
         // Compute infinitesimal strain
@@ -1355,8 +1357,7 @@ void SmallStrainUPwDiffOrderElement::CalculateMaterialStiffnessMatrix(MatrixType
         Variables.ConstitutiveMatrix = constitutive_matrices[GPoint];
 
         // calculating weighting coefficient for integration
-        Variables.IntegrationCoefficient =
-            this->CalculateIntegrationCoefficient(IntegrationPoints[GPoint], Variables.detJ);
+        Variables.IntegrationCoefficient = integration_coefficients[GPoint];
 
         // Contributions of material stiffness to the left hand side
         this->CalculateAndAddStiffnessMatrix(rStiffnessMatrix, Variables);

--- a/applications/GeoMechanicsApplication/custom_elements/small_strain_U_Pw_diff_order_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/small_strain_U_Pw_diff_order_element.cpp
@@ -1713,7 +1713,7 @@ void SmallStrainUPwDiffOrderElement::CalculateAndAddLHS(MatrixType& rLeftHandSid
 }
 
 void SmallStrainUPwDiffOrderElement::CalculateAndAddStiffnessMatrix(MatrixType& rLeftHandSideMatrix,
-                                                                    ElementVariables& rVariables) const
+                                                                    const ElementVariables& rVariables) const
 {
     KRATOS_TRY
 

--- a/applications/GeoMechanicsApplication/custom_elements/small_strain_U_Pw_diff_order_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/small_strain_U_Pw_diff_order_element.cpp
@@ -1351,23 +1351,6 @@ void SmallStrainUPwDiffOrderElement::CalculateMaterialStiffnessMatrix(MatrixType
 
     GeoElementUtilities::AssembleUUBlockMatrix(rStiffnessMatrix, stiffness_matrix);
 
-    /*for (unsigned int GPoint = 0; GPoint < IntegrationPoints.size(); ++GPoint) {
-        // compute element kinematics (Np, gradNpT, |J|, B, strains)
-        // this->CalculateKinematics(Variables, GPoint);
-        Variables.B = b_matrices[GPoint];
-
-        // Compute infinitesimal strain
-        Variables.F                  = deformation_gradients[GPoint];
-        Variables.StrainVector       = strain_vectors[GPoint];
-        Variables.ConstitutiveMatrix = constitutive_matrices[GPoint];
-
-        // calculating weighting coefficient for integration
-        Variables.IntegrationCoefficient = integration_coefficients[GPoint];
-
-        // Contributions of material stiffness to the left hand side
-        this->CalculateAndAddStiffnessMatrix(rStiffnessMatrix, Variables);
-    }*/
-
     KRATOS_CATCH("")
 }
 

--- a/applications/GeoMechanicsApplication/custom_elements/small_strain_U_Pw_diff_order_element.hpp
+++ b/applications/GeoMechanicsApplication/custom_elements/small_strain_U_Pw_diff_order_element.hpp
@@ -259,7 +259,7 @@ protected:
 
     void CalculateAndAddLHS(MatrixType& rLeftHandSideMatrix, ElementVariables& rVariables);
 
-    void CalculateAndAddStiffnessMatrix(MatrixType& rLeftHandSideMatrix, ElementVariables& rVariables) const;
+    void CalculateAndAddStiffnessMatrix(MatrixType& rLeftHandSideMatrix, const ElementVariables& rVariables) const;
 
     void CalculateAndAddCouplingMatrix(MatrixType& rLeftHandSideMatrix, const ElementVariables& rVariables);
 

--- a/applications/GeoMechanicsApplication/custom_utilities/README.md
+++ b/applications/GeoMechanicsApplication/custom_utilities/README.md
@@ -58,6 +58,14 @@ $$M = \int_\Omega N_{u}^T \rho N_u d\Omega$$
 
 Where $\Omega$ is the domain, $N_u$ is the displacement shape function and $\rho$ is the density matrix that holds density for all directions.
 
+### Stiffness Matrix (K)
+
+The mathematical definition is:
+$$K = \int_\Omega B^T C_{constitutive} B d\Omega$$
+
+Where $\Omega$ is the domain, $B$ is the B-matrix and $C_{constitutive}$ is the constitutive matrix.
+
+
 ### Damping Matrix (D)
 
 The mathematical definition is:
@@ -65,8 +73,10 @@ $$D = \alpha_R M + \beta_R K$$
 
 Where $M$ and $K$ are the mass and stiffness  matrices respectively and $\alpha_R$ and $\beta_R$ are the coefficients from the Rayleigh Method.
 
-File equation_of_motion_utilities.hpp includes 
+File equation_of_motion_utilities.h includes 
 -  CalculateMassMatrix function
+-  CalculateStiffnessMatrixGPoint provides a stiffness matrix for a specific integration point
+-  CalculateStiffnessMatrix provides a stiffness matrix for all integration points
 -  CalculateDampingMatrix function
 -  CalculateIntegrationCoefficientsInitialConfiguration function that calculates integration coefficient for all integration points
 

--- a/applications/GeoMechanicsApplication/custom_utilities/README.md
+++ b/applications/GeoMechanicsApplication/custom_utilities/README.md
@@ -76,7 +76,7 @@ Where $M$ and $K$ are the mass and stiffness  matrices respectively and $\alpha_
 File equation_of_motion_utilities.h includes 
 -  CalculateMassMatrix function
 -  CalculateStiffnessMatrixGPoint provides a stiffness matrix for a specific integration point
--  CalculateStiffnessMatrix provides a stiffness matrix for all integration points
+-  CalculateStiffnessMatrix provides a stiffness matrix for an element
 -  CalculateDampingMatrix function
 -  CalculateIntegrationCoefficientsInitialConfiguration function that calculates integration coefficient for all integration points
 

--- a/applications/GeoMechanicsApplication/custom_utilities/equation_of_motion_utilities.cpp
+++ b/applications/GeoMechanicsApplication/custom_utilities/equation_of_motion_utilities.cpp
@@ -66,4 +66,23 @@ Matrix GeoEquationOfMotionUtilities::CalculateDampingMatrix(double        Raylei
     return RayleighAlpha * rMassMatrix + RayleighBeta * rStiffnessMatrix;
 }
 
+Matrix GeoEquationOfMotionUtilities::CalculateStiffnessMatrixGPoint(const Matrix& rB,
+                                                                    const Matrix& rConstitutiveMatrix,
+                                                                    double IntegrationCoefficient)
+{
+    return prod(trans(rB), Matrix(prod(rConstitutiveMatrix, rB))) * IntegrationCoefficient;
+}
+
+Matrix GeoEquationOfMotionUtilities::CalculateStiffnessMatrix(const std::vector<Matrix>& rBs,
+                                                              const std::vector<Matrix>& rConstitutiveMatrices,
+                                                              std::vector<double> rIntegrationCoefficients)
+{
+    Matrix result = ZeroMatrix(rBs[0].size2(), rBs[0].size2());
+    for (unsigned int GPoint = 0; GPoint < rBs.size(); ++GPoint) {
+        result += CalculateStiffnessMatrixGPoint(rBs[GPoint], rConstitutiveMatrices[GPoint],
+                                                 rIntegrationCoefficients[GPoint]);
+    }
+    return result;
+}
+
 } /* namespace Kratos.*/

--- a/applications/GeoMechanicsApplication/custom_utilities/equation_of_motion_utilities.cpp
+++ b/applications/GeoMechanicsApplication/custom_utilities/equation_of_motion_utilities.cpp
@@ -75,7 +75,7 @@ Matrix GeoEquationOfMotionUtilities::CalculateStiffnessMatrixGPoint(const Matrix
 
 Matrix GeoEquationOfMotionUtilities::CalculateStiffnessMatrix(const std::vector<Matrix>& rBs,
                                                               const std::vector<Matrix>& rConstitutiveMatrices,
-                                                              std::vector<double> rIntegrationCoefficients)
+                                                              const std::vector<double>& rIntegrationCoefficients)
 {
     Matrix result = ZeroMatrix(rBs[0].size2(), rBs[0].size2());
     for (unsigned int GPoint = 0; GPoint < rBs.size(); ++GPoint) {

--- a/applications/GeoMechanicsApplication/custom_utilities/equation_of_motion_utilities.h
+++ b/applications/GeoMechanicsApplication/custom_utilities/equation_of_motion_utilities.h
@@ -45,9 +45,9 @@ public:
                                                  const Matrix& rConstitutiveMatrix,
                                                  double        IntegrationCoefficient);
 
-    static Matrix CalculateStiffnessMatrix(const std::vector<Matrix>& b_matrices,
-                                           const std::vector<Matrix>& constitutive_matrices,
-                                           const std::vector<double>& integration_coefficients);
+    static Matrix CalculateStiffnessMatrix(const std::vector<Matrix>& rBs,
+                                           const std::vector<Matrix>& rConstitutiveMatrices,
+                                           const std::vector<double>& rIntegrationCoefficients);
 
 }; /* Class GeoTransportEquationUtilities*/
 } /* namespace Kratos.*/

--- a/applications/GeoMechanicsApplication/custom_utilities/equation_of_motion_utilities.h
+++ b/applications/GeoMechanicsApplication/custom_utilities/equation_of_motion_utilities.h
@@ -41,5 +41,13 @@ public:
                                          const Matrix& rMassMatrix,
                                          const Matrix& rStiffnessMatrix);
 
+    static Matrix CalculateStiffnessMatrixGPoint(const Matrix& rB,
+                                                 const Matrix& rConstitutiveMatrix,
+                                                 double        IntegrationCoefficient);
+
+    static Matrix CalculateStiffnessMatrix(const std::vector<Matrix>& b_matrices,
+                                           const std::vector<Matrix>& constitutive_matrices,
+                                           std::vector<double>        integration_coefficients);
+
 }; /* Class GeoTransportEquationUtilities*/
 } /* namespace Kratos.*/

--- a/applications/GeoMechanicsApplication/custom_utilities/equation_of_motion_utilities.h
+++ b/applications/GeoMechanicsApplication/custom_utilities/equation_of_motion_utilities.h
@@ -47,7 +47,7 @@ public:
 
     static Matrix CalculateStiffnessMatrix(const std::vector<Matrix>& b_matrices,
                                            const std::vector<Matrix>& constitutive_matrices,
-                                           std::vector<double>        integration_coefficients);
+                                           const std::vector<double>& integration_coefficients);
 
 }; /* Class GeoTransportEquationUtilities*/
 } /* namespace Kratos.*/

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/test_equation_of_motion.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/test_equation_of_motion.cpp
@@ -158,4 +158,29 @@ KRATOS_TEST_CASE_IN_SUITE(CalculateDampingMatrixGivesCorrectResults, KratosGeoMe
     KRATOS_CHECK_MATRIX_NEAR(damping_matrix, expected_damping_matrix, 1e-4)
 }
 
+KRATOS_TEST_CASE_IN_SUITE(CalculateStiffnessMatrixGivesCorrectResults, KratosGeoMechanicsFastSuite)
+{
+    constexpr std::size_t voigt_size = 4;
+    constexpr std::size_t n          = 3;
+
+    const Matrix        b = ScalarMatrix(voigt_size, n, 0.5);
+    std::vector<Matrix> b_matrices;
+    b_matrices.push_back(b);
+    b_matrices.push_back(b);
+
+    const Matrix        constitutive = ScalarMatrix(voigt_size, voigt_size, 2.0);
+    std::vector<Matrix> constitutive_matrices;
+    constitutive_matrices.push_back(constitutive);
+    constitutive_matrices.push_back(constitutive);
+
+    std::vector<double> integration_coefficients{1.0, 2.0};
+
+    auto stiffness_matrix = GeoEquationOfMotionUtilities::CalculateStiffnessMatrix(
+        b_matrices, constitutive_matrices, integration_coefficients);
+
+    const auto expected_stiffness_matrix = ScalarMatrix(n, n, 24.0);
+
+    KRATOS_CHECK_MATRIX_NEAR(stiffness_matrix, expected_stiffness_matrix, 1e-4)
+}
+
 } // namespace Kratos::Testing


### PR DESCRIPTION
**📝 Description**
- Calculation of stiffness matrix is extracted as utility functions
- CalculateStiffnessMatrixGPoint provides the matrix for a specific integration point because some functions like CalculateAndAddLHS still work on this level
- CalculateStiffnessMatrix provides the matrix on the element level
- the function is documented and unit tested.
