### PR TITLE
[GeoMechanicsApplication] Make UPwBaseElement a non-template class

### DIFF
--- a/applications/GeoMechanicsApplication/custom_elements/U_Pw_base_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/U_Pw_base_element.cpp
@@ -142,10 +142,10 @@ void UPwBaseElement::Initialize(const ProcessInfo& rCurrentProcessInfo)
 
     if (mStressVector.size() != number_of_integration_points) {
         mStressVector.resize(number_of_integration_points);
-        for (unsigned int i = 0; i < mStressVector.size(); ++i) {
-            mStressVector[i].resize(GetStressStatePolicy().GetVoigtSize());
-            std::fill(mStressVector[i].begin(), mStressVector[i].end(), 0.0);
-        }
+        std::for_each(mStressVector.begin(), mStressVector.end(), [this](auto& stress_vector) {
+            stress_vector.resize(GetStressStatePolicy().GetVoigtSize());
+            std::fill(stress_vector.begin(), stress_vector.end(), 0.0);
+        });
     }
 
     mStateVariablesFinalized.resize(number_of_integration_points);
@@ -166,15 +166,12 @@ void UPwBaseElement::ResetConstitutiveLaw()
 {
     KRATOS_TRY
 
-    // erasing stress vectors
-    for (unsigned int i = 0; i < mStressVector.size(); ++i) {
-        mStressVector[i].clear();
-    }
+    std::for_each(mStressVector.begin(), mStressVector.end(),
+                  [](auto& stress_vector) { stress_vector.clear(); });
     mStressVector.clear();
 
-    for (unsigned int i = 0; i < mStateVariablesFinalized.size(); ++i) {
-        mStateVariablesFinalized[i].clear();
-    }
+    std::for_each(mStateVariablesFinalized.begin(), mStateVariablesFinalized.end(),
+                  [](auto& state_variables_finalized) { state_variables_finalized.clear(); });
     mStateVariablesFinalized.clear();
 
     KRATOS_CATCH("")

--- a/applications/GeoMechanicsApplication/custom_elements/U_Pw_base_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/U_Pw_base_element.cpp
@@ -115,7 +115,7 @@ int UPwBaseElement::Check(const ProcessInfo& rCurrentProcessInfo) const
 
     return 0;
 
-    KRATOS_CATCH("");
+    KRATOS_CATCH("")
 }
 
 void UPwBaseElement::Initialize(const ProcessInfo& rCurrentProcessInfo)

