### PR TITLE
[OptApp] Fix the segmentation fault of shape opt

### DIFF
--- a/applications/OptimizationApplication/python_scripts/controls/shape/vertex_morphing_shape_control.py
+++ b/applications/OptimizationApplication/python_scripts/controls/shape/vertex_morphing_shape_control.py
@@ -208,7 +208,8 @@ class VertexMorphingShapeControl(Control):
                     # now fix the design surface component
                     Kratos.VariableUtils().ApplyFixity(mesh_displacement_var, True, shape_update.GetModelPart().Nodes)
                     # now fix boundary condition components
-                    for model_part in self.filter.GetBoundaryConditions()[i_comp]:
+                    model_parts = self.filter.GetBoundaryConditions()
+                    for model_part in model_parts[i_comp]:
                         Kratos.VariableUtils().ApplyFixity(mesh_displacement_var, True, model_part.Nodes)
 
                 # solve for the volume mesh displacements


### PR DESCRIPTION
**📝 Description**
For some reason the optapp seg faults if this is not done like in this fix for some cases. @roigcarlo @matekelemen any ideas?

Following is the traceback which is showing some type casting problem from the pybind. My guess is, since it is vector of `ModelPart*`, it cannot deduce how to handle the `return_value_policy`,
```gdb
Thread 1 "python" received signal SIGSEGV, Segmentation fault.
0x00007fffeaf36355 in pybind11::polymorphic_type_hook_base<Kratos::ModelPart, void>::get (
    src=0x55555a27c220, type=@0x7fffffffc840: 0x7ffff4285760 <typeinfo for Kratos::ModelPart>)
    at /software/kratos/master/external_libraries/pybind11/detail/type_caster_base.h:895
895             return dynamic_cast<const void *>(src);
(gdb) bt
#0  0x00007fffeaf36355 in pybind11::polymorphic_type_hook_base<Kratos::ModelPart, void>::get (
    src=0x55555a27c220, type=@0x7fffffffc840: 0x7ffff4285760 <typeinfo for Kratos::ModelPart>)
    at /software/kratos/master/external_libraries/pybind11/detail/type_caster_base.h:895
#1  0x00007fffeaf3342d in pybind11::detail::type_caster_base<Kratos::ModelPart>::src_and_type (
    src=0x55555a27c220)
    at /software/kratos/master/external_libraries/pybind11/detail/type_caster_base.h:932
#2  0x00007fffeaf31add in pybind11::detail::type_caster_base<Kratos::ModelPart>::cast (
    src=0x55555a27c220, policy=pybind11::return_value_policy::automatic, parent=...)
    at /software/kratos/master/external_libraries/pybind11/detail/type_caster_base.h:952
#3  0x00007fffeaf2bb52 in pybind11::detail::list_caster<std::vector<Kratos::ModelPart*, std::allocator<Kratos::ModelPart*> >, Kratos::ModelPart*>::cast<std::vector<Kratos::ModelPart*, std::allocator<Kratos::ModelPart*> > > (src=..., policy=pybind11::return_value_policy::automatic, 
--Type <RET> for more, q to quit, c to continue without paging--
    parent=...) at /software/kratos/master/external_libraries/pybind11/stl.h:180
#4  0x00007fffeaf284b6 in pybind11::detail::list_caster<std::vector<std::vector<Kratos::ModelPart*, std::allocator<Kratos::ModelPart*> >, std::allocator<std::vector<Kratos::ModelPart*, std::allocator<Kratos::ModelPart*> > > >, std::vector<Kratos::ModelPart*, std::allocator<Kratos::ModelPart*> > >::cast<std::vector<std::vector<Kratos::ModelPart*, std::allocator<Kratos::ModelPart*> >, std::allocator<std::vector<Kratos::ModelPart*, std::allocator<Kratos::ModelPart*> > > > > (
    src=..., policy=pybind11::return_value_policy::automatic, parent=...)
    at /software/kratos/master/external_libraries/pybind11/stl.h:180
#5  0x00007fffeaf1d212 in pybind11::cpp_function::initialize<pybind11::cpp_function::initialize<std::vector<std::vector<Kratos::ModelPart*, std::allocator<Kratos::ModelPart*> >, std::allocator<std::vector<Kratos::ModelPart*, std::allocator<Kratos::ModelPart*> > > >, Kratos::ExplicitDamping<Kratos::PointerVectorSet<Kratos::Node, Kratos::IndexedObject, std::less<unsigned long>, std::--Type <RET> for more, q to quit, c to continue without paging--
equal_to<unsigned long>, Kratos::intrusive_ptr<Kratos::Node>, std::vector<Kratos::intrusive_ptr<Kratos::Node>, std::allocator<Kratos::intrusive_ptr<Kratos::Node> > > > >, , pybind11::name, pybind11::is_method, pybind11::sibling>(std::vector<std::vector<Kratos::ModelPart*, std::allocator<Kratos::ModelPart*> >, std::allocator<std::vector<Kratos::ModelPart*, std::allocator<Kratos::ModelPart*> > > > (Kratos::ExplicitDamping<Kratos::PointerVectorSet<Kratos::Node, Kratos::IndexedObject, std::less<unsigned long>, std::equal_to<unsigned long>, Kratos::intrusive_ptr<Kratos::Node>, std::vector<Kratos::intrusive_ptr<Kratos::Node>, std::allocator<Kratos::intrusive_ptr<Kratos::Node> > > > >::*)() const, pybind11::name const&, pybind11::is_method const&, pybind11::sibling const&)::{lambda(Kratos::ExplicitDamping<Kratos::PointerVectorSet<Kratos::Node, Kratos::IndexedObject, std::less<unsigned long>, std::equal_to<unsigned long>, Kratos::intrusive_ptr<Kratos::Node>, std::vector<Kratos::intrusive_ptr<Kratos::Node>, std::allocator<Kratos::intrusive_ptr<Kratos::Node> > > > > const*)#1}, std::vector<std::vector<Kratos::ModelPart*, std::allocator<Kratos::--Type <RET> for more, q to quit, c to continue without paging--
ModelPart*> >, std::allocator<std::vector<Kratos::ModelPart*, std::allocator<Kratos::ModelPart*> > > >, Kratos::ExplicitDamping<Kratos::PointerVectorSet<Kratos::Node, Kratos::IndexedObject, std::less<unsigned long>, std::equal_to<unsigned long>, Kratos::intrusive_ptr<Kratos::Node>, std::vector<Kratos::intrusive_ptr<Kratos::Node>, std::allocator<Kratos::intrusive_ptr<Kratos::Node> > > > > const*, pybind11::name, pybind11::is_method, pybind11::sibling>(pybind11::cpp_function::initialize<std::vector<std::vector<Kratos::ModelPart*, std::allocator<Kratos::ModelPart*> >, std::allocator<std::vector<Kratos::ModelPart*, std::allocator<Kratos::ModelPart*> > > >, Kratos::ExplicitDamping<Kratos::PointerVectorSet<Kratos::Node, Kratos::IndexedObject, std::less<unsigned long>, std::equal_to<unsigned long>, Kratos::intrusive_ptr<Kratos::Node>, std::vector<Kratos::intrusive_ptr<Kratos::Node>, std::allocator<Kratos::intrusive_ptr<Kratos::Node> > > > >, , pybind11::name, pybind11::is_method, pybind11::sibling>(std::vector<std::vector<Kratos::ModelPart*, std::allocator<Kratos::ModelPart*> >, std::allocator<std::vector<Kratos::ModelPart*, std::allocator<K--Type <RET> for more, q to quit, c to continue without paging--
ratos::ModelPart*> > > > (Kratos::ExplicitDamping<Kratos::PointerVectorSet<Kratos::Node, Kratos::IndexedObject, std::less<unsigned long>, std::equal_to<unsigned long>, Kratos::intrusive_ptr<Kratos::Node>, std::vector<Kratos::intrusive_ptr<Kratos::Node>, std::allocator<Kratos::intrusive_ptr<Kratos::Node> > > > >::*)() const, pybind11::name const&, pybind11::is_method const&, pybind11::sibling const&)::{lambda(Kratos::ExplicitDamping<Kratos::PointerVectorSet<Kratos::Node, Kratos::IndexedObject, std::less<unsigned long>, std::equal_to<unsigned long>, Kratos::intrusive_ptr<Kratos::Node>, std::vector<Kratos::intrusive_ptr<Kratos::Node>, std::allocator<Kratos::intrusive_ptr<Kratos::Node> > > > > const*)#1}&&, std::vector<std::vector<Kratos::ModelPart*, std::allocator<Kratos::ModelPart*> >, std::allocator<std::vector<Kratos::ModelPart*, std::allocator<Kratos::ModelPart*> > > > (*)(Kratos::ExplicitDamping<Kratos::PointerVectorSet<Kratos::Node, Kratos::IndexedObject, std::less<unsigned long>, std::equal_to<unsigned long>, Kratos::intrusive_ptr<Kratos::Node>, std::vector<Kratos::intrusive_ptr<Kratos::Node>, std::allocator<Kratos::intrusive_ptr<--Type <RET> for more, q to quit, c to continue without paging--
Kratos::Node> > > > > const*), pybind11::name const&, pybind11::is_method const&, pybind11::sibling const&)::{lambda(pybind11::detail::function_call&)#1}::operator()(pybind11::detail::function_call&) const (__closure=0x0, call=...)
    at /software/kratos/master/external_libraries/pybind11/pybind11.h:249
#6  0x00007fffeaf1d2a0 in pybind11::cpp_function::initialize<pybind11::cpp_function::initialize<std::vector<std::vector<Kratos::ModelPart*, std::allocator<Kratos::ModelPart*> >, std::allocator<std::vector<Kratos::ModelPart*, std::allocator<Kratos::ModelPart*> > > >, Kratos::ExplicitDamping<Kratos::PointerVectorSet<Kratos::Node, Kratos::IndexedObject, std::less<unsigned long>, std::equal_to<unsigned long>, Kratos::intrusive_ptr<Kratos::Node>, std::vector<Kratos::intrusive_ptr<Kratos::Node>, std::allocator<Kratos::intrusive_ptr<Kratos::Node> > > > >, , pybind11::name, pybind11::is_method, pybind11::sibling>(std::vector<std::vector<Kratos::ModelPart*, std::allocator<Kratos::ModelPart*> >, std::allocator<std::vector<Kratos::ModelPart*, std::allocator<Kratos::Mod--Type <RET> for more, q to quit, c to continue without paging--
elPart*> > > > (Kratos::ExplicitDamping<Kratos::PointerVectorSet<Kratos::Node, Kratos::IndexedObject, std::less<unsigned long>, std::equal_to<unsigned long>, Kratos::intrusive_ptr<Kratos::Node>, std::vector<Kratos::intrusive_ptr<Kratos::Node>, std::allocator<Kratos::intrusive_ptr<Kratos::Node> > > > >::*)() const, pybind11::name const&, pybind11::is_method const&, pybind11::sibling const&)::{lambda(Kratos::ExplicitDamping<Kratos::PointerVectorSet<Kratos::Node, Kratos::IndexedObject, std::less<unsigned long>, std::equal_to<unsigned long>, Kratos::intrusive_ptr<Kratos::Node>, std::vector<Kratos::intrusive_ptr<Kratos::Node>, std::allocator<Kratos::intrusive_ptr<Kratos::Node> > > > > const*)#1}, std::vector<std::vector<Kratos::ModelPart*, std::allocator<Kratos::ModelPart*> >, std::allocator<std::vector<Kratos::ModelPart*, std::allocator<Kratos::ModelPart*> > > >, Kratos::ExplicitDamping<Kratos::PointerVectorSet<Kratos::Node, Kratos::IndexedObject, std::less<unsigned long>, std::equal_to<unsigned long>, Kratos::intrusive_ptr<Kratos::Node>, std::vector<Kratos::intrusive_ptr<Kratos::Node>, std::allocator<Kratos::intrusive_ptr<Kratos::Node> >--Type <RET> for more, q to quit, c to continue without paging--
 > > > const*, pybind11::name, pybind11::is_method, pybind11::sibling>(pybind11::cpp_function::initialize<std::vector<std::vector<Kratos::ModelPart*, std::allocator<Kratos::ModelPart*> >, std::allocator<std::vector<Kratos::ModelPart*, std::allocator<Kratos::ModelPart*> > > >, Kratos::ExplicitDamping<Kratos::PointerVectorSet<Kratos::Node, Kratos::IndexedObject, std::less<unsigned long>, std::equal_to<unsigned long>, Kratos::intrusive_ptr<Kratos::Node>, std::vector<Kratos::intrusive_ptr<Kratos::Node>, std::allocator<Kratos::intrusive_ptr<Kratos::Node> > > > >, , pybind11::name, pybind11::is_method, pybind11::sibling>(std::vector<std::vector<Kratos::ModelPart*, std::allocator<Kratos::ModelPart*> >, std::allocator<std::vector<Kratos::ModelPart*, std::allocator<Kratos::ModelPart*> > > > (Kratos::ExplicitDamping<Kratos::PointerVectorSet<Kratos::Node, Kratos::IndexedObject, std::less<unsigned long>, std::equal_to<unsigned long>, Kratos::intrusive_ptr<Kratos::Node>, std::vector<Kratos::intrusive_ptr<Kratos::Node>, std::allocator<Kratos::intrusive_ptr<Kratos::Node> > > > >::*)() const, pybind11::name const&, pybind11::is_method const&, pybind1--Type <RET> for more, q to quit, c to continue without paging--
1::sibling const&)::{lambda(Kratos::ExplicitDamping<Kratos::PointerVectorSet<Kratos::Node, Kratos::IndexedObject, std::less<unsigned long>, std::equal_to<unsigned long>, Kratos::intrusive_ptr<Kratos::Node>, std::vector<Kratos::intrusive_ptr<Kratos::Node>, std::allocator<Kratos::intrusive_ptr<Kratos::Node> > > > > const*)#1}&&, std::vector<std::vector<Kratos::ModelPart*, std::allocator<Kratos::ModelPart*> >, std::allocator<std::vector<Kratos::ModelPart*, std::allocator<Kratos::ModelPart*> > > > (*)(Kratos::ExplicitDamping<Kratos::PointerVectorSet<Kratos::Node, Kratos::IndexedObject, std::less<unsigned long>, std::equal_to<unsigned long>, Kratos::intrusive_ptr<Kratos::Node>, std::vector<Kratos::intrusive_ptr<Kratos::Node>, std::allocator<Kratos::intrusive_ptr<Kratos::Node> > > > > const*), pybind11::name const&, pybind11::is_method const&, pybind11::sibling const&)::{lambda(pybind11::detail::function_call&)#1}::_FUN(pybind11::detail::function_call&) () at /software/kratos/master/external_libraries/pybind11/pybind11.h:224
#7  0x00007fffeaed45b8 in pybind11::cpp_function::dispatcher (self=0x7ffff4507c90, 
--Type <RET> for more, q to quit, c to continue without paging--
    args_in=0x7fffedb74dc0, kwargs_in=0x0)
    at /software/kratos/master/external_libraries/pybind11/pybind11.h:929
#8  0x00007ffff79a52c6 in ?? () from /usr/lib/libpython3.12.so.1.0
#9  0x00007ffff798550b in _PyObject_MakeTpCall () from /usr/lib/libpython3.12.so.1.0
#10 0x00007ffff788bdfa in ?? () from /usr/lib/libpython3.12.so.1.0
#11 0x00007ffff79d53ac in ?? () from /usr/lib/libpython3.12.so.1.0
#12 0x00007ffff79d4eb1 in ?? () from /usr/lib/libpython3.12.so.1.0
#13 0x00007ffff788cb8e in ?? () from /usr/lib/libpython3.12.so.1.0
#14 0x00007ffff7a3d767 in PyEval_EvalCode () from /usr/lib/libpython3.12.so.1.0
#15 0x00007ffff7a608b7 in ?? () from /usr/lib/libpython3.12.so.1.0
#16 0x00007ffff7a5b9dc in ?? () from /usr/lib/libpython3.12.so.1.0
#17 0x00007ffff7a74f33 in ?? () from /usr/lib/libpython3.12.so.1.0
--Type <RET> for more, q to quit, c to continue without paging--
#18 0x00007ffff7a74346 in _PyRun_SimpleFileObject () from /usr/lib/libpython3.12.so.1.0
#19 0x00007ffff7a73f88 in _PyRun_AnyFileObject () from /usr/lib/libpython3.12.so.1.0
#20 0x00007ffff7a6cc67 in Py_RunMain () from /usr/lib/libpython3.12.so.1.0
#21 0x00007ffff7a28fab in Py_BytesMain () from /usr/lib/libpython3.12.so.1.0
#22 0x00007ffff7639c88 in ?? () from /usr/lib/libc.so.6
#23 0x00007ffff7639d4c in __libc_start_main () from /usr/lib/libc.so.6
#24 0x0000555555555045 in _start ()
```

**🆕 Changelog**
- Fixes seg fault.
