### PR TITLE
[GeoMechanicsApplication] Investigate 1d consolidation test

### DIFF
--- a/applications/GeoMechanicsApplication/custom_elements/small_strain_U_Pw_diff_order_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/small_strain_U_Pw_diff_order_element.cpp
@@ -494,7 +494,7 @@ void SmallStrainUPwDiffOrderElement::CalculateDampingMatrix(MatrixType&        r
     MatrixType mass_matrix = ZeroMatrix(element_size, element_size);
     this->CalculateMassMatrix(mass_matrix, rCurrentProcessInfo);
 
-    MatrixType stiffness_matrix(element_size, element_size);
+    MatrixType stiffness_matrix = ZeroMatrix(element_size, element_size);
     this->CalculateMaterialStiffnessMatrix(stiffness_matrix, rCurrentProcessInfo);
 
     rDampingMatrix = GeoEquationOfMotionUtilities::CalculateDampingMatrix(
@@ -1635,7 +1635,8 @@ std::vector<double> SmallStrainUPwDiffOrderElement::CalculateIntegrationCoeffici
     return result;
 }
 
-void SmallStrainUPwDiffOrderElement::CalculateAndAddLHS(MatrixType& rLeftHandSideMatrix, ElementVariables& rVariables) const
+void SmallStrainUPwDiffOrderElement::CalculateAndAddLHS(MatrixType&       rLeftHandSideMatrix,
+                                                        ElementVariables& rVariables) const
 {
     KRATOS_TRY
 

--- a/applications/GeoMechanicsApplication/custom_strategies/schemes/geomechanics_time_integration_scheme.hpp
+++ b/applications/GeoMechanicsApplication/custom_strategies/schemes/geomechanics_time_integration_scheme.hpp
@@ -122,7 +122,7 @@ public:
         Scheme<TSparseSpace, TDenseSpace>::Initialize(rModelPart);
 
         KRATOS_TRY
-        // removed SetTimeFactor() because ProjectParameters.json file has not been read yet.
+        // SetTimeFactors(rModelPart); commented to avoid initialization of mDeltaTime when the value is not available yet
         KRATOS_CATCH("")
     }
 

--- a/applications/GeoMechanicsApplication/custom_strategies/schemes/geomechanics_time_integration_scheme.hpp
+++ b/applications/GeoMechanicsApplication/custom_strategies/schemes/geomechanics_time_integration_scheme.hpp
@@ -120,10 +120,6 @@ public:
     void Initialize(ModelPart& rModelPart) override
     {
         Scheme<TSparseSpace, TDenseSpace>::Initialize(rModelPart);
-
-        KRATOS_TRY
-        // SetTimeFactors(rModelPart); commented to avoid initialization of mDeltaTime when the value is not available yet
-        KRATOS_CATCH("")
     }
 
     void Predict(ModelPart& rModelPart, DofsArrayType&, TSystemMatrixType&, TSystemVectorType&, TSystemVectorType&) override

--- a/applications/GeoMechanicsApplication/custom_strategies/schemes/geomechanics_time_integration_scheme.hpp
+++ b/applications/GeoMechanicsApplication/custom_strategies/schemes/geomechanics_time_integration_scheme.hpp
@@ -122,7 +122,7 @@ public:
         Scheme<TSparseSpace, TDenseSpace>::Initialize(rModelPart);
 
         KRATOS_TRY
-
+        // removed SetTimeFactor() because ProjectParameters.json file has not been read yet.
         KRATOS_CATCH("")
     }
 

--- a/applications/GeoMechanicsApplication/custom_strategies/schemes/geomechanics_time_integration_scheme.hpp
+++ b/applications/GeoMechanicsApplication/custom_strategies/schemes/geomechanics_time_integration_scheme.hpp
@@ -122,7 +122,7 @@ public:
         Scheme<TSparseSpace, TDenseSpace>::Initialize(rModelPart);
 
         KRATOS_TRY
-        SetTimeFactors(rModelPart);
+
         KRATOS_CATCH("")
     }
 

--- a/applications/GeoMechanicsApplication/tests/1d_consolidation.py
+++ b/applications/GeoMechanicsApplication/tests/1d_consolidation.py
@@ -24,7 +24,6 @@ class KratosGeoMechanics1DConsolidation(KratosUnittest.TestCase):
         # Code here will be placed AFTER every test in this TestCase.
         pass
 
-    @KratosUnittest.skip("Test test_1d_consolidation skipped temporary.")
     def test_1d_consolidation(self):
         """
         test 1D consolidation on elastic soil.

--- a/applications/GeoMechanicsApplication/tests/1d_consolidation.py
+++ b/applications/GeoMechanicsApplication/tests/1d_consolidation.py
@@ -24,6 +24,7 @@ class KratosGeoMechanics1DConsolidation(KratosUnittest.TestCase):
         # Code here will be placed AFTER every test in this TestCase.
         pass
 
+    @KratosUnittest.skip("Test test_1d_consolidation skipped temporary.")
     def test_1d_consolidation(self):
         """
         test 1D consolidation on elastic soil.

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/test_backward_euler_Pw_scheme.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/test_backward_euler_Pw_scheme.cpp
@@ -16,64 +16,72 @@
 
 using namespace Kratos;
 using SparseSpaceType = UblasSpace<double, CompressedMatrix, Vector>;
-using LocalSpaceType = UblasSpace<double, Matrix, Vector>;
+using LocalSpaceType  = UblasSpace<double, Matrix, Vector>;
 
