### PR TITLE
Changed VOIGT_SIZE_2D_AXISYMMETRIC to VOIGT_SIZE_2D_PLANE_STRAIN

### DIFF
--- a/applications/GeoMechanicsApplication/custom_elements/plane_strain_stress_state.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/plane_strain_stress_state.cpp
@@ -19,7 +19,7 @@ Matrix PlaneStrainStressState::CalculateBMatrix(const Matrix& rDN_DX, const Vect
 {
     const auto dimension       = rGeometry.WorkingSpaceDimension();
     const auto number_of_nodes = rGeometry.size();
-    Matrix     result = ZeroMatrix(VOIGT_SIZE_2D_AXISYMMETRIC, dimension * number_of_nodes);
+    Matrix     result = ZeroMatrix(VOIGT_SIZE_2D_PLANE_STRAIN, dimension * number_of_nodes);
 
     for (unsigned int i = 0; i < number_of_nodes; ++i) {
         const auto offset = dimension * i;


### PR DESCRIPTION
These two variables point to the same number (see [definition](https://github.com/KratosMultiphysics/Kratos/blob/master/applications/GeoMechanicsApplication/geo_mechanics_application_constants.h#L43-L44)), but it is clearer to have the plane strain version in the plane strain stress state (as is done in the other functions in this class).


