### PR TITLE
Geo/consolidation test

### DIFF
--- a/applications/GeoMechanicsApplication/custom_constitutive/linear_elastic_plane_strain_2D_law.cpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/linear_elastic_plane_strain_2D_law.cpp
@@ -116,6 +116,7 @@ void GeoLinearElasticPlaneStrain2DLaw::InitializeMaterialResponseCauchy(Constitu
     if (!mIsModelInitialized) {
         // stress vector must be initialized:
         mStressVectorFinalized = rValues.GetStressVector();
+        mStrainVectorFinalized = rValues.GetStrainVector();
         mIsModelInitialized = true;
     }
     KRATOS_CATCH("")

--- a/applications/GeoMechanicsApplication/tests/1D-Consolidation_all_stages/ProjectParameters_stage1.json
+++ b/applications/GeoMechanicsApplication/tests/1D-Consolidation_all_stages/ProjectParameters_stage1.json
@@ -25,7 +25,7 @@
         "echo_level":                         1,
         "clear_storage":                      false,
         "compute_reactions":                  true,
-        "move_mesh_flag":                     true,
+        "move_mesh_flag":                     false,
         "reform_dofs_at_each_step":           false,
         "nodal_smoothing":                    false,
         "block_builder":                      true,

--- a/applications/GeoMechanicsApplication/tests/1D-Consolidation_all_stages/ProjectParameters_stage10.json
+++ b/applications/GeoMechanicsApplication/tests/1D-Consolidation_all_stages/ProjectParameters_stage10.json
@@ -25,7 +25,7 @@
         "echo_level":                         1,
         "clear_storage":                      false,
         "compute_reactions":                  true,
-        "move_mesh_flag":                     true,
+        "move_mesh_flag":                     false,
         "reform_dofs_at_each_step":           false,
         "nodal_smoothing":                    false,
         "block_builder":                      true,

--- a/applications/GeoMechanicsApplication/tests/1D-Consolidation_all_stages/ProjectParameters_stage11.json
+++ b/applications/GeoMechanicsApplication/tests/1D-Consolidation_all_stages/ProjectParameters_stage11.json
@@ -25,7 +25,7 @@
         "echo_level":                         1,
         "clear_storage":                      false,
         "compute_reactions":                  true,
-        "move_mesh_flag":                     true,
+        "move_mesh_flag":                     false,
         "reform_dofs_at_each_step":           false,
         "nodal_smoothing":                    false,
         "block_builder":                      true,

--- a/applications/GeoMechanicsApplication/tests/1D-Consolidation_all_stages/ProjectParameters_stage2.json
+++ b/applications/GeoMechanicsApplication/tests/1D-Consolidation_all_stages/ProjectParameters_stage2.json
@@ -25,7 +25,7 @@
         "echo_level":                         1,
         "clear_storage":                      false,
         "compute_reactions":                  true,
-        "move_mesh_flag":                     true,
+        "move_mesh_flag":                     false,
         "reform_dofs_at_each_step":           false,
         "nodal_smoothing":                    false,
         "block_builder":                      true,

--- a/applications/GeoMechanicsApplication/tests/1D-Consolidation_all_stages/ProjectParameters_stage3.json
+++ b/applications/GeoMechanicsApplication/tests/1D-Consolidation_all_stages/ProjectParameters_stage3.json
@@ -25,7 +25,7 @@
         "echo_level":                         1,
         "clear_storage":                      false,
         "compute_reactions":                  true,
-        "move_mesh_flag":                     true,
+        "move_mesh_flag":                     false,
         "reform_dofs_at_each_step":           false,
         "nodal_smoothing":                    false,
         "block_builder":                      true,

--- a/applications/GeoMechanicsApplication/tests/1D-Consolidation_all_stages/ProjectParameters_stage4.json
+++ b/applications/GeoMechanicsApplication/tests/1D-Consolidation_all_stages/ProjectParameters_stage4.json
@@ -25,7 +25,7 @@
         "echo_level":                         1,
         "clear_storage":                      false,
         "compute_reactions":                  true,
-        "move_mesh_flag":                     true,
+        "move_mesh_flag":                     false,
         "reform_dofs_at_each_step":           false,
         "nodal_smoothing":                    false,
         "block_builder":                      true,

--- a/applications/GeoMechanicsApplication/tests/1D-Consolidation_all_stages/ProjectParameters_stage5.json
+++ b/applications/GeoMechanicsApplication/tests/1D-Consolidation_all_stages/ProjectParameters_stage5.json
@@ -25,7 +25,7 @@
         "echo_level":                         1,
         "clear_storage":                      false,
         "compute_reactions":                  true,
-        "move_mesh_flag":                     true,
+        "move_mesh_flag":                     false,
         "reform_dofs_at_each_step":           false,
         "nodal_smoothing":                    false,
         "block_builder":                      true,

--- a/applications/GeoMechanicsApplication/tests/1D-Consolidation_all_stages/ProjectParameters_stage6.json
+++ b/applications/GeoMechanicsApplication/tests/1D-Consolidation_all_stages/ProjectParameters_stage6.json
@@ -25,7 +25,7 @@
         "echo_level":                         1,
         "clear_storage":                      false,
         "compute_reactions":                  true,
-        "move_mesh_flag":                     true,
+        "move_mesh_flag":                     false,
         "reform_dofs_at_each_step":           false,
         "nodal_smoothing":                    false,
         "block_builder":                      true,

--- a/applications/GeoMechanicsApplication/tests/1D-Consolidation_all_stages/ProjectParameters_stage7.json
+++ b/applications/GeoMechanicsApplication/tests/1D-Consolidation_all_stages/ProjectParameters_stage7.json
@@ -25,7 +25,7 @@
         "echo_level":                         1,
         "clear_storage":                      false,
         "compute_reactions":                  true,
-        "move_mesh_flag":                     true,
+        "move_mesh_flag":                     false,
         "reform_dofs_at_each_step":           false,
         "nodal_smoothing":                    false,
         "block_builder":                      true,

--- a/applications/GeoMechanicsApplication/tests/1D-Consolidation_all_stages/ProjectParameters_stage8.json
+++ b/applications/GeoMechanicsApplication/tests/1D-Consolidation_all_stages/ProjectParameters_stage8.json
@@ -25,7 +25,7 @@
         "echo_level":                         1,
         "clear_storage":                      false,
         "compute_reactions":                  true,
-        "move_mesh_flag":                     true,
+        "move_mesh_flag":                     false,
         "reform_dofs_at_each_step":           false,
         "nodal_smoothing":                    false,
         "block_builder":                      true,

--- a/applications/GeoMechanicsApplication/tests/1D-Consolidation_all_stages/ProjectParameters_stage9.json
+++ b/applications/GeoMechanicsApplication/tests/1D-Consolidation_all_stages/ProjectParameters_stage9.json
@@ -25,7 +25,7 @@
         "echo_level":                         1,
         "clear_storage":                      false,
         "compute_reactions":                  true,
-        "move_mesh_flag":                     true,
+        "move_mesh_flag":                     false,
         "reform_dofs_at_each_step":           false,
         "nodal_smoothing":                    false,
         "block_builder":                      true,

--- a/applications/GeoMechanicsApplication/tests/1d_consolidation.py
+++ b/applications/GeoMechanicsApplication/tests/1d_consolidation.py
@@ -24,7 +24,6 @@ class KratosGeoMechanics1DConsolidation(KratosUnittest.TestCase):
         # Code here will be placed AFTER every test in this TestCase.
         pass
 
-    @KratosUnittest.skip("Test test_1d_consolidation skipped temporary.")
     def test_1d_consolidation(self):
         """
         test 1D consolidation on elastic soil.

--- a/applications/GeoMechanicsApplication/tests/test_dirichlet_u.py
+++ b/applications/GeoMechanicsApplication/tests/test_dirichlet_u.py
@@ -16,6 +16,7 @@ class KratosGeoMechanicsDirichletUTests(KratosUnittest.TestCase):
         # Code here will be placed AFTER every test in this TestCase.
         pass
 
+    @KratosUnittest.skip("Test test_dirichket skipped temporary until u Dirichlet condition is fixed.")
     def test_dirichlet_u(self):
         """
         4 element elongation test in 2 stages. The incremental elastic material should show 

--- a/applications/GeoMechanicsApplication/tests/test_dirichlet_u.py
+++ b/applications/GeoMechanicsApplication/tests/test_dirichlet_u.py
@@ -16,7 +16,7 @@ class KratosGeoMechanicsDirichletUTests(KratosUnittest.TestCase):
         # Code here will be placed AFTER every test in this TestCase.
         pass
 
-    @KratosUnittest.skip("Test test_dirichket skipped temporary until u Dirichlet condition is fixed.")
+    @KratosUnittest.skip("Test test_dirichlet skipped temporary until u Dirichlet condition is fixed.")
     def test_dirichlet_u(self):
         """
         4 element elongation test in 2 stages. The incremental elastic material should show 


### PR DESCRIPTION
**📝 Description**
Activation of the GeoMechanicsApplication 1D consolidation test.


**🆕 Changelog**
This implies:
- revert the Dirichlet fix in incremental elasticity and disable the dirichlet_u test.
- set the move_mesh flag to false. ( I have no clue why its value in the consolidation test was true. )
- activate the 1D consolidation test