-namespace Kratos::Testing {
+namespace Kratos::Testing
+{
 
-KRATOS_TEST_CASE_IN_SUITE(BackwardEulerPwScheme_UpdatesVariablesDerivatives_WhenPredictIsCalled,
-                          KratosGeoMechanicsFastSuite)
+KRATOS_TEST_CASE_IN_SUITE(BackwardEulerPwScheme_UpdatesVariablesDerivatives_WhenPredictIsCalled, KratosGeoMechanicsFastSuite)
 {
     BackwardEulerQuasistaticPwScheme<SparseSpaceType, LocalSpaceType> scheme;
+
     Model model;
     auto& model_part = model.CreateModelPart("dummy", 2);
 
     model_part.AddNodalSolutionStepVariable(WATER_PRESSURE);
     model_part.AddNodalSolutionStepVariable(DT_WATER_PRESSURE);
 
-    constexpr double current_pressure = 1.0;
+    constexpr double current_pressure  = 1.0;
     constexpr double previous_pressure = 0.0;
-    constexpr double delta_time = 4.0;
+    constexpr double delta_time        = 4.0;
 
     model_part.GetProcessInfo()[DELTA_TIME] = delta_time;
+
     auto p_node = model_part.CreateNewNode(0, 0.0, 0.0, 0.0);
     p_node->FastGetSolutionStepValue(WATER_PRESSURE, 0) = current_pressure;
     p_node->FastGetSolutionStepValue(WATER_PRESSURE, 1) = previous_pressure;
 
     KRATOS_EXPECT_DOUBLE_EQ(p_node->FastGetSolutionStepValue(DT_WATER_PRESSURE, 0), 0.0);
 
-    scheme.Initialize(model_part);
     ModelPart::DofsArrayType dof_set;
-    CompressedMatrix A;
-    Vector Dx;
-    Vector b;
+    CompressedMatrix         A;
+    Vector                   Dx;
+    Vector                   b;
+
+    scheme.InitializeSolutionStep(model_part, A, Dx, b); // This is needed to set the time factors
+
     scheme.Predict(model_part, dof_set, A, Dx, b);
 
     constexpr double expected_dt_temperature = 0.25;
-    KRATOS_EXPECT_DOUBLE_EQ(p_node->FastGetSolutionStepValue(DT_WATER_PRESSURE, 0),
-                            expected_dt_temperature);
+    KRATOS_EXPECT_DOUBLE_EQ(p_node->FastGetSolutionStepValue(DT_WATER_PRESSURE, 0), expected_dt_temperature);
 }
 
 KRATOS_TEST_CASE_IN_SUITE(InitializeBackwardEulerPwScheme_SetsTimeFactors, KratosGeoMechanicsFastSuite)
 {
     BackwardEulerQuasistaticPwScheme<SparseSpaceType, LocalSpaceType> scheme;
+
     Model model;
     auto& model_part = model.CreateModelPart("dummy", 2);
 
     model_part.AddNodalSolutionStepVariable(WATER_PRESSURE);
     model_part.AddNodalSolutionStepVariable(DT_WATER_PRESSURE);
 
-    constexpr double delta_time = 3.0;
+    constexpr double delta_time             = 3.0;
     model_part.GetProcessInfo()[DELTA_TIME] = delta_time;
 
     scheme.Initialize(model_part);
 
     KRATOS_EXPECT_TRUE(scheme.SchemeIsInitialized())
-    KRATOS_EXPECT_DOUBLE_EQ(model_part.GetProcessInfo()[DT_PRESSURE_COEFFICIENT],
-                            1.0 / delta_time);
+
+    CompressedMatrix A;
+    Vector           Dx;
+    Vector           b;
+    scheme.InitializeSolutionStep(model_part, A, Dx, b); // This is needed to set the time factors
+
+    KRATOS_EXPECT_DOUBLE_EQ(model_part.GetProcessInfo()[DT_PRESSURE_COEFFICIENT], 1.0 / delta_time);
 }
 
-KRATOS_TEST_CASE_IN_SUITE(ForMissingNodalDof_CheckBackwardEulerPwScheme_Throws,
-                          KratosGeoMechanicsFastSuite)
+KRATOS_TEST_CASE_IN_SUITE(ForMissingNodalDof_CheckBackwardEulerPwScheme_Throws, KratosGeoMechanicsFastSuite)
 {
     BackwardEulerQuasistaticPwScheme<SparseSpaceType, LocalSpaceType> scheme;
 
@@ -98,9 +106,8 @@ KRATOS_TEST_CASE_IN_SUITE(ForMissingDtWaterPressureSolutionStepVariable_CheckBac
     auto p_node = model_part.CreateNewNode(0, 0.0, 0.0, 0.0);
     p_node->AddDof(WATER_PRESSURE);
 
-    KRATOS_EXPECT_EXCEPTION_IS_THROWN(
-        scheme.Check(model_part),
-        "DT_WATER_PRESSURE variable is not allocated for node 0")
+    KRATOS_EXPECT_EXCEPTION_IS_THROWN(scheme.Check(model_part),
+                                      "DT_WATER_PRESSURE variable is not allocated for node 0")
 }
 
 KRATOS_TEST_CASE_IN_SUITE(ForMissingWaterPressureSolutionStepVariable_CheckBackwardEulerPwScheme_Throws,
@@ -110,11 +117,10 @@ KRATOS_TEST_CASE_IN_SUITE(ForMissingWaterPressureSolutionStepVariable_CheckBackw
 
     Model model;
     auto& model_part = model.CreateModelPart("dummy", 2);
-    auto p_node = model_part.CreateNewNode(0, 0.0, 0.0, 0.0);
+    auto  p_node     = model_part.CreateNewNode(0, 0.0, 0.0, 0.0);
 
-    KRATOS_EXPECT_EXCEPTION_IS_THROWN(
-        scheme.Check(model_part),
-        "WATER_PRESSURE variable is not allocated for node 0")
+    KRATOS_EXPECT_EXCEPTION_IS_THROWN(scheme.Check(model_part),
+                                      "WATER_PRESSURE variable is not allocated for node 0")
 }
 
 } // namespace Kratos::Testing

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/test_backward_euler_T_scheme.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/test_backward_euler_T_scheme.cpp
@@ -14,62 +14,72 @@
 #include "spaces/ublas_space.h"
 #include "testing/testing.h"
 
-namespace Kratos::Testing {
+namespace Kratos::Testing
+{
 
 using namespace Kratos;
 using SparseSpaceType = UblasSpace<double, CompressedMatrix, Vector>;
-using LocalSpaceType = UblasSpace<double, Matrix, Vector>;
+using LocalSpaceType  = UblasSpace<double, Matrix, Vector>;
 
-KRATOS_TEST_CASE_IN_SUITE(BackwardEulerTScheme_UpdatesVariablesDerivatives_WhenPredictIsCalled,
-                          KratosGeoMechanicsFastSuite)
+KRATOS_TEST_CASE_IN_SUITE(BackwardEulerTScheme_UpdatesVariablesDerivatives_WhenPredictIsCalled, KratosGeoMechanicsFastSuite)
 {
     BackwardEulerTScheme<SparseSpaceType, LocalSpaceType> scheme;
+
     Model model;
     auto& model_part = model.CreateModelPart("dummy", 2);
 
     model_part.AddNodalSolutionStepVariable(TEMPERATURE);
     model_part.AddNodalSolutionStepVariable(DT_TEMPERATURE);
 
-    constexpr double current_temperature = 1.0;
+    constexpr double current_temperature  = 1.0;
     constexpr double previous_temperature = 0.0;
-    constexpr double delta_time = 4.0;
+    constexpr double delta_time           = 4.0;
 
     model_part.GetProcessInfo()[DELTA_TIME] = delta_time;
+
     auto p_node = model_part.CreateNewNode(0, 0.0, 0.0, 0.0);
+
     p_node->FastGetSolutionStepValue(TEMPERATURE, 0) = current_temperature;
     p_node->FastGetSolutionStepValue(TEMPERATURE, 1) = previous_temperature;
 
     KRATOS_EXPECT_DOUBLE_EQ(p_node->FastGetSolutionStepValue(DT_TEMPERATURE, 0), 0.0);
 
-    scheme.Initialize(model_part);
     ModelPart::DofsArrayType dof_set;
-    CompressedMatrix A;
-    Vector Dx;
-    Vector b;
+    CompressedMatrix         A;
+    Vector                   Dx;
+    Vector                   b;
+
+    scheme.InitializeSolutionStep(model_part, A, Dx, b); // This is needed to set the time factors
+
     scheme.Predict(model_part, dof_set, A, Dx, b);
 
     constexpr double expected_dt_temperature = 0.25;
-    KRATOS_EXPECT_DOUBLE_EQ(p_node->FastGetSolutionStepValue(DT_TEMPERATURE, 0),
-                            expected_dt_temperature);
+    KRATOS_EXPECT_DOUBLE_EQ(p_node->FastGetSolutionStepValue(DT_TEMPERATURE, 0), expected_dt_temperature);
 }
 
 KRATOS_TEST_CASE_IN_SUITE(InitializeBackwardEulerTScheme_SetsTimeFactors, KratosGeoMechanicsFastSuite)
 {
     BackwardEulerTScheme<SparseSpaceType, LocalSpaceType> scheme;
+
     Model model;
     auto& model_part = model.CreateModelPart("dummy", 2);
 
     model_part.AddNodalSolutionStepVariable(TEMPERATURE);
     model_part.AddNodalSolutionStepVariable(DT_TEMPERATURE);
 
-    constexpr double delta_time = 3.0;
+    constexpr double delta_time             = 3.0;
     model_part.GetProcessInfo()[DELTA_TIME] = delta_time;
 
     scheme.Initialize(model_part);
 
     KRATOS_EXPECT_TRUE(scheme.SchemeIsInitialized())
-    KRATOS_EXPECT_DOUBLE_EQ(
-        model_part.GetProcessInfo()[DT_TEMPERATURE_COEFFICIENT], 1.0 / delta_time);
+
+    CompressedMatrix A;
+    Vector           Dx;
+    Vector           b;
+    scheme.InitializeSolutionStep(model_part, A, Dx, b); // This is needed to set the time factors
+
+    KRATOS_EXPECT_DOUBLE_EQ(model_part.GetProcessInfo()[DT_TEMPERATURE_COEFFICIENT], 1.0 / delta_time);
 }
 
 KRATOS_TEST_CASE_IN_SUITE(ForMissingNodalDof_CheckBackwardEulerTScheme_Throws, KratosGeoMechanicsFastSuite)
@@ -82,8 +92,7 @@ KRATOS_TEST_CASE_IN_SUITE(ForMissingNodalDof_CheckBackwardEulerTScheme_Throws, K
     model_part.AddNodalSolutionStepVariable(DT_TEMPERATURE);
     auto p_node = model_part.CreateNewNode(0, 0.0, 0.0, 0.0);
 
-    KRATOS_EXPECT_EXCEPTION_IS_THROWN(scheme.Check(model_part),
-                                      "missing TEMPERATURE dof on node ")
+    KRATOS_EXPECT_EXCEPTION_IS_THROWN(scheme.Check(model_part), "missing TEMPERATURE dof on node ")
 }
 
 KRATOS_TEST_CASE_IN_SUITE(ForMissingDtTemperatureSolutionStepVariable_CheckBackwardEulerTScheme_Throws,
@@ -97,9 +106,8 @@ KRATOS_TEST_CASE_IN_SUITE(ForMissingDtTemperatureSolutionStepVariable_CheckBackw
     auto p_node = model_part.CreateNewNode(0, 0.0, 0.0, 0.0);
     p_node->AddDof(TEMPERATURE);
 
-    KRATOS_EXPECT_EXCEPTION_IS_THROWN(
-        scheme.Check(model_part),
-        "DT_TEMPERATURE variable is not allocated for node 0")
+    KRATOS_EXPECT_EXCEPTION_IS_THROWN(scheme.Check(model_part),
+                                      "DT_TEMPERATURE variable is not allocated for node 0")
 }
 
 KRATOS_TEST_CASE_IN_SUITE(ForMissingTemperatureSolutionStepVariable_CheckBackwardEulerTScheme_Throws,
@@ -109,11 +117,10 @@ KRATOS_TEST_CASE_IN_SUITE(ForMissingTemperatureSolutionStepVariable_CheckBackwar
 
     Model model;
     auto& model_part = model.CreateModelPart("dummy", 2);
-    auto p_node = model_part.CreateNewNode(0, 0.0, 0.0, 0.0);
+    auto  p_node     = model_part.CreateNewNode(0, 0.0, 0.0, 0.0);
 
-    KRATOS_EXPECT_EXCEPTION_IS_THROWN(
-        scheme.Check(model_part),
-        "TEMPERATURE variable is not allocated for node 0")
+    KRATOS_EXPECT_EXCEPTION_IS_THROWN(scheme.Check(model_part),
+                                      "TEMPERATURE variable is not allocated for node 0")
 }
 
 } // namespace Kratos::Testing

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/test_backward_euler_UPw_scheme.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/test_backward_euler_UPw_scheme.cpp
@@ -20,12 +20,13 @@ namespace Kratos::Testing
 
 using namespace Kratos;
 using SparseSpaceType = UblasSpace<double, CompressedMatrix, Vector>;
-using LocalSpaceType = UblasSpace<double, Matrix, Vector>;
+using LocalSpaceType  = UblasSpace<double, Matrix, Vector>;
 
 class BackwardEulerUPwSchemeTester
 {
 public:
     Model mModel;
+
     BackwardEulerQuasistaticUPwScheme<SparseSpaceType, LocalSpaceType> mScheme;
 
     BackwardEulerUPwSchemeTester() { CreateValidModelPart(); }
@@ -46,12 +47,9 @@ public:
         p_node->AddDof(WATER_PRESSURE);
         result.GetProcessInfo()[DELTA_TIME] = 4.0;
 
-        p_node->FastGetSolutionStepValue(DISPLACEMENT, 1) =
-            Kratos::array_1d<double, 3>{7.0, 8.0, 9.0};
-        p_node->FastGetSolutionStepValue(VELOCITY, 1) =
-            Kratos::array_1d<double, 3>{1.0, 2.0, 3.0};
-        p_node->FastGetSolutionStepValue(ACCELERATION, 1) =
-            Kratos::array_1d<double, 3>{4.0, 5.0, 6.0};
+        p_node->FastGetSolutionStepValue(DISPLACEMENT, 1) = Kratos::array_1d<double, 3>{7.0, 8.0, 9.0};
+        p_node->FastGetSolutionStepValue(VELOCITY, 1) = Kratos::array_1d<double, 3>{1.0, 2.0, 3.0};
+        p_node->FastGetSolutionStepValue(ACCELERATION, 1) = Kratos::array_1d<double, 3>{4.0, 5.0, 6.0};
 
         p_node->FastGetSolutionStepValue(WATER_PRESSURE, 1) = 1.0;
         p_node->FastGetSolutionStepValue(WATER_PRESSURE, 0) = 2.0;
@@ -60,8 +58,7 @@ public:
     ModelPart& GetModelPart() { return mModel.GetModelPart("dummy"); }
 };
 
-KRATOS_TEST_CASE_IN_SUITE(CheckBackwardEulerUPwScheme_ReturnsZeroForValidModelPart,
-                          KratosGeoMechanicsFastSuite)
+KRATOS_TEST_CASE_IN_SUITE(CheckBackwardEulerUPwScheme_ReturnsZeroForValidModelPart, KratosGeoMechanicsFastSuite)
 {
     BackwardEulerUPwSchemeTester tester;
     KRATOS_EXPECT_EQ(tester.mScheme.Check(tester.GetModelPart()), 0);
@@ -75,55 +72,61 @@ KRATOS_TEST_CASE_IN_SUITE(InitializeBackwardEulerUPwScheme_SetsTimeFactors, Krat
 
     // These are the expected numbers according to the SetTimeFactors function
     constexpr double expected_dt_pressure_coefficient = 1.0 / 4.0;
-    constexpr double expected_velocity_coefficient = 1.0 / 4.0;
+    constexpr double expected_velocity_coefficient    = 1.0 / 4.0;
     KRATOS_EXPECT_TRUE(tester.mScheme.SchemeIsInitialized())
+
+    CompressedMatrix A;
+    Vector           Dx;
+    Vector           b;
+    tester.mScheme.InitializeSolutionStep(tester.GetModelPart(), A, Dx, b); // This is needed to set the time factors
+
     KRATOS_EXPECT_DOUBLE_EQ(tester.GetModelPart().GetProcessInfo()[DT_PRESSURE_COEFFICIENT],
                             expected_dt_pressure_coefficient);
     KRATOS_EXPECT_DOUBLE_EQ(tester.GetModelPart().GetProcessInfo()[VELOCITY_COEFFICIENT],
                             expected_velocity_coefficient);
 }
 
-KRATOS_TEST_CASE_IN_SUITE(BackwardEulerUPwSchemePredict_UpdatesVariablesDerivatives,
-                          KratosGeoMechanicsFastSuite)
+KRATOS_TEST_CASE_IN_SUITE(BackwardEulerUPwSchemePredict_UpdatesVariablesDerivatives, KratosGeoMechanicsFastSuite)
 {
     BackwardEulerUPwSchemeTester tester;
 
-    tester.mScheme.Initialize(tester.GetModelPart()); // This is needed to set the time factors
     ModelPart::DofsArrayType dof_set;
-    CompressedMatrix A;
-    Vector Dx;
-    Vector b;
+    CompressedMatrix         A;
+    Vector                   Dx;
+    Vector                   b;
+
+    tester.mScheme.InitializeSolutionStep(tester.GetModelPart(), A, Dx, b); // This is needed to set the time factors
 
     tester.mScheme.Predict(tester.GetModelPart(), dof_set, A, Dx, b);
 
     // These expected numbers result from the calculations in UpdateVariablesDerivatives
-    const auto expected_acceleration = Kratos::array_1d<double, 3>{-0.6875, -1.0, -1.3125};
-    const auto expected_velocity = Kratos::array_1d<double, 3>{-1.75, -2.0, -2.25};
+    const auto     expected_acceleration      = Kratos::array_1d<double, 3>{-0.6875, -1.0, -1.3125};
+    const auto     expected_velocity          = Kratos::array_1d<double, 3>{-1.75, -2.0, -2.25};
     constexpr auto expected_dt_water_pressure = 0.25;
 
     const auto actual_acceleration =
         tester.GetModelPart().Nodes()[0].FastGetSolutionStepValue(ACCELERATION, 0);
-    const auto actual_velocity =
-        tester.GetModelPart().Nodes()[0].FastGetSolutionStepValue(VELOCITY, 0);
+    const auto actual_velocity = tester.GetModelPart().Nodes()[0].FastGetSolutionStepValue(VELOCITY, 0);
 
     constexpr auto absolute_tolerance = 1.0e-6;
     KRATOS_EXPECT_VECTOR_NEAR(expected_acceleration, actual_acceleration, absolute_tolerance)
     KRATOS_EXPECT_VECTOR_NEAR(expected_velocity, actual_velocity, absolute_tolerance)
 
-    KRATOS_EXPECT_DOUBLE_EQ(
-        tester.GetModelPart().Nodes()[0].FastGetSolutionStepValue(DT_WATER_PRESSURE, 0),
-        expected_dt_water_pressure);
+    KRATOS_EXPECT_DOUBLE_EQ(tester.GetModelPart().Nodes()[0].FastGetSolutionStepValue(DT_WATER_PRESSURE, 0),
+                            expected_dt_water_pressure);
 }
 
 KRATOS_TEST_CASE_IN_SUITE(BackwardEulerUPwSchemeUpdate_DoesNotUpdateFixedScalarVariable, KratosGeoMechanicsFastSuite)
 {
     BackwardEulerUPwSchemeTester tester;
 
-    tester.mScheme.Initialize(tester.GetModelPart()); // This is needed to set the time factors
     ModelPart::DofsArrayType dof_set;
     CompressedMatrix         A;
     Vector                   Dx;
     Vector                   b;
+
+    tester.mScheme.InitializeSolutionStep(tester.GetModelPart(), A, Dx, b); // This is needed to set the time factors
+
     tester.GetModelPart().Nodes()[0].Fix(DT_WATER_PRESSURE);
 
     tester.mScheme.Update(tester.GetModelPart(), dof_set, A, Dx, b);
@@ -141,11 +144,13 @@ KRATOS_TEST_CASE_IN_SUITE(BackwardEulerUPwSchemeUpdate_DoesNotUpdateFixedSecondD
 {
     BackwardEulerUPwSchemeTester tester;
 
-    tester.mScheme.Initialize(tester.GetModelPart()); // This is needed to set the time factors
     ModelPart::DofsArrayType dof_set;
     CompressedMatrix         A;
     Vector                   Dx;
     Vector                   b;
+
+    tester.mScheme.InitializeSolutionStep(tester.GetModelPart(), A, Dx, b); // This is needed to set the time factors
+
     tester.GetModelPart().Nodes()[0].Fix(ACCELERATION_X);
     tester.GetModelPart().Nodes()[0].Fix(ACCELERATION_Z);
 
@@ -164,11 +169,13 @@ KRATOS_TEST_CASE_IN_SUITE(BackwardEulerUPwSchemeUpdate_DoesNotUpdateFixedFirstDe
 {
     BackwardEulerUPwSchemeTester tester;
 
-    tester.mScheme.Initialize(tester.GetModelPart()); // This is needed to set the time factors
     ModelPart::DofsArrayType dof_set;
     CompressedMatrix         A;
     Vector                   Dx;
     Vector                   b;
+
+    tester.mScheme.InitializeSolutionStep(tester.GetModelPart(), A, Dx, b); // This is needed to set the time factors
+
     tester.GetModelPart().Nodes()[0].Fix(VELOCITY_Y);
 
     tester.mScheme.Update(tester.GetModelPart(), dof_set, A, Dx, b);

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/test_generalized_newmark_T_scheme.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/test_generalized_newmark_T_scheme.cpp
@@ -16,9 +16,10 @@
 
 using namespace Kratos;
 using SparseSpaceType = UblasSpace<double, CompressedMatrix, Vector>;
-using LocalSpaceType = UblasSpace<double, Matrix, Vector>;
+using LocalSpaceType  = UblasSpace<double, Matrix, Vector>;
 
-namespace Kratos::Testing {
+namespace Kratos::Testing
+{
 
 ModelPart& CreateValidTemperatureModelPart(Model& rModel)
 {
@@ -34,9 +35,10 @@ ModelPart& CreateValidTemperatureModelPart(Model& rModel)
 KRATOS_TEST_CASE_IN_SUITE(CheckNewmarkTScheme_WithAllNecessaryParts_Returns0, KratosGeoMechanicsFastSuite)
 {
     constexpr double theta = 0.75;
+
     GeneralizedNewmarkTScheme<SparseSpaceType, LocalSpaceType> scheme(theta);
 
-    Model model;
+    Model       model;
     const auto& model_part = CreateValidTemperatureModelPart(model);
 
     KRATOS_EXPECT_EQ(scheme.Check(model_part), 0);
@@ -45,6 +47,7 @@ KRATOS_TEST_CASE_IN_SUITE(CheckNewmarkTScheme_WithAllNecessaryParts_Returns0, Kr
 KRATOS_TEST_CASE_IN_SUITE(ForMissingNodalDof_CheckNewmarkTScheme_Throws, KratosGeoMechanicsFastSuite)
 {
     constexpr double theta = 0.75;
+    
     GeneralizedNewmarkTScheme<SparseSpaceType, LocalSpaceType> scheme(theta);
 
     Model model;
@@ -53,14 +56,13 @@ KRATOS_TEST_CASE_IN_SUITE(ForMissingNodalDof_CheckNewmarkTScheme_Throws, KratosG
     model_part.AddNodalSolutionStepVariable(DT_TEMPERATURE);
     auto p_node = model_part.CreateNewNode(0, 0.0, 0.0, 0.0);
 
-    KRATOS_EXPECT_EXCEPTION_IS_THROWN(scheme.Check(model_part),
-                                      "missing TEMPERATURE dof on node ")
+    KRATOS_EXPECT_EXCEPTION_IS_THROWN(scheme.Check(model_part), "missing TEMPERATURE dof on node ")
 }
 
-KRATOS_TEST_CASE_IN_SUITE(ForMissingDtTemperatureSolutionStepVariable_CheckNewmarkTScheme_Throws,
-                          KratosGeoMechanicsFastSuite)
+KRATOS_TEST_CASE_IN_SUITE(ForMissingDtTemperatureSolutionStepVariable_CheckNewmarkTScheme_Throws, KratosGeoMechanicsFastSuite)
 {
     constexpr double theta = 0.75;
+
     GeneralizedNewmarkTScheme<SparseSpaceType, LocalSpaceType> scheme(theta);
 
     Model model;
@@ -69,51 +71,50 @@ KRATOS_TEST_CASE_IN_SUITE(ForMissingDtTemperatureSolutionStepVariable_CheckNewma
     auto p_node = model_part.CreateNewNode(0, 0.0, 0.0, 0.0);
     p_node->AddDof(TEMPERATURE);
 
-    KRATOS_EXPECT_EXCEPTION_IS_THROWN(
-        scheme.Check(model_part),
-        "DT_TEMPERATURE variable is not allocated for node 0")
+    KRATOS_EXPECT_EXCEPTION_IS_THROWN(scheme.Check(model_part),
+                                      "DT_TEMPERATURE variable is not allocated for node 0")
 }
 
-KRATOS_TEST_CASE_IN_SUITE(ForMissingTemperatureSolutionStepVariable_CheckNewmarkTScheme_Throws,
-                          KratosGeoMechanicsFastSuite)
+KRATOS_TEST_CASE_IN_SUITE(ForMissingTemperatureSolutionStepVariable_CheckNewmarkTScheme_Throws, KratosGeoMechanicsFastSuite)
 {
     constexpr double theta = 0.75;
+
     GeneralizedNewmarkTScheme<SparseSpaceType, LocalSpaceType> scheme(theta);
 
     Model model;
     auto& model_part = model.CreateModelPart("dummy", 2);
-    auto p_node = model_part.CreateNewNode(0, 0.0, 0.0, 0.0);
+    auto  p_node     = model_part.CreateNewNode(0, 0.0, 0.0, 0.0);
 
-    KRATOS_EXPECT_EXCEPTION_IS_THROWN(
-        scheme.Check(model_part),
-        "TEMPERATURE variable is not allocated for node 0")
+    KRATOS_EXPECT_EXCEPTION_IS_THROWN(scheme.Check(model_part),
+                                      "TEMPERATURE variable is not allocated for node 0")
 }
 
 KRATOS_TEST_CASE_IN_SUITE(NewmarkTSchemeUpdate_SetsDtTemperature, KratosGeoMechanicsFastSuite)
 {
     constexpr double theta = 0.75;
+
     GeneralizedNewmarkTScheme<SparseSpaceType, LocalSpaceType> scheme(theta);
 
-    Model model;
+    Model      model;
     ModelPart& model_part = CreateValidTemperatureModelPart(model);
 
-    constexpr double current_temperature = 10.0;
-    constexpr double previous_temperature = 5.0;
+    constexpr double current_temperature     = 10.0;
+    constexpr double previous_temperature    = 5.0;
     constexpr double previous_dt_temperature = 3.0;
-    constexpr double delta_time = 2.0;
+    constexpr double delta_time              = 2.0;
 
-    model_part.GetProcessInfo()[DELTA_TIME] = delta_time;
-    Node& node = model_part.Nodes()[0];
-    node.FastGetSolutionStepValue(TEMPERATURE, 0) = current_temperature;
-    node.FastGetSolutionStepValue(TEMPERATURE, 1) = previous_temperature;
+    model_part.GetProcessInfo()[DELTA_TIME]          = delta_time;
+    Node& node                                       = model_part.Nodes()[0];
+    node.FastGetSolutionStepValue(TEMPERATURE, 0)    = current_temperature;
+    node.FastGetSolutionStepValue(TEMPERATURE, 1)    = previous_temperature;
     node.FastGetSolutionStepValue(DT_TEMPERATURE, 1) = previous_dt_temperature;
 
     ModelPart::DofsArrayType dof_set;
-    CompressedMatrix A;
-    Vector Dx;
-    Vector b;
+    CompressedMatrix         A;
+    Vector                   Dx;
+    Vector                   b;
 
-    scheme.Initialize(model_part);
+    scheme.InitializeSolutionStep(model_part, A, Dx, b); // This is needed to set the time factors
     scheme.Predict(model_part, dof_set, A, Dx, b);
 
     // This is the expected value as calculated by the UpdateVariablesDerivatives
@@ -123,18 +124,23 @@ KRATOS_TEST_CASE_IN_SUITE(NewmarkTSchemeUpdate_SetsDtTemperature, KratosGeoMecha
 KRATOS_TEST_CASE_IN_SUITE(InitializeNewmarkTScheme_SetsTimeFactors, KratosGeoMechanicsFastSuite)
 {
     constexpr double theta = 0.75;
+
     GeneralizedNewmarkTScheme<SparseSpaceType, LocalSpaceType> scheme(theta);
 
-    Model model;
-    ModelPart& model_part = CreateValidTemperatureModelPart(model);
-    constexpr double delta_time = 3.0;
+    Model            model;
+    ModelPart&       model_part             = CreateValidTemperatureModelPart(model);
+    constexpr double delta_time             = 3.0;
     model_part.GetProcessInfo()[DELTA_TIME] = delta_time;
 
+    CompressedMatrix A;
+    Vector           Dx;
+    Vector           b;
     scheme.Initialize(model_part);
 
     KRATOS_EXPECT_TRUE(scheme.SchemeIsInitialized())
-    KRATOS_EXPECT_DOUBLE_EQ(model_part.GetProcessInfo()[DT_TEMPERATURE_COEFFICIENT],
-                            1.0 / (theta * delta_time));
+
+    scheme.InitializeSolutionStep(model_part, A, Dx, b); // This is needed to set the time factors
+    KRATOS_EXPECT_DOUBLE_EQ(model_part.GetProcessInfo()[DT_TEMPERATURE_COEFFICIENT], 1.0 / (theta * delta_time));
 }
 
 } // namespace Kratos::Testing

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/test_newmark_Pw_scheme.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/test_newmark_Pw_scheme.cpp
@@ -137,13 +137,13 @@ KRATOS_TEST_CASE_IN_SUITE(InitializeNewmarkPwScheme_SetsTimeFactors, KratosGeoMe
     constexpr double delta_time             = 3.0;
     model_part.GetProcessInfo()[DELTA_TIME] = delta_time;
 
-    CompressedMatrix A;
-    Vector           Dx;
-    Vector           b;
     scheme.Initialize(model_part);
 
     KRATOS_EXPECT_TRUE(scheme.SchemeIsInitialized())
 
+    CompressedMatrix A;
+    Vector           Dx;
+    Vector           b;
     scheme.InitializeSolutionStep(model_part, A, Dx, b); // This is needed to set the time factors
     KRATOS_EXPECT_DOUBLE_EQ(model_part.GetProcessInfo()[DT_PRESSURE_COEFFICIENT], 1.0 / (theta * delta_time));
 }

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/test_newmark_Pw_scheme.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/test_newmark_Pw_scheme.cpp
@@ -16,11 +16,13 @@
 
 using namespace Kratos;
 using SparseSpaceType = UblasSpace<double, CompressedMatrix, Vector>;
-using LocalSpaceType = UblasSpace<double, Matrix, Vector>;
+using LocalSpaceType  = UblasSpace<double, Matrix, Vector>;
 
-namespace Kratos::Testing {
+namespace Kratos::Testing
+{
 
-namespace {
+namespace
+{
 
 ModelPart& CreateValidModelPart(Model& rModel)
 {
@@ -36,8 +38,9 @@ ModelPart& CreateValidModelPart(Model& rModel)
 
 KRATOS_TEST_CASE_IN_SUITE(CheckNewmarkPwScheme_WithAllNecessaryParts_Returns0, KratosGeoMechanicsFastSuite)
 {
-    Model model;
+    Model            model;
     constexpr double theta = 0.75;
+
     NewmarkQuasistaticPwScheme<SparseSpaceType, LocalSpaceType> scheme(theta);
     const auto& model_part = CreateValidModelPart(model);
 
@@ -47,6 +50,7 @@ KRATOS_TEST_CASE_IN_SUITE(CheckNewmarkPwScheme_WithAllNecessaryParts_Returns0, K
 KRATOS_TEST_CASE_IN_SUITE(ForMissingNodalDof_CheckNewmarkPwScheme_Throws, KratosGeoMechanicsFastSuite)
 {
     constexpr double theta = 0.75;
+
     NewmarkQuasistaticPwScheme<SparseSpaceType, LocalSpaceType> scheme(theta);
 
     Model model;
@@ -63,6 +67,7 @@ KRATOS_TEST_CASE_IN_SUITE(ForMissingDtWaterPressureSolutionStepVariable_CheckNew
                           KratosGeoMechanicsFastSuite)
 {
     constexpr double theta = 0.75;
+
     NewmarkQuasistaticPwScheme<SparseSpaceType, LocalSpaceType> scheme(theta);
 
     Model model;
@@ -71,51 +76,50 @@ KRATOS_TEST_CASE_IN_SUITE(ForMissingDtWaterPressureSolutionStepVariable_CheckNew
     auto p_node = model_part.CreateNewNode(0, 0.0, 0.0, 0.0);
     p_node->AddDof(WATER_PRESSURE);
 
-    KRATOS_EXPECT_EXCEPTION_IS_THROWN(
-        scheme.Check(model_part),
-        "DT_WATER_PRESSURE variable is not allocated for node 0")
+    KRATOS_EXPECT_EXCEPTION_IS_THROWN(scheme.Check(model_part),
+                                      "DT_WATER_PRESSURE variable is not allocated for node 0")
 }
 
-KRATOS_TEST_CASE_IN_SUITE(ForMissingWaterPressureSolutionStepVariable_CheckNewmarkPwScheme_Throws,
-                          KratosGeoMechanicsFastSuite)
+KRATOS_TEST_CASE_IN_SUITE(ForMissingWaterPressureSolutionStepVariable_CheckNewmarkPwScheme_Throws, KratosGeoMechanicsFastSuite)
 {
     constexpr double theta = 0.75;
+
     NewmarkQuasistaticPwScheme<SparseSpaceType, LocalSpaceType> scheme(theta);
 
     Model model;
     auto& model_part = model.CreateModelPart("dummy", 2);
-    auto p_node = model_part.CreateNewNode(0, 0.0, 0.0, 0.0);
+    auto  p_node     = model_part.CreateNewNode(0, 0.0, 0.0, 0.0);
 
-    KRATOS_EXPECT_EXCEPTION_IS_THROWN(
-        scheme.Check(model_part),
-        "WATER_PRESSURE variable is not allocated for node 0")
+    KRATOS_EXPECT_EXCEPTION_IS_THROWN(scheme.Check(model_part),
+                                      "WATER_PRESSURE variable is not allocated for node 0")
 }
 
 KRATOS_TEST_CASE_IN_SUITE(NewmarkPwSchemeUpdate_SetsDtPressure, KratosGeoMechanicsFastSuite)
 {
     constexpr double theta = 0.75;
+
     NewmarkQuasistaticPwScheme<SparseSpaceType, LocalSpaceType> scheme(theta);
 
-    Model model;
+    Model      model;
     ModelPart& model_part = CreateValidModelPart(model);
 
-    constexpr double current_pressure = 10.0;
-    constexpr double previous_pressure = 5.0;
+    constexpr double current_pressure     = 10.0;
+    constexpr double previous_pressure    = 5.0;
     constexpr double previous_dt_pressure = 3.0;
-    constexpr double delta_time = 2.0;
+    constexpr double delta_time           = 2.0;
 
-    model_part.GetProcessInfo()[DELTA_TIME] = delta_time;
-    Node& node = model_part.Nodes()[0];
-    node.FastGetSolutionStepValue(WATER_PRESSURE, 0) = current_pressure;
-    node.FastGetSolutionStepValue(WATER_PRESSURE, 1) = previous_pressure;
+    model_part.GetProcessInfo()[DELTA_TIME]             = delta_time;
+    Node& node                                          = model_part.Nodes()[0];
+    node.FastGetSolutionStepValue(WATER_PRESSURE, 0)    = current_pressure;
+    node.FastGetSolutionStepValue(WATER_PRESSURE, 1)    = previous_pressure;
     node.FastGetSolutionStepValue(DT_WATER_PRESSURE, 1) = previous_dt_pressure;
 
     ModelPart::DofsArrayType dof_set;
-    CompressedMatrix A;
-    Vector Dx;
-    Vector b;
+    CompressedMatrix         A;
+    Vector                   Dx;
+    Vector                   b;
 
-    scheme.Initialize(model_part);
+    scheme.InitializeSolutionStep(model_part, A, Dx, b); // This is needed to set the time factors
     scheme.Predict(model_part, dof_set, A, Dx, b);
 
     // This is the expected value as calculated by the UpdateVariablesDerivatives
@@ -125,18 +129,23 @@ KRATOS_TEST_CASE_IN_SUITE(NewmarkPwSchemeUpdate_SetsDtPressure, KratosGeoMechani
 KRATOS_TEST_CASE_IN_SUITE(InitializeNewmarkPwScheme_SetsTimeFactors, KratosGeoMechanicsFastSuite)
 {
     constexpr double theta = 0.75;
+
     NewmarkQuasistaticPwScheme<SparseSpaceType, LocalSpaceType> scheme(theta);
 
-    Model model;
-    ModelPart& model_part = CreateValidModelPart(model);
-    constexpr double delta_time = 3.0;
+    Model            model;
+    ModelPart&       model_part             = CreateValidModelPart(model);
+    constexpr double delta_time             = 3.0;
     model_part.GetProcessInfo()[DELTA_TIME] = delta_time;
 
+    CompressedMatrix A;
+    Vector           Dx;
+    Vector           b;
     scheme.Initialize(model_part);
 
     KRATOS_EXPECT_TRUE(scheme.SchemeIsInitialized())
-    KRATOS_EXPECT_DOUBLE_EQ(model_part.GetProcessInfo()[DT_PRESSURE_COEFFICIENT],
-                            1.0 / (theta * delta_time));
+
+    scheme.InitializeSolutionStep(model_part, A, Dx, b); // This is needed to set the time factors
+    KRATOS_EXPECT_DOUBLE_EQ(model_part.GetProcessInfo()[DT_PRESSURE_COEFFICIENT], 1.0 / (theta * delta_time));
 }
 
 } // namespace Kratos::Testing

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/test_newmark_dynamic_U_Pw_scheme.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/test_newmark_dynamic_U_Pw_scheme.cpp
@@ -82,11 +82,12 @@ KRATOS_TEST_CASE_IN_SUITE(NewmarkDynamicUPwSchemePredictWithFixedAccelerations_U
 {
     NewmarkDynamicUPwSchemeTester tester;
 
-    tester.mScheme.Initialize(tester.GetModelPart()); // This is needed to set the time factors
     ModelPart::DofsArrayType dof_set;
     CompressedMatrix         A;
     Vector                   Dx;
     Vector                   b;
+
+    tester.mScheme.InitializeSolutionStep(tester.GetModelPart(), A, Dx, b); // This is needed to set the time factors
 
     tester.GetModelPart().GetNode(0).Fix(ACCELERATION_X);
     tester.GetModelPart().GetNode(0).Fix(ACCELERATION_Y);
@@ -106,11 +107,12 @@ KRATOS_TEST_CASE_IN_SUITE(NewmarkDynamicUPwSchemePredictWithFixedVelocities_Upda
 {
     NewmarkDynamicUPwSchemeTester tester;
 
-    tester.mScheme.Initialize(tester.GetModelPart()); // This is needed to set the time factors
     ModelPart::DofsArrayType dof_set;
     CompressedMatrix         A;
     Vector                   Dx;
     Vector                   b;
+
+    tester.mScheme.InitializeSolutionStep(tester.GetModelPart(), A, Dx, b); // This is needed to set the time factors
 
     tester.GetModelPart().GetNode(0).Fix(VELOCITY_X);
     tester.GetModelPart().GetNode(0).Fix(VELOCITY_Y);
@@ -130,11 +132,12 @@ KRATOS_TEST_CASE_IN_SUITE(NewmarkDynamicUPwSchemePredictWithNoFixedVariables_Upd
 {
     NewmarkDynamicUPwSchemeTester tester;
 
-    tester.mScheme.Initialize(tester.GetModelPart()); // This is needed to set the time factors
     ModelPart::DofsArrayType dof_set;
     CompressedMatrix         A;
     Vector                   Dx;
     Vector                   b;
+
+    tester.mScheme.InitializeSolutionStep(tester.GetModelPart(), A, Dx, b); // This is needed to set the time factors
 
     tester.mScheme.Predict(tester.GetModelPart(), dof_set, A, Dx, b);
 
@@ -150,11 +153,12 @@ KRATOS_TEST_CASE_IN_SUITE(NewmarkDynamicUPwSchemePredictFixedDisplacements_DoesN
 {
     NewmarkDynamicUPwSchemeTester tester;
 
-    tester.mScheme.Initialize(tester.GetModelPart()); // This is needed to set the time factors
     ModelPart::DofsArrayType dof_set;
     CompressedMatrix         A;
     Vector                   Dx;
     Vector                   b;
+
+    tester.mScheme.InitializeSolutionStep(tester.GetModelPart(), A, Dx, b); // This is needed to set the time factors
 
     tester.GetModelPart().GetNode(0).Fix(DISPLACEMENT_X);
     tester.GetModelPart().GetNode(0).Fix(DISPLACEMENT_Y);
@@ -174,11 +178,12 @@ KRATOS_TEST_CASE_IN_SUITE(NewmarkDynamicUPwSchemePredictWithout3DDofs_DoesNotUpd
     const bool                    three_d_case = false;
     NewmarkDynamicUPwSchemeTester tester(three_d_case);
 
-    tester.mScheme.Initialize(tester.GetModelPart()); // This is needed to set the time factors
     ModelPart::DofsArrayType dof_set;
     CompressedMatrix         A;
     Vector                   Dx;
     Vector                   b;
+
+    tester.mScheme.InitializeSolutionStep(tester.GetModelPart(), A, Dx, b); // This is needed to set the time factors
 
     tester.mScheme.Predict(tester.GetModelPart(), dof_set, A, Dx, b);
 
@@ -193,11 +198,12 @@ KRATOS_TEST_CASE_IN_SUITE(NewmarkDynamicUPwSchemePredict_UpdatesVariablesDerivat
 {
     NewmarkDynamicUPwSchemeTester tester;
 
-    tester.mScheme.Initialize(tester.GetModelPart()); // This is needed to set the time factors
     ModelPart::DofsArrayType dof_set;
     CompressedMatrix         A;
     Vector                   Dx;
     Vector                   b;
+
+    tester.mScheme.InitializeSolutionStep(tester.GetModelPart(), A, Dx, b); // This is needed to set the time factors
 
     tester.mScheme.Predict(tester.GetModelPart(), dof_set, A, Dx, b);
 
@@ -222,11 +228,13 @@ KRATOS_TEST_CASE_IN_SUITE(NewmarkDynamicUPwSchemeUpdate_DoesNotUpdateFixedSecond
 {
     NewmarkDynamicUPwSchemeTester tester;
 
-    tester.mScheme.Initialize(tester.GetModelPart()); // This is needed to set the time factors
     ModelPart::DofsArrayType dof_set;
     CompressedMatrix         A;
     Vector                   Dx;
     Vector                   b;
+
+    tester.mScheme.InitializeSolutionStep(tester.GetModelPart(), A, Dx, b); // This is needed to set the time factors
+
     tester.GetModelPart().Nodes()[0].Fix(ACCELERATION_X);
     tester.GetModelPart().Nodes()[0].Fix(ACCELERATION_Z);
 
@@ -245,11 +253,13 @@ KRATOS_TEST_CASE_IN_SUITE(NewmarkDynamicUPwSchemeUpdate_DoesNotUpdateFixedFirstD
 {
     NewmarkDynamicUPwSchemeTester tester;
 
-    tester.mScheme.Initialize(tester.GetModelPart()); // This is needed to set the time factors
     ModelPart::DofsArrayType dof_set;
     CompressedMatrix         A;
     Vector                   Dx;
     Vector                   b;
+
+    tester.mScheme.InitializeSolutionStep(tester.GetModelPart(), A, Dx, b); // This is needed to set the time factors
+
     tester.GetModelPart().Nodes()[0].Fix(VELOCITY_Y);
 
     tester.mScheme.Update(tester.GetModelPart(), dof_set, A, Dx, b);
@@ -265,11 +275,13 @@ KRATOS_TEST_CASE_IN_SUITE(NewmarkDynamicUPwSchemeUpdate_DoesNotUpdateFixedScalar
 {
     NewmarkDynamicUPwSchemeTester tester;
 
-    tester.mScheme.Initialize(tester.GetModelPart()); // This is needed to set the time factors
     ModelPart::DofsArrayType dof_set;
     CompressedMatrix         A;
     Vector                   Dx;
     Vector                   b;
+
+    tester.mScheme.InitializeSolutionStep(tester.GetModelPart(), A, Dx, b); // This is needed to set the time factors
+
     tester.GetModelPart().Nodes()[0].Fix(DT_WATER_PRESSURE);
 
     tester.mScheme.Update(tester.GetModelPart(), dof_set, A, Dx, b);

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/test_newmark_quasistatic_U_Pw_scheme.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/test_newmark_quasistatic_U_Pw_scheme.cpp
@@ -14,25 +14,24 @@
 
 #include "custom_strategies/schemes/newmark_quasistatic_U_Pw_scheme.hpp"
 #include "spaces/ublas_space.h"
-#include "test_utilities/spy_element.h"
 #include "test_utilities/spy_condition.h"
+#include "test_utilities/spy_element.h"
 
-namespace Kratos::Testing {
+namespace Kratos::Testing
+{
 
 using namespace Kratos;
 using SparseSpaceType = UblasSpace<double, CompressedMatrix, Vector>;
-using LocalSpaceType = UblasSpace<double, Matrix, Vector>;
+using LocalSpaceType  = UblasSpace<double, Matrix, Vector>;
 
-class NewmarkQuasistaticUPwSchemeTester {
+class NewmarkQuasistaticUPwSchemeTester
+{
 public:
     Model mModel;
-    NewmarkQuasistaticUPwScheme<SparseSpaceType, LocalSpaceType> mScheme =
-        CreateValidScheme();
 
-    NewmarkQuasistaticUPwSchemeTester()
-    {
-        CreateValidModelPart();
-    }
+    NewmarkQuasistaticUPwScheme<SparseSpaceType, LocalSpaceType> mScheme = CreateValidScheme();
+
+    NewmarkQuasistaticUPwSchemeTester() { CreateValidModelPart(); }
 
     NewmarkQuasistaticUPwScheme<SparseSpaceType, LocalSpaceType> CreateValidScheme() const
     {
@@ -55,21 +54,15 @@ public:
         p_node->AddDof(WATER_PRESSURE);
         result.GetProcessInfo()[DELTA_TIME] = 4.0;
 
-        p_node->FastGetSolutionStepValue(DISPLACEMENT, 1) =
-            Kratos::array_1d<double, 3>{7.0, 8.0, 9.0};
-        p_node->FastGetSolutionStepValue(VELOCITY, 1) =
-            Kratos::array_1d<double, 3>{0.0, 0.0, 0.0};
-        p_node->FastGetSolutionStepValue(ACCELERATION, 1) =
-            Kratos::array_1d<double, 3>{0.0, 0.0, 0.0};
+        p_node->FastGetSolutionStepValue(DISPLACEMENT, 1) = Kratos::array_1d<double, 3>{7.0, 8.0, 9.0};
+        p_node->FastGetSolutionStepValue(VELOCITY, 1) = Kratos::array_1d<double, 3>{0.0, 0.0, 0.0};
+        p_node->FastGetSolutionStepValue(ACCELERATION, 1) = Kratos::array_1d<double, 3>{0.0, 0.0, 0.0};
 
         p_node->FastGetSolutionStepValue(WATER_PRESSURE, 1) = 1.0;
         p_node->FastGetSolutionStepValue(WATER_PRESSURE, 0) = 2.0;
     }
 
-    ModelPart& GetModelPart()
-    {
-        return mModel.GetModelPart("dummy");
-    }
+    ModelPart& GetModelPart() { return mModel.GetModelPart("dummy"); }
 };
 
 KRATOS_TEST_CASE_IN_SUITE(CheckNewmarkUPwScheme_ReturnsZeroForValidScheme, KratosGeoMechanicsFastSuite)
@@ -82,12 +75,19 @@ KRATOS_TEST_CASE_IN_SUITE(InitializeNewmarkUPwScheme_SetsTimeFactors, KratosGeoM
 {
     NewmarkQuasistaticUPwSchemeTester tester;
 
+    CompressedMatrix A;
+    Vector           Dx;
+    Vector           b;
+
     tester.mScheme.Initialize(tester.GetModelPart());
 
     // These are the expected numbers according to the SetTimeFactors function
     constexpr double expected_dt_pressure_coefficient = 1.0 / 3.0;
-    constexpr double expected_velocity_coefficient = 0.5;
+    constexpr double expected_velocity_coefficient    = 0.5;
     KRATOS_EXPECT_TRUE(tester.mScheme.SchemeIsInitialized())
+
+    tester.mScheme.InitializeSolutionStep(tester.GetModelPart(), A, Dx, b); // This is needed to set the time factors
+
     KRATOS_EXPECT_DOUBLE_EQ(tester.GetModelPart().GetProcessInfo()[DT_PRESSURE_COEFFICIENT],
                             expected_dt_pressure_coefficient);
     KRATOS_EXPECT_DOUBLE_EQ(tester.GetModelPart().GetProcessInfo()[VELOCITY_COEFFICIENT],
@@ -98,20 +98,22 @@ KRATOS_TEST_CASE_IN_SUITE(NewmarkUPwSchemePredict_UpdatesVariablesDerivatives, K
 {
     NewmarkQuasistaticUPwSchemeTester tester;
 
-    tester.mScheme.Initialize(tester.GetModelPart()); // This is needed to set the time factors
     ModelPart::DofsArrayType dof_set;
-    CompressedMatrix A;
-    Vector Dx;
-    Vector b;
+    CompressedMatrix         A;
+    Vector                   Dx;
+    Vector                   b;
+
+    tester.mScheme.InitializeSolutionStep(tester.GetModelPart(), A, Dx, b); // This is needed to set the time factors
 
     tester.mScheme.Predict(tester.GetModelPart(), dof_set, A, Dx, b);
 
     // These expected numbers result from the calculations in UpdateVariablesDerivatives
-    const auto expected_acceleration = Kratos::array_1d<double, 3>{0.0, 0.0, 0.0};
-    const auto expected_velocity = Kratos::array_1d<double, 3>{0.0, 0.0, 0.0};
+    const auto     expected_acceleration      = Kratos::array_1d<double, 3>{0.0, 0.0, 0.0};
+    const auto     expected_velocity          = Kratos::array_1d<double, 3>{0.0, 0.0, 0.0};
     constexpr auto expected_dt_water_pressure = 1.0 / 3.0;
 
-    const auto actual_acceleration = tester.GetModelPart().Nodes()[0].FastGetSolutionStepValue(ACCELERATION, 0);
+    const auto actual_acceleration =
+        tester.GetModelPart().Nodes()[0].FastGetSolutionStepValue(ACCELERATION, 0);
     KRATOS_EXPECT_EQ(actual_acceleration.size(), expected_acceleration.size());
     for (std::size_t i = 0; i < actual_acceleration.size(); ++i)
         KRATOS_EXPECT_DOUBLE_EQ(actual_acceleration[i], expected_acceleration[i]);
@@ -120,9 +122,8 @@ KRATOS_TEST_CASE_IN_SUITE(NewmarkUPwSchemePredict_UpdatesVariablesDerivatives, K
     for (std::size_t i = 0; i < actual_velocity.size(); ++i)
         KRATOS_EXPECT_DOUBLE_EQ(actual_velocity[i], expected_velocity[i]);
 
-    KRATOS_EXPECT_DOUBLE_EQ(
-        tester.GetModelPart().Nodes()[0].FastGetSolutionStepValue(DT_WATER_PRESSURE, 0),
-        expected_dt_water_pressure);
+    KRATOS_EXPECT_DOUBLE_EQ(tester.GetModelPart().Nodes()[0].FastGetSolutionStepValue(DT_WATER_PRESSURE, 0),
+                            expected_dt_water_pressure);
 }
 
 KRATOS_TEST_CASE_IN_SUITE(ForMissingNodalDof_CheckNewmarkUPwScheme_Throws, KratosGeoMechanicsFastSuite)
@@ -141,35 +142,32 @@ KRATOS_TEST_CASE_IN_SUITE(ForMissingNodalDof_CheckNewmarkUPwScheme_Throws, Krato
     p_node->AddDof(WATER_PRESSURE);
     model_part.GetProcessInfo()[DELTA_TIME] = 4.0;
 
-    p_node->FastGetSolutionStepValue(VELOCITY, 1) =
-        Kratos::array_1d<double, 3>{0.0, 0.0, 0.0};
-    p_node->FastGetSolutionStepValue(DISPLACEMENT, 1) =
-        Kratos::array_1d<double, 3>{0.0, 0.0, 0.0};
+    p_node->FastGetSolutionStepValue(VELOCITY, 1)     = Kratos::array_1d<double, 3>{0.0, 0.0, 0.0};
+    p_node->FastGetSolutionStepValue(DISPLACEMENT, 1) = Kratos::array_1d<double, 3>{0.0, 0.0, 0.0};
 
     p_node->FastGetSolutionStepValue(WATER_PRESSURE, 1) = 1.0;
     p_node->FastGetSolutionStepValue(WATER_PRESSURE, 0) = 2.0;
 
-    KRATOS_EXPECT_EXCEPTION_IS_THROWN(tester.mScheme.Check(model_part), "ACCELERATION variable is not allocated for node 0")
+    KRATOS_EXPECT_EXCEPTION_IS_THROWN(tester.mScheme.Check(model_part),
+                                      "ACCELERATION variable is not allocated for node 0")
 }
 
 KRATOS_TEST_CASE_IN_SUITE(ForInvalidBeta_CheckNewmarkUPwScheme_Throws, KratosGeoMechanicsFastSuite)
 {
     constexpr double invalid_beta = -2.3;
-    using SchemeType = NewmarkQuasistaticUPwScheme<SparseSpaceType, LocalSpaceType>;
+    using SchemeType              = NewmarkQuasistaticUPwScheme<SparseSpaceType, LocalSpaceType>;
 
-    KRATOS_EXPECT_EXCEPTION_IS_THROWN(
-        SchemeType scheme(invalid_beta, 0.5, 0.75),
-        "Beta must be larger than zero, but got -2.3")
+    KRATOS_EXPECT_EXCEPTION_IS_THROWN(SchemeType scheme(invalid_beta, 0.5, 0.75),
+                                      "Beta must be larger than zero, but got -2.3")
 }
 
 KRATOS_TEST_CASE_IN_SUITE(ForInvalidGamma_CheckNewmarkUPwScheme_Throws, KratosGeoMechanicsFastSuite)
 {
     constexpr double invalid_gamma = -2.5;
-    using SchemeType = NewmarkQuasistaticUPwScheme<SparseSpaceType, LocalSpaceType>;
+    using SchemeType               = NewmarkQuasistaticUPwScheme<SparseSpaceType, LocalSpaceType>;
 
-    KRATOS_EXPECT_EXCEPTION_IS_THROWN(
-        SchemeType scheme(0.25, invalid_gamma, 0.75),
-        "Gamma must be larger than zero, but got -2.5")
+    KRATOS_EXPECT_EXCEPTION_IS_THROWN(SchemeType scheme(0.25, invalid_gamma, 0.75),
+                                      "Gamma must be larger than zero, but got -2.5")
 }
 
 } // namespace Kratos::Testing


### PR DESCRIPTION
**📝 Description**

Investigation is done. The test is stable now. 

Valgrind was used for profiling but it provided about 4,000,000 problems that is difficult to study. Therefore, the investigation was done as usual by using debugger and placing required prints in specific places. ;) 

Two problems are found and fixed.
1. SetTimeFactors is called in Initialize when file ProjectParameters.json has not been read yet. This also required to fix a number of unit tests.
2. MatrixType StiffnessMatrix is created but not initialized with zeros. 

There are still two problems
1. the major one causes negative value of detJ
2. the minor one is a lost of float precision in analytical_solution. An input for the exp function can be a very large negative value. This is only important when the float arithmetic is checked.  It can be fixed with the following change         
       exp_value_in = -1 * (2 * j - 1) ** 2 * pi ** 2 / 4 * T_v
        exp_value = 0
        if exp_value_in > -600:
            exp_value = exp(exp_value_in)

        rel_p = (-1) ** (j - 1) / (2 * j - 1) * cos((2 * j - 1) * pi / 2 * y_coord / H) * exp_value + rel_p_old