--- a/applications/GeoMechanicsApplication/custom_elements/U_Pw_base_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/U_Pw_base_element.cpp
@@ -166,12 +166,14 @@ void UPwBaseElement::ResetConstitutiveLaw()
 {
     KRATOS_TRY
 
-    std::for_each(mStressVector.begin(), mStressVector.end(),
-                  [](auto& stress_vector) { stress_vector.clear(); });
+    for (auto& r_stress_vector : mStressVector) {
+        r_stress_vector.clear();
+    }
     mStressVector.clear();
 
-    std::for_each(mStateVariablesFinalized.begin(), mStateVariablesFinalized.end(),
-                  [](auto& state_variables_finalized) { state_variables_finalized.clear(); });
+    for (auto& r_state_variables : mStateVariablesFinalized) {
+        r_state_variables.clear();
+    }
     mStateVariablesFinalized.clear();
 
     KRATOS_CATCH("")

--- a/applications/GeoMechanicsApplication/custom_elements/U_Pw_base_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/U_Pw_base_element.cpp
@@ -19,9 +19,7 @@
 namespace Kratos
 {
 
-//----------------------------------------------------------------------------------------
-template <unsigned int TDim, unsigned int TNumNodes>
-int UPwBaseElement<TDim, TNumNodes>::Check(const ProcessInfo& rCurrentProcessInfo) const
+int UPwBaseElement::Check(const ProcessInfo& rCurrentProcessInfo) const
 {
     KRATOS_TRY
 
@@ -33,7 +31,7 @@ int UPwBaseElement<TDim, TNumNodes>::Check(const ProcessInfo& rCurrentProcessInf
     const GeometryType&   rGeom = this->GetGeometry();
 
     // verify nodal variables and dofs
-    for (unsigned int i = 0; i < TNumNodes; ++i) {
+    for (unsigned int i = 0; i < this->GetGeometry().PointsNumber(); ++i) {
         if (rGeom[i].SolutionStepsDataHas(DISPLACEMENT) == false)
             KRATOS_ERROR << "missing variable DISPLACEMENT on node " << rGeom[i].Id() << std::endl;
 
@@ -108,9 +106,9 @@ int UPwBaseElement<TDim, TNumNodes>::Check(const ProcessInfo& rCurrentProcessInf
                         "invalid value at element"
                      << this->Id() << std::endl;
 
-    if (TDim == 2) {
+    if (this->GetGeometry().WorkingSpaceDimension() == 2) {
         // If this is a 2D problem, nodes must be in XY plane
-        for (unsigned int i = 0; i < TNumNodes; ++i) {
+        for (unsigned int i = 0; i < this->GetGeometry().PointsNumber(); ++i) {
             if (rGeom[i].Z() != 0.0)
                 KRATOS_ERROR << " Node with non-zero Z coordinate found. Id: " << rGeom[i].Id() << std::endl;
         }
@@ -121,9 +119,7 @@ int UPwBaseElement<TDim, TNumNodes>::Check(const ProcessInfo& rCurrentProcessInf
     KRATOS_CATCH("");
 }
 
-//----------------------------------------------------------------------------------------
-template <unsigned int TDim, unsigned int TNumNodes>
-void UPwBaseElement<TDim, TNumNodes>::Initialize(const ProcessInfo& rCurrentProcessInfo)
+void UPwBaseElement::Initialize(const ProcessInfo& rCurrentProcessInfo)
 {
     KRATOS_TRY
 
@@ -167,9 +163,7 @@ void UPwBaseElement<TDim, TNumNodes>::Initialize(const ProcessInfo& rCurrentProc
     KRATOS_CATCH("")
 }
 
-//----------------------------------------------------------------------------------------
-template <unsigned int TDim, unsigned int TNumNodes>
-void UPwBaseElement<TDim, TNumNodes>::ResetConstitutiveLaw()
+void UPwBaseElement::ResetConstitutiveLaw()
 {
     KRATOS_TRY
 
@@ -187,20 +181,16 @@ void UPwBaseElement<TDim, TNumNodes>::ResetConstitutiveLaw()
     KRATOS_CATCH("")
 }
 
-//----------------------------------------------------------------------------------------
-template <unsigned int TDim, unsigned int TNumNodes>
-void UPwBaseElement<TDim, TNumNodes>::GetDofList(DofsVectorType& rElementalDofList, const ProcessInfo&) const
+void UPwBaseElement::GetDofList(DofsVectorType& rElementalDofList, const ProcessInfo&) const
 {
     rElementalDofList = GetDofs();
 }
 
-//----------------------------------------------------------------------------------------
-template <unsigned int TDim, unsigned int TNumNodes>
-GeometryData::IntegrationMethod UPwBaseElement<TDim, TNumNodes>::GetIntegrationMethod() const
+GeometryData::IntegrationMethod UPwBaseElement::GetIntegrationMethod() const
 {
     GeometryData::IntegrationMethod GI_GAUSS;
 
-    switch (TNumNodes) {
+    switch (this->GetGeometry().PointsNumber()) {
     case 3:
         GI_GAUSS = GeometryData::IntegrationMethod::GI_GAUSS_2;
         break;
@@ -221,11 +211,9 @@ GeometryData::IntegrationMethod UPwBaseElement<TDim, TNumNodes>::GetIntegrationM
     return GI_GAUSS;
 }
 
-//----------------------------------------------------------------------------------------
-template <unsigned int TDim, unsigned int TNumNodes>
-void UPwBaseElement<TDim, TNumNodes>::CalculateLocalSystem(MatrixType&        rLeftHandSideMatrix,
-                                                           VectorType&        rRightHandSideVector,
-                                                           const ProcessInfo& rCurrentProcessInfo)
+void UPwBaseElement::CalculateLocalSystem(MatrixType&        rLeftHandSideMatrix,
+                                          VectorType&        rRightHandSideVector,
+                                          const ProcessInfo& rCurrentProcessInfo)
 {
     KRATOS_TRY
 
@@ -239,10 +227,7 @@ void UPwBaseElement<TDim, TNumNodes>::CalculateLocalSystem(MatrixType&        rL
     KRATOS_CATCH("")
 }
 
-//----------------------------------------------------------------------------------------
-template <unsigned int TDim, unsigned int TNumNodes>
-void UPwBaseElement<TDim, TNumNodes>::CalculateLeftHandSide(MatrixType&        rLeftHandSideMatrix,
-                                                            const ProcessInfo& rCurrentProcessInfo)
+void UPwBaseElement::CalculateLeftHandSide(MatrixType& rLeftHandSideMatrix, const ProcessInfo& rCurrentProcessInfo)
 {
     KRATOS_TRY
 
@@ -256,10 +241,7 @@ void UPwBaseElement<TDim, TNumNodes>::CalculateLeftHandSide(MatrixType&        r
     KRATOS_CATCH("")
 }
 
-//----------------------------------------------------------------------------------------
-template <unsigned int TDim, unsigned int TNumNodes>
-void UPwBaseElement<TDim, TNumNodes>::CalculateRightHandSide(VectorType& rRightHandSideVector,
-                                                             const ProcessInfo& rCurrentProcessInfo)
+void UPwBaseElement::CalculateRightHandSide(VectorType& rRightHandSideVector, const ProcessInfo& rCurrentProcessInfo)
 {
     KRATOS_TRY
 
@@ -273,16 +255,12 @@ void UPwBaseElement<TDim, TNumNodes>::CalculateRightHandSide(VectorType& rRightH
     KRATOS_CATCH("")
 }
 
-//----------------------------------------------------------------------------------------
-template <unsigned int TDim, unsigned int TNumNodes>
-void UPwBaseElement<TDim, TNumNodes>::EquationIdVector(EquationIdVectorType& rResult, const ProcessInfo&) const
+void UPwBaseElement::EquationIdVector(EquationIdVectorType& rResult, const ProcessInfo&) const
 {
     rResult = Geo::DofUtilities::ExtractEquationIdsFrom(GetDofs());
 }
 
-//----------------------------------------------------------------------------------------
-template <unsigned int TDim, unsigned int TNumNodes>
-void UPwBaseElement<TDim, TNumNodes>::CalculateMassMatrix(MatrixType& rMassMatrix, const ProcessInfo& rCurrentProcessInfo)
+void UPwBaseElement::CalculateMassMatrix(MatrixType& rMassMatrix, const ProcessInfo& rCurrentProcessInfo)
 {
     KRATOS_TRY
 
@@ -293,10 +271,7 @@ void UPwBaseElement<TDim, TNumNodes>::CalculateMassMatrix(MatrixType& rMassMatri
     KRATOS_CATCH("")
 }
 
-//----------------------------------------------------------------------------------------
-template <unsigned int TDim, unsigned int TNumNodes>
-void UPwBaseElement<TDim, TNumNodes>::CalculateDampingMatrix(MatrixType&        rDampingMatrix,
-                                                             const ProcessInfo& rCurrentProcessInfo)
+void UPwBaseElement::CalculateDampingMatrix(MatrixType& rDampingMatrix, const ProcessInfo& rCurrentProcessInfo)
 {
     KRATOS_TRY
 
@@ -315,32 +290,24 @@ void UPwBaseElement<TDim, TNumNodes>::CalculateDampingMatrix(MatrixType&        
     KRATOS_CATCH("")
 }
 
-//----------------------------------------------------------------------------------------
-template <unsigned int TDim, unsigned int TNumNodes>
-void UPwBaseElement<TDim, TNumNodes>::GetValuesVector(Vector& rValues, int Step) const
+void UPwBaseElement::GetValuesVector(Vector& rValues, int Step) const
 {
     rValues = Geo::DofUtilities::ExtractSolutionStepValuesOfUPwDofs(GetDofs(), Step);
 }
 
-//----------------------------------------------------------------------------------------
-template <unsigned int TDim, unsigned int TNumNodes>
-void UPwBaseElement<TDim, TNumNodes>::GetFirstDerivativesVector(Vector& rValues, int Step) const
+void UPwBaseElement::GetFirstDerivativesVector(Vector& rValues, int Step) const
 {
     rValues = Geo::DofUtilities::ExtractFirstTimeDerivativesOfUPwDofs(GetDofs(), Step);
 }
 
-//----------------------------------------------------------------------------------------
-template <unsigned int TDim, unsigned int TNumNodes>
-void UPwBaseElement<TDim, TNumNodes>::GetSecondDerivativesVector(Vector& rValues, int Step) const
+void UPwBaseElement::GetSecondDerivativesVector(Vector& rValues, int Step) const
 {
     rValues = Geo::DofUtilities::ExtractSecondTimeDerivativesOfUPwDofs(GetDofs(), Step);
 }
 
-//-------------------------------------------------------------------------------------------------------------------------------------------
-template <unsigned int TDim, unsigned int TNumNodes>
-void UPwBaseElement<TDim, TNumNodes>::SetValuesOnIntegrationPoints(const Variable<Vector>& rVariable,
-                                                                   const std::vector<Vector>& rValues,
-                                                                   const ProcessInfo& rCurrentProcessInfo)
+void UPwBaseElement::SetValuesOnIntegrationPoints(const Variable<Vector>&    rVariable,
+                                                  const std::vector<Vector>& rValues,
+                                                  const ProcessInfo&         rCurrentProcessInfo)
 {
     KRATOS_TRY
 
@@ -350,11 +317,9 @@ void UPwBaseElement<TDim, TNumNodes>::SetValuesOnIntegrationPoints(const Variabl
     KRATOS_CATCH("")
 }
 
-//-------------------------------------------------------------------------------------------------------------------------------------------
-template <unsigned int TDim, unsigned int TNumNodes>
-void UPwBaseElement<TDim, TNumNodes>::SetValuesOnIntegrationPoints(const Variable<Matrix>& rVariable,
-                                                                   const std::vector<Matrix>& rValues,
-                                                                   const ProcessInfo& rCurrentProcessInfo)
+void UPwBaseElement::SetValuesOnIntegrationPoints(const Variable<Matrix>&    rVariable,
+                                                  const std::vector<Matrix>& rValues,
+                                                  const ProcessInfo&         rCurrentProcessInfo)
 {
     KRATOS_TRY
 
@@ -365,11 +330,9 @@ void UPwBaseElement<TDim, TNumNodes>::SetValuesOnIntegrationPoints(const Variabl
     KRATOS_CATCH("")
 }
 
-//-------------------------------------------------------------------------------------------------------------------------------------------
-template <unsigned int TDim, unsigned int TNumNodes>
-void UPwBaseElement<TDim, TNumNodes>::SetValuesOnIntegrationPoints(const Variable<double>& rVariable,
-                                                                   const std::vector<double>& rValues,
-                                                                   const ProcessInfo& rCurrentProcessInfo)
+void UPwBaseElement::SetValuesOnIntegrationPoints(const Variable<double>&    rVariable,
+                                                  const std::vector<double>& rValues,
+                                                  const ProcessInfo&         rCurrentProcessInfo)
 {
     KRATOS_TRY
 
@@ -380,11 +343,9 @@ void UPwBaseElement<TDim, TNumNodes>::SetValuesOnIntegrationPoints(const Variabl
     KRATOS_CATCH("")
 }
 
-//----------------------------------------------------------------------------------------
-template <unsigned int TDim, unsigned int TNumNodes>
-void UPwBaseElement<TDim, TNumNodes>::CalculateOnIntegrationPoints(const Variable<ConstitutiveLaw::Pointer>& rVariable,
-                                                                   std::vector<ConstitutiveLaw::Pointer>& rValues,
-                                                                   const ProcessInfo& rCurrentProcessInfo)
+void UPwBaseElement::CalculateOnIntegrationPoints(const Variable<ConstitutiveLaw::Pointer>& rVariable,
+                                                  std::vector<ConstitutiveLaw::Pointer>& rValues,
+                                                  const ProcessInfo& rCurrentProcessInfo)
 {
     KRATOS_TRY
 
@@ -398,11 +359,9 @@ void UPwBaseElement<TDim, TNumNodes>::CalculateOnIntegrationPoints(const Variabl
     KRATOS_CATCH("")
 }
 
-//----------------------------------------------------------------------------------------
-template <unsigned int TDim, unsigned int TNumNodes>
-void UPwBaseElement<TDim, TNumNodes>::CalculateOnIntegrationPoints(const Variable<array_1d<double, 3>>& rVariable,
-                                                                   std::vector<array_1d<double, 3>>& rValues,
-                                                                   const ProcessInfo& rCurrentProcessInfo)
+void UPwBaseElement::CalculateOnIntegrationPoints(const Variable<array_1d<double, 3>>& rVariable,
+                                                  std::vector<array_1d<double, 3>>&    rValues,
+                                                  const ProcessInfo& rCurrentProcessInfo)
 {
     KRATOS_TRY
 
@@ -413,11 +372,9 @@ void UPwBaseElement<TDim, TNumNodes>::CalculateOnIntegrationPoints(const Variabl
     KRATOS_CATCH("")
 }
 
-//----------------------------------------------------------------------------------------
-template <unsigned int TDim, unsigned int TNumNodes>
-void UPwBaseElement<TDim, TNumNodes>::CalculateOnIntegrationPoints(const Variable<Matrix>& rVariable,
-                                                                   std::vector<Matrix>& rValues,
-                                                                   const ProcessInfo& rCurrentProcessInfo)
+void UPwBaseElement::CalculateOnIntegrationPoints(const Variable<Matrix>& rVariable,
+                                                  std::vector<Matrix>&    rValues,
+                                                  const ProcessInfo&      rCurrentProcessInfo)
 {
     KRATOS_TRY
 
@@ -428,11 +385,9 @@ void UPwBaseElement<TDim, TNumNodes>::CalculateOnIntegrationPoints(const Variabl
     KRATOS_CATCH("")
 }
 
-//----------------------------------------------------------------------------------------
-template <unsigned int TDim, unsigned int TNumNodes>
-void UPwBaseElement<TDim, TNumNodes>::CalculateOnIntegrationPoints(const Variable<Vector>& rVariable,
-                                                                   std::vector<Vector>& rValues,
-                                                                   const ProcessInfo& rCurrentProcessInfo)
+void UPwBaseElement::CalculateOnIntegrationPoints(const Variable<Vector>& rVariable,
+                                                  std::vector<Vector>&    rValues,
+                                                  const ProcessInfo&      rCurrentProcessInfo)
 {
     KRATOS_TRY
 
@@ -443,11 +398,9 @@ void UPwBaseElement<TDim, TNumNodes>::CalculateOnIntegrationPoints(const Variabl
     KRATOS_CATCH("")
 }
 
-//----------------------------------------------------------------------------------------
-template <unsigned int TDim, unsigned int TNumNodes>
-void UPwBaseElement<TDim, TNumNodes>::CalculateOnIntegrationPoints(const Variable<double>& rVariable,
-                                                                   std::vector<double>& rValues,
-                                                                   const ProcessInfo& rCurrentProcessInfo)
+void UPwBaseElement::CalculateOnIntegrationPoints(const Variable<double>& rVariable,
+                                                  std::vector<double>&    rValues,
+                                                  const ProcessInfo&      rCurrentProcessInfo)
 {
     KRATOS_TRY
 
@@ -458,10 +411,7 @@ void UPwBaseElement<TDim, TNumNodes>::CalculateOnIntegrationPoints(const Variabl
     KRATOS_CATCH("")
 }
 
-//----------------------------------------------------------------------------------------
-template <unsigned int TDim, unsigned int TNumNodes>
-void UPwBaseElement<TDim, TNumNodes>::CalculateMaterialStiffnessMatrix(MatrixType& rStiffnessMatrix,
-                                                                       const ProcessInfo& CurrentProcessInfo)
+void UPwBaseElement::CalculateMaterialStiffnessMatrix(MatrixType& rStiffnessMatrix, const ProcessInfo& CurrentProcessInfo)
 {
     KRATOS_TRY
 
@@ -472,14 +422,11 @@ void UPwBaseElement<TDim, TNumNodes>::CalculateMaterialStiffnessMatrix(MatrixTyp
     KRATOS_CATCH("")
 }
 
-//----------------------------------------------------------------------------------------
-
-template <unsigned int TDim, unsigned int TNumNodes>
-void UPwBaseElement<TDim, TNumNodes>::CalculateAll(MatrixType&        rLeftHandSideMatrix,
-                                                   VectorType&        rRightHandSideVector,
-                                                   const ProcessInfo& CurrentProcessInfo,
-                                                   const bool         CalculateStiffnessMatrixFlag,
-                                                   const bool         CalculateResidualVectorFlag)
+void UPwBaseElement::CalculateAll(MatrixType&        rLeftHandSideMatrix,
+                                  VectorType&        rRightHandSideVector,
+                                  const ProcessInfo& CurrentProcessInfo,
+                                  const bool         CalculateStiffnessMatrixFlag,
+                                  const bool         CalculateResidualVectorFlag)
 {
     KRATOS_TRY
 
@@ -490,17 +437,14 @@ void UPwBaseElement<TDim, TNumNodes>::CalculateAll(MatrixType&        rLeftHandS
     KRATOS_CATCH("")
 }
 
-//----------------------------------------------------------------------------------------
-template <unsigned int TDim, unsigned int TNumNodes>
-double UPwBaseElement<TDim, TNumNodes>::CalculateIntegrationCoefficient(const GeometryType::IntegrationPointType& rIntegrationPoint,
-                                                                        double detJ) const
+double UPwBaseElement::CalculateIntegrationCoefficient(const GeometryType::IntegrationPointType& rIntegrationPoint,
+                                                       double detJ) const
 
 {
     return mpStressStatePolicy->CalculateIntegrationCoefficient(rIntegrationPoint, detJ, GetGeometry());
 }
 
-template <unsigned int TDim, unsigned int TNumNodes>
-std::vector<double> UPwBaseElement<TDim, TNumNodes>::CalculateIntegrationCoefficients(
+std::vector<double> UPwBaseElement::CalculateIntegrationCoefficients(
     const GeometryType::IntegrationPointsArrayType& rIntegrationPoints, const Vector& rDetJs) const
 {
     auto result = std::vector<double>{};
@@ -511,9 +455,7 @@ std::vector<double> UPwBaseElement<TDim, TNumNodes>::CalculateIntegrationCoeffic
     return result;
 }
 
-//----------------------------------------------------------------------------------------
-template <unsigned int TDim, unsigned int TNumNodes>
-void UPwBaseElement<TDim, TNumNodes>::CalculateDerivativesOnInitialConfiguration(
+void UPwBaseElement::CalculateDerivativesOnInitialConfiguration(
     double& detJ, Matrix& J0, Matrix& InvJ0, Matrix& DNu_DX0, unsigned int GPoint) const
 {
     KRATOS_TRY
@@ -530,12 +472,7 @@ void UPwBaseElement<TDim, TNumNodes>::CalculateDerivativesOnInitialConfiguration
     KRATOS_CATCH("")
 }
 
-//----------------------------------------------------------------------------------------
-template <unsigned int TDim, unsigned int TNumNodes>
-void UPwBaseElement<TDim, TNumNodes>::CalculateJacobianOnCurrentConfiguration(double& detJ,
-                                                                              Matrix& rJ,
-                                                                              Matrix& rInvJ,
-                                                                              unsigned int GPoint) const
+void UPwBaseElement::CalculateJacobianOnCurrentConfiguration(double& detJ, Matrix& rJ, Matrix& rInvJ, unsigned int GPoint) const
 {
     KRATOS_TRY
 
@@ -545,40 +482,17 @@ void UPwBaseElement<TDim, TNumNodes>::CalculateJacobianOnCurrentConfiguration(do
     KRATOS_CATCH("")
 }
 
-//----------------------------------------------------------------------------------------
-template <unsigned int TDim, unsigned int TNumNodes>
-unsigned int UPwBaseElement<TDim, TNumNodes>::GetNumberOfDOF() const
+unsigned int UPwBaseElement::GetNumberOfDOF() const
 {
-    return TNumNodes * (TDim + 1);
+    return this->GetGeometry().PointsNumber() * (this->GetGeometry().WorkingSpaceDimension() + 1);
 }
 
-template <unsigned int TDim, unsigned int TNumNodes>
-Element::DofsVectorType UPwBaseElement<TDim, TNumNodes>::GetDofs() const
+Element::DofsVectorType UPwBaseElement::GetDofs() const
 {
     return Geo::DofUtilities::ExtractUPwDofsFromNodes(this->GetGeometry(),
                                                       this->GetGeometry().WorkingSpaceDimension());
 }
 
-template <unsigned int TDim, unsigned int TNumNodes>
-StressStatePolicy& UPwBaseElement<TDim, TNumNodes>::GetStressStatePolicy() const
-{
-    return *mpStressStatePolicy;
-}
-
-//----------------------------------------------------------------------------------------
-template class UPwBaseElement<2, 3>;
-template class UPwBaseElement<2, 4>;
-template class UPwBaseElement<3, 4>;
-template class UPwBaseElement<3, 6>;
-template class UPwBaseElement<3, 8>;
-
-template class UPwBaseElement<2, 6>;
-template class UPwBaseElement<2, 8>;
-template class UPwBaseElement<2, 9>;
-template class UPwBaseElement<2, 10>;
-template class UPwBaseElement<2, 15>;
-template class UPwBaseElement<3, 10>;
-template class UPwBaseElement<3, 20>;
-template class UPwBaseElement<3, 27>;
+StressStatePolicy& UPwBaseElement::GetStressStatePolicy() const { return *mpStressStatePolicy; }
 
 } // Namespace Kratos

--- a/applications/GeoMechanicsApplication/custom_elements/U_Pw_base_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/U_Pw_base_element.cpp
@@ -478,7 +478,7 @@ void UPwBaseElement::CalculateJacobianOnCurrentConfiguration(double& detJ, Matri
     KRATOS_CATCH("")
 }
 
-unsigned int UPwBaseElement::GetNumberOfDOF() const
+std::size_t UPwBaseElement::GetNumberOfDOF() const
 {
     return this->GetGeometry().PointsNumber() * (this->GetGeometry().WorkingSpaceDimension() + 1);
 }

--- a/applications/GeoMechanicsApplication/custom_elements/U_Pw_base_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/U_Pw_base_element.cpp
@@ -24,8 +24,7 @@ int UPwBaseElement::Check(const ProcessInfo& rCurrentProcessInfo) const
     KRATOS_TRY
 
     // Base class checks for positive area and Id > 0
-    int ierr = Element::Check(rCurrentProcessInfo);
-    if (ierr != 0) return ierr;
+    if (int ierr = Element::Check(rCurrentProcessInfo); ierr != 0) return ierr;
 
     const PropertiesType& rProp = this->GetProperties();
     const GeometryType&   rGeom = this->GetGeometry();

--- a/applications/GeoMechanicsApplication/custom_elements/U_Pw_base_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/U_Pw_base_element.cpp
@@ -142,10 +142,10 @@ void UPwBaseElement::Initialize(const ProcessInfo& rCurrentProcessInfo)
 
     if (mStressVector.size() != number_of_integration_points) {
         mStressVector.resize(number_of_integration_points);
-        std::for_each(mStressVector.begin(), mStressVector.end(), [this](auto& stress_vector) {
-            stress_vector.resize(GetStressStatePolicy().GetVoigtSize());
-            std::fill(stress_vector.begin(), stress_vector.end(), 0.0);
-        });
+        for (auto& r_stress_vector : mStressVector) {
+            r_stress_vector.resize(GetStressStatePolicy().GetVoigtSize());
+            std::fill(r_stress_vector.begin(), r_stress_vector.end(), 0.0);
+        }
     }
 
     mStateVariablesFinalized.resize(number_of_integration_points);

--- a/applications/GeoMechanicsApplication/custom_elements/U_Pw_base_element.hpp
+++ b/applications/GeoMechanicsApplication/custom_elements/U_Pw_base_element.hpp
@@ -173,7 +173,7 @@ protected:
 
     void CalculateJacobianOnCurrentConfiguration(double& detJ, Matrix& rJ, Matrix& rInvJ, unsigned int GPoint) const;
 
-    virtual unsigned int GetNumberOfDOF() const;
+    virtual std::size_t GetNumberOfDOF() const;
 
     StressStatePolicy& GetStressStatePolicy() const;
 

--- a/applications/GeoMechanicsApplication/custom_elements/U_Pw_base_element.hpp
+++ b/applications/GeoMechanicsApplication/custom_elements/U_Pw_base_element.hpp
@@ -39,7 +39,7 @@ public:
 
     KRATOS_CLASS_INTRUSIVE_POINTER_DEFINITION(UPwBaseElement);
 
-    explicit UPwBaseElement(IndexType NewId = 0) : Element(NewId) {}
+    using Element::Element;
 
     /// Constructor using an array of nodes
     UPwBaseElement(IndexType NewId, const NodesArrayType& ThisNodes, std::unique_ptr<StressStatePolicy> pStressStatePolicy)

--- a/applications/GeoMechanicsApplication/custom_elements/U_Pw_base_element.hpp
+++ b/applications/GeoMechanicsApplication/custom_elements/U_Pw_base_element.hpp
@@ -32,7 +32,6 @@
 namespace Kratos
 {
 
-template <unsigned int TDim, unsigned int TNumNodes>
 class KRATOS_API(GEO_MECHANICS_APPLICATION) UPwBaseElement : public Element
 {
 public:

--- a/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_FIC_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_FIC_element.cpp
@@ -45,7 +45,7 @@ void UPwSmallStrainFICElement<TDim, TNumNodes>::Initialize(const ProcessInfo& rC
 {
     KRATOS_TRY
 
-    UPwBaseElement<TDim, TNumNodes>::Initialize(rCurrentProcessInfo);
+    UPwBaseElement::Initialize(rCurrentProcessInfo);
 
     auto const VoigtSize = this->GetStressStatePolicy().GetVoigtSize();
     for (unsigned int i = 0; i < TDim; ++i) {

--- a/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_FIC_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_FIC_element.cpp
@@ -85,7 +85,7 @@ int UPwSmallStrainFICElement<TDim, TNumNodes>::Check(const ProcessInfo& rCurrent
 
     return ierr;
 
-    KRATOS_CATCH("");
+    KRATOS_CATCH("")
 }
 
 //----------------------------------------------------------------------------------------------------

--- a/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_FIC_element.hpp
+++ b/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_FIC_element.hpp
@@ -42,10 +42,10 @@ public:
     using NodesArrayType = GeometryType::PointsArrayType;
     using VectorType     = Vector;
     using MatrixType     = Matrix;
-    using UPwBaseElement<TDim, TNumNodes>::mConstitutiveLawVector;
-    using UPwBaseElement<TDim, TNumNodes>::mStressVector;
-    using UPwBaseElement<TDim, TNumNodes>::mStateVariablesFinalized;
-    using UPwBaseElement<TDim, TNumNodes>::mThisIntegrationMethod;
+    using UPwBaseElement::mConstitutiveLawVector;
+    using UPwBaseElement::mStateVariablesFinalized;
+    using UPwBaseElement::mStressVector;
+    using UPwBaseElement::mThisIntegrationMethod;
 
     using ElementVariables = typename UPwSmallStrainElement<TDim, TNumNodes>::ElementVariables;
 

--- a/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_element.cpp
@@ -46,7 +46,7 @@ int UPwSmallStrainElement<TDim, TNumNodes>::Check(const ProcessInfo& rCurrentPro
 
     // Base class checks for positive area and Id > 0
     // Verify generic variables
-    int ierr = UPwBaseElement<TDim, TNumNodes>::Check(rCurrentProcessInfo);
+    int ierr = UPwBaseElement::Check(rCurrentProcessInfo);
     if (ierr != 0) return ierr;
 
     const PropertiesType& rProp = this->GetProperties();

--- a/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_element.hpp
+++ b/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_element.hpp
@@ -26,7 +26,7 @@ namespace Kratos
 {
 
 template <unsigned int TDim, unsigned int TNumNodes>
-class KRATOS_API(GEO_MECHANICS_APPLICATION) UPwSmallStrainElement : public UPwBaseElement<TDim, TNumNodes>
+class KRATOS_API(GEO_MECHANICS_APPLICATION) UPwSmallStrainElement : public UPwBaseElement
 {
 public:
     KRATOS_CLASS_INTRUSIVE_POINTER_DEFINITION(UPwSmallStrainElement);
@@ -40,25 +40,25 @@ public:
     using MatrixType     = Matrix;
     /// The definition of the sizetype
     using SizeType = std::size_t;
-    using UPwBaseElement<TDim, TNumNodes>::mConstitutiveLawVector;
-    using UPwBaseElement<TDim, TNumNodes>::mRetentionLawVector;
-    using UPwBaseElement<TDim, TNumNodes>::mStressVector;
-    using UPwBaseElement<TDim, TNumNodes>::mStateVariablesFinalized;
-    using UPwBaseElement<TDim, TNumNodes>::mIsInitialised;
-    using UPwBaseElement<TDim, TNumNodes>::CalculateDerivativesOnInitialConfiguration;
-    using UPwBaseElement<TDim, TNumNodes>::mThisIntegrationMethod;
+    using UPwBaseElement::CalculateDerivativesOnInitialConfiguration;
+    using UPwBaseElement::mConstitutiveLawVector;
+    using UPwBaseElement::mIsInitialised;
+    using UPwBaseElement::mRetentionLawVector;
+    using UPwBaseElement::mStateVariablesFinalized;
+    using UPwBaseElement::mStressVector;
+    using UPwBaseElement::mThisIntegrationMethod;
 
-    explicit UPwSmallStrainElement(IndexType NewId = 0) : UPwBaseElement<TDim, TNumNodes>(NewId) {}
+    explicit UPwSmallStrainElement(IndexType NewId = 0) : UPwBaseElement(NewId) {}
 
     /// Constructor using an array of nodes
     UPwSmallStrainElement(IndexType NewId, const NodesArrayType& ThisNodes, std::unique_ptr<StressStatePolicy> pStressStatePolicy)
-        : UPwBaseElement<TDim, TNumNodes>(NewId, ThisNodes, std::move(pStressStatePolicy))
+        : UPwBaseElement(NewId, ThisNodes, std::move(pStressStatePolicy))
     {
     }
 
     /// Constructor using Geometry
     UPwSmallStrainElement(IndexType NewId, GeometryType::Pointer pGeometry, std::unique_ptr<StressStatePolicy> pStressStatePolicy)
-        : UPwBaseElement<TDim, TNumNodes>(NewId, pGeometry, std::move(pStressStatePolicy))
+        : UPwBaseElement(NewId, pGeometry, std::move(pStressStatePolicy))
     {
     }
 
@@ -67,7 +67,7 @@ public:
                           GeometryType::Pointer              pGeometry,
                           PropertiesType::Pointer            pProperties,
                           std::unique_ptr<StressStatePolicy> pStressStatePolicy)
-        : UPwBaseElement<TDim, TNumNodes>(NewId, pGeometry, pProperties, std::move(pStressStatePolicy))
+        : UPwBaseElement(NewId, pGeometry, pProperties, std::move(pStressStatePolicy))
     {
     }
 
@@ -97,7 +97,7 @@ public:
                                       const std::vector<Vector>& rValues,
                                       const ProcessInfo&         rCurrentProcessInfo) override;
 
-    using UPwBaseElement<TDim, TNumNodes>::SetValuesOnIntegrationPoints;
+    using UPwBaseElement::SetValuesOnIntegrationPoints;
 
     void CalculateOnIntegrationPoints(const Variable<double>& rVariable,
                                       std::vector<double>&    rOutput,

--- a/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_element.hpp
+++ b/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_element.hpp
@@ -115,6 +115,8 @@ public:
                                       std::vector<Matrix>&    rOutput,
                                       const ProcessInfo&      rCurrentProcessInfo) override;
 
+    using UPwBaseElement::CalculateOnIntegrationPoints;
+
     std::string Info() const override
     {
         return "U-Pw small strain Element #" + std::to_string(this->Id()) +

--- a/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_interface_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_interface_element.cpp
@@ -49,7 +49,7 @@ int UPwSmallStrainInterfaceElement<TDim, TNumNodes>::Check(const ProcessInfo& rC
         << "Element found with Id 0 or negative, element: " << this->Id() << std::endl;
 
     // Verify generic variables
-    int ierr = UPwBaseElement<TDim, TNumNodes>::Check(rCurrentProcessInfo);
+    int ierr = UPwBaseElement::Check(rCurrentProcessInfo);
     if (ierr != 0) return ierr;
 
     // Verify specific properties
@@ -124,7 +124,7 @@ void UPwSmallStrainInterfaceElement<TDim, TNumNodes>::Initialize(const ProcessIn
 {
     KRATOS_TRY
 
-    UPwBaseElement<TDim, TNumNodes>::Initialize(rCurrentProcessInfo);
+    UPwBaseElement::Initialize(rCurrentProcessInfo);
 
     // Compute initial gap of the joint
     this->CalculateInitialGap(this->GetGeometry());
@@ -1873,11 +1873,11 @@ void UPwSmallStrainInterfaceElement<TDim, TNumNodes>::CalculateAndAddCouplingMat
 
     if (!rVariables.IgnoreUndrained) {
         const double SaturationCoefficient = rVariables.DegreeOfSaturation / rVariables.BishopCoefficient;
-        const BoundedMatrix<double, TNumNodes, TNumNodes * TDim> undrained_terms =
+        const BoundedMatrix<double, TNumNodes, TNumNodes * TDim> transposed_coupling_matrix =
             PORE_PRESSURE_SIGN_FACTOR * SaturationCoefficient * rVariables.VelocityCoefficient *
             trans(coupling_matrix);
 
-        GeoElementUtilities::AssemblePUBlockMatrix(rLeftHandSideMatrix, undrained_terms);
+        GeoElementUtilities::AssemblePUBlockMatrix(rLeftHandSideMatrix, transposed_coupling_matrix);
     }
 
     KRATOS_CATCH("")

--- a/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_interface_element.hpp
+++ b/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_interface_element.hpp
@@ -105,6 +105,8 @@ public:
     void CalculateOnIntegrationPoints(const Variable<array_1d<double, 3>>& rVariable,
                                       std::vector<array_1d<double, 3>>&    rValues,
                                       const ProcessInfo& rCurrentProcessInfo) override;
+    
+    using UPwBaseElement::CalculateOnIntegrationPoints;
 
 protected:
     struct SFGradAuxVariables {

--- a/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_interface_element.hpp
+++ b/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_interface_element.hpp
@@ -25,8 +25,7 @@ namespace Kratos
 {
 
 template <unsigned int TDim, unsigned int TNumNodes>
-class KRATOS_API(GEO_MECHANICS_APPLICATION) UPwSmallStrainInterfaceElement
-    : public UPwBaseElement<TDim, TNumNodes>
+class KRATOS_API(GEO_MECHANICS_APPLICATION) UPwSmallStrainInterfaceElement : public UPwBaseElement
 {
 public:
     KRATOS_CLASS_INTRUSIVE_POINTER_DEFINITION(UPwSmallStrainInterfaceElement);
@@ -38,23 +37,20 @@ public:
     using NodesArrayType = GeometryType::PointsArrayType;
     using VectorType     = Vector;
     using MatrixType     = Matrix;
-    using UPwBaseElement<TDim, TNumNodes>::mConstitutiveLawVector;
-    using UPwBaseElement<TDim, TNumNodes>::mRetentionLawVector;
-    using UPwBaseElement<TDim, TNumNodes>::mStressVector;
-    using UPwBaseElement<TDim, TNumNodes>::mStateVariablesFinalized;
-    using UPwBaseElement<TDim, TNumNodes>::CalculateDerivativesOnInitialConfiguration;
-    using UPwBaseElement<TDim, TNumNodes>::mThisIntegrationMethod;
+    using UPwBaseElement::CalculateDerivativesOnInitialConfiguration;
+    using UPwBaseElement::mConstitutiveLawVector;
+    using UPwBaseElement::mRetentionLawVector;
+    using UPwBaseElement::mStateVariablesFinalized;
+    using UPwBaseElement::mStressVector;
+    using UPwBaseElement::mThisIntegrationMethod;
 
-    explicit UPwSmallStrainInterfaceElement(IndexType NewId = 0)
-        : UPwBaseElement<TDim, TNumNodes>(NewId)
-    {
-    }
+    explicit UPwSmallStrainInterfaceElement(IndexType NewId = 0) : UPwBaseElement(NewId) {}
 
     /// Constructor using an array of nodes
     UPwSmallStrainInterfaceElement(IndexType                          NewId,
                                    const NodesArrayType&              ThisNodes,
                                    std::unique_ptr<StressStatePolicy> pStressStatePolicy)
-        : UPwBaseElement<TDim, TNumNodes>(NewId, ThisNodes, std::move(pStressStatePolicy))
+        : UPwBaseElement(NewId, ThisNodes, std::move(pStressStatePolicy))
     {
     }
 
@@ -62,7 +58,7 @@ public:
     UPwSmallStrainInterfaceElement(IndexType                          NewId,
                                    GeometryType::Pointer              pGeometry,
                                    std::unique_ptr<StressStatePolicy> pStressStatePolicy)
-        : UPwBaseElement<TDim, TNumNodes>(NewId, pGeometry, std::move(pStressStatePolicy))
+        : UPwBaseElement(NewId, pGeometry, std::move(pStressStatePolicy))
     {
     }
 
@@ -71,7 +67,7 @@ public:
                                    GeometryType::Pointer              pGeometry,
                                    PropertiesType::Pointer            pProperties,
                                    std::unique_ptr<StressStatePolicy> pStressStatePolicy)
-        : UPwBaseElement<TDim, TNumNodes>(NewId, pGeometry, pProperties, std::move(pStressStatePolicy))
+        : UPwBaseElement(NewId, pGeometry, pProperties, std::move(pStressStatePolicy))
     {
         /// Lobatto integration method with the integration points located at the "mid plane nodes" of the interface
         mThisIntegrationMethod = GeometryData::IntegrationMethod::GI_GAUSS_1;

--- a/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_link_interface_element.hpp
+++ b/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_link_interface_element.hpp
@@ -41,10 +41,10 @@ public:
     using NodesArrayType = GeometryType::PointsArrayType;
     using VectorType     = Vector;
     using MatrixType     = Matrix;
-    using UPwBaseElement<TDim, TNumNodes>::mConstitutiveLawVector;
-    using UPwBaseElement<TDim, TNumNodes>::mRetentionLawVector;
-    using UPwBaseElement<TDim, TNumNodes>::mStressVector;
-    using UPwBaseElement<TDim, TNumNodes>::mThisIntegrationMethod;
+    using UPwBaseElement::mConstitutiveLawVector;
+    using UPwBaseElement::mRetentionLawVector;
+    using UPwBaseElement::mStressVector;
+    using UPwBaseElement::mThisIntegrationMethod;
 
     using SFGradAuxVariables = typename UPwSmallStrainInterfaceElement<TDim, TNumNodes>::SFGradAuxVariables;
     using InterfaceElementVariables =

--- a/applications/GeoMechanicsApplication/custom_elements/U_Pw_updated_lagrangian_FIC_element.hpp
+++ b/applications/GeoMechanicsApplication/custom_elements/U_Pw_updated_lagrangian_FIC_element.hpp
@@ -71,11 +71,11 @@ public:
 
     /// The definition of the sizetype
     using SizeType = std::size_t;
-    using UPwBaseElement<TDim, TNumNodes>::mConstitutiveLawVector;
-    using UPwBaseElement<TDim, TNumNodes>::mStressVector;
-    using UPwBaseElement<TDim, TNumNodes>::mStateVariablesFinalized;
-    using UPwBaseElement<TDim, TNumNodes>::CalculateDerivativesOnInitialConfiguration;
-    using UPwBaseElement<TDim, TNumNodes>::mThisIntegrationMethod;
+    using UPwBaseElement::CalculateDerivativesOnInitialConfiguration;
+    using UPwBaseElement::mConstitutiveLawVector;
+    using UPwBaseElement::mStateVariablesFinalized;
+    using UPwBaseElement::mStressVector;
+    using UPwBaseElement::mThisIntegrationMethod;
     using UPwSmallStrainFICElement<TDim, TNumNodes>::CalculateShearModulus;
 
     using ElementVariables = typename UPwSmallStrainElement<TDim, TNumNodes>::ElementVariables;

--- a/applications/GeoMechanicsApplication/custom_elements/U_Pw_updated_lagrangian_element.hpp
+++ b/applications/GeoMechanicsApplication/custom_elements/U_Pw_updated_lagrangian_element.hpp
@@ -71,12 +71,12 @@ public:
 
     /// The definition of the sizetype
     using SizeType = std::size_t;
-    using UPwBaseElement<TDim, TNumNodes>::mConstitutiveLawVector;
-    using UPwBaseElement<TDim, TNumNodes>::mRetentionLawVector;
-    using UPwBaseElement<TDim, TNumNodes>::mStressVector;
-    using UPwBaseElement<TDim, TNumNodes>::mStateVariablesFinalized;
-    using UPwBaseElement<TDim, TNumNodes>::CalculateDerivativesOnInitialConfiguration;
-    using UPwBaseElement<TDim, TNumNodes>::mThisIntegrationMethod;
+    using UPwBaseElement::CalculateDerivativesOnInitialConfiguration;
+    using UPwBaseElement::mConstitutiveLawVector;
+    using UPwBaseElement::mRetentionLawVector;
+    using UPwBaseElement::mStateVariablesFinalized;
+    using UPwBaseElement::mStressVector;
+    using UPwBaseElement::mThisIntegrationMethod;
 
     using ElementVariables = typename UPwSmallStrainElement<TDim, TNumNodes>::ElementVariables;
 

--- a/applications/GeoMechanicsApplication/custom_elements/drained_U_Pw_small_strain_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/drained_U_Pw_small_strain_element.cpp
@@ -44,7 +44,7 @@ void DrainedUPwSmallStrainElement<TDim, TNumNodes>::InitializeSolutionStep(const
 
     UPwSmallStrainElement<TDim, TNumNodes>::InitializeSolutionStep(rCurrentProcessInfo);
 
-    KRATOS_CATCH("");
+    KRATOS_CATCH("")
 }
 
 //----------------------------------------------------------------------------------------
@@ -90,7 +90,7 @@ int DrainedUPwSmallStrainElement<TDim, TNumNodes>::Check(const ProcessInfo& rCur
 
     return ierr;
 
-    KRATOS_CATCH("");
+    KRATOS_CATCH("")
 }
 
 //----------------------------------------------------------------------------------------------------
@@ -102,7 +102,7 @@ void DrainedUPwSmallStrainElement<TDim, TNumNodes>::CalculateAndAddLHS(MatrixTyp
 
     UPwSmallStrainElement<TDim, TNumNodes>::CalculateAndAddStiffnessMatrix(rLeftHandSideMatrix, rVariables);
 
-    KRATOS_CATCH("");
+    KRATOS_CATCH("")
 }
 
 //----------------------------------------------------------------------------------------------------
@@ -118,7 +118,7 @@ void DrainedUPwSmallStrainElement<TDim, TNumNodes>::CalculateAndAddRHS(VectorTyp
 
     UPwSmallStrainElement<TDim, TNumNodes>::CalculateAndAddMixBodyForce(rRightHandSideVector, rVariables);
 
-    KRATOS_CATCH("");
+    KRATOS_CATCH("")
 }
 
 //----------------------------------------------------------------------------------------------------

--- a/applications/GeoMechanicsApplication/custom_elements/drained_U_Pw_small_strain_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/drained_U_Pw_small_strain_element.cpp
@@ -54,7 +54,7 @@ int DrainedUPwSmallStrainElement<TDim, TNumNodes>::Check(const ProcessInfo& rCur
     KRATOS_TRY
 
     // Verify generic variables
-    int ierr = UPwBaseElement<TDim, TNumNodes>::Check(rCurrentProcessInfo);
+    int ierr = UPwBaseElement::Check(rCurrentProcessInfo);
     if (ierr != 0) return ierr;
 
     const PropertiesType& Prop = this->GetProperties();

--- a/applications/GeoMechanicsApplication/custom_elements/geo_cable_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/geo_cable_element.cpp
@@ -154,7 +154,7 @@ void GeoCableElement<TDim, TNumNodes>::UpdateInternalForces(BoundedVector<double
     f_local[TDim]                                   = 1.00 * normal_force;
     rInternalForces                                 = ZeroVector(TDim * TNumNodes);
     noalias(rInternalForces)                        = prod(transformation_matrix, f_local);
-    KRATOS_CATCH("");
+    KRATOS_CATCH("")
 }
 
 //----------------------------------------------------------------------------------------

--- a/applications/GeoMechanicsApplication/custom_elements/geo_linear_truss_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/geo_linear_truss_element.cpp
@@ -169,7 +169,7 @@ void GeoLinearTrussElement<TDim, TNumNodes>::UpdateInternalForces(FullDofVectorT
 
     rInternalForces = prod(transformation_matrix, rInternalForces);
 
-    KRATOS_CATCH("");
+    KRATOS_CATCH("")
 }
 
 //----------------------------------------------------------------------------------------
@@ -181,7 +181,7 @@ void GeoLinearTrussElement<TDim, TNumNodes>::FinalizeSolutionStep(const ProcessI
     GeoTrussElementLinearBase<TDim, TNumNodes>::FinalizeSolutionStep(rCurrentProcessInfo);
     mInternalStressesFinalized = mInternalStresses + mInternalStressesFinalizedPrevious;
 
-    KRATOS_CATCH("");
+    KRATOS_CATCH("")
 }
 
 //----------------------------------------------------------------------------------------

--- a/applications/GeoMechanicsApplication/custom_elements/geo_structural_base_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/geo_structural_base_element.cpp
@@ -120,7 +120,7 @@ int GeoStructuralBaseElement<TDim, TNumNodes>::Check(const ProcessInfo& rCurrent
 
     return 0;
 
-    KRATOS_CATCH("");
+    KRATOS_CATCH("")
 }
 
 //----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
@@ -212,7 +212,7 @@ void GeoStructuralBaseElement<TDim, TNumNodes>::CalculateLeftHandSide(MatrixType
     CalculateAll(rLeftHandSideMatrix, TempVector, rCurrentProcessInfo, CalculateStiffnessMatrixFlag,
                  CalculateResidualVectorFlag);
 
-    KRATOS_CATCH("");
+    KRATOS_CATCH("")
 }
 
 //----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
@@ -377,7 +377,7 @@ void GeoStructuralBaseElement<TDim, TNumNodes>::CalculateNodalCrossDirection(Mat
                     "for a particular element ... illegal operation!!"
                  << this->Id() << std::endl;
 
-    KRATOS_CATCH("");
+    KRATOS_CATCH("")
 }
 
 //----------------------------------------------------------------------------------------

--- a/applications/GeoMechanicsApplication/custom_elements/geo_truss_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/geo_truss_element.cpp
@@ -238,7 +238,7 @@ void GeoTrussElement<TDim, TNumNodes>::UpdateInternalForces(BoundedVector<double
     f_local[TDim]                                   = 1.00 * normal_force;
     rInternalForces                                 = ZeroVector(TDim * TNumNodes);
     noalias(rInternalForces)                        = prod(transformation_matrix, f_local);
-    KRATOS_CATCH("");
+    KRATOS_CATCH("")
 }
 
 //----------------------------------------------------------------------------------------
@@ -250,7 +250,7 @@ void GeoTrussElement<TDim, TNumNodes>::FinalizeSolutionStep(const ProcessInfo& r
     GeoTrussElementBase<TDim, TNumNodes>::FinalizeSolutionStep(rCurrentProcessInfo);
     mInternalStressesFinalized = mInternalStresses + mInternalStressesFinalizedPrevious;
 
-    KRATOS_CATCH("");
+    KRATOS_CATCH("")
 }
 
 //--------------------------------------------------------------------------------------------

--- a/applications/GeoMechanicsApplication/custom_elements/geo_truss_element_base.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/geo_truss_element_base.cpp
@@ -1094,7 +1094,7 @@ void GeoTrussElementBase<TDim, TNumNodes>::FinalizeSolutionStep(const ProcessInf
     Values.SetStressVector(temp_stress);
     mpConstitutiveLaw->FinalizeMaterialResponse(Values, ConstitutiveLaw::StressMeasure_PK2);
 
-    KRATOS_CATCH("");
+    KRATOS_CATCH("")
 }
 
 //----------------------------------------------------------------------------------------

--- a/applications/GeoMechanicsApplication/custom_elements/steady_state_Pw_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/steady_state_Pw_element.cpp
@@ -130,7 +130,7 @@ int SteadyStatePwElement<TDim, TNumNodes>::Check(const ProcessInfo& rCurrentProc
 
     return 0;
 
-    KRATOS_CATCH("");
+    KRATOS_CATCH("")
 }
 
 //----------------------------------------------------------------------------------------
@@ -212,7 +212,7 @@ void SteadyStatePwElement<TDim, TNumNodes>::CalculateAndAddRHS(VectorType& rRigh
     this->CalculateAndAddPermeabilityFlow(rRightHandSideVector, rVariables);
     this->CalculateAndAddFluidBodyFlow(rRightHandSideVector, rVariables);
 
-    KRATOS_CATCH("");
+    KRATOS_CATCH("")
 }
 
 //----------------------------------------------------------------------------------------------------

--- a/applications/GeoMechanicsApplication/custom_elements/steady_state_Pw_interface_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/steady_state_Pw_interface_element.cpp
@@ -108,7 +108,7 @@ int SteadyStatePwInterfaceElement<TDim, TNumNodes>::Check(const ProcessInfo& rCu
 
     return ierr;
 
-    KRATOS_CATCH("");
+    KRATOS_CATCH("")
 }
 
 //----------------------------------------------------------------------------------------

--- a/applications/GeoMechanicsApplication/custom_elements/steady_state_Pw_piping_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/steady_state_Pw_piping_element.cpp
@@ -76,7 +76,7 @@ int SteadyStatePwPipingElement<TDim, TNumNodes>::Check(const ProcessInfo& rCurre
         KRATOS_ERROR << "PIPE_MODEL_FACTOR has Key zero, is not defined or has "
                         "an invalid value at element "
                      << this->Id() << std::endl;
-    KRATOS_CATCH("");
+    KRATOS_CATCH("")
 
     return ierr;
 }
@@ -103,7 +103,7 @@ void SteadyStatePwPipingElement<TDim, TNumNodes>::Initialize(const ProcessInfo& 
         this->SetValue(PIPE_ACTIVE, false);
     }
 
-    KRATOS_CATCH("");
+    KRATOS_CATCH("")
 }
 
 template <>

--- a/applications/GeoMechanicsApplication/custom_elements/transient_Pw_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/transient_Pw_element.cpp
@@ -629,7 +629,7 @@ void TransientPwElement<TDim, TNumNodes>::CalculateKinematics(ElementVariables& 
 
 //----------------------------------------------------------------------------------------
 template <unsigned int TDim, unsigned int TNumNodes>
-unsigned int TransientPwElement<TDim, TNumNodes>::GetNumberOfDOF() const
+std::size_t TransientPwElement<TDim, TNumNodes>::GetNumberOfDOF() const
 {
     return TNumNodes;
 }

--- a/applications/GeoMechanicsApplication/custom_elements/transient_Pw_element.hpp
+++ b/applications/GeoMechanicsApplication/custom_elements/transient_Pw_element.hpp
@@ -172,7 +172,7 @@ protected:
     void CalculateAndAddCompressibilityFlow(VectorType&             rRightHandSideVector,
                                             const ElementVariables& rVariables) override;
 
-    unsigned int GetNumberOfDOF() const override;
+    std::size_t GetNumberOfDOF() const override;
     ///----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
 private:

--- a/applications/GeoMechanicsApplication/custom_elements/transient_Pw_interface_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/transient_Pw_interface_element.cpp
@@ -741,7 +741,7 @@ void TransientPwInterfaceElement<TDim, TNumNodes>::GetSecondDerivativesVector(Ve
 }
 
 template <unsigned int TDim, unsigned int TNumNodes>
-unsigned int TransientPwInterfaceElement<TDim, TNumNodes>::GetNumberOfDOF() const
+std::size_t TransientPwInterfaceElement<TDim, TNumNodes>::GetNumberOfDOF() const
 {
     return TNumNodes;
 }

--- a/applications/GeoMechanicsApplication/custom_elements/transient_Pw_interface_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/transient_Pw_interface_element.cpp
@@ -111,7 +111,7 @@ int TransientPwInterfaceElement<TDim, TNumNodes>::Check(const ProcessInfo& rCurr
 
     return ierr;
 
-    KRATOS_CATCH("");
+    KRATOS_CATCH("")
 }
 
 template <unsigned int TDim, unsigned int TNumNodes>

--- a/applications/GeoMechanicsApplication/custom_elements/transient_Pw_interface_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/transient_Pw_interface_element.cpp
@@ -119,7 +119,7 @@ void TransientPwInterfaceElement<TDim, TNumNodes>::Initialize(const ProcessInfo&
 {
     KRATOS_TRY
 
-    UPwBaseElement<TDim, TNumNodes>::Initialize(rCurrentProcessInfo);
+    UPwBaseElement::Initialize(rCurrentProcessInfo);
 
     // Compute initial gap of the joint
     this->CalculateInitialGap(this->GetGeometry());

--- a/applications/GeoMechanicsApplication/custom_elements/transient_Pw_interface_element.hpp
+++ b/applications/GeoMechanicsApplication/custom_elements/transient_Pw_interface_element.hpp
@@ -164,7 +164,7 @@ protected:
     void CalculateAndAddFluidBodyFlow(VectorType&                      rRightHandSideVector,
                                       const InterfaceElementVariables& rVariables) override;
 
-    unsigned int GetNumberOfDOF() const override;
+    std::size_t GetNumberOfDOF() const override;
 
 private:
     [[nodiscard]] DofsVectorType GetDofs() const;

--- a/applications/GeoMechanicsApplication/custom_elements/undrained_U_Pw_small_strain_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/undrained_U_Pw_small_strain_element.cpp
@@ -53,7 +53,7 @@ int UndrainedUPwSmallStrainElement<TDim, TNumNodes>::Check(const ProcessInfo& rC
         KRATOS_ERROR << "DomainSize < 1.0e-15 for the element " << this->Id() << std::endl;
 
     // Verify generic variables
-    ierr = UPwBaseElement<TDim, TNumNodes>::Check(rCurrentProcessInfo);
+    ierr = UPwBaseElement::Check(rCurrentProcessInfo);
     if (ierr != 0) return ierr;
 
     // Verify specific properties

--- a/applications/GeoMechanicsApplication/custom_elements/undrained_U_Pw_small_strain_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/undrained_U_Pw_small_strain_element.cpp
@@ -87,7 +87,7 @@ int UndrainedUPwSmallStrainElement<TDim, TNumNodes>::Check(const ProcessInfo& rC
 
     return ierr;
 
-    KRATOS_CATCH("");
+    KRATOS_CATCH("")
 }
 
 //----------------------------------------------------------------------------------------------------
@@ -103,7 +103,7 @@ void UndrainedUPwSmallStrainElement<TDim, TNumNodes>::CalculateAndAddLHS(MatrixT
 
     UPwSmallStrainElement<TDim, TNumNodes>::CalculateAndAddCompressibilityMatrix(rLeftHandSideMatrix, rVariables);
 
-    KRATOS_CATCH("");
+    KRATOS_CATCH("")
 }
 
 //----------------------------------------------------------------------------------------------------
@@ -123,7 +123,7 @@ void UndrainedUPwSmallStrainElement<TDim, TNumNodes>::CalculateAndAddRHS(VectorT
 
     UPwSmallStrainElement<TDim, TNumNodes>::CalculateAndAddCompressibilityFlow(rRightHandSideVector, rVariables);
 
-    KRATOS_CATCH("");
+    KRATOS_CATCH("")
 }
 
 //----------------------------------------------------------------------------------------------------

--- a/applications/GeoMechanicsApplication/custom_utilities/element_utilities.hpp
+++ b/applications/GeoMechanicsApplication/custom_utilities/element_utilities.hpp
@@ -121,23 +121,6 @@ public:
         }
     }
 
-    template <unsigned int TDim, unsigned int TNumNodes>
-    static inline void GetNodalVariableMatrix(Matrix&                      rNodalVariableMatrix,
-                                              const Element::GeometryType& rGeom,
-                                              const Variable<array_1d<double, 3>>& Variable,
-                                              IndexType SolutionStepIndex = 0)
-    {
-        rNodalVariableMatrix.resize(TNumNodes, TDim, false);
-
-        for (IndexType node = 0; node < TNumNodes; ++node) {
-            const array_1d<double, 3>& NodalVariableAux =
-                rGeom[node].FastGetSolutionStepValue(Variable, SolutionStepIndex);
-
-            for (IndexType iDim = 0; iDim < TDim; ++iDim)
-                rNodalVariableMatrix(node, iDim) = NodalVariableAux[iDim];
-        }
-    }
-
     static inline void FillPermeabilityMatrix(BoundedMatrix<double, 1, 1>&   rPermeabilityMatrix,
                                               const Element::PropertiesType& Prop)
     {


### PR DESCRIPTION
**📝 Description**
The step to make non-templated `SmallStrainUPwDiffOrderElement` class inherited from `UPwBaseElement` class. 

- Removed the template parameters `TDim` and `TNumNodes` from the member function signatures.
- Use of `TDim` is replaced with` this->GetGeometry().WorkingSpaceDimension()`. 
- Use of `TNumNodes` is replaced with `this->GetGeometry().PointsNumber()`.
- Removed the explicit class instantiations from the implementation file.
- Removed `GeoElementUtilities::GetNodalVariableMatrix` because it is not used any longer.
- Renamed `undrained_terms` into `transposed_coupling_matrix`, that was missed in https://github.com/orgs/Deltares/projects/55/views/1?pane=issue&itemId=66055494
- Fixed a number of code smells. Only one code smell left is 'Remove this call from a constructor/destructor to the overridable "GetIntegrationMethod" method.'
