### PR TITLE
[GeoMechanicsApplication] Make U-Pw elements more similar

### DIFF
--- a/applications/GeoMechanicsApplication/custom_elements/U_Pw_base_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/U_Pw_base_element.cpp
@@ -551,8 +551,7 @@ void UPwBaseElement<TDim, TNumNodes>::CalculateJacobianOnCurrentConfiguration(do
 {
     KRATOS_TRY
 
-    const GeometryType& rGeom = this->GetGeometry();
-    rJ                        = rGeom.Jacobian(rJ, GPoint, mThisIntegrationMethod);
+    rJ = this->GetGeometry().Jacobian(rJ, GPoint, mThisIntegrationMethod);
     MathUtils<double>::InvertMatrix(rJ, rInvJ, detJ);
 
     KRATOS_CATCH("")

--- a/applications/GeoMechanicsApplication/custom_elements/U_Pw_base_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/U_Pw_base_element.cpp
@@ -559,41 +559,6 @@ void UPwBaseElement<TDim, TNumNodes>::CalculateJacobianOnCurrentConfiguration(do
 
 //----------------------------------------------------------------------------------------
 template <unsigned int TDim, unsigned int TNumNodes>
-void UPwBaseElement<TDim, TNumNodes>::CalculateJacobianOnCurrentConfiguration(
-    double& detJ, Matrix& J, Matrix& InvJ, Matrix& GradNpT, unsigned int GPoint) const
-{
-    KRATOS_TRY
-
-    const GeometryType& rGeom = this->GetGeometry();
-    Matrix              DisplacementMatrix;
-    GeoElementUtilities::GetNodalVariableMatrix<TDim, TNumNodes>(DisplacementMatrix, rGeom, DISPLACEMENT);
-
-    J.clear();
-    J = this->GetGeometry().Jacobian(J, GPoint, mThisIntegrationMethod, DisplacementMatrix);
-
-    MathUtils<double>::InvertMatrix(J, InvJ, detJ);
-
-    const Matrix& DN_De = this->GetGeometry().ShapeFunctionsLocalGradients(mThisIntegrationMethod)[GPoint];
-    noalias(GradNpT) = prod(DN_De, InvJ);
-
-    KRATOS_CATCH("")
-}
-
-//----------------------------------------------------------------------------------------
-template <unsigned int TDim, unsigned int TNumNodes>
-double UPwBaseElement<TDim, TNumNodes>::CalculateDerivativesOnCurrentConfiguration(
-    Matrix& rJ, Matrix& rInvJ, Matrix& rDN_DX, const IndexType& PointNumber, IntegrationMethod ThisIntegrationMethod) const
-{
-    double detJ;
-    rJ = this->GetGeometry().Jacobian(rJ, PointNumber, ThisIntegrationMethod);
-    const Matrix& DN_De = this->GetGeometry().ShapeFunctionsLocalGradients(ThisIntegrationMethod)[PointNumber];
-    MathUtils<double>::InvertMatrix(rJ, rInvJ, detJ);
-    GeometryUtils::ShapeFunctionsGradients(DN_De, rInvJ, rDN_DX);
-    return detJ;
-}
-
-//----------------------------------------------------------------------------------------
-template <unsigned int TDim, unsigned int TNumNodes>
 unsigned int UPwBaseElement<TDim, TNumNodes>::GetNumberOfDOF() const
 {
     return TNumNodes * (TDim + 1);

--- a/applications/GeoMechanicsApplication/custom_elements/U_Pw_base_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/U_Pw_base_element.cpp
@@ -265,10 +265,10 @@ void UPwBaseElement<TDim, TNumNodes>::CalculateLeftHandSide(MatrixType&        r
     KRATOS_TRY
 
     rLeftHandSideMatrix = ZeroMatrix{this->GetNumberOfDOF(), this->GetNumberOfDOF()};
-    VectorType dummy_right_hand_side;
+    auto       dummy_right_hand_side_vector = Vector{};
     const auto CalculateStiffnessMatrixFlag = true;
     const auto CalculateResidualVectorFlag  = false;
-    CalculateAll(rLeftHandSideMatrix, dummy_right_hand_side, rCurrentProcessInfo,
+    CalculateAll(rLeftHandSideMatrix, dummy_right_hand_side_vector, rCurrentProcessInfo,
                  CalculateStiffnessMatrixFlag, CalculateResidualVectorFlag);
 
     KRATOS_CATCH("")
@@ -281,17 +281,11 @@ void UPwBaseElement<TDim, TNumNodes>::CalculateRightHandSide(VectorType& rRightH
 {
     KRATOS_TRY
 
-    const unsigned int N_DOF = this->GetNumberOfDOF();
-
-    // Resetting the RHS
-    if (rRightHandSideVector.size() != N_DOF) rRightHandSideVector.resize(N_DOF, false);
-    noalias(rRightHandSideVector) = ZeroVector(N_DOF);
-
-    const bool CalculateStiffnessMatrixFlag = false;
-    const bool CalculateResidualVectorFlag  = true;
-    MatrixType TempMatrix                   = Matrix();
-
-    CalculateAll(TempMatrix, rRightHandSideVector, rCurrentProcessInfo,
+    auto dummy_left_hand_side_matrix        = Matrix{};
+    rRightHandSideVector                    = ZeroVector{this->GetNumberOfDOF()};
+    const auto CalculateStiffnessMatrixFlag = false;
+    const auto CalculateResidualVectorFlag  = true;
+    CalculateAll(dummy_left_hand_side_matrix, rRightHandSideVector, rCurrentProcessInfo,
                  CalculateStiffnessMatrixFlag, CalculateResidualVectorFlag);
 
     KRATOS_CATCH("")

--- a/applications/GeoMechanicsApplication/custom_elements/U_Pw_base_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/U_Pw_base_element.cpp
@@ -205,7 +205,7 @@ template <unsigned int TDim, unsigned int TNumNodes>
 GeometryData::IntegrationMethod UPwBaseElement<TDim, TNumNodes>::GetIntegrationMethod() const
 {
     GeometryData::IntegrationMethod GI_GAUSS;
-    //
+
     switch (TNumNodes) {
     case 3:
         GI_GAUSS = GeometryData::IntegrationMethod::GI_GAUSS_2;

--- a/applications/GeoMechanicsApplication/custom_elements/U_Pw_base_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/U_Pw_base_element.cpp
@@ -318,16 +318,14 @@ void UPwBaseElement<TDim, TNumNodes>::CalculateDampingMatrix(MatrixType&        
 {
     KRATOS_TRY
 
-    const unsigned int N_DOF = this->GetNumberOfDOF();
-
-    MatrixType mass_matrix(N_DOF, N_DOF);
+    MatrixType mass_matrix = ZeroMatrix{this->GetNumberOfDOF(), this->GetNumberOfDOF()};
     this->CalculateMassMatrix(mass_matrix, rCurrentProcessInfo);
 
-    MatrixType stiffness_matrix(N_DOF, N_DOF);
+    MatrixType stiffness_matrix = ZeroMatrix{this->GetNumberOfDOF(), this->GetNumberOfDOF()};
     this->CalculateMaterialStiffnessMatrix(stiffness_matrix, rCurrentProcessInfo);
 
-    const PropertiesType& r_prop = this->GetProperties();
-    rDampingMatrix               = GeoEquationOfMotionUtilities::CalculateDampingMatrix(
+    const auto& r_prop = this->GetProperties();
+    rDampingMatrix     = GeoEquationOfMotionUtilities::CalculateDampingMatrix(
         r_prop.Has(RAYLEIGH_ALPHA) ? r_prop[RAYLEIGH_ALPHA] : rCurrentProcessInfo[RAYLEIGH_ALPHA],
         r_prop.Has(RAYLEIGH_BETA) ? r_prop[RAYLEIGH_BETA] : rCurrentProcessInfo[RAYLEIGH_BETA],
         mass_matrix, stiffness_matrix);

--- a/applications/GeoMechanicsApplication/custom_elements/U_Pw_base_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/U_Pw_base_element.cpp
@@ -376,8 +376,9 @@ void UPwBaseElement<TDim, TNumNodes>::SetValuesOnIntegrationPoints(const Variabl
 {
     KRATOS_TRY
 
-    for (unsigned int i = 0; i < mConstitutiveLawVector.size(); ++i)
+    for (unsigned int i = 0; i < mConstitutiveLawVector.size(); ++i) {
         mConstitutiveLawVector[i]->SetValue(rVariable, rValues[i], rCurrentProcessInfo);
+    }
 
     KRATOS_CATCH("")
 }
@@ -390,8 +391,9 @@ void UPwBaseElement<TDim, TNumNodes>::SetValuesOnIntegrationPoints(const Variabl
 {
     KRATOS_TRY
 
-    for (unsigned int i = 0; i < mConstitutiveLawVector.size(); ++i)
+    for (unsigned int i = 0; i < mConstitutiveLawVector.size(); ++i) {
         mConstitutiveLawVector[i]->SetValue(rVariable, rValues[i], rCurrentProcessInfo);
+    }
 
     KRATOS_CATCH("")
 }

--- a/applications/GeoMechanicsApplication/custom_elements/U_Pw_base_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/U_Pw_base_element.cpp
@@ -235,7 +235,7 @@ void UPwBaseElement<TDim, TNumNodes>::CalculateLocalSystem(MatrixType&        rL
 {
     KRATOS_TRY
 
-    const unsigned int number_of_dofs = this->GetNumberOfDOF();
+    const auto number_of_dofs = this->GetNumberOfDOF();
 
     // Resetting the LHS
     if (rLeftHandSideMatrix.size1() != number_of_dofs)

--- a/applications/GeoMechanicsApplication/custom_elements/U_Pw_base_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/U_Pw_base_element.cpp
@@ -127,8 +127,8 @@ void UPwBaseElement<TDim, TNumNodes>::Initialize(const ProcessInfo& rCurrentProc
 {
     KRATOS_TRY
 
-    const PropertiesType& r_properties = this->GetProperties();
-    const GeometryType&   r_geometry   = this->GetGeometry();
+    const auto& r_properties = this->GetProperties();
+    const auto& r_geometry   = this->GetGeometry();
     const auto number_of_integration_points = r_geometry.IntegrationPointsNumber(mThisIntegrationMethod);
 
     mConstitutiveLawVector.resize(number_of_integration_points);
@@ -229,22 +229,10 @@ void UPwBaseElement<TDim, TNumNodes>::CalculateLocalSystem(MatrixType&        rL
 {
     KRATOS_TRY
 
-    const auto number_of_dofs = this->GetNumberOfDOF();
-
-    // Resetting the LHS
-    if (rLeftHandSideMatrix.size1() != number_of_dofs)
-        rLeftHandSideMatrix.resize(number_of_dofs, number_of_dofs, false);
-    noalias(rLeftHandSideMatrix) = ZeroMatrix(number_of_dofs, number_of_dofs);
-
-    // Resetting the RHS
-    if (rRightHandSideVector.size() != number_of_dofs)
-        rRightHandSideVector.resize(number_of_dofs, false);
-    noalias(rRightHandSideVector) = ZeroVector(number_of_dofs);
-
-    // calculation flags
-    const bool CalculateStiffnessMatrixFlag = true;
-    const bool CalculateResidualVectorFlag  = true;
-
+    rLeftHandSideMatrix  = ZeroMatrix{this->GetNumberOfDOF(), this->GetNumberOfDOF()};
+    rRightHandSideVector = ZeroVector{this->GetNumberOfDOF()};
+    const auto CalculateStiffnessMatrixFlag = true;
+    const auto CalculateResidualVectorFlag  = true;
     CalculateAll(rLeftHandSideMatrix, rRightHandSideVector, rCurrentProcessInfo,
                  CalculateStiffnessMatrixFlag, CalculateResidualVectorFlag);
 

--- a/applications/GeoMechanicsApplication/custom_elements/U_Pw_base_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/U_Pw_base_element.cpp
@@ -407,11 +407,10 @@ void UPwBaseElement<TDim, TNumNodes>::CalculateOnIntegrationPoints(const Variabl
     KRATOS_TRY
 
     if (rVariable == CONSTITUTIVE_LAW) {
-        if (rValues.size() != mConstitutiveLawVector.size())
-            rValues.resize(mConstitutiveLawVector.size());
-
-        for (unsigned int i = 0; i < mConstitutiveLawVector.size(); ++i)
+        rValues.resize(mConstitutiveLawVector.size());
+        for (unsigned int i = 0; i < mConstitutiveLawVector.size(); ++i) {
             rValues[i] = mConstitutiveLawVector[i];
+        }
     }
 
     KRATOS_CATCH("")

--- a/applications/GeoMechanicsApplication/custom_elements/U_Pw_base_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/U_Pw_base_element.cpp
@@ -262,17 +262,16 @@ template <unsigned int TDim, unsigned int TNumNodes>
 void UPwBaseElement<TDim, TNumNodes>::CalculateLeftHandSide(MatrixType&        rLeftHandSideMatrix,
                                                             const ProcessInfo& rCurrentProcessInfo)
 {
-    KRATOS_TRY;
+    KRATOS_TRY
 
-    // Calculation flags
-    const bool CalculateStiffnessMatrixFlag = true;
-    const bool CalculateResidualVectorFlag  = false;
-    VectorType TempVector;
+    rLeftHandSideMatrix = ZeroMatrix{this->GetNumberOfDOF(), this->GetNumberOfDOF()};
+    VectorType dummy_right_hand_side;
+    const auto CalculateStiffnessMatrixFlag = true;
+    const auto CalculateResidualVectorFlag  = false;
+    CalculateAll(rLeftHandSideMatrix, dummy_right_hand_side, rCurrentProcessInfo,
+                 CalculateStiffnessMatrixFlag, CalculateResidualVectorFlag);
 
-    CalculateAll(rLeftHandSideMatrix, TempVector, rCurrentProcessInfo, CalculateStiffnessMatrixFlag,
-                 CalculateResidualVectorFlag);
-
-    KRATOS_CATCH("");
+    KRATOS_CATCH("")
 }
 
 //----------------------------------------------------------------------------------------

--- a/applications/GeoMechanicsApplication/custom_elements/U_Pw_base_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/U_Pw_base_element.cpp
@@ -235,15 +235,17 @@ void UPwBaseElement<TDim, TNumNodes>::CalculateLocalSystem(MatrixType&        rL
 {
     KRATOS_TRY
 
-    const unsigned int N_DOF = this->GetNumberOfDOF();
+    const unsigned int number_of_dofs = this->GetNumberOfDOF();
 
     // Resetting the LHS
-    if (rLeftHandSideMatrix.size1() != N_DOF) rLeftHandSideMatrix.resize(N_DOF, N_DOF, false);
-    noalias(rLeftHandSideMatrix) = ZeroMatrix(N_DOF, N_DOF);
+    if (rLeftHandSideMatrix.size1() != number_of_dofs)
+        rLeftHandSideMatrix.resize(number_of_dofs, number_of_dofs, false);
+    noalias(rLeftHandSideMatrix) = ZeroMatrix(number_of_dofs, number_of_dofs);
 
     // Resetting the RHS
-    if (rRightHandSideVector.size() != N_DOF) rRightHandSideVector.resize(N_DOF, false);
-    noalias(rRightHandSideVector) = ZeroVector(N_DOF);
+    if (rRightHandSideVector.size() != number_of_dofs)
+        rRightHandSideVector.resize(number_of_dofs, false);
+    noalias(rRightHandSideVector) = ZeroVector(number_of_dofs);
 
     // calculation flags
     const bool CalculateStiffnessMatrixFlag = true;

--- a/applications/GeoMechanicsApplication/custom_elements/U_Pw_base_element.hpp
+++ b/applications/GeoMechanicsApplication/custom_elements/U_Pw_base_element.hpp
@@ -174,33 +174,6 @@ protected:
 
     void CalculateJacobianOnCurrentConfiguration(double& detJ, Matrix& rJ, Matrix& rInvJ, unsigned int GPoint) const;
 
-    /**
-     * @brief This functions calculate the derivatives in the reference frame
-     * @param J0 The jacobian in the reference configuration
-     * @param InvJ0 The inverse of the jacobian in the reference configuration
-     * @param DN_DX The gradient derivative of the shape function
-     * @param PointNumber The id of the integration point considered
-     * @param ThisIntegrationMethod The integration method considered
-     * @return The determinant of the jacobian in the reference configuration
-     */
-    void CalculateJacobianOnCurrentConfiguration(
-        double& detJ, Matrix& J0, Matrix& InvJ0, Matrix& DN_DX, unsigned int PointNumber) const;
-
-    /**
-     * @brief This functions calculate the derivatives in the current frame
-     * @param rJ The jacobian in the current configuration
-     * @param rInvJ The inverse of the jacobian in the current configuration
-     * @param rDN_DX The gradient derivative of the shape function
-     * @param PointNumber The id of the integration point considered
-     * @param ThisIntegrationMethod The integration method considered
-     * @return The determinant of the jacobian in the current configuration
-     */
-    double CalculateDerivativesOnCurrentConfiguration(Matrix&          rJ,
-                                                      Matrix&          rInvJ,
-                                                      Matrix&          rDN_DX,
-                                                      const IndexType& PointNumber,
-                                                      IntegrationMethod ThisIntegrationMethod) const;
-
     virtual unsigned int GetNumberOfDOF() const;
 
     StressStatePolicy& GetStressStatePolicy() const;

--- a/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_element.cpp
@@ -1442,17 +1442,21 @@ Matrix UPwSmallStrainElement<TDim, TNumNodes>::CalculateDeformationGradient(unsi
 
     // Calculation of derivative of shape function with respect to reference
     // configuration derivative of shape function (displacement)
-    Matrix J0, InvJ0, DNu_DX0;
+    Matrix J0;
+    Matrix InvJ0;
+    Matrix DNu_DX0;
     double detJ0;
     this->CalculateDerivativesOnInitialConfiguration(detJ0, J0, InvJ0, DNu_DX0, GPoint);
 
     // Calculating current Jacobian in order to find deformation gradient
-    Matrix J, InvJ, DNu_DX;
+    Matrix J;
+    Matrix InvJ;
     double detJ;
     this->CalculateJacobianOnCurrentConfiguration(detJ, J, InvJ, GPoint);
 
-    KRATOS_ERROR_IF(detJ < 0.0) << "ERROR:: ELEMENT ID: " << this->Id() << " INVERTED. DETJ: " << detJ
-                                << " nodes:" << this->GetGeometry() << std::endl;
+    KRATOS_ERROR_IF(detJ < 0.0)
+        << "ERROR:: Element " << this->Id() << " is inverted. DetJ: " << detJ << std::endl
+        << "This usually indicates that the deformations are too large for the mesh size." << std::endl;
 
     return prod(J, InvJ0);
 

--- a/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_element.cpp
@@ -627,8 +627,8 @@ void UPwSmallStrainElement<TDim, TNumNodes>::CalculateOnIntegrationPoints(
         }
     } else {
         for (unsigned int i = 0; i < mConstitutiveLawVector.size(); ++i) {
-            noalias(rOutput[i]) = ZeroVector(3);
-            rOutput[i]          = mConstitutiveLawVector[i]->GetValue(rVariable, rOutput[i]);
+            rOutput[i] = ZeroVector(3);
+            rOutput[i] = mConstitutiveLawVector[i]->GetValue(rVariable, rOutput[i]);
         }
     }
 

--- a/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_element.cpp
@@ -137,15 +137,10 @@ void UPwSmallStrainElement<TDim, TNumNodes>::InitializeSolutionStep(const Proces
 
     if (!mIsInitialised) this->Initialize(rCurrentProcessInfo);
 
-    // Defining necessary variables
-    const GeometryType& rGeom      = this->GetGeometry();
-    const IndexType     NumGPoints = rGeom.IntegrationPointsNumber(mThisIntegrationMethod);
-
-    ConstitutiveLaw::Parameters ConstitutiveParameters(rGeom, this->GetProperties(), rCurrentProcessInfo);
+    ConstitutiveLaw::Parameters ConstitutiveParameters(this->GetGeometry(), this->GetProperties(), rCurrentProcessInfo);
     ConstitutiveParameters.Set(ConstitutiveLaw::USE_ELEMENT_PROVIDED_STRAIN);
     ConstitutiveParameters.Set(ConstitutiveLaw::INITIALIZE_MATERIAL_RESPONSE); // Note: this is for nonlocal damage
 
-    // Element variables
     ElementVariables Variables;
     this->InitializeElementVariables(Variables, rCurrentProcessInfo);
 
@@ -159,13 +154,11 @@ void UPwSmallStrainElement<TDim, TNumNodes>::InitializeSolutionStep(const Proces
         deformation_gradients, b_matrices, Variables.DisplacementVector, Variables.UseHenckyStrain,
         this->GetStressStatePolicy().GetVoigtSize());
 
-    // Loop over integration points
-    for (unsigned int GPoint = 0; GPoint < NumGPoints; ++GPoint) {
-        // Compute Np, GradNpT, B and StrainVector
+    const auto number_of_integration_points =
+        this->GetGeometry().IntegrationPointsNumber(this->GetIntegrationMethod());
+    for (unsigned int GPoint = 0; GPoint < number_of_integration_points; ++GPoint) {
         this->CalculateKinematics(Variables, GPoint);
-        Variables.B = b_matrices[GPoint];
-
-        // Compute infinitesimal strain
+        Variables.B            = b_matrices[GPoint];
         Variables.F            = deformation_gradients[GPoint];
         Variables.StrainVector = strain_vectors[GPoint];
 
@@ -173,12 +166,10 @@ void UPwSmallStrainElement<TDim, TNumNodes>::InitializeSolutionStep(const Proces
             ConstitutiveParameters, Variables.StrainVector, Variables.ConstitutiveMatrix, Variables.Np,
             Variables.GradNpT, Variables.F, determinants_of_deformation_gradients[GPoint]);
 
-        // Initialize constitutive law
         noalias(Variables.StressVector) = mStressVector[GPoint];
         ConstitutiveParameters.SetStressVector(Variables.StressVector);
         mConstitutiveLawVector[GPoint]->InitializeMaterialResponseCauchy(ConstitutiveParameters);
 
-        // Initialize retention law
         mRetentionLawVector[GPoint]->InitializeSolutionStep(RetentionParameters);
     }
 

--- a/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_element.cpp
@@ -886,10 +886,6 @@ void UPwSmallStrainElement<TDim, TNumNodes>::CalculateMassMatrix(MatrixType& rMa
 {
     KRATOS_TRY
 
-    const IndexType N_DOF = this->GetNumberOfDOF();
-    if (rMassMatrix.size1() != N_DOF) rMassMatrix.resize(N_DOF, N_DOF, false);
-    noalias(rMassMatrix) = ZeroMatrix(N_DOF, N_DOF);
-
     const GeometryType& r_geom             = this->GetGeometry();
     const auto          integration_method = this->GetIntegrationMethod();
     const GeometryType::IntegrationPointsArrayType& integration_points =
@@ -913,6 +909,7 @@ void UPwSmallStrainElement<TDim, TNumNodes>::CalculateMassMatrix(MatrixType& rMa
         r_geom.WorkingSpaceDimension(), r_geom.PointsNumber(), integration_points.size(),
         r_geom.ShapeFunctionsValues(integration_method), solid_densities, integration_coefficients);
 
+    rMassMatrix = ZeroMatrix(this->GetNumberOfDOF(), this->GetNumberOfDOF());
     GeoElementUtilities::AssembleUUBlockMatrix(rMassMatrix, mass_matrix_u);
 
     KRATOS_CATCH("")

--- a/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_element.cpp
@@ -747,39 +747,28 @@ void UPwSmallStrainElement<TDim, TNumNodes>::CalculateOnIntegrationPoints(const 
     rOutput.resize(number_of_integration_points);
 
     if (rVariable == CAUCHY_STRESS_TENSOR) {
-        auto const StressTensorSize = this->GetStressStatePolicy().GetStressTensorSize();
         for (unsigned int GPoint = 0; GPoint < number_of_integration_points; ++GPoint) {
-            rOutput[GPoint].resize(StressTensorSize, StressTensorSize, false);
             rOutput[GPoint] = MathUtils<double>::StressVectorToTensor(mStressVector[GPoint]);
         }
     } else if (rVariable == TOTAL_STRESS_TENSOR) {
         std::vector<Vector> StressVector;
-
         this->CalculateOnIntegrationPoints(TOTAL_STRESS_VECTOR, StressVector, rCurrentProcessInfo);
 
         for (unsigned int GPoint = 0; GPoint < mConstitutiveLawVector.size(); ++GPoint) {
-            if (rOutput[GPoint].size2() != TDim) rOutput[GPoint].resize(TDim, TDim, false);
-
             rOutput[GPoint] = MathUtils<double>::StressVectorToTensor(StressVector[GPoint]);
         }
     } else if (rVariable == ENGINEERING_STRAIN_TENSOR) {
         std::vector<Vector> StrainVector;
-
         CalculateOnIntegrationPoints(ENGINEERING_STRAIN_VECTOR, StrainVector, rCurrentProcessInfo);
 
         for (unsigned int GPoint = 0; GPoint < mConstitutiveLawVector.size(); ++GPoint) {
-            if (rOutput[GPoint].size2() != TDim) rOutput[GPoint].resize(TDim, TDim, false);
-
             rOutput[GPoint] = MathUtils<double>::StrainVectorToTensor(StrainVector[GPoint]);
         }
     } else if (rVariable == GREEN_LAGRANGE_STRAIN_TENSOR) {
         std::vector<Vector> StrainVector;
-
         CalculateOnIntegrationPoints(GREEN_LAGRANGE_STRAIN_VECTOR, StrainVector, rCurrentProcessInfo);
 
         for (unsigned int GPoint = 0; GPoint < mConstitutiveLawVector.size(); ++GPoint) {
-            if (rOutput[GPoint].size2() != TDim) rOutput[GPoint].resize(TDim, TDim, false);
-
             rOutput[GPoint] = MathUtils<double>::StrainVectorToTensor(StrainVector[GPoint]);
         }
     } else if (rVariable == PERMEABILITY_MATRIX) {
@@ -788,14 +777,12 @@ void UPwSmallStrainElement<TDim, TNumNodes>::CalculateOnIntegrationPoints(const 
         GeoElementUtilities::FillPermeabilityMatrix(PermeabilityMatrix, this->GetProperties());
 
         for (unsigned int GPoint = 0; GPoint < number_of_integration_points; ++GPoint) {
-            rOutput[GPoint].resize(TDim, TDim, false);
-            noalias(rOutput[GPoint]) = PermeabilityMatrix;
+            rOutput[GPoint] = PermeabilityMatrix;
         }
     } else {
         for (unsigned int i = 0; i < mConstitutiveLawVector.size(); ++i) {
-            rOutput[i].resize(TDim, TDim, false);
-            noalias(rOutput[i]) = ZeroMatrix(TDim, TDim);
-            rOutput[i]          = mConstitutiveLawVector[i]->GetValue(rVariable, rOutput[i]);
+            rOutput[i] = ZeroMatrix(TDim, TDim);
+            rOutput[i] = mConstitutiveLawVector[i]->GetValue(rVariable, rOutput[i]);
         }
     }
 

--- a/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_element.cpp
@@ -137,7 +137,8 @@ void UPwSmallStrainElement<TDim, TNumNodes>::InitializeSolutionStep(const Proces
 
     if (!mIsInitialised) this->Initialize(rCurrentProcessInfo);
 
-    ConstitutiveLaw::Parameters ConstitutiveParameters(this->GetGeometry(), this->GetProperties(), rCurrentProcessInfo);
+    ConstitutiveLaw::Parameters ConstitutiveParameters(this->GetGeometry(), this->GetProperties(),
+                                                       rCurrentProcessInfo);
     ConstitutiveParameters.Set(ConstitutiveLaw::USE_ELEMENT_PROVIDED_STRAIN);
     ConstitutiveParameters.Set(ConstitutiveLaw::INITIALIZE_MATERIAL_RESPONSE); // Note: this is for nonlocal damage
 
@@ -282,7 +283,8 @@ void UPwSmallStrainElement<TDim, TNumNodes>::FinalizeSolutionStep(const ProcessI
 
     this->CalculateHydraulicDischarge(rCurrentProcessInfo);
 
-    ConstitutiveLaw::Parameters ConstitutiveParameters(this->GetGeometry(), this->GetProperties(), rCurrentProcessInfo);
+    ConstitutiveLaw::Parameters ConstitutiveParameters(this->GetGeometry(), this->GetProperties(),
+                                                       rCurrentProcessInfo);
     ConstitutiveParameters.Set(ConstitutiveLaw::USE_ELEMENT_PROVIDED_STRAIN);
 
     ElementVariables Variables;
@@ -298,7 +300,8 @@ void UPwSmallStrainElement<TDim, TNumNodes>::FinalizeSolutionStep(const ProcessI
         deformation_gradients, b_matrices, Variables.DisplacementVector, Variables.UseHenckyStrain,
         this->GetStressStatePolicy().GetVoigtSize());
 
-    const auto number_of_integration_points = this->GetGeometry().IntegrationPointsNumber(this->GetIntegrationMethod());
+    const auto number_of_integration_points =
+        this->GetGeometry().IntegrationPointsNumber(this->GetIntegrationMethod());
     Matrix StressContainer(number_of_integration_points, mStressVector[0].size());
 
     for (unsigned int GPoint = 0; GPoint < number_of_integration_points; ++GPoint) {
@@ -443,7 +446,7 @@ void UPwSmallStrainElement<TDim, TNumNodes>::CalculateOnIntegrationPoints(const 
 {
     KRATOS_TRY
 
-    const GeometryType& rGeom               = this->GetGeometry();
+    const GeometryType& rGeom = this->GetGeometry();
     const auto number_of_integration_points = rGeom.IntegrationPointsNumber(this->GetIntegrationMethod());
 
     auto& r_prop = this->GetProperties();
@@ -639,9 +642,9 @@ void UPwSmallStrainElement<TDim, TNumNodes>::CalculateOnIntegrationPoints(const 
 {
     KRATOS_TRY
 
-    const GeometryType& rGeom               = this->GetGeometry();
-    const auto number_of_integration_points = rGeom.IntegrationPointsNumber(mThisIntegrationMethod);
-    const PropertiesType& rProp             = this->GetProperties();
+    const auto& r_geometry = this->GetGeometry();
+    const auto number_of_integration_points = r_geometry.IntegrationPointsNumber(mThisIntegrationMethod);
+    const auto& r_properties = this->GetProperties();
 
     rOutput.resize(number_of_integration_points);
 
@@ -656,7 +659,7 @@ void UPwSmallStrainElement<TDim, TNumNodes>::CalculateOnIntegrationPoints(const 
         ElementVariables Variables;
         this->InitializeElementVariables(Variables, rCurrentProcessInfo);
 
-        ConstitutiveLaw::Parameters ConstitutiveParameters(rGeom, this->GetProperties(), rCurrentProcessInfo);
+        ConstitutiveLaw::Parameters ConstitutiveParameters(r_geometry, this->GetProperties(), rCurrentProcessInfo);
         ConstitutiveParameters.Set(ConstitutiveLaw::COMPUTE_CONSTITUTIVE_TENSOR);
         ConstitutiveParameters.Set(ConstitutiveLaw::USE_ELEMENT_PROVIDED_STRAIN);
 
@@ -719,10 +722,10 @@ void UPwSmallStrainElement<TDim, TNumNodes>::CalculateOnIntegrationPoints(const 
         rOutput                          = StressStrainUtilities::CalculateStrains(
             deformation_gradients, b_matrices, Variables.DisplacementVector,
             Variables.UseHenckyStrain, this->GetStressStatePolicy().GetVoigtSize());
-    } else if (rProp.Has(rVariable)) {
+    } else if (r_properties.Has(rVariable)) {
         // Map initial material property to Gauss points, as required for the output
         rOutput.clear();
-        std::fill_n(std::back_inserter(rOutput), mConstitutiveLawVector.size(), rProp.GetValue(rVariable));
+        std::fill_n(std::back_inserter(rOutput), mConstitutiveLawVector.size(), r_properties.GetValue(rVariable));
     } else {
         for (unsigned int i = 0; i < mConstitutiveLawVector.size(); ++i)
             rOutput[i] = mConstitutiveLawVector[i]->GetValue(rVariable, rOutput[i]);
@@ -738,8 +741,8 @@ void UPwSmallStrainElement<TDim, TNumNodes>::CalculateOnIntegrationPoints(const 
 {
     KRATOS_TRY
 
-    const GeometryType& rGeom               = this->GetGeometry();
-    const auto number_of_integration_points = rGeom.IntegrationPointsNumber(mThisIntegrationMethod);
+    const auto& r_geometry = this->GetGeometry();
+    const auto number_of_integration_points = r_geometry.IntegrationPointsNumber(mThisIntegrationMethod);
 
     rOutput.resize(number_of_integration_points);
 
@@ -987,7 +990,8 @@ void UPwSmallStrainElement<TDim, TNumNodes>::CalculateAll(MatrixType&        rLe
 }
 
 template <unsigned int TDim, unsigned int TNumNodes>
-std::vector<double> UPwSmallStrainElement<TDim, TNumNodes>::CalculateDerivativesOfSaturation(const std::vector<double>& rFluidPressures) const
+std::vector<double> UPwSmallStrainElement<TDim, TNumNodes>::CalculateDerivativesOfSaturation(
+    const std::vector<double>& rFluidPressures) const
 {
     KRATOS_ERROR_IF(rFluidPressures.size() != mRetentionLawVector.size());
     std::vector<double> result;
@@ -1003,7 +1007,8 @@ std::vector<double> UPwSmallStrainElement<TDim, TNumNodes>::CalculateDerivatives
 }
 
 template <unsigned int TDim, unsigned int TNumNodes>
-std::vector<double> UPwSmallStrainElement<TDim, TNumNodes>::CalculateDegreesOfSaturation(const std::vector<double>& rFluidPressures) const
+std::vector<double> UPwSmallStrainElement<TDim, TNumNodes>::CalculateDegreesOfSaturation(
+    const std::vector<double>& rFluidPressures) const
 {
     KRATOS_ERROR_IF(rFluidPressures.size() != mRetentionLawVector.size());
     std::vector<double> result;
@@ -1280,7 +1285,6 @@ void UPwSmallStrainElement<TDim, TNumNodes>::CalculateAndAddCouplingTerms(Vector
                                        rVariables.B, this->GetStressStatePolicy().GetVoigtVector(),
                                        rVariables.Np, rVariables.BiotCoefficient,
                                        rVariables.BishopCoefficient, rVariables.IntegrationCoefficient);
-
     rVariables.UVector = prod(rVariables.UPMatrix, rVariables.PressureVector);
     GeoElementUtilities::AssembleUBlockVector(rRightHandSideVector, rVariables.UVector);
 

--- a/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_element.hpp
+++ b/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_element.hpp
@@ -150,9 +150,6 @@ protected:
         array_1d<double, TNumNodes * TDim> VelocityVector;
         array_1d<double, TNumNodes * TDim> VolumeAcceleration;
 
-        /// General elemental variables
-        Vector VoigtVector;
-
         /// Variables computed at each GP
         Matrix                                        B;
         BoundedMatrix<double, TDim, TNumNodes * TDim> Nu;

--- a/applications/GeoMechanicsApplication/custom_elements/small_strain_U_Pw_diff_order_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/small_strain_U_Pw_diff_order_element.cpp
@@ -1615,21 +1615,15 @@ void SmallStrainUPwDiffOrderElement::CalculateAndAddCouplingMatrix(MatrixType& r
 {
     KRATOS_TRY
 
-    const Vector& VoigtVector = mpStressStatePolicy->GetVoigtVector();
-
     Matrix CouplingMatrix = GeoTransportEquationUtilities::CalculateCouplingMatrix(
-        rVariables.B, VoigtVector, rVariables.Np, rVariables.BiotCoefficient,
-        rVariables.BishopCoefficient, rVariables.IntegrationCoefficient);
-
-    // Distribute coupling block matrix into the elemental matrix
+        rVariables.B, GetStressStatePolicy().GetVoigtVector(), rVariables.Np,
+        rVariables.BiotCoefficient, rVariables.BishopCoefficient, rVariables.IntegrationCoefficient);
     GeoElementUtilities::AssembleUPBlockMatrix(rLeftHandSideMatrix, CouplingMatrix);
 
     if (!rVariables.IgnoreUndrained) {
         const double SaturationCoefficient = rVariables.DegreeOfSaturation / rVariables.BishopCoefficient;
         Matrix CouplingMatrixT = PORE_PRESSURE_SIGN_FACTOR * SaturationCoefficient *
                                  rVariables.VelocityCoefficient * trans(CouplingMatrix);
-
-        // Distribute transposed coupling block matrix into the elemental matrix
         GeoElementUtilities::AssemblePUBlockMatrix(rLeftHandSideMatrix, CouplingMatrixT);
     }
 
@@ -1724,23 +1718,18 @@ void SmallStrainUPwDiffOrderElement::CalculateAndAddCouplingTerms(VectorType& rR
 {
     KRATOS_TRY
 
-    const Vector& VoigtVector = mpStressStatePolicy->GetVoigtVector();
-
     Matrix CouplingMatrix = (-1.0) * GeoTransportEquationUtilities::CalculateCouplingMatrix(
-                                         rVariables.B, VoigtVector, rVariables.Np, rVariables.BiotCoefficient,
+                                         rVariables.B, GetStressStatePolicy().GetVoigtVector(),
+                                         rVariables.Np, rVariables.BiotCoefficient,
                                          rVariables.BishopCoefficient, rVariables.IntegrationCoefficient);
 
     Vector CouplingForce = prod(CouplingMatrix, rVariables.PressureVector);
-
-    // Distribute coupling block vector 1 into the elemental vector
     GeoElementUtilities::AssembleUBlockVector(rRightHandSideVector, CouplingForce);
 
     if (!rVariables.IgnoreUndrained) {
         const double SaturationCoefficient = rVariables.DegreeOfSaturation / rVariables.BishopCoefficient;
         Vector CouplingFlow = PORE_PRESSURE_SIGN_FACTOR * SaturationCoefficient *
                               prod(trans(CouplingMatrix), rVariables.VelocityVector);
-
-        // Distribute coupling block vector 2 into the elemental vector
         GeoElementUtilities::AssemblePBlockVector(rRightHandSideVector, CouplingFlow);
     }
 

--- a/applications/GeoMechanicsApplication/custom_elements/small_strain_U_Pw_diff_order_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/small_strain_U_Pw_diff_order_element.cpp
@@ -1867,10 +1867,8 @@ void SmallStrainUPwDiffOrderElement::CalculateAndAddFluidBodyFlow(VectorType& rR
 GeometryData::IntegrationMethod SmallStrainUPwDiffOrderElement::GetIntegrationMethod() const
 {
     GeometryData::IntegrationMethod GI_GAUSS;
-    const GeometryType&             rGeom     = GetGeometry();
-    const SizeType                  TNumNodes = rGeom.PointsNumber();
-    //
-    switch (TNumNodes) {
+
+    switch (GetGeometry().PointsNumber()) {
     case 3:
         GI_GAUSS = GeometryData::IntegrationMethod::GI_GAUSS_2;
         break;

--- a/applications/GeoMechanicsApplication/custom_elements/small_strain_U_Pw_diff_order_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/small_strain_U_Pw_diff_order_element.cpp
@@ -389,19 +389,11 @@ void SmallStrainUPwDiffOrderElement::CalculateLeftHandSide(MatrixType&        rL
 {
     KRATOS_TRY
 
-    const auto number_of_dofs = GetNumberOfDOF();
-
-    // Resetting the LHS
-    if (rLeftHandSideMatrix.size1() != number_of_dofs)
-        rLeftHandSideMatrix.resize(number_of_dofs, number_of_dofs, false);
-    noalias(rLeftHandSideMatrix) = ZeroMatrix(number_of_dofs, number_of_dofs);
-
-    // calculation flags
-    const bool CalculateStiffnessMatrixFlag = true;
-    const bool CalculateResidualVectorFlag  = false;
-    VectorType tempRightHandSideVector;
-
-    CalculateAll(rLeftHandSideMatrix, tempRightHandSideVector, rCurrentProcessInfo,
+    rLeftHandSideMatrix = ZeroMatrix{GetNumberOfDOF(), GetNumberOfDOF()};
+    VectorType dummy_right_hand_side;
+    const auto CalculateStiffnessMatrixFlag = true;
+    const auto CalculateResidualVectorFlag  = false;
+    CalculateAll(rLeftHandSideMatrix, dummy_right_hand_side, rCurrentProcessInfo,
                  CalculateStiffnessMatrixFlag, CalculateResidualVectorFlag);
 
     KRATOS_CATCH("")

--- a/applications/GeoMechanicsApplication/custom_elements/small_strain_U_Pw_diff_order_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/small_strain_U_Pw_diff_order_element.cpp
@@ -225,10 +225,10 @@ void SmallStrainUPwDiffOrderElement::Initialize(const ProcessInfo& rCurrentProce
         }
     }
 
-    const SizeType NumUNodes = r_geometry.PointsNumber();
-    const SizeType NumDim    = r_geometry.WorkingSpaceDimension();
+    const auto number_of_U_nodes = r_geometry.PointsNumber();
+    const auto dimension         = r_geometry.WorkingSpaceDimension();
 
-    switch (NumUNodes) {
+    switch (number_of_U_nodes) {
     case 6: // 2D T6P3
         mpPressureGeometry = make_shared<Triangle2D3<Node>>(r_geometry(0), r_geometry(1), r_geometry(2));
         break;
@@ -241,10 +241,10 @@ void SmallStrainUPwDiffOrderElement::Initialize(const ProcessInfo& rCurrentProce
                                                                  r_geometry(2), r_geometry(3));
         break;
     case 10: // 3D T10P4  //2D T10P6
-        if (NumDim == 3)
+        if (dimension == 3)
             mpPressureGeometry = make_shared<Tetrahedra3D4<Node>>(r_geometry(0), r_geometry(1),
                                                                   r_geometry(2), r_geometry(3));
-        else if (NumDim == 2)
+        else if (dimension == 2)
             mpPressureGeometry = make_shared<Triangle2D6<Node>>(
                 r_geometry(0), r_geometry(1), r_geometry(2), r_geometry(3), r_geometry(4), r_geometry(5));
         break;
@@ -1072,54 +1072,34 @@ void SmallStrainUPwDiffOrderElement::CalculateOnIntegrationPoints(const Variable
 {
     KRATOS_TRY
 
-    const GeometryType& rGeom = GetGeometry();
-    const auto number_of_integration_points = rGeom.IntegrationPointsNumber(this->GetIntegrationMethod());
-    const auto dimension = rGeom.WorkingSpaceDimension();
-
-    rOutput.resize(number_of_integration_points);
+    rOutput.resize(GetGeometry().IntegrationPointsNumber(this->GetIntegrationMethod()));
 
     if (rVariable == CAUCHY_STRESS_TENSOR) {
         std::vector<Vector> StressVector;
-
         this->CalculateOnIntegrationPoints(CAUCHY_STRESS_VECTOR, StressVector, rCurrentProcessInfo);
 
         for (unsigned int GPoint = 0; GPoint < mConstitutiveLawVector.size(); ++GPoint) {
-            if (rOutput[GPoint].size2() != dimension)
-                rOutput[GPoint].resize(dimension, dimension, false);
-
             rOutput[GPoint] = MathUtils<double>::StressVectorToTensor(StressVector[GPoint]);
         }
     } else if (rVariable == TOTAL_STRESS_TENSOR) {
         std::vector<Vector> StressVector;
-
         this->CalculateOnIntegrationPoints(TOTAL_STRESS_VECTOR, StressVector, rCurrentProcessInfo);
 
         for (unsigned int GPoint = 0; GPoint < mConstitutiveLawVector.size(); ++GPoint) {
-            if (rOutput[GPoint].size2() != dimension)
-                rOutput[GPoint].resize(dimension, dimension, false);
-
             rOutput[GPoint] = MathUtils<double>::StressVectorToTensor(StressVector[GPoint]);
         }
     } else if (rVariable == ENGINEERING_STRAIN_TENSOR) {
         std::vector<Vector> StrainVector;
-
         CalculateOnIntegrationPoints(ENGINEERING_STRAIN_VECTOR, StrainVector, rCurrentProcessInfo);
 
         for (unsigned int GPoint = 0; GPoint < mConstitutiveLawVector.size(); ++GPoint) {
-            if (rOutput[GPoint].size2() != dimension)
-                rOutput[GPoint].resize(dimension, dimension, false);
-
             rOutput[GPoint] = MathUtils<double>::StrainVectorToTensor(StrainVector[GPoint]);
         }
     } else if (rVariable == GREEN_LAGRANGE_STRAIN_TENSOR) {
         std::vector<Vector> StrainVector;
-
         CalculateOnIntegrationPoints(GREEN_LAGRANGE_STRAIN_VECTOR, StrainVector, rCurrentProcessInfo);
 
         for (unsigned int GPoint = 0; GPoint < mConstitutiveLawVector.size(); ++GPoint) {
-            if (rOutput[GPoint].size2() != dimension)
-                rOutput[GPoint].resize(dimension, dimension, false);
-
             rOutput[GPoint] = MathUtils<double>::StrainVectorToTensor(StrainVector[GPoint]);
         }
     } else {

--- a/applications/GeoMechanicsApplication/custom_elements/small_strain_U_Pw_diff_order_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/small_strain_U_Pw_diff_order_element.cpp
@@ -1870,9 +1870,7 @@ void SmallStrainUPwDiffOrderElement::CalculateJacobianOnCurrentConfiguration(dou
 {
     KRATOS_TRY
 
-    const GeometryType& rGeom = this->GetGeometry();
-
-    rJ = rGeom.Jacobian(rJ, GPoint, this->GetIntegrationMethod());
+    rJ = GetGeometry().Jacobian(rJ, GPoint, this->GetIntegrationMethod());
     MathUtils<double>::InvertMatrix(rJ, rInvJ, detJ);
 
     KRATOS_CATCH("")

--- a/applications/GeoMechanicsApplication/custom_elements/small_strain_U_Pw_diff_order_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/small_strain_U_Pw_diff_order_element.cpp
@@ -389,11 +389,11 @@ void SmallStrainUPwDiffOrderElement::CalculateLeftHandSide(MatrixType&        rL
 {
     KRATOS_TRY
 
-    rLeftHandSideMatrix = ZeroMatrix{GetNumberOfDOF(), GetNumberOfDOF()};
-    VectorType dummy_right_hand_side;
+    rLeftHandSideMatrix                     = ZeroMatrix{GetNumberOfDOF(), GetNumberOfDOF()};
+    auto       dummy_right_hand_side_vector = Vector{};
     const auto CalculateStiffnessMatrixFlag = true;
     const auto CalculateResidualVectorFlag  = false;
-    CalculateAll(rLeftHandSideMatrix, dummy_right_hand_side, rCurrentProcessInfo,
+    CalculateAll(rLeftHandSideMatrix, dummy_right_hand_side_vector, rCurrentProcessInfo,
                  CalculateStiffnessMatrixFlag, CalculateResidualVectorFlag);
 
     KRATOS_CATCH("")
@@ -404,24 +404,12 @@ void SmallStrainUPwDiffOrderElement::CalculateRightHandSide(VectorType&        r
 {
     KRATOS_TRY
 
-    const GeometryType& rGeom     = GetGeometry();
-    const SizeType      Dim       = rGeom.WorkingSpaceDimension();
-    const SizeType      NumUNodes = rGeom.PointsNumber();
-    const SizeType      NumPNodes = mpPressureGeometry->PointsNumber();
-
-    const SizeType ElementSize = NumUNodes * Dim + NumPNodes;
-
-    // Resetting the RHS
-    if (rRightHandSideVector.size() != ElementSize) rRightHandSideVector.resize(ElementSize, false);
-    noalias(rRightHandSideVector) = ZeroVector(ElementSize);
-
-    // calculation flags
-    bool CalculateStiffnessMatrixFlag = false;
-    bool CalculateResidualVectorFlag  = true;
-    auto temp                         = Matrix();
-
-    CalculateAll(temp, rRightHandSideVector, rCurrentProcessInfo, CalculateStiffnessMatrixFlag,
-                 CalculateResidualVectorFlag);
+    auto dummy_left_hand_side_matrix        = Matrix{};
+    rRightHandSideVector                    = ZeroVector{GetNumberOfDOF()};
+    const auto CalculateStiffnessMatrixFlag = false;
+    const auto CalculateResidualVectorFlag  = true;
+    CalculateAll(dummy_left_hand_side_matrix, rRightHandSideVector, rCurrentProcessInfo,
+                 CalculateStiffnessMatrixFlag, CalculateResidualVectorFlag);
 
     KRATOS_CATCH("")
 }

--- a/applications/GeoMechanicsApplication/custom_elements/small_strain_U_Pw_diff_order_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/small_strain_U_Pw_diff_order_element.cpp
@@ -362,12 +362,7 @@ void SmallStrainUPwDiffOrderElement::CalculateLocalSystem(MatrixType&        rLe
 {
     KRATOS_TRY
 
-    const GeometryType& rGeom     = GetGeometry();
-    const SizeType      Dim       = rGeom.WorkingSpaceDimension();
-    const SizeType      NumUNodes = rGeom.PointsNumber();
-    const SizeType      NumPNodes = mpPressureGeometry->PointsNumber();
-
-    const SizeType number_of_dofs = NumUNodes * Dim + NumPNodes;
+    const auto number_of_dofs = GetNumberOfDOF();
 
     // Resetting the LHS
     if (rLeftHandSideMatrix.size1() != number_of_dofs)
@@ -394,21 +389,16 @@ void SmallStrainUPwDiffOrderElement::CalculateLeftHandSide(MatrixType&        rL
 {
     KRATOS_TRY
 
-    const GeometryType& rGeom     = GetGeometry();
-    const SizeType      Dim       = rGeom.WorkingSpaceDimension();
-    const SizeType      NumUNodes = rGeom.PointsNumber();
-    const SizeType      NumPNodes = mpPressureGeometry->PointsNumber();
-
-    const SizeType ElementSize = NumUNodes * Dim + NumPNodes;
+    const auto number_of_dofs = GetNumberOfDOF();
 
     // Resetting the LHS
-    if (rLeftHandSideMatrix.size1() != ElementSize)
-        rLeftHandSideMatrix.resize(ElementSize, ElementSize, false);
-    noalias(rLeftHandSideMatrix) = ZeroMatrix(ElementSize, ElementSize);
+    if (rLeftHandSideMatrix.size1() != number_of_dofs)
+        rLeftHandSideMatrix.resize(number_of_dofs, number_of_dofs, false);
+    noalias(rLeftHandSideMatrix) = ZeroMatrix(number_of_dofs, number_of_dofs);
 
     // calculation flags
-    bool       CalculateStiffnessMatrixFlag = true;
-    bool       CalculateResidualVectorFlag  = false;
+    const bool CalculateStiffnessMatrixFlag = true;
+    const bool CalculateResidualVectorFlag  = false;
     VectorType tempRightHandSideVector;
 
     CalculateAll(rLeftHandSideMatrix, tempRightHandSideVector, rCurrentProcessInfo,
@@ -1979,6 +1969,12 @@ void SmallStrainUPwDiffOrderElement::CalculateJacobianOnCurrentConfiguration(dou
     MathUtils<double>::InvertMatrix(rJ, rInvJ, detJ);
 
     KRATOS_CATCH("")
+}
+
+SizeType SmallStrainUPwDiffOrderElement::GetNumberOfDOF() const
+{
+    return GetGeometry().PointsNumber() * GetGeometry().WorkingSpaceDimension() +
+           mpPressureGeometry->PointsNumber();
 }
 
 Element::DofsVectorType SmallStrainUPwDiffOrderElement::GetDofs() const

--- a/applications/GeoMechanicsApplication/custom_elements/small_strain_U_Pw_diff_order_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/small_strain_U_Pw_diff_order_element.cpp
@@ -367,20 +367,21 @@ void SmallStrainUPwDiffOrderElement::CalculateLocalSystem(MatrixType&        rLe
     const SizeType      NumUNodes = rGeom.PointsNumber();
     const SizeType      NumPNodes = mpPressureGeometry->PointsNumber();
 
-    const SizeType ElementSize = NumUNodes * Dim + NumPNodes;
+    const SizeType number_of_dofs = NumUNodes * Dim + NumPNodes;
 
     // Resetting the LHS
-    if (rLeftHandSideMatrix.size1() != ElementSize)
-        rLeftHandSideMatrix.resize(ElementSize, ElementSize, false);
-    noalias(rLeftHandSideMatrix) = ZeroMatrix(ElementSize, ElementSize);
+    if (rLeftHandSideMatrix.size1() != number_of_dofs)
+        rLeftHandSideMatrix.resize(number_of_dofs, number_of_dofs, false);
+    noalias(rLeftHandSideMatrix) = ZeroMatrix(number_of_dofs, number_of_dofs);
 
     // Resetting the RHS
-    if (rRightHandSideVector.size() != ElementSize) rRightHandSideVector.resize(ElementSize, false);
-    noalias(rRightHandSideVector) = ZeroVector(ElementSize);
+    if (rRightHandSideVector.size() != number_of_dofs)
+        rRightHandSideVector.resize(number_of_dofs, false);
+    noalias(rRightHandSideVector) = ZeroVector(number_of_dofs);
 
     // calculation flags
-    bool CalculateStiffnessMatrixFlag = true;
-    bool CalculateResidualVectorFlag  = true;
+    const bool CalculateStiffnessMatrixFlag = true;
+    const bool CalculateResidualVectorFlag  = true;
 
     CalculateAll(rLeftHandSideMatrix, rRightHandSideVector, rCurrentProcessInfo,
                  CalculateStiffnessMatrixFlag, CalculateResidualVectorFlag);

--- a/applications/GeoMechanicsApplication/custom_elements/small_strain_U_Pw_diff_order_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/small_strain_U_Pw_diff_order_element.cpp
@@ -1683,7 +1683,6 @@ void SmallStrainUPwDiffOrderElement::CalculateAndAddStiffnessForce(VectorType& r
     Vector StiffnessForce =
         -1.0 * prod(trans(rVariables.B), mStressVector[GPoint]) * rVariables.IntegrationCoefficient;
 
-    // Distribute stiffness block vector into the elemental vector
     GeoElementUtilities::AssembleUBlockVector(rRightHandSideVector, StiffnessForce);
 
     KRATOS_CATCH("")

--- a/applications/GeoMechanicsApplication/custom_elements/small_strain_U_Pw_diff_order_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/small_strain_U_Pw_diff_order_element.cpp
@@ -1837,7 +1837,7 @@ Matrix SmallStrainUPwDiffOrderElement::CalculateDeformationGradient(unsigned int
 {
     KRATOS_TRY
 
-    // calculation of derivative of shape function with respect to reference
+    // Calculation of derivative of shape function with respect to reference
     // configuration derivative of shape function (displacement)
     Matrix J0;
     Matrix InvJ0;
@@ -1853,9 +1853,7 @@ Matrix SmallStrainUPwDiffOrderElement::CalculateDeformationGradient(unsigned int
 
     KRATOS_ERROR_IF(detJ < 0.0)
         << "ERROR:: Element " << this->Id() << " is inverted. DetJ: " << detJ << std::endl
-        << "This usually indicates that the deformations are too large for the "
-           "mesh size."
-        << std::endl;
+        << "This usually indicates that the deformations are too large for the mesh size." << std::endl;
 
     return prod(J, InvJ0);
 

--- a/applications/GeoMechanicsApplication/custom_elements/small_strain_U_Pw_diff_order_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/small_strain_U_Pw_diff_order_element.cpp
@@ -445,18 +445,14 @@ void SmallStrainUPwDiffOrderElement::CalculateDampingMatrix(MatrixType&        r
 {
     KRATOS_TRY
 
-    const GeometryType&   r_geom = GetGeometry();
-    const PropertiesType& r_prop = this->GetProperties();
-    const SizeType        element_size =
-        r_geom.PointsNumber() * r_geom.WorkingSpaceDimension() + mpPressureGeometry->PointsNumber();
-
-    MatrixType mass_matrix = ZeroMatrix(element_size, element_size);
+    MatrixType mass_matrix = ZeroMatrix{GetNumberOfDOF(), GetNumberOfDOF()};
     this->CalculateMassMatrix(mass_matrix, rCurrentProcessInfo);
 
-    MatrixType stiffness_matrix(element_size, element_size);
+    MatrixType stiffness_matrix = ZeroMatrix{GetNumberOfDOF(), GetNumberOfDOF()};
     this->CalculateMaterialStiffnessMatrix(stiffness_matrix, rCurrentProcessInfo);
 
-    rDampingMatrix = GeoEquationOfMotionUtilities::CalculateDampingMatrix(
+    const auto& r_prop = this->GetProperties();
+    rDampingMatrix     = GeoEquationOfMotionUtilities::CalculateDampingMatrix(
         r_prop.Has(RAYLEIGH_ALPHA) ? r_prop[RAYLEIGH_ALPHA] : rCurrentProcessInfo[RAYLEIGH_ALPHA],
         r_prop.Has(RAYLEIGH_BETA) ? r_prop[RAYLEIGH_BETA] : rCurrentProcessInfo[RAYLEIGH_BETA],
         mass_matrix, stiffness_matrix);

--- a/applications/GeoMechanicsApplication/custom_elements/small_strain_U_Pw_diff_order_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/small_strain_U_Pw_diff_order_element.cpp
@@ -907,8 +907,8 @@ void SmallStrainUPwDiffOrderElement::CalculateOnIntegrationPoints(const Variable
 {
     KRATOS_TRY
 
-    const GeometryType& rGeom               = GetGeometry();
-    const auto number_of_integration_points = rGeom.IntegrationPointsNumber(GetIntegrationMethod());
+    const auto& r_geometry = GetGeometry();
+    const auto number_of_integration_points = r_geometry.IntegrationPointsNumber(GetIntegrationMethod());
     rOutput.resize(number_of_integration_points);
 
     if (rVariable == FLUID_FLUX_VECTOR) {
@@ -936,8 +936,8 @@ void SmallStrainUPwDiffOrderElement::CalculateOnIntegrationPoints(const Variable
             Variables.B = b_matrices[GPoint];
 
             // Compute FluidFlux vector q [m/s]
-            const SizeType Dim       = rGeom.WorkingSpaceDimension();
-            const SizeType NumUNodes = rGeom.PointsNumber();
+            const SizeType Dim       = r_geometry.WorkingSpaceDimension();
+            const SizeType NumUNodes = r_geometry.PointsNumber();
 
             Vector   BodyAcceleration = ZeroVector(Dim);
             SizeType Index            = 0;

--- a/applications/GeoMechanicsApplication/custom_elements/small_strain_U_Pw_diff_order_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/small_strain_U_Pw_diff_order_element.cpp
@@ -715,8 +715,8 @@ void SmallStrainUPwDiffOrderElement::SetValuesOnIntegrationPoints(const Variable
 {
     KRATOS_TRY
 
-    for (unsigned int GPoint = 0; GPoint < mConstitutiveLawVector.size(); ++GPoint) {
-        mConstitutiveLawVector[GPoint]->SetValue(rVariable, rValues[GPoint], rCurrentProcessInfo);
+    for (unsigned int i = 0; i < mConstitutiveLawVector.size(); ++i) {
+        mConstitutiveLawVector[i]->SetValue(rVariable, rValues[i], rCurrentProcessInfo);
     }
 
     KRATOS_CATCH("")
@@ -753,8 +753,8 @@ void SmallStrainUPwDiffOrderElement::SetValuesOnIntegrationPoints(const Variable
 {
     KRATOS_TRY
 
-    for (unsigned int GPoint = 0; GPoint < mConstitutiveLawVector.size(); ++GPoint) {
-        mConstitutiveLawVector[GPoint]->SetValue(rVariable, rValues[GPoint], rCurrentProcessInfo);
+    for (unsigned int i = 0; i < mConstitutiveLawVector.size(); ++i) {
+        mConstitutiveLawVector[i]->SetValue(rVariable, rValues[i], rCurrentProcessInfo);
     }
 
     KRATOS_CATCH("")

--- a/applications/GeoMechanicsApplication/custom_elements/small_strain_U_Pw_diff_order_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/small_strain_U_Pw_diff_order_element.cpp
@@ -415,15 +415,14 @@ void SmallStrainUPwDiffOrderElement::CalculateMassMatrix(MatrixType& rMassMatrix
     const auto          integration_method = this->GetIntegrationMethod();
     const GeometryType::IntegrationPointsArrayType& integration_points =
         r_geom.IntegrationPoints(integration_method);
-    const MatrixType Np_container = mpPressureGeometry->ShapeFunctionsValues(integration_method);
-    const PropertiesType& r_prop  = this->GetProperties();
+    const auto Np_container = mpPressureGeometry->ShapeFunctionsValues(integration_method);
 
     const auto fluid_pressures = GeoTransportEquationUtilities::CalculateFluidPressures(
         Np_container, this->GetPressureSolutionVector());
     const auto degrees_saturation = this->CalculateDegreesOfSaturation(fluid_pressures);
 
     const auto solid_densities =
-        GeoTransportEquationUtilities::CalculateSoilDensities(degrees_saturation, r_prop);
+        GeoTransportEquationUtilities::CalculateSoilDensities(degrees_saturation, GetProperties());
 
     const auto det_Js_initial_configuration =
         GeoEquationOfMotionUtilities::CalculateDetJsInitialConfiguration(r_geom, integration_method);
@@ -435,11 +434,7 @@ void SmallStrainUPwDiffOrderElement::CalculateMassMatrix(MatrixType& rMassMatrix
         r_geom.WorkingSpaceDimension(), r_geom.PointsNumber(), integration_points.size(),
         r_geom.ShapeFunctionsValues(integration_method), solid_densities, integration_coefficients);
 
-    const SizeType element_size =
-        r_geom.PointsNumber() * r_geom.WorkingSpaceDimension() + mpPressureGeometry->PointsNumber();
-    if (rMassMatrix.size1() != element_size || rMassMatrix.size2() != element_size)
-        rMassMatrix.resize(element_size, element_size, false);
-    noalias(rMassMatrix) = ZeroMatrix(element_size, element_size);
+    rMassMatrix = ZeroMatrix(GetNumberOfDOF(), GetNumberOfDOF());
     GeoElementUtilities::AssembleUUBlockMatrix(rMassMatrix, mass_matrix_u);
 
     KRATOS_CATCH("")

--- a/applications/GeoMechanicsApplication/custom_elements/small_strain_U_Pw_diff_order_element.hpp
+++ b/applications/GeoMechanicsApplication/custom_elements/small_strain_U_Pw_diff_order_element.hpp
@@ -315,6 +315,8 @@ protected:
     [[nodiscard]] std::vector<double> CalculateDegreesOfSaturation(const std::vector<double>& rFluidPressures);
     [[nodiscard]] std::vector<double> CalculateDerivativesOfSaturation(const std::vector<double>& rFluidPressures);
 
+    [[nodiscard]] SizeType GetNumberOfDOF() const;
+
     //----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
 private:


### PR DESCRIPTION
**📝 Description**
Reduced the number of differences between template classes `UPwBaseElement` and `UPwSmallStrainElement` on the one hand and class `SmallStrainUPwDiffOrderElement` on the other hand. Lines have been reordered, redundant comments have been removed, names have been made consistent. This helps to make it more visible where the duplicated code is (which will be removed in small increments), but also where the actual differences are (whether they were intended or not).

**🆕 Changelog**
Changes include:
- Removed several redundant size checks to decide whether a container needs to be resized or not. This check is also done by the `resize` operation itself, so there is no need to explicitly repeat the check.
- Replaced several explicit type names by `auto`.
- Renamed several local variables to comply with the Kratos Style  Guide.
- Removed some redundant comments.
- Removed several redundant `resize` operations (ones that were immediately followed by an assignment operation). Also removed some `noalias` usages that wouldn't yield any performance benefits.
- Eliminated a few intermediate variables, by replacing their usages by calls to functions that retrieve their (constant) values.
- Reused `GetVoigtSize` when initializing a `UPwBaseElement` instance rather than repeating the logic it encapsulates.
- Removed a few empty statements.
- Removed two unused member functions of class template `UPwBaseElement`.
- Reformatted some code using clang-format.
- Make sure each variable definition is at its own line (avoid C-style declarations).
- Removed data member `VoigtVector` from class `UPwSmallStrainElement::ElementVariables`. Its usages have been replaced by calling `GetVoigtVector` directly.
- Added member function `GetNumberOfDOF` to class `SmallStrainUPwDiffOrderElement`.
- Removed some commented out code.
