### PR TITLE
[GeoMechanicsApplication] Towards element permeability matrices

### DIFF
--- a/applications/GeoMechanicsApplication/custom_constitutive/thermal_dispersion_law.cpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/thermal_dispersion_law.cpp
@@ -26,12 +26,11 @@ GeoThermalDispersionLaw::GeoThermalDispersionLaw(std::size_t NumberOfDimensions)
         << "Got invalid number of dimensions: " << mNumberOfDimensions << std::endl;
 }
 
-Matrix GeoThermalDispersionLaw::CalculateThermalDispersionMatrix(const Properties& rProp,
-                                                                 const ProcessInfo& rProcessInfo) const
+Matrix GeoThermalDispersionLaw::CalculateThermalDispersionMatrix(const Properties& rProp) const
 {
     Matrix result = ZeroMatrix(mNumberOfDimensions, mNumberOfDimensions);
 
-    RetentionLaw::Parameters parameters(rProp, rProcessInfo);
+    RetentionLaw::Parameters parameters(rProp);
     auto                     retention_law  = RetentionLawFactory::Clone(rProp);
     const double             saturation     = retention_law->CalculateSaturation(parameters);
     const double             water_fraction = rProp[POROSITY] * saturation;

--- a/applications/GeoMechanicsApplication/custom_constitutive/thermal_dispersion_law.h
+++ b/applications/GeoMechanicsApplication/custom_constitutive/thermal_dispersion_law.h
@@ -30,7 +30,7 @@ public:
 
     explicit GeoThermalDispersionLaw(SizeType NumberOfDimensions);
 
-    Matrix CalculateThermalDispersionMatrix(const Properties& rProp) const override;
+    [[nodiscard]] Matrix CalculateThermalDispersionMatrix(const Properties& rProp) const override;
 
 private:
     std::size_t mNumberOfDimensions = 2;

--- a/applications/GeoMechanicsApplication/custom_constitutive/thermal_dispersion_law.h
+++ b/applications/GeoMechanicsApplication/custom_constitutive/thermal_dispersion_law.h
@@ -30,7 +30,7 @@ public:
 
     explicit GeoThermalDispersionLaw(SizeType NumberOfDimensions);
 
-    Matrix CalculateThermalDispersionMatrix(const Properties& rProp, const ProcessInfo& rProcessInfo) const override;
+    Matrix CalculateThermalDispersionMatrix(const Properties& rProp) const override;
 
 private:
     std::size_t mNumberOfDimensions = 2;

--- a/applications/GeoMechanicsApplication/custom_constitutive/thermal_filter_law.cpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/thermal_filter_law.cpp
@@ -17,7 +17,7 @@
 namespace Kratos
 {
 
-Matrix GeoThermalFilterLaw::CalculateThermalDispersionMatrix(const Properties& rProp, const ProcessInfo&) const
+Matrix GeoThermalFilterLaw::CalculateThermalDispersionMatrix(const Properties& rProp) const
 {
     return ScalarMatrix(1, 1, rProp[THERMAL_CONDUCTIVITY_WATER]);
 }

--- a/applications/GeoMechanicsApplication/custom_constitutive/thermal_filter_law.h
+++ b/applications/GeoMechanicsApplication/custom_constitutive/thermal_filter_law.h
@@ -23,7 +23,7 @@ class KRATOS_API(GEO_MECHANICS_APPLICATION) GeoThermalFilterLaw : public GeoTher
 public:
     KRATOS_CLASS_POINTER_DEFINITION(GeoThermalFilterLaw);
 
-    Matrix CalculateThermalDispersionMatrix(const Properties& rProp) const override;
+    [[nodiscard]] Matrix CalculateThermalDispersionMatrix(const Properties& rProp) const override;
 
 private:
     friend class Serializer;

--- a/applications/GeoMechanicsApplication/custom_constitutive/thermal_filter_law.h
+++ b/applications/GeoMechanicsApplication/custom_constitutive/thermal_filter_law.h
@@ -23,7 +23,7 @@ class KRATOS_API(GEO_MECHANICS_APPLICATION) GeoThermalFilterLaw : public GeoTher
 public:
     KRATOS_CLASS_POINTER_DEFINITION(GeoThermalFilterLaw);
 
-    Matrix CalculateThermalDispersionMatrix(const Properties& rProp, const ProcessInfo&) const override;
+    Matrix CalculateThermalDispersionMatrix(const Properties& rProp) const override;
 
 private:
     friend class Serializer;

--- a/applications/GeoMechanicsApplication/custom_constitutive/thermal_law.h
+++ b/applications/GeoMechanicsApplication/custom_constitutive/thermal_law.h
@@ -27,8 +27,7 @@ public:
 
     virtual ~GeoThermalLaw() = default;
 
-    virtual Matrix CalculateThermalDispersionMatrix(const Properties&  rProp,
-                                                    const ProcessInfo& rProcessInfo) const = 0;
+    virtual Matrix CalculateThermalDispersionMatrix(const Properties& rProp) const = 0;
 
 private:
     friend class Serializer;

--- a/applications/GeoMechanicsApplication/custom_constitutive/thermal_law.h
+++ b/applications/GeoMechanicsApplication/custom_constitutive/thermal_law.h
@@ -27,7 +27,7 @@ public:
 
     virtual ~GeoThermalLaw() = default;
 
-    virtual Matrix CalculateThermalDispersionMatrix(const Properties& rProp) const = 0;
+    [[nodiscard]] virtual Matrix CalculateThermalDispersionMatrix(const Properties& rProp) const = 0;
 
 private:
     friend class Serializer;

--- a/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_FIC_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_FIC_element.cpp
@@ -472,6 +472,7 @@ void UPwSmallStrainFICElement<TDim, TNumNodes>::CalculateAll(MatrixType& rLeftHa
 
         this->CalculateShapeFunctionsSecondOrderGradients(FICVariables, Variables);
         this->CalculateRetentionResponse(Variables, RetentionParameters, GPoint);
+        Variables.RelativePermeability = relative_permeability_values[GPoint];
 
         FICVariables.ShearModulus = CalculateShearModulus(Variables.ConstitutiveMatrix);
 
@@ -479,7 +480,6 @@ void UPwSmallStrainFICElement<TDim, TNumNodes>::CalculateAll(MatrixType& rLeftHa
         Variables.BiotModulusInverse = GeoTransportEquationUtilities::CalculateBiotModulusInverse(
             Variables.BiotCoefficient, Variables.DegreeOfSaturation, Variables.DerivativeOfSaturation, Prop);
 
-        Variables.RelativePermeability   = relative_permeability_values[GPoint];
         Variables.IntegrationCoefficient = integration_coefficients[GPoint];
 
         Variables.IntegrationCoefficientInitialConfiguration = this->CalculateIntegrationCoefficient(

--- a/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_FIC_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_FIC_element.cpp
@@ -442,7 +442,7 @@ void UPwSmallStrainFICElement<TDim, TNumNodes>::CalculateAll(MatrixType& rLeftHa
     this->InitializeFICElementVariables(FICVariables, Variables.DN_DXContainer, Geom, Prop, CurrentProcessInfo);
 
     // create general parameters of retention law
-    RetentionLaw::Parameters RetentionParameters(this->GetProperties(), CurrentProcessInfo);
+    RetentionLaw::Parameters RetentionParameters(this->GetProperties());
 
     const auto b_matrices = this->CalculateBMatrices(Variables.DN_DXContainer, Variables.NContainer);
     const auto integration_coefficients =

--- a/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_FIC_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_FIC_element.cpp
@@ -441,7 +441,6 @@ void UPwSmallStrainFICElement<TDim, TNumNodes>::CalculateAll(MatrixType& rLeftHa
     FICElementVariables FICVariables;
     this->InitializeFICElementVariables(FICVariables, Variables.DN_DXContainer, Geom, Prop, CurrentProcessInfo);
 
-    // create general parameters of retention law
     RetentionLaw::Parameters RetentionParameters(this->GetProperties());
 
     const auto b_matrices = this->CalculateBMatrices(Variables.DN_DXContainer, Variables.NContainer);

--- a/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_FIC_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_FIC_element.cpp
@@ -456,6 +456,8 @@ void UPwSmallStrainFICElement<TDim, TNumNodes>::CalculateAll(MatrixType& rLeftHa
                                          strain_vectors, mStressVector, constitutive_matrices);
     const auto biot_coefficients =
         GeoTransportEquationUtilities::CalculateBiotCoefficients(constitutive_matrices, Prop);
+    const auto relative_permeability_values = this->CalculateRelativePermeabilityValues(
+        GeoTransportEquationUtilities::CalculateFluidPressures(Variables.NContainer, Variables.PressureVector));
 
     for (unsigned int GPoint = 0; GPoint < NumGPoints; ++GPoint) {
         this->CalculateKinematics(Variables, GPoint);
@@ -477,6 +479,7 @@ void UPwSmallStrainFICElement<TDim, TNumNodes>::CalculateAll(MatrixType& rLeftHa
         Variables.BiotModulusInverse = GeoTransportEquationUtilities::CalculateBiotModulusInverse(
             Variables.BiotCoefficient, Variables.DegreeOfSaturation, Variables.DerivativeOfSaturation, Prop);
 
+        Variables.RelativePermeability   = relative_permeability_values[GPoint];
         Variables.IntegrationCoefficient = integration_coefficients[GPoint];
 
         Variables.IntegrationCoefficientInitialConfiguration = this->CalculateIntegrationCoefficient(

--- a/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_element.cpp
@@ -149,7 +149,6 @@ void UPwSmallStrainElement<TDim, TNumNodes>::InitializeSolutionStep(const Proces
     ElementVariables Variables;
     this->InitializeElementVariables(Variables, rCurrentProcessInfo);
 
-    // Create general parameters of retention law
     RetentionLaw::Parameters RetentionParameters(this->GetProperties());
 
     const auto b_matrices = CalculateBMatrices(Variables.DN_DXContainer, Variables.NContainer);
@@ -302,7 +301,6 @@ void UPwSmallStrainElement<TDim, TNumNodes>::FinalizeSolutionStep(const ProcessI
     ElementVariables Variables;
     this->InitializeElementVariables(Variables, rCurrentProcessInfo);
 
-    // Create general parameters of retention law
     RetentionLaw::Parameters RetentionParameters(this->GetProperties());
 
     const auto b_matrices = CalculateBMatrices(Variables.DN_DXContainer, Variables.NContainer);
@@ -513,7 +511,6 @@ void UPwSmallStrainElement<TDim, TNumNodes>::CalculateOnIntegrationPoints(const 
         ElementVariables Variables;
         this->InitializeElementVariables(Variables, rCurrentProcessInfo);
 
-        // create general parameters of retention law
         RetentionLaw::Parameters RetentionParameters(this->GetProperties());
 
         for (unsigned int GPoint = 0; GPoint < NumGPoints; ++GPoint) {
@@ -686,7 +683,6 @@ void UPwSmallStrainElement<TDim, TNumNodes>::CalculateOnIntegrationPoints(const 
         ElementVariables Variables;
         this->InitializeElementVariables(Variables, rCurrentProcessInfo);
 
-        // Create general parameters of retention law
         RetentionLaw::Parameters RetentionParameters(this->GetProperties());
 
         Vector VoigtVector(mStressVector[0].size());
@@ -960,7 +956,6 @@ void UPwSmallStrainElement<TDim, TNumNodes>::CalculateAll(MatrixType&        rLe
     ElementVariables Variables;
     this->InitializeElementVariables(Variables, rCurrentProcessInfo);
 
-    // Create general parameters of retention law
     RetentionLaw::Parameters RetentionParameters(this->GetProperties());
 
     const auto b_matrices = CalculateBMatrices(Variables.DN_DXContainer, Variables.NContainer);

--- a/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_element.cpp
@@ -992,7 +992,7 @@ void UPwSmallStrainElement<TDim, TNumNodes>::CalculateAll(MatrixType&        rLe
         GeoElementUtilities::InterpolateVariableWithComponents<TDim, TNumNodes>(
             Variables.BodyAcceleration, Variables.NContainer, Variables.VolumeAcceleration, GPoint);
 
-        CalculateRetentionResponse(Variables, RetentionParameters, GPoint);
+        this->CalculateRetentionResponse(Variables, RetentionParameters, GPoint);
 
         Variables.BiotCoefficient    = biot_coefficients[GPoint];
         Variables.BiotModulusInverse = GeoTransportEquationUtilities::CalculateBiotModulusInverse(

--- a/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_element.cpp
@@ -1166,7 +1166,11 @@ void UPwSmallStrainElement<TDim, TNumNodes>::CalculateAndAddLHS(MatrixType& rLef
 
     if (!rVariables.IgnoreUndrained) {
         this->CalculateAndAddCouplingMatrix(rLeftHandSideMatrix, rVariables);
-        this->CalculateAndAddPermeabilityMatrix(rLeftHandSideMatrix, rVariables);
+
+        const auto permeability_matrix = GeoTransportEquationUtilities::CalculatePermeabilityMatrix<TDim, TNumNodes>(
+            rVariables.GradNpT, rVariables.DynamicViscosityInverse, rVariables.PermeabilityMatrix,
+            rVariables.RelativePermeability, rVariables.PermeabilityUpdateFactor, rVariables.IntegrationCoefficient);
+        GeoElementUtilities::AssemblePPBlockMatrix(rLeftHandSideMatrix, permeability_matrix);
     }
 
     KRATOS_CATCH("")
@@ -1222,22 +1226,6 @@ void UPwSmallStrainElement<TDim, TNumNodes>::CalculateAndAddCompressibilityMatri
     // Distribute compressibility block matrix into the elemental matrix
     GeoElementUtilities::AssemblePPBlockMatrix(
         rLeftHandSideMatrix, rVariables.PPMatrix * rVariables.DtPressureCoefficient);
-
-    KRATOS_CATCH("")
-}
-
-template <unsigned int TDim, unsigned int TNumNodes>
-void UPwSmallStrainElement<TDim, TNumNodes>::CalculateAndAddPermeabilityMatrix(MatrixType& rLeftHandSideMatrix,
-                                                                               const ElementVariables& rVariables)
-{
-    KRATOS_TRY
-
-    const auto permeability_matrix = GeoTransportEquationUtilities::CalculatePermeabilityMatrix<TDim, TNumNodes>(
-        rVariables.GradNpT, rVariables.DynamicViscosityInverse, rVariables.PermeabilityMatrix,
-        rVariables.RelativePermeability, rVariables.PermeabilityUpdateFactor, rVariables.IntegrationCoefficient);
-
-    // Distribute permeability block matrix into the elemental matrix
-    GeoElementUtilities::AssemblePPBlockMatrix(rLeftHandSideMatrix, permeability_matrix);
 
     KRATOS_CATCH("")
 }

--- a/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_element.cpp
@@ -1551,8 +1551,6 @@ void UPwSmallStrainElement<TDim, TNumNodes>::InitializeProperties(ElementVariabl
     rVariables.Porosity                = rProp[POROSITY];
     GeoElementUtilities::FillPermeabilityMatrix(rVariables.PermeabilityMatrix, rProp);
 
-    rVariables.PermeabilityUpdateFactor = 1.0;
-
     KRATOS_CATCH("")
 }
 

--- a/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_element.cpp
@@ -996,12 +996,12 @@ void UPwSmallStrainElement<TDim, TNumNodes>::CalculateAll(MatrixType&        rLe
             Variables.BodyAcceleration, Variables.NContainer, Variables.VolumeAcceleration, GPoint);
 
         this->CalculateRetentionResponse(Variables, RetentionParameters, GPoint);
+        Variables.RelativePermeability = relative_permeability_values[GPoint];
 
         Variables.BiotCoefficient    = biot_coefficients[GPoint];
         Variables.BiotModulusInverse = GeoTransportEquationUtilities::CalculateBiotModulusInverse(
             Variables.BiotCoefficient, Variables.DegreeOfSaturation,
             Variables.DerivativeOfSaturation, this->GetProperties());
-        Variables.RelativePermeability = relative_permeability_values[GPoint];
 
         Variables.IntegrationCoefficient = integration_coefficients[GPoint];
 
@@ -1557,8 +1557,6 @@ void UPwSmallStrainElement<TDim, TNumNodes>::CalculateRetentionResponse(ElementV
     rVariables.DegreeOfSaturation = mRetentionLawVector[GPoint]->CalculateSaturation(rRetentionParameters);
     rVariables.DerivativeOfSaturation =
         mRetentionLawVector[GPoint]->CalculateDerivativeOfSaturation(rRetentionParameters);
-    rVariables.RelativePermeability =
-        mRetentionLawVector[GPoint]->CalculateRelativePermeability(rRetentionParameters);
     rVariables.BishopCoefficient = mRetentionLawVector[GPoint]->CalculateBishopCoefficient(rRetentionParameters);
 
     KRATOS_CATCH("")

--- a/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_element.cpp
@@ -150,7 +150,7 @@ void UPwSmallStrainElement<TDim, TNumNodes>::InitializeSolutionStep(const Proces
     this->InitializeElementVariables(Variables, rCurrentProcessInfo);
 
     // Create general parameters of retention law
-    RetentionLaw::Parameters RetentionParameters(this->GetProperties(), rCurrentProcessInfo);
+    RetentionLaw::Parameters RetentionParameters(this->GetProperties());
 
     const auto b_matrices = CalculateBMatrices(Variables.DN_DXContainer, Variables.NContainer);
     const auto deformation_gradients = CalculateDeformationGradients();
@@ -303,7 +303,7 @@ void UPwSmallStrainElement<TDim, TNumNodes>::FinalizeSolutionStep(const ProcessI
     this->InitializeElementVariables(Variables, rCurrentProcessInfo);
 
     // Create general parameters of retention law
-    RetentionLaw::Parameters RetentionParameters(this->GetProperties(), rCurrentProcessInfo);
+    RetentionLaw::Parameters RetentionParameters(this->GetProperties());
 
     const auto b_matrices = CalculateBMatrices(Variables.DN_DXContainer, Variables.NContainer);
     const auto deformation_gradients = CalculateDeformationGradients();
@@ -514,7 +514,7 @@ void UPwSmallStrainElement<TDim, TNumNodes>::CalculateOnIntegrationPoints(const 
         this->InitializeElementVariables(Variables, rCurrentProcessInfo);
 
         // create general parameters of retention law
-        RetentionLaw::Parameters RetentionParameters(this->GetProperties(), rCurrentProcessInfo);
+        RetentionLaw::Parameters RetentionParameters(this->GetProperties());
 
         for (unsigned int GPoint = 0; GPoint < NumGPoints; ++GPoint) {
             // Compute Np, GradNpT, B and StrainVector
@@ -689,7 +689,7 @@ void UPwSmallStrainElement<TDim, TNumNodes>::CalculateOnIntegrationPoints(const 
         this->InitializeElementVariables(Variables, rCurrentProcessInfo);
 
         // Create general parameters of retention law
-        RetentionLaw::Parameters RetentionParameters(this->GetProperties(), rCurrentProcessInfo);
+        RetentionLaw::Parameters RetentionParameters(this->GetProperties());
 
         Vector VoigtVector(mStressVector[0].size());
         noalias(VoigtVector) = ZeroVector(VoigtVector.size());
@@ -915,8 +915,7 @@ void UPwSmallStrainElement<TDim, TNumNodes>::CalculateMassMatrix(MatrixType& rMa
     const auto N_container = r_geom.ShapeFunctionsValues(integration_method);
 
     const auto degrees_saturation = GeoTransportEquationUtilities::CalculateDegreesSaturation(
-        this->GetPressureSolutionVector(), N_container, mRetentionLawVector, this->GetProperties(),
-        rCurrentProcessInfo);
+        this->GetPressureSolutionVector(), N_container, mRetentionLawVector, this->GetProperties());
 
     const auto solid_densities =
         GeoTransportEquationUtilities::CalculateSoilDensities(degrees_saturation, this->GetProperties());
@@ -964,7 +963,7 @@ void UPwSmallStrainElement<TDim, TNumNodes>::CalculateAll(MatrixType&        rLe
     this->InitializeElementVariables(Variables, rCurrentProcessInfo);
 
     // Create general parameters of retention law
-    RetentionLaw::Parameters RetentionParameters(this->GetProperties(), rCurrentProcessInfo);
+    RetentionLaw::Parameters RetentionParameters(this->GetProperties());
 
     const auto b_matrices = CalculateBMatrices(Variables.DN_DXContainer, Variables.NContainer);
     const auto integration_coefficients =
@@ -1031,7 +1030,7 @@ std::vector<array_1d<double, TDim>> UPwSmallStrainElement<TDim, TNumNodes>::Calc
     array_1d<double, TDim> GradPressureTerm;
 
     // Create general parameters of retention law
-    RetentionLaw::Parameters RetentionParameters(this->GetProperties(), rCurrentProcessInfo);
+    RetentionLaw::Parameters RetentionParameters(this->GetProperties());
 
     for (unsigned int GPoint = 0; GPoint < NumGPoints; ++GPoint) {
         this->CalculateKinematics(Variables, GPoint);

--- a/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_element.hpp
+++ b/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_element.hpp
@@ -220,7 +220,8 @@ protected:
 
     virtual void CalculateKinematics(ElementVariables& rVariables, unsigned int PointNumber);
 
-    double CalculatePermeabilityUpdateFactor(const Vector& rStrainVector) const;
+    [[nodiscard]] double CalculatePermeabilityUpdateFactor(const Vector& rStrainVector) const;
+    [[nodiscard]] std::vector<double> CalculatePermeabilityUpdateFactors(const std::vector<Vector>& rStrainVectors) const;
 
     Matrix CalculateBMatrix(const Matrix& rDN_DX, const Vector& rN) const;
     std::vector<Matrix> CalculateBMatrices(const GeometryType::ShapeFunctionsGradientsType& rDN_DXContainer,

--- a/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_element.hpp
+++ b/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_element.hpp
@@ -250,8 +250,9 @@ protected:
                                               array_1d<double, TNumNodes>&                 rPVector,
                                               const ElementVariables& rVariables) const;
 
+    [[nodiscard]] std::vector<double> CalculateRelativePermeabilityValues(
+        const Matrix& rNContainer, const array_1d<double, TNumNodes>& rNodalPressures) const;
     virtual void CalculateAndAddPermeabilityFlow(VectorType& rRightHandSideVector, ElementVariables& rVariables);
-
     virtual void CalculatePermeabilityFlow(BoundedMatrix<double, TNumNodes, TNumNodes>& rPMatrix,
                                            array_1d<double, TNumNodes>&                 rPVector,
                                            const ElementVariables& rVariables) const;

--- a/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_element.hpp
+++ b/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_element.hpp
@@ -234,9 +234,6 @@ protected:
 
     virtual void CalculateAndAddCompressibilityMatrix(MatrixType& rLeftHandSideMatrix, ElementVariables& rVariables);
 
-    virtual void CalculateAndAddPermeabilityMatrix(MatrixType&             rLeftHandSideMatrix,
-                                                   const ElementVariables& rVariables);
-
     virtual void CalculateAndAddRHS(VectorType& rRightHandSideVector, ElementVariables& rVariables, unsigned int GPoint);
 
     void CalculateAndAddStiffnessForce(VectorType&       rRightHandSideVector,

--- a/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_element.hpp
+++ b/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_element.hpp
@@ -219,9 +219,6 @@ protected:
 
     virtual void CalculateKinematics(ElementVariables& rVariables, unsigned int PointNumber);
 
-    [[nodiscard]] double CalculatePermeabilityUpdateFactor(const Vector& rStrainVector) const;
-    [[nodiscard]] std::vector<double> CalculatePermeabilityUpdateFactors(const std::vector<Vector>& rStrainVectors) const;
-
     Matrix CalculateBMatrix(const Matrix& rDN_DX, const Vector& rN) const;
     std::vector<Matrix> CalculateBMatrices(const GeometryType::ShapeFunctionsGradientsType& rDN_DXContainer,
                                            const Matrix& rNContainer) const;

--- a/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_element.hpp
+++ b/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_element.hpp
@@ -138,7 +138,6 @@ protected:
         double SolidDensity;
         double Density;
         double Porosity;
-        double PermeabilityUpdateFactor;
 
         double                            BiotCoefficient;
         double                            BiotModulusInverse;

--- a/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_element.hpp
+++ b/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_element.hpp
@@ -250,8 +250,7 @@ protected:
                                               array_1d<double, TNumNodes>&                 rPVector,
                                               const ElementVariables& rVariables) const;
 
-    [[nodiscard]] std::vector<double> CalculateRelativePermeabilityValues(
-        const Matrix& rNContainer, const array_1d<double, TNumNodes>& rNodalPressures) const;
+    [[nodiscard]] std::vector<double> CalculateRelativePermeabilityValues(const std::vector<double>& rFluidPressures) const;
     virtual void CalculateAndAddPermeabilityFlow(VectorType& rRightHandSideVector, ElementVariables& rVariables);
     virtual void CalculatePermeabilityFlow(BoundedMatrix<double, TNumNodes, TNumNodes>& rPMatrix,
                                            array_1d<double, TNumNodes>&                 rPVector,

--- a/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_interface_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_interface_element.cpp
@@ -173,7 +173,6 @@ void UPwSmallStrainInterfaceElement<TDim, TNumNodes>::CalculateMassMatrix(Matrix
     InterfaceElementVariables Variables;
     this->InitializeElementVariables(Variables, Geom, Prop, rCurrentProcessInfo);
 
-    // create general parameters of retention law
     RetentionLaw::Parameters RetentionParameters(this->GetProperties());
 
     // Defining necessary variables
@@ -253,7 +252,6 @@ void UPwSmallStrainInterfaceElement<TDim, TNumNodes>::InitializeSolutionStep(con
     unsigned int        NumGPoints = mConstitutiveLawVector.size();
     std::vector<double> JointWidthContainer(NumGPoints);
 
-    // create general parameters of retention law
     RetentionLaw::Parameters RetentionParameters(this->GetProperties());
 
     // Loop over integration points
@@ -315,7 +313,6 @@ void UPwSmallStrainInterfaceElement<TDim, TNumNodes>::FinalizeSolutionStep(const
     unsigned int        NumGPoints = mConstitutiveLawVector.size();
     std::vector<double> JointWidthContainer(NumGPoints);
 
-    // create general parameters of retention law
     RetentionLaw::Parameters RetentionParameters(this->GetProperties());
 
     // Loop over integration points
@@ -597,8 +594,8 @@ void UPwSmallStrainInterfaceElement<TDim, TNumNodes>::CalculateOnIntegrationPoin
         InterfaceElementVariables Variables;
         this->InitializeElementVariables(Variables, rGeom, this->GetProperties(), rCurrentProcessInfo);
 
-        // create general parameters of retention law
         RetentionLaw::Parameters RetentionParameters(this->GetProperties());
+
         // Loop over integration points
         for (unsigned int GPoint = 0; GPoint < NumGPoints; ++GPoint) {
             Variables.FluidPressure = GeoTransportEquationUtilities::CalculateFluidPressure(
@@ -823,7 +820,6 @@ void UPwSmallStrainInterfaceElement<TDim, TNumNodes>::CalculateOnLobattoIntegrat
         InterfaceElementVariables Variables;
         this->InitializeElementVariables(Variables, Geom, Prop, rCurrentProcessInfo);
 
-        // create general parameters of retention law
         RetentionLaw::Parameters RetentionParameters(this->GetProperties());
 
         // Loop over integration points
@@ -990,7 +986,6 @@ void UPwSmallStrainInterfaceElement<TDim, TNumNodes>::CalculateOnLobattoIntegrat
         InterfaceElementVariables Variables;
         this->InitializeElementVariables(Variables, rGeom, rProp, rCurrentProcessInfo);
 
-        // create general parameters of retention law
         RetentionLaw::Parameters RetentionParameters(this->GetProperties());
 
         Vector VoigtVector(mStressVector[0].size());
@@ -1343,7 +1338,6 @@ void UPwSmallStrainInterfaceElement<TDim, TNumNodes>::CalculateAll(MatrixType& r
     array_1d<double, TDim> RelDispVector;
     SFGradAuxVariables     SFGradAuxVars;
 
-    // create general parameters of retention law
     RetentionLaw::Parameters RetentionParameters(this->GetProperties());
 
     const bool hasBiotCoefficient = Prop.Has(BIOT_COEFFICIENT);

--- a/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_interface_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_interface_element.cpp
@@ -174,7 +174,7 @@ void UPwSmallStrainInterfaceElement<TDim, TNumNodes>::CalculateMassMatrix(Matrix
     this->InitializeElementVariables(Variables, Geom, Prop, rCurrentProcessInfo);
 
     // create general parameters of retention law
-    RetentionLaw::Parameters RetentionParameters(this->GetProperties(), rCurrentProcessInfo);
+    RetentionLaw::Parameters RetentionParameters(this->GetProperties());
 
     // Defining necessary variables
     BoundedMatrix<double, TDim, TNumNodes * TDim> AuxDensityMatrix = ZeroMatrix(TDim, TNumNodes * TDim);
@@ -254,7 +254,7 @@ void UPwSmallStrainInterfaceElement<TDim, TNumNodes>::InitializeSolutionStep(con
     std::vector<double> JointWidthContainer(NumGPoints);
 
     // create general parameters of retention law
-    RetentionLaw::Parameters RetentionParameters(this->GetProperties(), rCurrentProcessInfo);
+    RetentionLaw::Parameters RetentionParameters(this->GetProperties());
 
     // Loop over integration points
     for (unsigned int GPoint = 0; GPoint < NumGPoints; ++GPoint) {
@@ -316,7 +316,7 @@ void UPwSmallStrainInterfaceElement<TDim, TNumNodes>::FinalizeSolutionStep(const
     std::vector<double> JointWidthContainer(NumGPoints);
 
     // create general parameters of retention law
-    RetentionLaw::Parameters RetentionParameters(this->GetProperties(), rCurrentProcessInfo);
+    RetentionLaw::Parameters RetentionParameters(this->GetProperties());
 
     // Loop over integration points
     for (unsigned int GPoint = 0; GPoint < NumGPoints; ++GPoint) {
@@ -598,7 +598,7 @@ void UPwSmallStrainInterfaceElement<TDim, TNumNodes>::CalculateOnIntegrationPoin
         this->InitializeElementVariables(Variables, rGeom, this->GetProperties(), rCurrentProcessInfo);
 
         // create general parameters of retention law
-        RetentionLaw::Parameters RetentionParameters(this->GetProperties(), rCurrentProcessInfo);
+        RetentionLaw::Parameters RetentionParameters(this->GetProperties());
         // Loop over integration points
         for (unsigned int GPoint = 0; GPoint < NumGPoints; ++GPoint) {
             Variables.FluidPressure = GeoTransportEquationUtilities::CalculateFluidPressure(
@@ -824,7 +824,7 @@ void UPwSmallStrainInterfaceElement<TDim, TNumNodes>::CalculateOnLobattoIntegrat
         this->InitializeElementVariables(Variables, Geom, Prop, rCurrentProcessInfo);
 
         // create general parameters of retention law
-        RetentionLaw::Parameters RetentionParameters(this->GetProperties(), rCurrentProcessInfo);
+        RetentionLaw::Parameters RetentionParameters(this->GetProperties());
 
         // Loop over integration points
         for (unsigned int GPoint = 0; GPoint < NumGPoints; ++GPoint) {
@@ -991,7 +991,7 @@ void UPwSmallStrainInterfaceElement<TDim, TNumNodes>::CalculateOnLobattoIntegrat
         this->InitializeElementVariables(Variables, rGeom, rProp, rCurrentProcessInfo);
 
         // create general parameters of retention law
-        RetentionLaw::Parameters RetentionParameters(this->GetProperties(), rCurrentProcessInfo);
+        RetentionLaw::Parameters RetentionParameters(this->GetProperties());
 
         Vector VoigtVector(mStressVector[0].size());
         noalias(VoigtVector) = ZeroVector(VoigtVector.size());
@@ -1344,7 +1344,7 @@ void UPwSmallStrainInterfaceElement<TDim, TNumNodes>::CalculateAll(MatrixType& r
     SFGradAuxVariables     SFGradAuxVars;
 
     // create general parameters of retention law
-    RetentionLaw::Parameters RetentionParameters(this->GetProperties(), CurrentProcessInfo);
+    RetentionLaw::Parameters RetentionParameters(this->GetProperties());
 
     const bool hasBiotCoefficient = Prop.Has(BIOT_COEFFICIENT);
 

--- a/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_interface_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_interface_element.cpp
@@ -1918,7 +1918,7 @@ void UPwSmallStrainInterfaceElement<TDim, TNumNodes>::CalculateAndAddPermeabilit
 
     rVariables.PPMatrix = GeoTransportEquationUtilities::CalculatePermeabilityMatrix<TDim, TNumNodes>(
         rVariables.GradNpT, rVariables.DynamicViscosityInverse, rVariables.LocalPermeabilityMatrix,
-        rVariables.RelativePermeability, rVariables.JointWidth, rVariables.IntegrationCoefficient);
+        rVariables.RelativePermeability * rVariables.JointWidth, rVariables.IntegrationCoefficient);
 
     // Distribute permeability block matrix into the elemental matrix
     GeoElementUtilities::AssemblePPBlockMatrix(rLeftHandSideMatrix, rVariables.PPMatrix);

--- a/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_interface_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_interface_element.cpp
@@ -1382,7 +1382,7 @@ void UPwSmallStrainInterfaceElement<TDim, TNumNodes>::CalculateAll(MatrixType& r
 
         ModifyInactiveElementStress(Variables.JointWidth, mStressVector[GPoint]);
 
-        CalculateRetentionResponse(Variables, RetentionParameters, GPoint);
+        this->CalculateRetentionResponse(Variables, RetentionParameters, GPoint);
 
         this->InitializeBiotCoefficients(Variables, hasBiotCoefficient);
 

--- a/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_link_interface_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_link_interface_element.cpp
@@ -332,7 +332,6 @@ void UPwSmallStrainLinkInterfaceElement<TDim, TNumNodes>::CalculateAll(MatrixTyp
     array_1d<double, TDim> RelDispVector;
     SFGradAuxVariables     SFGradAuxVars;
 
-    // create general parametes of retention law
     RetentionLaw::Parameters RetentionParameters(this->GetProperties());
 
     const bool hasBiotCoefficient = Prop.Has(BIOT_COEFFICIENT);

--- a/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_link_interface_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_link_interface_element.cpp
@@ -333,7 +333,7 @@ void UPwSmallStrainLinkInterfaceElement<TDim, TNumNodes>::CalculateAll(MatrixTyp
     SFGradAuxVariables     SFGradAuxVars;
 
     // create general parametes of retention law
-    RetentionLaw::Parameters RetentionParameters(this->GetProperties(), CurrentProcessInfo);
+    RetentionLaw::Parameters RetentionParameters(this->GetProperties());
 
     const bool hasBiotCoefficient = Prop.Has(BIOT_COEFFICIENT);
 

--- a/applications/GeoMechanicsApplication/custom_elements/U_Pw_updated_lagrangian_FIC_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/U_Pw_updated_lagrangian_FIC_element.cpp
@@ -110,6 +110,7 @@ void UPwUpdatedLagrangianFICElement<TDim, TNumNodes>::CalculateAll(MatrixType& r
         this->CalculateShapeFunctionsSecondOrderGradients(FICVariables, Variables);
 
         this->CalculateRetentionResponse(Variables, RetentionParameters, GPoint);
+        Variables.RelativePermeability = relative_permeability_values[GPoint];
 
         // set shear modulus from stiffness matrix
         FICVariables.ShearModulus = CalculateShearModulus(Variables.ConstitutiveMatrix);
@@ -119,7 +120,6 @@ void UPwUpdatedLagrangianFICElement<TDim, TNumNodes>::CalculateAll(MatrixType& r
             Variables.BiotCoefficient, Variables.DegreeOfSaturation,
             Variables.DerivativeOfSaturation, this->GetProperties());
 
-        Variables.RelativePermeability   = relative_permeability_values[GPoint];
         Variables.IntegrationCoefficient = integration_coefficients[GPoint];
 
         Variables.IntegrationCoefficientInitialConfiguration = this->CalculateIntegrationCoefficient(

--- a/applications/GeoMechanicsApplication/custom_elements/U_Pw_updated_lagrangian_FIC_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/U_Pw_updated_lagrangian_FIC_element.cpp
@@ -70,7 +70,7 @@ void UPwUpdatedLagrangianFICElement<TDim, TNumNodes>::CalculateAll(MatrixType& r
     this->InitializeFICElementVariables(FICVariables, Variables.DN_DXContainer, Geom, Prop, rCurrentProcessInfo);
 
     // create general parameters of retention law
-    RetentionLaw::Parameters RetentionParameters(this->GetProperties(), rCurrentProcessInfo);
+    RetentionLaw::Parameters RetentionParameters(this->GetProperties());
 
     const auto b_matrices = this->CalculateBMatrices(Variables.DN_DXContainer, Variables.NContainer);
     const auto integration_coefficients =

--- a/applications/GeoMechanicsApplication/custom_elements/U_Pw_updated_lagrangian_FIC_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/U_Pw_updated_lagrangian_FIC_element.cpp
@@ -85,6 +85,8 @@ void UPwUpdatedLagrangianFICElement<TDim, TNumNodes>::CalculateAll(MatrixType& r
                                          strain_vectors, mStressVector, constitutive_matrices);
     const auto biot_coefficients =
         GeoTransportEquationUtilities::CalculateBiotCoefficients(constitutive_matrices, Prop);
+    const auto relative_permeability_values = this->CalculateRelativePermeabilityValues(
+        GeoTransportEquationUtilities::CalculateFluidPressures(Variables.NContainer, Variables.PressureVector));
 
     // Computing in all integrations points
     for (IndexType GPoint = 0; GPoint < IntegrationPoints.size(); ++GPoint) {
@@ -117,6 +119,7 @@ void UPwUpdatedLagrangianFICElement<TDim, TNumNodes>::CalculateAll(MatrixType& r
             Variables.BiotCoefficient, Variables.DegreeOfSaturation,
             Variables.DerivativeOfSaturation, this->GetProperties());
 
+        Variables.RelativePermeability   = relative_permeability_values[GPoint];
         Variables.IntegrationCoefficient = integration_coefficients[GPoint];
 
         Variables.IntegrationCoefficientInitialConfiguration = this->CalculateIntegrationCoefficient(

--- a/applications/GeoMechanicsApplication/custom_elements/U_Pw_updated_lagrangian_FIC_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/U_Pw_updated_lagrangian_FIC_element.cpp
@@ -69,7 +69,6 @@ void UPwUpdatedLagrangianFICElement<TDim, TNumNodes>::CalculateAll(MatrixType& r
     FICElementVariables FICVariables;
     this->InitializeFICElementVariables(FICVariables, Variables.DN_DXContainer, Geom, Prop, rCurrentProcessInfo);
 
-    // create general parameters of retention law
     RetentionLaw::Parameters RetentionParameters(this->GetProperties());
 
     const auto b_matrices = this->CalculateBMatrices(Variables.DN_DXContainer, Variables.NContainer);

--- a/applications/GeoMechanicsApplication/custom_elements/U_Pw_updated_lagrangian_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/U_Pw_updated_lagrangian_element.cpp
@@ -67,7 +67,7 @@ void UPwUpdatedLagrangianElement<TDim, TNumNodes>::CalculateAll(MatrixType& rLef
     this->InitializeElementVariables(Variables, rCurrentProcessInfo);
 
     // create general parameters of retention law
-    RetentionLaw::Parameters RetentionParameters(this->GetProperties(), rCurrentProcessInfo);
+    RetentionLaw::Parameters RetentionParameters(this->GetProperties());
 
     const auto b_matrices = this->CalculateBMatrices(Variables.DN_DXContainer, Variables.NContainer);
     const auto integration_coefficients =

--- a/applications/GeoMechanicsApplication/custom_elements/U_Pw_updated_lagrangian_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/U_Pw_updated_lagrangian_element.cpp
@@ -66,7 +66,6 @@ void UPwUpdatedLagrangianElement<TDim, TNumNodes>::CalculateAll(MatrixType& rLef
     ElementVariables Variables;
     this->InitializeElementVariables(Variables, rCurrentProcessInfo);
 
-    // create general parameters of retention law
     RetentionLaw::Parameters RetentionParameters(this->GetProperties());
 
     const auto b_matrices = this->CalculateBMatrices(Variables.DN_DXContainer, Variables.NContainer);

--- a/applications/GeoMechanicsApplication/custom_elements/U_Pw_updated_lagrangian_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/U_Pw_updated_lagrangian_element.cpp
@@ -82,6 +82,8 @@ void UPwUpdatedLagrangianElement<TDim, TNumNodes>::CalculateAll(MatrixType& rLef
                                          strain_vectors, mStressVector, constitutive_matrices);
     const auto biot_coefficients = GeoTransportEquationUtilities::CalculateBiotCoefficients(
         constitutive_matrices, this->GetProperties());
+    const auto relative_permeability_values = this->CalculateRelativePermeabilityValues(
+        GeoTransportEquationUtilities::CalculateFluidPressures(Variables.NContainer, Variables.PressureVector));
 
     for (IndexType GPoint = 0; GPoint < IntegrationPoints.size(); ++GPoint) {
         this->CalculateKinematics(Variables, GPoint);
@@ -105,6 +107,7 @@ void UPwUpdatedLagrangianElement<TDim, TNumNodes>::CalculateAll(MatrixType& rLef
             Variables.BiotCoefficient, Variables.DegreeOfSaturation,
             Variables.DerivativeOfSaturation, this->GetProperties());
 
+        Variables.RelativePermeability   = relative_permeability_values[GPoint];
         Variables.IntegrationCoefficient = integration_coefficients[GPoint];
 
         Variables.IntegrationCoefficientInitialConfiguration = this->CalculateIntegrationCoefficient(

--- a/applications/GeoMechanicsApplication/custom_elements/U_Pw_updated_lagrangian_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/U_Pw_updated_lagrangian_element.cpp
@@ -101,13 +101,13 @@ void UPwUpdatedLagrangianElement<TDim, TNumNodes>::CalculateAll(MatrixType& rLef
             Variables.BodyAcceleration, Variables.NContainer, Variables.VolumeAcceleration, GPoint);
 
         this->CalculateRetentionResponse(Variables, RetentionParameters, GPoint);
+        Variables.RelativePermeability = relative_permeability_values[GPoint];
 
         Variables.BiotCoefficient    = biot_coefficients[GPoint];
         Variables.BiotModulusInverse = GeoTransportEquationUtilities::CalculateBiotModulusInverse(
             Variables.BiotCoefficient, Variables.DegreeOfSaturation,
             Variables.DerivativeOfSaturation, this->GetProperties());
 
-        Variables.RelativePermeability   = relative_permeability_values[GPoint];
         Variables.IntegrationCoefficient = integration_coefficients[GPoint];
 
         Variables.IntegrationCoefficientInitialConfiguration = this->CalculateIntegrationCoefficient(

--- a/applications/GeoMechanicsApplication/custom_elements/small_strain_U_Pw_diff_order_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/small_strain_U_Pw_diff_order_element.cpp
@@ -315,7 +315,7 @@ void SmallStrainUPwDiffOrderElement::InitializeSolutionStep(const ProcessInfo& r
     ConstitutiveParameters.Set(ConstitutiveLaw::INITIALIZE_MATERIAL_RESPONSE); // Note: this is for nonlocal damage
 
     // create general parameters of retention law
-    RetentionLaw::Parameters RetentionParameters(GetProperties(), rCurrentProcessInfo);
+    RetentionLaw::Parameters RetentionParameters(GetProperties());
 
     const auto b_matrices = CalculateBMatrices(Variables.DNu_DXContainer, Variables.NuContainer);
     const auto deformation_gradients = CalculateDeformationGradients();
@@ -456,7 +456,7 @@ void SmallStrainUPwDiffOrderElement::CalculateMassMatrix(MatrixType& rMassMatrix
     const PropertiesType& r_prop  = this->GetProperties();
 
     const auto degrees_saturation = GeoTransportEquationUtilities::CalculateDegreesSaturation(
-        this->GetPressureSolutionVector(), Np_container, mRetentionLawVector, r_prop, rCurrentProcessInfo);
+        this->GetPressureSolutionVector(), Np_container, mRetentionLawVector, r_prop);
 
     const auto solid_densities =
         GeoTransportEquationUtilities::CalculateSoilDensities(degrees_saturation, r_prop);
@@ -533,7 +533,7 @@ void SmallStrainUPwDiffOrderElement::FinalizeSolutionStep(const ProcessInfo& rCu
     ConstitutiveParameters.GetOptions().Set(ConstitutiveLaw::USE_ELEMENT_PROVIDED_STRAIN);
 
     // create general parameters of retention law
-    RetentionLaw::Parameters RetentionParameters(GetProperties(), rCurrentProcessInfo);
+    RetentionLaw::Parameters RetentionParameters(GetProperties());
     const auto b_matrices = CalculateBMatrices(Variables.DNu_DXContainer, Variables.NuContainer);
     const auto deformation_gradients = CalculateDeformationGradients();
     const auto determinants_of_deformation_gradients =
@@ -916,7 +916,7 @@ void SmallStrainUPwDiffOrderElement::CalculateOnIntegrationPoints(const Variable
         this->InitializeElementVariables(Variables, rCurrentProcessInfo);
 
         // create general parameters of retention law
-        RetentionLaw::Parameters RetentionParameters(GetProperties(), rCurrentProcessInfo);
+        RetentionLaw::Parameters RetentionParameters(GetProperties());
 
         // Loop over integration points
         for (unsigned int GPoint = 0; GPoint < mRetentionLawVector.size(); ++GPoint) {
@@ -1005,7 +1005,7 @@ void SmallStrainUPwDiffOrderElement::CalculateOnIntegrationPoints(const Variable
         this->InitializeElementVariables(Variables, rCurrentProcessInfo);
 
         // create general parameters of retention law
-        RetentionLaw::Parameters RetentionParameters(GetProperties(), rCurrentProcessInfo);
+        RetentionLaw::Parameters RetentionParameters(GetProperties());
         const auto b_matrices = CalculateBMatrices(Variables.DNu_DXContainer, Variables.NuContainer);
         const auto deformation_gradients = CalculateDeformationGradients();
         const auto strain_vectors        = StressStrainUtilities::CalculateStrains(
@@ -1135,7 +1135,7 @@ void SmallStrainUPwDiffOrderElement::CalculateOnIntegrationPoints(const Variable
             VoigtVector[i] = 1.0;
 
         // create general parameters of retention law
-        RetentionLaw::Parameters RetentionParameters(GetProperties(), rCurrentProcessInfo);
+        RetentionLaw::Parameters RetentionParameters(GetProperties());
 
         const auto b_matrices = CalculateBMatrices(Variables.DNu_DXContainer, Variables.NuContainer);
         const auto deformation_gradients = CalculateDeformationGradients();
@@ -1261,7 +1261,7 @@ void SmallStrainUPwDiffOrderElement::CalculateAll(MatrixType&        rLeftHandSi
         ConstitutiveParameters.GetOptions().Set(ConstitutiveLaw::COMPUTE_STRESS);
 
     // create general parameters of retention law
-    RetentionLaw::Parameters RetentionParameters(rProp, rCurrentProcessInfo);
+    RetentionLaw::Parameters RetentionParameters(rProp);
 
     // Loop over integration points
     const GeometryType::IntegrationPointsArrayType& IntegrationPoints =

--- a/applications/GeoMechanicsApplication/custom_elements/small_strain_U_Pw_diff_order_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/small_strain_U_Pw_diff_order_element.cpp
@@ -1622,7 +1622,7 @@ void SmallStrainUPwDiffOrderElement::CalculateAndAddLHS(MatrixType& rLeftHandSid
 
         const auto permeability_matrix = GeoTransportEquationUtilities::CalculatePermeabilityMatrix(
             rVariables.DNp_DX, rVariables.DynamicViscosityInverse, rVariables.IntrinsicPermeability,
-            rVariables.RelativePermeability, rVariables.PermeabilityUpdateFactor,
+            rVariables.RelativePermeability * rVariables.PermeabilityUpdateFactor,
             rVariables.IntegrationCoefficient);
         GeoElementUtilities::AssemblePPBlockMatrix(rLeftHandSideMatrix, permeability_matrix);
     }

--- a/applications/GeoMechanicsApplication/custom_elements/small_strain_U_Pw_diff_order_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/small_strain_U_Pw_diff_order_element.cpp
@@ -1633,7 +1633,12 @@ void SmallStrainUPwDiffOrderElement::CalculateAndAddLHS(MatrixType& rLeftHandSid
 
     if (!rVariables.IgnoreUndrained) {
         this->CalculateAndAddCouplingMatrix(rLeftHandSideMatrix, rVariables);
-        this->CalculateAndAddPermeabilityMatrix(rLeftHandSideMatrix, rVariables);
+
+        const auto permeability_matrix = GeoTransportEquationUtilities::CalculatePermeabilityMatrix(
+            rVariables.DNp_DX, rVariables.DynamicViscosityInverse, rVariables.IntrinsicPermeability,
+            rVariables.RelativePermeability, rVariables.PermeabilityUpdateFactor,
+            rVariables.IntegrationCoefficient);
+        GeoElementUtilities::AssemblePPBlockMatrix(rLeftHandSideMatrix, permeability_matrix);
     }
 
     KRATOS_CATCH("")
@@ -1697,21 +1702,6 @@ void SmallStrainUPwDiffOrderElement::CalculateAndAddCompressibilityMatrix(Matrix
     // Distribute compressibility block matrix into the elemental matrix
     GeoElementUtilities::AssemblePPBlockMatrix(
         rLeftHandSideMatrix, CompressibilityMatrix * rVariables.DtPressureCoefficient);
-
-    KRATOS_CATCH("")
-}
-
-void SmallStrainUPwDiffOrderElement::CalculateAndAddPermeabilityMatrix(MatrixType& rLeftHandSideMatrix,
-                                                                       const ElementVariables& rVariables) const
-{
-    KRATOS_TRY
-
-    Matrix PermeabilityMatrix = GeoTransportEquationUtilities::CalculatePermeabilityMatrix(
-        rVariables.DNp_DX, rVariables.DynamicViscosityInverse, rVariables.IntrinsicPermeability,
-        rVariables.RelativePermeability, rVariables.PermeabilityUpdateFactor, rVariables.IntegrationCoefficient);
-
-    // Distribute permeability block matrix into the elemental matrix
-    GeoElementUtilities::AssemblePPBlockMatrix(rLeftHandSideMatrix, PermeabilityMatrix);
 
     KRATOS_CATCH("")
 }

--- a/applications/GeoMechanicsApplication/custom_elements/small_strain_U_Pw_diff_order_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/small_strain_U_Pw_diff_order_element.cpp
@@ -314,7 +314,6 @@ void SmallStrainUPwDiffOrderElement::InitializeSolutionStep(const ProcessInfo& r
     ConstitutiveParameters.Set(ConstitutiveLaw::USE_ELEMENT_PROVIDED_STRAIN);
     ConstitutiveParameters.Set(ConstitutiveLaw::INITIALIZE_MATERIAL_RESPONSE); // Note: this is for nonlocal damage
 
-    // create general parameters of retention law
     RetentionLaw::Parameters RetentionParameters(GetProperties());
 
     const auto b_matrices = CalculateBMatrices(Variables.DNu_DXContainer, Variables.NuContainer);
@@ -532,8 +531,8 @@ void SmallStrainUPwDiffOrderElement::FinalizeSolutionStep(const ProcessInfo& rCu
     ConstitutiveLaw::Parameters ConstitutiveParameters(GetGeometry(), GetProperties(), rCurrentProcessInfo);
     ConstitutiveParameters.GetOptions().Set(ConstitutiveLaw::USE_ELEMENT_PROVIDED_STRAIN);
 
-    // create general parameters of retention law
     RetentionLaw::Parameters RetentionParameters(GetProperties());
+
     const auto b_matrices = CalculateBMatrices(Variables.DNu_DXContainer, Variables.NuContainer);
     const auto deformation_gradients = CalculateDeformationGradients();
     const auto determinants_of_deformation_gradients =
@@ -915,7 +914,6 @@ void SmallStrainUPwDiffOrderElement::CalculateOnIntegrationPoints(const Variable
         ElementVariables Variables;
         this->InitializeElementVariables(Variables, rCurrentProcessInfo);
 
-        // create general parameters of retention law
         RetentionLaw::Parameters RetentionParameters(GetProperties());
 
         // Loop over integration points
@@ -1004,8 +1002,8 @@ void SmallStrainUPwDiffOrderElement::CalculateOnIntegrationPoints(const Variable
         ElementVariables Variables;
         this->InitializeElementVariables(Variables, rCurrentProcessInfo);
 
-        // create general parameters of retention law
         RetentionLaw::Parameters RetentionParameters(GetProperties());
+
         const auto b_matrices = CalculateBMatrices(Variables.DNu_DXContainer, Variables.NuContainer);
         const auto deformation_gradients = CalculateDeformationGradients();
         const auto strain_vectors        = StressStrainUtilities::CalculateStrains(
@@ -1134,7 +1132,6 @@ void SmallStrainUPwDiffOrderElement::CalculateOnIntegrationPoints(const Variable
         for (unsigned int i = 0; i < StressTensorSize; ++i)
             VoigtVector[i] = 1.0;
 
-        // create general parameters of retention law
         RetentionLaw::Parameters RetentionParameters(GetProperties());
 
         const auto b_matrices = CalculateBMatrices(Variables.DNu_DXContainer, Variables.NuContainer);
@@ -1260,7 +1257,6 @@ void SmallStrainUPwDiffOrderElement::CalculateAll(MatrixType&        rLeftHandSi
     if (CalculateResidualVectorFlag)
         ConstitutiveParameters.GetOptions().Set(ConstitutiveLaw::COMPUTE_STRESS);
 
-    // create general parameters of retention law
     RetentionLaw::Parameters RetentionParameters(rProp);
 
     // Loop over integration points
@@ -1287,7 +1283,7 @@ void SmallStrainUPwDiffOrderElement::CalculateAll(MatrixType&        rLeftHandSi
         GeoTransportEquationUtilities::CalculatePermeabilityUpdateFactors(strain_vectors, GetProperties());
     std::transform(relative_permeability_values.cbegin(), relative_permeability_values.cend(),
                    permeability_update_factors.cbegin(), relative_permeability_values.begin(),
-                   std::multiplies{});
+                   std::multiplies<>{});
 
     for (unsigned int GPoint = 0; GPoint < IntegrationPoints.size(); ++GPoint) {
         this->CalculateKinematics(Variables, GPoint);
@@ -1297,7 +1293,7 @@ void SmallStrainUPwDiffOrderElement::CalculateAll(MatrixType&        rLeftHandSi
         Variables.ConstitutiveMatrix = constitutive_matrices[GPoint];
 
         CalculateRetentionResponse(Variables, RetentionParameters, GPoint);
-kp        Variables.RelativePermeability = relative_permeability_values[GPoint];
+        Variables.RelativePermeability = relative_permeability_values[GPoint];
 
         Variables.BiotCoefficient    = biot_coefficients[GPoint];
         Variables.BiotModulusInverse = GeoTransportEquationUtilities::CalculateBiotModulusInverse(

--- a/applications/GeoMechanicsApplication/custom_elements/small_strain_U_Pw_diff_order_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/small_strain_U_Pw_diff_order_element.cpp
@@ -1297,12 +1297,12 @@ void SmallStrainUPwDiffOrderElement::CalculateAll(MatrixType&        rLeftHandSi
         Variables.ConstitutiveMatrix = constitutive_matrices[GPoint];
 
         CalculateRetentionResponse(Variables, RetentionParameters, GPoint);
+kp        Variables.RelativePermeability = relative_permeability_values[GPoint];
 
         Variables.BiotCoefficient    = biot_coefficients[GPoint];
         Variables.BiotModulusInverse = GeoTransportEquationUtilities::CalculateBiotModulusInverse(
             Variables.BiotCoefficient, Variables.DegreeOfSaturation,
             Variables.DerivativeOfSaturation, this->GetProperties());
-        Variables.RelativePermeability   = relative_permeability_values[GPoint];
         Variables.IntegrationCoefficient = integration_coefficients[GPoint];
 
         Variables.IntegrationCoefficientInitialConfiguration = this->CalculateIntegrationCoefficient(
@@ -1978,8 +1978,6 @@ void SmallStrainUPwDiffOrderElement::CalculateRetentionResponse(ElementVariables
     rVariables.DegreeOfSaturation = mRetentionLawVector[GPoint]->CalculateSaturation(rRetentionParameters);
     rVariables.DerivativeOfSaturation =
         mRetentionLawVector[GPoint]->CalculateDerivativeOfSaturation(rRetentionParameters);
-    rVariables.RelativePermeability =
-        mRetentionLawVector[GPoint]->CalculateRelativePermeability(rRetentionParameters);
     rVariables.BishopCoefficient = mRetentionLawVector[GPoint]->CalculateBishopCoefficient(rRetentionParameters);
 
     KRATOS_CATCH("")

--- a/applications/GeoMechanicsApplication/custom_elements/small_strain_U_Pw_diff_order_element.hpp
+++ b/applications/GeoMechanicsApplication/custom_elements/small_strain_U_Pw_diff_order_element.hpp
@@ -271,6 +271,7 @@ protected:
     void CalculateAndAddCompressibilityFlow(VectorType&             rRightHandSideVector,
                                             const ElementVariables& rVariables) const;
 
+    [[nodiscard]] std::vector<double> CalculateRelativePermeabilityValues(const std::vector<double>& rFluidPressures) const;
     void CalculateAndAddPermeabilityFlow(VectorType& rRightHandSideVector, ElementVariables& rVariables) const;
 
     void CalculateAndAddFluidBodyFlow(VectorType& rRightHandSideVector, ElementVariables& rVariables);

--- a/applications/GeoMechanicsApplication/custom_elements/small_strain_U_Pw_diff_order_element.hpp
+++ b/applications/GeoMechanicsApplication/custom_elements/small_strain_U_Pw_diff_order_element.hpp
@@ -204,7 +204,6 @@ protected:
         bool ConsiderGeometricStiffness;
 
         // stress/flow variables
-        double PermeabilityUpdateFactor;
         double BiotCoefficient;
         double BiotModulusInverse;
         double DynamicViscosityInverse;

--- a/applications/GeoMechanicsApplication/custom_elements/small_strain_U_Pw_diff_order_element.hpp
+++ b/applications/GeoMechanicsApplication/custom_elements/small_strain_U_Pw_diff_order_element.hpp
@@ -238,8 +238,6 @@ protected:
 
     void InitializeProperties(ElementVariables& rVariables);
 
-    double CalculatePermeabilityUpdateFactor(const Vector& rStrainVector) const;
-
     virtual void CalculateKinematics(ElementVariables& rVariables, unsigned int GPoint);
 
     void CalculateDerivativesOnInitialConfiguration(

--- a/applications/GeoMechanicsApplication/custom_elements/small_strain_U_Pw_diff_order_element.hpp
+++ b/applications/GeoMechanicsApplication/custom_elements/small_strain_U_Pw_diff_order_element.hpp
@@ -258,8 +258,6 @@ protected:
 
     void CalculateAndAddCompressibilityMatrix(MatrixType& rLeftHandSideMatrix, ElementVariables& rVariables) const;
 
-    void CalculateAndAddPermeabilityMatrix(MatrixType& rLeftHandSideMatrix, const ElementVariables& rVariables) const;
-
     void CalculateAndAddRHS(VectorType& rRightHandSideVector, ElementVariables& rVariables, unsigned int GPoint);
 
     void CalculateAndAddStiffnessForce(VectorType&       rRightHandSideVector,

--- a/applications/GeoMechanicsApplication/custom_elements/steady_state_Pw_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/steady_state_Pw_element.cpp
@@ -153,7 +153,6 @@ void SteadyStatePwElement<TDim, TNumNodes>::CalculateAll(MatrixType&        rLef
     ElementVariables Variables;
     this->InitializeElementVariables(Variables, rCurrentProcessInfo);
 
-    // create general parameters of retention law
     RetentionLaw::Parameters RetentionParameters(this->GetProperties());
 
     const auto relative_permeability_values = this->CalculateRelativePermeabilityValues(

--- a/applications/GeoMechanicsApplication/custom_elements/steady_state_Pw_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/steady_state_Pw_element.cpp
@@ -194,7 +194,7 @@ void SteadyStatePwElement<TDim, TNumNodes>::CalculateAndAddLHS(MatrixType& rLeft
 {
     const auto permeability_matrix = GeoTransportEquationUtilities::CalculatePermeabilityMatrix<TDim, TNumNodes>(
         rVariables.GradNpT, rVariables.DynamicViscosityInverse, rVariables.PermeabilityMatrix,
-        rVariables.RelativePermeability, rVariables.PermeabilityUpdateFactor, rVariables.IntegrationCoefficient);
+        rVariables.RelativePermeability, rVariables.IntegrationCoefficient);
     rLeftHandSideMatrix += permeability_matrix;
 }
 

--- a/applications/GeoMechanicsApplication/custom_elements/steady_state_Pw_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/steady_state_Pw_element.cpp
@@ -154,7 +154,7 @@ void SteadyStatePwElement<TDim, TNumNodes>::CalculateAll(MatrixType&        rLef
     this->InitializeElementVariables(Variables, rCurrentProcessInfo);
 
     // create general parameters of retention law
-    RetentionLaw::Parameters RetentionParameters(this->GetProperties(), rCurrentProcessInfo);
+    RetentionLaw::Parameters RetentionParameters(this->GetProperties());
 
     const auto integration_coefficients =
         this->CalculateIntegrationCoefficients(IntegrationPoints, Variables.detJContainer);

--- a/applications/GeoMechanicsApplication/custom_elements/steady_state_Pw_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/steady_state_Pw_element.cpp
@@ -12,6 +12,7 @@
 
 // Application includes
 #include "custom_elements/steady_state_Pw_element.hpp"
+#include "custom_utilities/transport_equation_utilities.hpp"
 
 namespace Kratos
 {
@@ -188,11 +189,10 @@ template <unsigned int TDim, unsigned int TNumNodes>
 void SteadyStatePwElement<TDim, TNumNodes>::CalculateAndAddLHS(MatrixType& rLeftHandSideMatrix,
                                                                ElementVariables& rVariables)
 {
-    KRATOS_TRY;
-
-    this->CalculateAndAddPermeabilityMatrix(rLeftHandSideMatrix, rVariables);
-
-    KRATOS_CATCH("");
+    const auto permeability_matrix = GeoTransportEquationUtilities::CalculatePermeabilityMatrix<TDim, TNumNodes>(
+        rVariables.GradNpT, rVariables.DynamicViscosityInverse, rVariables.PermeabilityMatrix,
+        rVariables.RelativePermeability, rVariables.PermeabilityUpdateFactor, rVariables.IntegrationCoefficient);
+    rLeftHandSideMatrix += permeability_matrix;
 }
 
 //----------------------------------------------------------------------------------------

--- a/applications/GeoMechanicsApplication/custom_elements/steady_state_Pw_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/steady_state_Pw_element.cpp
@@ -156,9 +156,11 @@ void SteadyStatePwElement<TDim, TNumNodes>::CalculateAll(MatrixType&        rLef
     // create general parameters of retention law
     RetentionLaw::Parameters RetentionParameters(this->GetProperties());
 
+    const auto relative_permeability_values = this->CalculateRelativePermeabilityValues(
+        GeoTransportEquationUtilities::CalculateFluidPressures(Variables.NContainer, Variables.PressureVector));
     const auto integration_coefficients =
         this->CalculateIntegrationCoefficients(IntegrationPoints, Variables.detJContainer);
-    
+
     // Loop over integration points
     for (unsigned int GPoint = 0; GPoint < NumGPoints; GPoint++) {
         // Compute GradNpT, B and StrainVector
@@ -171,6 +173,7 @@ void SteadyStatePwElement<TDim, TNumNodes>::CalculateAll(MatrixType&        rLef
 
         this->CalculateRetentionResponse(Variables, RetentionParameters, GPoint);
 
+        Variables.RelativePermeability   = relative_permeability_values[GPoint];
         Variables.IntegrationCoefficient = integration_coefficients[GPoint];
 
         // Contributions to the left hand side

--- a/applications/GeoMechanicsApplication/custom_elements/steady_state_Pw_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/steady_state_Pw_element.cpp
@@ -172,8 +172,8 @@ void SteadyStatePwElement<TDim, TNumNodes>::CalculateAll(MatrixType&        rLef
             Variables.BodyAcceleration, Variables.NContainer, Variables.VolumeAcceleration, GPoint);
 
         this->CalculateRetentionResponse(Variables, RetentionParameters, GPoint);
+        Variables.RelativePermeability = relative_permeability_values[GPoint];
 
-        Variables.RelativePermeability   = relative_permeability_values[GPoint];
         Variables.IntegrationCoefficient = integration_coefficients[GPoint];
 
         // Contributions to the left hand side

--- a/applications/GeoMechanicsApplication/custom_elements/steady_state_Pw_interface_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/steady_state_Pw_interface_element.cpp
@@ -171,7 +171,7 @@ void SteadyStatePwInterfaceElement<TDim, TNumNodes>::CalculateAll(MatrixType& rL
         InterfaceElementUtilities::FillPermeabilityMatrix(
             Variables.LocalPermeabilityMatrix, Variables.JointWidth, Prop[TRANSVERSAL_PERMEABILITY]);
 
-        CalculateRetentionResponse(Variables, RetentionParameters, GPoint);
+        this->CalculateRetentionResponse(Variables, RetentionParameters, GPoint);
 
         Variables.IntegrationCoefficient = integration_coefficients[GPoint];
 

--- a/applications/GeoMechanicsApplication/custom_elements/steady_state_Pw_interface_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/steady_state_Pw_interface_element.cpp
@@ -150,7 +150,7 @@ void SteadyStatePwInterfaceElement<TDim, TNumNodes>::CalculateAll(MatrixType& rL
     SFGradAuxVariables     SFGradAuxVars;
 
     // create general parameters of retention law
-    RetentionLaw::Parameters RetentionParameters(this->GetProperties(), CurrentProcessInfo);
+    RetentionLaw::Parameters RetentionParameters(this->GetProperties());
 
     const auto integration_coefficients =
         this->CalculateIntegrationCoefficients(IntegrationPoints, detJContainer);

--- a/applications/GeoMechanicsApplication/custom_elements/steady_state_Pw_interface_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/steady_state_Pw_interface_element.cpp
@@ -149,7 +149,6 @@ void SteadyStatePwInterfaceElement<TDim, TNumNodes>::CalculateAll(MatrixType& rL
     array_1d<double, TDim> RelDispVector;
     SFGradAuxVariables     SFGradAuxVars;
 
-    // create general parameters of retention law
     RetentionLaw::Parameters RetentionParameters(this->GetProperties());
 
     const auto integration_coefficients =

--- a/applications/GeoMechanicsApplication/custom_elements/steady_state_Pw_interface_element.hpp
+++ b/applications/GeoMechanicsApplication/custom_elements/steady_state_Pw_interface_element.hpp
@@ -47,7 +47,6 @@ public:
     /// The definition of the sizetype
     using SizeType = std::size_t;
 
-    using BaseType::CalculateRetentionResponse;
     using BaseType::mRetentionLawVector;
     using BaseType::mThisIntegrationMethod;
 

--- a/applications/GeoMechanicsApplication/custom_elements/steady_state_Pw_piping_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/steady_state_Pw_piping_element.cpp
@@ -212,7 +212,7 @@ void SteadyStatePwPipingElement<TDim, TNumNodes>::CalculateAll(MatrixType& rLeft
     SFGradAuxVariables     SFGradAuxVars;
 
     // create general parameters of retention law
-    RetentionLaw::Parameters RetentionParameters(this->GetProperties(), CurrentProcessInfo);
+    RetentionLaw::Parameters RetentionParameters(this->GetProperties());
 
     const auto integration_coefficients =
         this->CalculateIntegrationCoefficients(IntegrationPoints, detJContainer);

--- a/applications/GeoMechanicsApplication/custom_elements/steady_state_Pw_piping_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/steady_state_Pw_piping_element.cpp
@@ -211,7 +211,6 @@ void SteadyStatePwPipingElement<TDim, TNumNodes>::CalculateAll(MatrixType& rLeft
     array_1d<double, TDim> RelDispVector;
     SFGradAuxVariables     SFGradAuxVars;
 
-    // create general parameters of retention law
     RetentionLaw::Parameters RetentionParameters(this->GetProperties());
 
     const auto integration_coefficients =

--- a/applications/GeoMechanicsApplication/custom_elements/steady_state_Pw_piping_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/steady_state_Pw_piping_element.cpp
@@ -233,7 +233,7 @@ void SteadyStatePwPipingElement<TDim, TNumNodes>::CalculateAll(MatrixType& rLeft
         InterfaceElementUtilities::FillPermeabilityMatrix(
             Variables.LocalPermeabilityMatrix, Variables.JointWidth, Prop[TRANSVERSAL_PERMEABILITY]);
 
-        CalculateRetentionResponse(Variables, RetentionParameters, GPoint);
+        this->CalculateRetentionResponse(Variables, RetentionParameters, GPoint);
 
         Variables.IntegrationCoefficient = integration_coefficients[GPoint];
 

--- a/applications/GeoMechanicsApplication/custom_elements/steady_state_Pw_piping_element.hpp
+++ b/applications/GeoMechanicsApplication/custom_elements/steady_state_Pw_piping_element.hpp
@@ -47,7 +47,6 @@ public:
     /// The definition of the sizetype
     using SizeType = std::size_t;
 
-    using BaseType::CalculateRetentionResponse;
     using BaseType::mRetentionLawVector;
     using BaseType::mThisIntegrationMethod;
 

--- a/applications/GeoMechanicsApplication/custom_elements/transient_Pw_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/transient_Pw_element.cpp
@@ -453,6 +453,8 @@ void TransientPwElement<TDim, TNumNodes>::CalculateAll(MatrixType&        rLeftH
     // create general parameters of retention law
     RetentionLaw::Parameters RetentionParameters(this->GetProperties());
 
+    const auto relative_permeability_values = this->CalculateRelativePermeabilityValues(
+        GeoTransportEquationUtilities::CalculateFluidPressures(Variables.NContainer, Variables.PressureVector));
     const auto integration_coefficients =
         this->CalculateIntegrationCoefficients(IntegrationPoints, Variables.detJContainer);
     std::vector<double> biot_coefficients(NumGPoints, Prop[BIOT_COEFFICIENT]);
@@ -474,6 +476,7 @@ void TransientPwElement<TDim, TNumNodes>::CalculateAll(MatrixType&        rLeftH
             Variables.BiotCoefficient, Variables.DegreeOfSaturation,
             Variables.DerivativeOfSaturation, this->GetProperties());
 
+        Variables.RelativePermeability   = relative_permeability_values[GPoint];
         Variables.IntegrationCoefficient = integration_coefficients[GPoint];
 
         // Contributions to the left hand side

--- a/applications/GeoMechanicsApplication/custom_elements/transient_Pw_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/transient_Pw_element.cpp
@@ -540,7 +540,11 @@ void TransientPwElement<TDim, TNumNodes>::CalculateAndAddLHS(MatrixType&       r
     KRATOS_TRY;
 
     this->CalculateAndAddCompressibilityMatrix(rLeftHandSideMatrix, rVariables);
-    this->CalculateAndAddPermeabilityMatrix(rLeftHandSideMatrix, rVariables);
+
+    const auto permeability_matrix = GeoTransportEquationUtilities::CalculatePermeabilityMatrix<TDim, TNumNodes>(
+        rVariables.GradNpT, rVariables.DynamicViscosityInverse, rVariables.PermeabilityMatrix,
+        rVariables.RelativePermeability, rVariables.PermeabilityUpdateFactor, rVariables.IntegrationCoefficient);
+    rLeftHandSideMatrix += permeability_matrix;
 
     KRATOS_CATCH("");
 }
@@ -557,23 +561,6 @@ void TransientPwElement<TDim, TNumNodes>::CalculateAndAddCompressibilityMatrix(M
 
     // Distribute compressibility block matrix into the elemental matrix
     rLeftHandSideMatrix += (rVariables.PPMatrix * rVariables.DtPressureCoefficient);
-
-    KRATOS_CATCH("");
-}
-
-//----------------------------------------------------------------------------------------
-template <unsigned int TDim, unsigned int TNumNodes>
-void TransientPwElement<TDim, TNumNodes>::CalculateAndAddPermeabilityMatrix(MatrixType& rLeftHandSideMatrix,
-                                                                            const ElementVariables& rVariables)
-{
-    KRATOS_TRY;
-
-    const auto permeability_matrix = GeoTransportEquationUtilities::CalculatePermeabilityMatrix<TDim, TNumNodes>(
-        rVariables.GradNpT, rVariables.DynamicViscosityInverse, rVariables.PermeabilityMatrix,
-        rVariables.RelativePermeability, rVariables.PermeabilityUpdateFactor, rVariables.IntegrationCoefficient);
-
-    // Distribute permeability block matrix into the elemental matrix
-    rLeftHandSideMatrix += permeability_matrix;
 
     KRATOS_CATCH("");
 }

--- a/applications/GeoMechanicsApplication/custom_elements/transient_Pw_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/transient_Pw_element.cpp
@@ -292,7 +292,7 @@ void TransientPwElement<TDim, TNumNodes>::InitializeSolutionStep(const ProcessIn
     const unsigned int  NumGPoints = Geom.IntegrationPointsNumber(this->GetIntegrationMethod());
 
     // create general parameters of retention law
-    RetentionLaw::Parameters RetentionParameters(this->GetProperties(), rCurrentProcessInfo);
+    RetentionLaw::Parameters RetentionParameters(this->GetProperties());
 
     // Loop over integration points
     for (unsigned int GPoint = 0; GPoint < NumGPoints; ++GPoint) {
@@ -342,7 +342,7 @@ void TransientPwElement<TDim, TNumNodes>::FinalizeSolutionStep(const ProcessInfo
     const unsigned int  NumGPoints = Geom.IntegrationPointsNumber(this->GetIntegrationMethod());
 
     // create general parameters of retention law
-    RetentionLaw::Parameters RetentionParameters(this->GetProperties(), rCurrentProcessInfo);
+    RetentionLaw::Parameters RetentionParameters(this->GetProperties());
 
     // Loop over integration points
     for (unsigned int GPoint = 0; GPoint < NumGPoints; ++GPoint) {
@@ -451,7 +451,7 @@ void TransientPwElement<TDim, TNumNodes>::CalculateAll(MatrixType&        rLeftH
     this->InitializeElementVariables(Variables, rCurrentProcessInfo);
 
     // create general parameters of retention law
-    RetentionLaw::Parameters RetentionParameters(this->GetProperties(), rCurrentProcessInfo);
+    RetentionLaw::Parameters RetentionParameters(this->GetProperties());
 
     const auto integration_coefficients =
         this->CalculateIntegrationCoefficients(IntegrationPoints, Variables.detJContainer);

--- a/applications/GeoMechanicsApplication/custom_elements/transient_Pw_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/transient_Pw_element.cpp
@@ -283,7 +283,7 @@ int TransientPwElement<TDim, TNumNodes>::Check(const ProcessInfo& rCurrentProces
 template <unsigned int TDim, unsigned int TNumNodes>
 void TransientPwElement<TDim, TNumNodes>::InitializeSolutionStep(const ProcessInfo& rCurrentProcessInfo)
 {
-    KRATOS_TRY;
+    KRATOS_TRY
 
     if (!mIsInitialised) this->Initialize(rCurrentProcessInfo);
 
@@ -291,7 +291,6 @@ void TransientPwElement<TDim, TNumNodes>::InitializeSolutionStep(const ProcessIn
     const GeometryType& Geom       = this->GetGeometry();
     const unsigned int  NumGPoints = Geom.IntegrationPointsNumber(this->GetIntegrationMethod());
 
-    // create general parameters of retention law
     RetentionLaw::Parameters RetentionParameters(this->GetProperties());
 
     // Loop over integration points
@@ -303,30 +302,22 @@ void TransientPwElement<TDim, TNumNodes>::InitializeSolutionStep(const ProcessIn
     // reset hydraulic discharge
     this->ResetHydraulicDischarge();
 
-    KRATOS_CATCH("");
+    KRATOS_CATCH("")
 }
 
 //----------------------------------------------------------------------------------------------------
 template <unsigned int TDim, unsigned int TNumNodes>
-void TransientPwElement<TDim, TNumNodes>::InitializeNonLinearIteration(const ProcessInfo& rCurrentProcessInfo)
+void TransientPwElement<TDim, TNumNodes>::InitializeNonLinearIteration(const ProcessInfo&)
 {
-    KRATOS_TRY;
-
     // nothing
-
-    KRATOS_CATCH("");
 }
 
 //----------------------------------------------------------------------------------------------------
 
 template <unsigned int TDim, unsigned int TNumNodes>
-void TransientPwElement<TDim, TNumNodes>::FinalizeNonLinearIteration(const ProcessInfo& rCurrentProcessInfo)
+void TransientPwElement<TDim, TNumNodes>::FinalizeNonLinearIteration(const ProcessInfo&)
 {
-    KRATOS_TRY;
-
     // nothing
-
-    KRATOS_CATCH("");
 }
 
 //----------------------------------------------------------------------------------------------------
@@ -341,7 +332,6 @@ void TransientPwElement<TDim, TNumNodes>::FinalizeSolutionStep(const ProcessInfo
     const GeometryType& Geom       = this->GetGeometry();
     const unsigned int  NumGPoints = Geom.IntegrationPointsNumber(this->GetIntegrationMethod());
 
-    // create general parameters of retention law
     RetentionLaw::Parameters RetentionParameters(this->GetProperties());
 
     // Loop over integration points
@@ -450,7 +440,6 @@ void TransientPwElement<TDim, TNumNodes>::CalculateAll(MatrixType&        rLeftH
     ElementVariables Variables;
     this->InitializeElementVariables(Variables, rCurrentProcessInfo);
 
-    // create general parameters of retention law
     RetentionLaw::Parameters RetentionParameters(this->GetProperties());
 
     const auto relative_permeability_values = this->CalculateRelativePermeabilityValues(
@@ -540,7 +529,7 @@ template <unsigned int TDim, unsigned int TNumNodes>
 void TransientPwElement<TDim, TNumNodes>::CalculateAndAddLHS(MatrixType&       rLeftHandSideMatrix,
                                                              ElementVariables& rVariables)
 {
-    KRATOS_TRY;
+    KRATOS_TRY
 
     this->CalculateAndAddCompressibilityMatrix(rLeftHandSideMatrix, rVariables);
 
@@ -549,7 +538,7 @@ void TransientPwElement<TDim, TNumNodes>::CalculateAndAddLHS(MatrixType&       r
         rVariables.RelativePermeability, rVariables.IntegrationCoefficient);
     rLeftHandSideMatrix += permeability_matrix;
 
-    KRATOS_CATCH("");
+    KRATOS_CATCH("")
 }
 
 //----------------------------------------------------------------------------------------

--- a/applications/GeoMechanicsApplication/custom_elements/transient_Pw_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/transient_Pw_element.cpp
@@ -546,7 +546,7 @@ void TransientPwElement<TDim, TNumNodes>::CalculateAndAddLHS(MatrixType&       r
 
     const auto permeability_matrix = GeoTransportEquationUtilities::CalculatePermeabilityMatrix<TDim, TNumNodes>(
         rVariables.GradNpT, rVariables.DynamicViscosityInverse, rVariables.PermeabilityMatrix,
-        rVariables.RelativePermeability, rVariables.PermeabilityUpdateFactor, rVariables.IntegrationCoefficient);
+        rVariables.RelativePermeability, rVariables.IntegrationCoefficient);
     rLeftHandSideMatrix += permeability_matrix;
 
     KRATOS_CATCH("");

--- a/applications/GeoMechanicsApplication/custom_elements/transient_Pw_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/transient_Pw_element.cpp
@@ -470,13 +470,13 @@ void TransientPwElement<TDim, TNumNodes>::CalculateAll(MatrixType&        rLeftH
             Variables.BodyAcceleration, Variables.NContainer, Variables.VolumeAcceleration, GPoint);
 
         this->CalculateRetentionResponse(Variables, RetentionParameters, GPoint);
+        Variables.RelativePermeability = relative_permeability_values[GPoint];
 
         Variables.BiotCoefficient    = biot_coefficients[GPoint];
         Variables.BiotModulusInverse = GeoTransportEquationUtilities::CalculateBiotModulusInverse(
             Variables.BiotCoefficient, Variables.DegreeOfSaturation,
             Variables.DerivativeOfSaturation, this->GetProperties());
 
-        Variables.RelativePermeability   = relative_permeability_values[GPoint];
         Variables.IntegrationCoefficient = integration_coefficients[GPoint];
 
         // Contributions to the left hand side

--- a/applications/GeoMechanicsApplication/custom_elements/transient_Pw_element.hpp
+++ b/applications/GeoMechanicsApplication/custom_elements/transient_Pw_element.hpp
@@ -93,9 +93,9 @@ public:
 
     void InitializeSolutionStep(const ProcessInfo& rCurrentProcessInfo) override;
 
-    void InitializeNonLinearIteration(const ProcessInfo& rCurrentProcessInfo) override;
+    void InitializeNonLinearIteration(const ProcessInfo&) override;
 
-    void FinalizeNonLinearIteration(const ProcessInfo& rCurrentProcessInfo) override;
+    void FinalizeNonLinearIteration(const ProcessInfo&) override;
 
     void FinalizeSolutionStep(const ProcessInfo& rCurrentProcessInfo) override;
 

--- a/applications/GeoMechanicsApplication/custom_elements/transient_Pw_element.hpp
+++ b/applications/GeoMechanicsApplication/custom_elements/transient_Pw_element.hpp
@@ -167,7 +167,6 @@ protected:
     void CalculateAndAddCompressibilityMatrix(MatrixType& rLeftHandSideMatrix, ElementVariables& rVariables) override;
     void CalculateAndAddPermeabilityFlow(VectorType& rRightHandSideVector, ElementVariables& rVariables) override;
     void CalculateAndAddFluidBodyFlow(VectorType& rRightHandSideVector, ElementVariables& rVariables) override;
-    void CalculateAndAddPermeabilityMatrix(MatrixType& rLeftHandSideMatrix, const ElementVariables& rVariables) override;
     void CalculateAndAddCompressibilityFlow(VectorType& rRightHandSideVector, ElementVariables& rVariables) override;
 
     unsigned int GetNumberOfDOF() const override;

--- a/applications/GeoMechanicsApplication/custom_elements/transient_Pw_interface_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/transient_Pw_interface_element.cpp
@@ -599,7 +599,7 @@ void TransientPwInterfaceElement<TDim, TNumNodes>::CalculateAndAddPermeabilityMa
 
     rVariables.PPMatrix = GeoTransportEquationUtilities::CalculatePermeabilityMatrix<TDim, TNumNodes>(
         rVariables.GradNpT, rVariables.DynamicViscosityInverse, rVariables.LocalPermeabilityMatrix,
-        rVariables.RelativePermeability, rVariables.JointWidth, rVariables.IntegrationCoefficient);
+        rVariables.RelativePermeability * rVariables.JointWidth, rVariables.IntegrationCoefficient);
 
     // Distribute permeability block matrix into the elemental matrix
     rLeftHandSideMatrix += rVariables.PPMatrix;

--- a/applications/GeoMechanicsApplication/custom_elements/transient_Pw_interface_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/transient_Pw_interface_element.cpp
@@ -147,7 +147,6 @@ void TransientPwInterfaceElement<TDim, TNumNodes>::InitializeSolutionStep(const 
 {
     KRATOS_TRY
 
-    // create general parameters of retention law
     RetentionLaw::Parameters RetentionParameters(this->GetProperties());
 
     // Loop over integration points
@@ -164,7 +163,6 @@ void TransientPwInterfaceElement<TDim, TNumNodes>::FinalizeSolutionStep(const Pr
 {
     KRATOS_TRY
 
-    // create general parameters of retention law
     RetentionLaw::Parameters RetentionParameters(this->GetProperties());
 
     // Loop over integration points
@@ -295,7 +293,6 @@ void TransientPwInterfaceElement<TDim, TNumNodes>::CalculateOnLobattoIntegration
         // VG: Perhaps a new parameter to get join width and not minimum joint width
         const double& JointWidth = Prop[MINIMUM_JOINT_WIDTH];
 
-        // create general parameters of retention law
         RetentionLaw::Parameters RetentionParameters(this->GetProperties());
 
         // Loop over integration points
@@ -474,7 +471,6 @@ void TransientPwInterfaceElement<TDim, TNumNodes>::CalculateAll(MatrixType& rLef
     array_1d<double, TDim> RelDispVector;
     SFGradAuxVariables     SFGradAuxVars;
 
-    // create general parameters of retention law
     RetentionLaw::Parameters RetentionParameters(this->GetProperties());
 
     const bool hasBiotCoefficient = Prop.Has(BIOT_COEFFICIENT);

--- a/applications/GeoMechanicsApplication/custom_elements/transient_Pw_interface_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/transient_Pw_interface_element.cpp
@@ -498,7 +498,7 @@ void TransientPwInterfaceElement<TDim, TNumNodes>::CalculateAll(MatrixType& rLef
         InterfaceElementUtilities::FillPermeabilityMatrix(
             Variables.LocalPermeabilityMatrix, Variables.JointWidth, Prop[TRANSVERSAL_PERMEABILITY]);
 
-        CalculateRetentionResponse(Variables, RetentionParameters, GPoint);
+        this->CalculateRetentionResponse(Variables, RetentionParameters, GPoint);
 
         this->InitializeBiotCoefficients(Variables, hasBiotCoefficient);
 

--- a/applications/GeoMechanicsApplication/custom_elements/transient_Pw_interface_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/transient_Pw_interface_element.cpp
@@ -143,12 +143,12 @@ void TransientPwInterfaceElement<TDim, TNumNodes>::CalculateMassMatrix(MatrixTyp
 }
 
 template <unsigned int TDim, unsigned int TNumNodes>
-void TransientPwInterfaceElement<TDim, TNumNodes>::InitializeSolutionStep(const ProcessInfo& rCurrentProcessInfo)
+void TransientPwInterfaceElement<TDim, TNumNodes>::InitializeSolutionStep(const ProcessInfo&)
 {
     KRATOS_TRY
 
     // create general parameters of retention law
-    RetentionLaw::Parameters RetentionParameters(this->GetProperties(), rCurrentProcessInfo);
+    RetentionLaw::Parameters RetentionParameters(this->GetProperties());
 
     // Loop over integration points
     for (unsigned int GPoint = 0; GPoint < mRetentionLawVector.size(); ++GPoint) {
@@ -160,12 +160,12 @@ void TransientPwInterfaceElement<TDim, TNumNodes>::InitializeSolutionStep(const 
 }
 
 template <unsigned int TDim, unsigned int TNumNodes>
-void TransientPwInterfaceElement<TDim, TNumNodes>::FinalizeSolutionStep(const ProcessInfo& rCurrentProcessInfo)
+void TransientPwInterfaceElement<TDim, TNumNodes>::FinalizeSolutionStep(const ProcessInfo&)
 {
     KRATOS_TRY
 
     // create general parameters of retention law
-    RetentionLaw::Parameters RetentionParameters(this->GetProperties(), rCurrentProcessInfo);
+    RetentionLaw::Parameters RetentionParameters(this->GetProperties());
 
     // Loop over integration points
     for (unsigned int GPoint = 0; GPoint < mRetentionLawVector.size(); ++GPoint) {
@@ -296,7 +296,7 @@ void TransientPwInterfaceElement<TDim, TNumNodes>::CalculateOnLobattoIntegration
         const double& JointWidth = Prop[MINIMUM_JOINT_WIDTH];
 
         // create general parameters of retention law
-        RetentionLaw::Parameters RetentionParameters(this->GetProperties(), rCurrentProcessInfo);
+        RetentionLaw::Parameters RetentionParameters(this->GetProperties());
 
         // Loop over integration points
         for (unsigned int GPoint = 0; GPoint < NumGPoints; ++GPoint) {
@@ -475,7 +475,7 @@ void TransientPwInterfaceElement<TDim, TNumNodes>::CalculateAll(MatrixType& rLef
     SFGradAuxVariables     SFGradAuxVars;
 
     // create general parameters of retention law
-    RetentionLaw::Parameters RetentionParameters(this->GetProperties(), CurrentProcessInfo);
+    RetentionLaw::Parameters RetentionParameters(this->GetProperties());
 
     const bool hasBiotCoefficient = Prop.Has(BIOT_COEFFICIENT);
 

--- a/applications/GeoMechanicsApplication/custom_elements/transient_Pw_interface_element.hpp
+++ b/applications/GeoMechanicsApplication/custom_elements/transient_Pw_interface_element.hpp
@@ -44,7 +44,6 @@ public:
     /// The definition of the sizetype
     using SizeType = std::size_t;
 
-    using BaseType::CalculateRetentionResponse;
     using BaseType::mRetentionLawVector;
     using BaseType::mThisIntegrationMethod;
 

--- a/applications/GeoMechanicsApplication/custom_elements/transient_Pw_interface_element.hpp
+++ b/applications/GeoMechanicsApplication/custom_elements/transient_Pw_interface_element.hpp
@@ -109,8 +109,8 @@ public:
 
     void CalculateMassMatrix(MatrixType& rMassMatrix, const ProcessInfo& rCurrentProcessInfo) override;
 
-    void InitializeSolutionStep(const ProcessInfo& rCurrentProcessInfo) override;
-    void FinalizeSolutionStep(const ProcessInfo& rCurrentProcessInfo) override;
+    void InitializeSolutionStep(const ProcessInfo&) override;
+    void FinalizeSolutionStep(const ProcessInfo&) override;
 
     void CalculateOnIntegrationPoints(const Variable<Matrix>& rVariable,
                                       std::vector<Matrix>&    rValues,

--- a/applications/GeoMechanicsApplication/custom_elements/transient_Pw_line_element.h
+++ b/applications/GeoMechanicsApplication/custom_elements/transient_Pw_line_element.h
@@ -235,7 +235,7 @@ private:
             double dynamic_viscosity_inverse = 1.0 / r_properties[DYNAMIC_VISCOSITY];
             result += GeoTransportEquationUtilities::CalculatePermeabilityMatrix<TDim, TNumNodes>(
                 rShapeFunctionGradients[integration_point_index], dynamic_viscosity_inverse, constitutive_matrix,
-                RelativePermeability, 1.0, rIntegrationCoefficients[integration_point_index]);
+                RelativePermeability, rIntegrationCoefficients[integration_point_index]);
         }
         return result;
     }

--- a/applications/GeoMechanicsApplication/custom_elements/transient_thermal_element.h
+++ b/applications/GeoMechanicsApplication/custom_elements/transient_thermal_element.h
@@ -88,8 +88,8 @@ public:
         
         const auto integration_coefficients = CalculateIntegrationCoefficients(det_J_container);
         const auto conductivity_matrix =
-            CalculateConductivityMatrix(dN_dX_container, integration_coefficients, rCurrentProcessInfo);
-        const auto capacity_matrix = CalculateCapacityMatrix(integration_coefficients, rCurrentProcessInfo);
+            CalculateConductivityMatrix(dN_dX_container, integration_coefficients);
+        const auto capacity_matrix = CalculateCapacityMatrix(integration_coefficients);
 
         AddContributionsToLhsMatrix(rLeftHandSideMatrix, conductivity_matrix, capacity_matrix,
                                     rCurrentProcessInfo[DT_TEMPERATURE_COEFFICIENT]);
@@ -266,11 +266,10 @@ private:
 
     BoundedMatrix<double, TNumNodes, TNumNodes> CalculateConductivityMatrix(
         const GeometryType::ShapeFunctionsGradientsType& rShapeFunctionGradients,
-        const Vector&                                    rIntegrationCoefficients,
-        const ProcessInfo&                               rCurrentProcessInfo) const
+        const Vector&                                    rIntegrationCoefficients) const
     {
         const auto law = CreateThermalLaw();
-        const auto constitutive_matrix = law->CalculateThermalDispersionMatrix(GetProperties(), rCurrentProcessInfo);
+        const auto constitutive_matrix = law->CalculateThermalDispersionMatrix(GetProperties());
 
         auto result = BoundedMatrix<double, TNumNodes, TNumNodes>{ZeroMatrix{TNumNodes, TNumNodes}};
         for (unsigned int integration_point_index = 0;
@@ -285,11 +284,10 @@ private:
         return result;
     }
 
-    BoundedMatrix<double, TNumNodes, TNumNodes> CalculateCapacityMatrix(const Vector& rIntegrationCoefficients,
-                                                                        const ProcessInfo& rCurrentProcessInfo) const
+    BoundedMatrix<double, TNumNodes, TNumNodes> CalculateCapacityMatrix(const Vector& rIntegrationCoefficients) const
     {
         const auto&              r_properties = GetProperties();
-        RetentionLaw::Parameters parameters(r_properties, rCurrentProcessInfo);
+        RetentionLaw::Parameters parameters(r_properties);
         auto                     retention_law = RetentionLawFactory::Clone(r_properties);
         const double             saturation    = retention_law->CalculateSaturation(parameters);
         const auto c_water = r_properties[POROSITY] * saturation * r_properties[DENSITY_WATER] *

--- a/applications/GeoMechanicsApplication/custom_elements/updated_lagrangian_U_Pw_diff_order_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/updated_lagrangian_U_Pw_diff_order_element.cpp
@@ -65,7 +65,7 @@ void UpdatedLagrangianUPwDiffOrderElement::CalculateAll(MatrixType&        rLeft
         ConstitutiveParameters.GetOptions().Set(ConstitutiveLaw::COMPUTE_STRESS);
 
     // create general parameters of retention law
-    RetentionLaw::Parameters RetentionParameters(rProp, rCurrentProcessInfo);
+    RetentionLaw::Parameters RetentionParameters(rProp);
 
     // Loop over integration points
     const GeometryType::IntegrationPointsArrayType& IntegrationPoints =

--- a/applications/GeoMechanicsApplication/custom_elements/updated_lagrangian_U_Pw_diff_order_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/updated_lagrangian_U_Pw_diff_order_element.cpp
@@ -64,7 +64,6 @@ void UpdatedLagrangianUPwDiffOrderElement::CalculateAll(MatrixType&        rLeft
     if (CalculateResidualVectorFlag)
         ConstitutiveParameters.GetOptions().Set(ConstitutiveLaw::COMPUTE_STRESS);
 
-    // create general parameters of retention law
     RetentionLaw::Parameters RetentionParameters(rProp);
 
     // Loop over integration points

--- a/applications/GeoMechanicsApplication/custom_elements/updated_lagrangian_U_Pw_diff_order_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/updated_lagrangian_U_Pw_diff_order_element.cpp
@@ -96,13 +96,13 @@ void UpdatedLagrangianUPwDiffOrderElement::CalculateAll(MatrixType&        rLeft
         Variables.ConstitutiveMatrix = constitutive_matrices[GPoint];
 
         CalculateRetentionResponse(Variables, RetentionParameters, GPoint);
+        Variables.RelativePermeability = relative_permeability_values[GPoint];
 
         Variables.BiotCoefficient    = biot_coefficients[GPoint];
         Variables.BiotModulusInverse = GeoTransportEquationUtilities::CalculateBiotModulusInverse(
             Variables.BiotCoefficient, Variables.DegreeOfSaturation,
             Variables.DerivativeOfSaturation, this->GetProperties());
 
-        Variables.RelativePermeability   = relative_permeability_values[GPoint];
         Variables.IntegrationCoefficient = integration_coefficients[GPoint];
 
         Variables.IntegrationCoefficientInitialConfiguration = this->CalculateIntegrationCoefficient(

--- a/applications/GeoMechanicsApplication/custom_elements/updated_lagrangian_U_Pw_diff_order_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/updated_lagrangian_U_Pw_diff_order_element.cpp
@@ -84,6 +84,8 @@ void UpdatedLagrangianUPwDiffOrderElement::CalculateAll(MatrixType&        rLeft
                                          strain_vectors, mStressVector, constitutive_matrices);
     const auto biot_coefficients = GeoTransportEquationUtilities::CalculateBiotCoefficients(
         constitutive_matrices, this->GetProperties());
+    const auto relative_permeability_values = CalculateRelativePermeabilityValues(
+        GeoTransportEquationUtilities::CalculateFluidPressures(Variables.NpContainer, Variables.PressureVector));
 
     for (IndexType GPoint = 0; GPoint < IntegrationPoints.size(); ++GPoint) {
         this->CalculateKinematics(Variables, GPoint);
@@ -100,6 +102,7 @@ void UpdatedLagrangianUPwDiffOrderElement::CalculateAll(MatrixType&        rLeft
             Variables.BiotCoefficient, Variables.DegreeOfSaturation,
             Variables.DerivativeOfSaturation, this->GetProperties());
 
+        Variables.RelativePermeability   = relative_permeability_values[GPoint];
         Variables.IntegrationCoefficient = integration_coefficients[GPoint];
 
         Variables.IntegrationCoefficientInitialConfiguration = this->CalculateIntegrationCoefficient(

--- a/applications/GeoMechanicsApplication/custom_retention/retention_law.h
+++ b/applications/GeoMechanicsApplication/custom_retention/retention_law.h
@@ -67,8 +67,10 @@ public:
         */
 
     public:
-        Parameters(const Properties& rMaterialProperties, const ProcessInfo& rCurrentProcessInfo)
-            : mrCurrentProcessInfo(rCurrentProcessInfo), mrMaterialProperties(rMaterialProperties){};
+        explicit Parameters(const Properties& rMaterialProperties)
+            : mrMaterialProperties(rMaterialProperties)
+        {
+        }
 
         ~Parameters() = default;
 
@@ -82,13 +84,10 @@ public:
             return mFluidPressure.value();
         }
 
-        const ProcessInfo& GetProcessInfo() const { return mrCurrentProcessInfo; }
-
         const Properties& GetMaterialProperties() const { return mrMaterialProperties; }
 
     private:
         std::optional<double> mFluidPressure;
-        const ProcessInfo&    mrCurrentProcessInfo;
         const Properties&     mrMaterialProperties;
 
     }; // class Parameters end

--- a/applications/GeoMechanicsApplication/custom_utilities/transport_equation_utilities.hpp
+++ b/applications/GeoMechanicsApplication/custom_utilities/transport_equation_utilities.hpp
@@ -31,32 +31,6 @@ public:
         double                                   DynamicViscosityInverse,
         const BoundedMatrix<double, TDim, TDim>& rMaterialPermeabilityMatrix,
         double                                   RelativePermeability,
-        double                                   PermeabilityUpdateFactor,
-        double                                   IntegrationCoefficient)
-    {
-        return CalculatePermeabilityMatrix(rGradNpT, DynamicViscosityInverse,
-                                           rMaterialPermeabilityMatrix, RelativePermeability,
-                                           PermeabilityUpdateFactor, IntegrationCoefficient);
-    }
-
-    static inline Matrix CalculatePermeabilityMatrix(const Matrix& rGradNpT,
-                                                     double        DynamicViscosityInverse,
-                                                     const Matrix& rMaterialPermeabilityMatrix,
-                                                     double        RelativePermeability,
-                                                     double        PermeabilityUpdateFactor,
-                                                     double        IntegrationCoefficient)
-    {
-        return CalculatePermeabilityMatrix(rGradNpT, DynamicViscosityInverse, rMaterialPermeabilityMatrix,
-                                           RelativePermeability * PermeabilityUpdateFactor,
-                                           IntegrationCoefficient);
-    }
-
-    template <unsigned int TDim, unsigned int TNumNodes>
-    static inline BoundedMatrix<double, TNumNodes, TNumNodes> CalculatePermeabilityMatrix(
-        const Matrix&                            rGradNpT,
-        double                                   DynamicViscosityInverse,
-        const BoundedMatrix<double, TDim, TDim>& rMaterialPermeabilityMatrix,
-        double                                   RelativePermeability,
         double                                   IntegrationCoefficient)
     {
         return CalculatePermeabilityMatrix(rGradNpT, DynamicViscosityInverse, rMaterialPermeabilityMatrix,

--- a/applications/GeoMechanicsApplication/custom_utilities/transport_equation_utilities.hpp
+++ b/applications/GeoMechanicsApplication/custom_utilities/transport_equation_utilities.hpp
@@ -100,10 +100,9 @@ public:
     static Vector CalculateDegreesSaturation(const Vector& rPressureSolution,
                                              const Matrix& rNContainer,
                                              const std::vector<RetentionLaw::Pointer>& rRetentionLawVector,
-                                             const Properties&  rProp,
-                                             const ProcessInfo& rCurrentProcessInfo)
+                                             const Properties& rProp)
     {
-        RetentionLaw::Parameters retention_parameters(rProp, rCurrentProcessInfo);
+        RetentionLaw::Parameters retention_parameters(rProp);
         Vector                   result(rRetentionLawVector.size());
         for (unsigned int g_point = 0; g_point < rRetentionLawVector.size(); ++g_point) {
             const double fluid_pressure = CalculateFluidPressure(row(rNContainer, g_point), rPressureSolution);

--- a/applications/GeoMechanicsApplication/custom_utilities/transport_equation_utilities.hpp
+++ b/applications/GeoMechanicsApplication/custom_utilities/transport_equation_utilities.hpp
@@ -45,9 +45,32 @@ public:
                                                      double        PermeabilityUpdateFactor,
                                                      double        IntegrationCoefficient)
     {
+        return CalculatePermeabilityMatrix(rGradNpT, DynamicViscosityInverse, rMaterialPermeabilityMatrix,
+                                           RelativePermeability * PermeabilityUpdateFactor,
+                                           IntegrationCoefficient);
+    }
+
+    template <unsigned int TDim, unsigned int TNumNodes>
+    static inline BoundedMatrix<double, TNumNodes, TNumNodes> CalculatePermeabilityMatrix(
+        const Matrix&                            rGradNpT,
+        double                                   DynamicViscosityInverse,
+        const BoundedMatrix<double, TDim, TDim>& rMaterialPermeabilityMatrix,
+        double                                   RelativePermeability,
+        double                                   IntegrationCoefficient)
+    {
+        return CalculatePermeabilityMatrix(rGradNpT, DynamicViscosityInverse, rMaterialPermeabilityMatrix,
+                                           RelativePermeability, IntegrationCoefficient);
+    }
+
+    static inline Matrix CalculatePermeabilityMatrix(const Matrix& rGradNpT,
+                                                     double        DynamicViscosityInverse,
+                                                     const Matrix& rMaterialPermeabilityMatrix,
+                                                     double        RelativePermeability,
+                                                     double        IntegrationCoefficient)
+    {
         return -PORE_PRESSURE_SIGN_FACTOR * DynamicViscosityInverse *
                prod(rGradNpT, Matrix(prod(rMaterialPermeabilityMatrix, trans(rGradNpT)))) *
-               RelativePermeability * PermeabilityUpdateFactor * IntegrationCoefficient;
+               RelativePermeability * IntegrationCoefficient;
     }
 
     template <unsigned int TDim, unsigned int TNumNodes>

--- a/applications/GeoMechanicsApplication/custom_utilities/transport_equation_utilities.hpp
+++ b/applications/GeoMechanicsApplication/custom_utilities/transport_equation_utilities.hpp
@@ -152,6 +152,15 @@ public:
         return result;
     }
 
+    [[nodiscard]] static std::vector<double> CalculateFluidPressures(const Matrix& rNContainer, const Vector& rPressureVector)
+    {
+        auto result = std::vector<double>{};
+        for (auto i = std::size_t{0}; i < rNContainer.size1(); ++i) {
+            result.emplace_back(CalculateFluidPressure(row(rNContainer, i), rPressureVector));
+        }
+        return result;
+    }
+
 private:
     [[nodiscard]] static double CalculateBiotCoefficient(const Matrix&     rConstitutiveMatrix,
                                                          const Properties& rProperties)
@@ -160,6 +169,5 @@ private:
                    ? rProperties[BIOT_COEFFICIENT]
                    : 1.0 - CalculateBulkModulus(rConstitutiveMatrix) / rProperties[BULK_MODULUS_SOLID];
     }
-
 }; /* Class GeoTransportEquationUtilities*/
 } /* namespace Kratos.*/

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/test_permeability_matrix.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/test_permeability_matrix.cpp
@@ -41,8 +41,8 @@ KRATOS_TEST_CASE_IN_SUITE(CalculatePermeabilityMatrix2D3NGivesCorrectResults, Kr
     const double RelativePermeability     = 0.02;
     const double PermeabilityUpdateFactor = 1.5;
     PermeabilityMatrix = GeoTransportEquationUtilities::CalculatePermeabilityMatrix<2, 3>(
-        GradNpT, DynamicViscosityInverse, MaterialPermeabilityMatrix, RelativePermeability,
-        PermeabilityUpdateFactor, IntegrationCoefficient);
+        GradNpT, DynamicViscosityInverse, MaterialPermeabilityMatrix,
+        RelativePermeability * PermeabilityUpdateFactor, IntegrationCoefficient);
 
     BoundedMatrix<double, 3, 3> PMatrix;
     // clang-format off
@@ -76,8 +76,8 @@ KRATOS_TEST_CASE_IN_SUITE(CalculatePermeabilityMatrix3D4NGivesCorrectResults, Kr
     const double RelativePermeability     = 0.1;
     const double PermeabilityUpdateFactor = 2.0;
     PermeabilityMatrix = GeoTransportEquationUtilities::CalculatePermeabilityMatrix<3, 4>(
-        GradNpT, DynamicViscosityInverse, MaterialPermeabilityMatrix, RelativePermeability,
-        PermeabilityUpdateFactor, IntegrationCoefficient);
+        GradNpT, DynamicViscosityInverse, MaterialPermeabilityMatrix,
+        RelativePermeability * PermeabilityUpdateFactor, IntegrationCoefficient);
 
     BoundedMatrix<double, 4, 4> PMatrix;
     // clang-format off

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/test_thermal_dispersion_law.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/test_thermal_dispersion_law.cpp
@@ -33,11 +33,9 @@ KRATOS_TEST_CASE_IN_SUITE(CalculateThermalDispersionMatrix2D, KratosGeoMechanics
 
     const SizeType dimension = 2;
     GeoThermalDispersionLaw geo_thermal_dispersion_2D_law(dimension);
-    ProcessInfo info;
 
     const Matrix thermal_dispersion_matrix =
-        geo_thermal_dispersion_2D_law.CalculateThermalDispersionMatrix(
-            *cond_prop, info);
+        geo_thermal_dispersion_2D_law.CalculateThermalDispersionMatrix(*cond_prop);
 
     Matrix expected_solution = ZeroMatrix(2, 2);
     expected_solution(0, 0) = 1125.0;
@@ -74,11 +72,9 @@ KRATOS_TEST_CASE_IN_SUITE(CalculateThermalDispersionMatrix3D, KratosGeoMechanics
 
     const SizeType dimension = 3;
     GeoThermalDispersionLaw geo_thermal_dispersion_3D_law(dimension);
-    ProcessInfo info;
 
     const Matrix thermal_dispersion_matrix =
-        geo_thermal_dispersion_3D_law.CalculateThermalDispersionMatrix(
-            *cond_prop, info);
+        geo_thermal_dispersion_3D_law.CalculateThermalDispersionMatrix(*cond_prop);
 
     Matrix expected_solution = ZeroMatrix(3, 3);
     expected_solution(0, 0) = 800.0;

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/test_thermal_filter_law.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/test_thermal_filter_law.cpp
@@ -27,9 +27,8 @@ KRATOS_TEST_CASE_IN_SUITE(CalculateThermalFilterLawMatrix, KratosGeoMechanicsFas
     p_cond_prop->SetValue(THERMAL_CONDUCTIVITY_WATER, 1000.0);
 
     GeoThermalFilterLaw geo_thermal_filter_law;
-    ProcessInfo         info;
 
-    const Matrix thermal_filter_matrix = geo_thermal_filter_law.CalculateThermalDispersionMatrix(*p_cond_prop, info);
+    const Matrix thermal_filter_matrix = geo_thermal_filter_law.CalculateThermalDispersionMatrix(*p_cond_prop);
 
     Matrix expected_solution = ScalarMatrix(1, 1, 1000.0);
 

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/test_transport_equation_utilities.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/test_transport_equation_utilities.cpp
@@ -134,4 +134,22 @@ KRATOS_TEST_CASE_IN_SUITE(CalculateBiotCoefficients_GivesInfResults_ForZeroBulkM
                                    [](const double value) { return std::isinf(value); }))
 }
 
+KRATOS_TEST_CASE_IN_SUITE(EachFluidPressureIsTheInnerProductOfShapeFunctionsAndPressure, KratosGeoMechanicsFastSuite)
+{
+    auto shape_function_values = Matrix{3, 3, 0.0};
+    // clang-format off
+    shape_function_values <<= 0.8, 0.2, 0.3,
+                              0.1, 0.7, 0.4,
+                              0.2, 0.5, 0.6;
+    // clang-format on
+
+    auto pore_water_pressures = Vector(3);
+    pore_water_pressures <<= 2.0, 3.0, 4.0;
+
+    const auto expected_fluid_pressures = std::vector<double>{3.4, 3.9, 4.3};
+    KRATOS_EXPECT_VECTOR_NEAR(GeoTransportEquationUtilities::CalculateFluidPressures(
+                                  shape_function_values, pore_water_pressures),
+                              expected_fluid_pressures, 1e-12)
+}
+
 } // namespace Kratos::Testing


### PR DESCRIPTION
**📝 Description**
Pre-calculate relative permeability values as preparation for calculating element permeability matrices. When needed, modify these values by accounting for the permeability update factors (i.e. to account for volume changes in geometrically linear elements).

**🆕 Changelog**
Other changes include:
- Members `CalculateRetentionResponse` no longer compute the relative permeability. It is now pre-calculated.
- Extracted members that calculate the relative permeability values for all integration points of an element.
- Moved the calculation of permeability update factors to the transport equation utilities.
- Extracted a utility function that calculates fluid pressures at all integration points of an element.
- Inlined the wrapper member functions that calculate and add the permeability matrix, to avoid needless levels of indirection.
- Removed member `PermeabilityUpdateFactor` from two `ElementVariables` data structures.
- Removed the unused `ProcessInfo` data member from the retention laws.
- Removed several comments that had no additional value.
- Miscellaneous cleanup:
  * Reduced the scope of some variables.
  * Don't use `noalias` if no performance benefit is to be expected.
  * Prefer to use `this->` to refer to base members rather than a `using` statement.
  * Removed some unnecessary `KRATOS_TRY` and `KRATOS_CATCH` statements.
  * Removed several empty statements.
  * Unnamed some unused function parameters.
