### PR TITLE
[StructuralMechanicsApplication] Custom tangent modulus for linear truss 3D2N

### DIFF
--- a/applications/StructuralMechanicsApplication/custom_elements/truss_element_3D2N.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/truss_element_3D2N.cpp
@@ -1040,7 +1040,7 @@ void TrussElement3D2N::CalculateLumpedMassVector(
 }
 
 
-double TrussElement3D2N::ReturnTangentModulus1D(const ProcessInfo& rCurrentProcessInfo)
+double TrussElement3D2N::ReturnTangentModulus1D(const ProcessInfo& rCurrentProcessInfo) const
 {
     KRATOS_TRY;
     double tangent_modulus(0.00);

--- a/applications/StructuralMechanicsApplication/custom_elements/truss_element_3D2N.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/truss_element_3D2N.cpp
@@ -1039,13 +1039,19 @@ void TrussElement3D2N::CalculateLumpedMassVector(
     KRATOS_CATCH("")
 }
 
-
 double TrussElement3D2N::ReturnTangentModulus1D(const ProcessInfo& rCurrentProcessInfo) const
+{
+    KRATOS_TRY
+    return ReturnTangentModulus1D(CalculateGreenLagrangeStrain(), rCurrentProcessInfo);
+    KRATOS_CATCH("")
+}
+
+double TrussElement3D2N::ReturnTangentModulus1D(double Strain, const ProcessInfo& rCurrentProcessInfo) const
 {
     KRATOS_TRY
     double tangent_modulus(0.00);
     Vector strain_vector = ZeroVector(mpConstitutiveLaw->GetStrainSize());
-    strain_vector[0] = CalculateGreenLagrangeStrain();
+    strain_vector[0] = Strain;
 
     ConstitutiveLaw::Parameters Values(GetGeometry(),GetProperties(),rCurrentProcessInfo);
     Values.SetStrainVector(strain_vector);

--- a/applications/StructuralMechanicsApplication/custom_elements/truss_element_3D2N.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/truss_element_3D2N.cpp
@@ -1042,7 +1042,7 @@ void TrussElement3D2N::CalculateLumpedMassVector(
 
 double TrussElement3D2N::ReturnTangentModulus1D(const ProcessInfo& rCurrentProcessInfo) const
 {
-    KRATOS_TRY;
+    KRATOS_TRY
     double tangent_modulus(0.00);
     Vector strain_vector = ZeroVector(mpConstitutiveLaw->GetStrainSize());
     strain_vector[0] = CalculateGreenLagrangeStrain();
@@ -1052,7 +1052,7 @@ double TrussElement3D2N::ReturnTangentModulus1D(const ProcessInfo& rCurrentProce
 
     mpConstitutiveLaw->CalculateValue(Values,TANGENT_MODULUS,tangent_modulus);
     return tangent_modulus;
-    KRATOS_CATCH("");
+    KRATOS_CATCH("")
 }
 
 

--- a/applications/StructuralMechanicsApplication/custom_elements/truss_element_3D2N.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/truss_element_3D2N.cpp
@@ -1039,7 +1039,7 @@ void TrussElement3D2N::CalculateLumpedMassVector(
     KRATOS_CATCH("")
 }
 
-double TrussElement3D2N::ReturnTangentModulus1D(const ProcessInfo& rCurrentProcessInfo) const
+double TrussElement3D2N::ReturnTangentModulus1D(const ProcessInfo& rCurrentProcessInfo)
 {
     KRATOS_TRY
     return ReturnTangentModulus1D(CalculateGreenLagrangeStrain(), rCurrentProcessInfo);

--- a/applications/StructuralMechanicsApplication/custom_elements/truss_element_3D2N.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/truss_element_3D2N.cpp
@@ -1039,6 +1039,7 @@ void TrussElement3D2N::CalculateLumpedMassVector(
     KRATOS_CATCH("")
 }
 
+
 double TrussElement3D2N::ReturnTangentModulus1D(const ProcessInfo& rCurrentProcessInfo)
 {
     KRATOS_TRY

--- a/applications/StructuralMechanicsApplication/custom_elements/truss_element_3D2N.hpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/truss_element_3D2N.hpp
@@ -246,7 +246,7 @@ namespace Kratos
         virtual void WriteTransformationCoordinates(
             BoundedVector<double,msLocalSize>& rReferenceCoordinates);
 
-        double ReturnTangentModulus1D(const ProcessInfo& rCurrentProcessInfo) const;
+        double ReturnTangentModulus1D(const ProcessInfo& rCurrentProcessInfo);
 
         void FinalizeSolutionStep(const ProcessInfo& rCurrentProcessInfo) override;
 

--- a/applications/StructuralMechanicsApplication/custom_elements/truss_element_3D2N.hpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/truss_element_3D2N.hpp
@@ -246,7 +246,7 @@ namespace Kratos
         virtual void WriteTransformationCoordinates(
             BoundedVector<double,msLocalSize>& rReferenceCoordinates);
 
-        double ReturnTangentModulus1D(const ProcessInfo& rCurrentProcessInfo);
+        virtual double ReturnTangentModulus1D(const ProcessInfo& rCurrentProcessInfo);
 
         void FinalizeSolutionStep(const ProcessInfo& rCurrentProcessInfo) override;
 

--- a/applications/StructuralMechanicsApplication/custom_elements/truss_element_3D2N.hpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/truss_element_3D2N.hpp
@@ -257,6 +257,9 @@ namespace Kratos
 
         const Parameters GetSpecifications() const override;
 
+protected:
+    double ReturnTangentModulus1D(double Strain, const ProcessInfo& rCurrentProcessInfo) const;
+
 private:
     /**
      * @brief This method computes directly the lumped mass vector

--- a/applications/StructuralMechanicsApplication/custom_elements/truss_element_3D2N.hpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/truss_element_3D2N.hpp
@@ -246,7 +246,7 @@ namespace Kratos
         virtual void WriteTransformationCoordinates(
             BoundedVector<double,msLocalSize>& rReferenceCoordinates);
 
-        double ReturnTangentModulus1D(const ProcessInfo& rCurrentProcessInfo);
+        double ReturnTangentModulus1D(const ProcessInfo& rCurrentProcessInfo) const;
 
         void FinalizeSolutionStep(const ProcessInfo& rCurrentProcessInfo) override;
 

--- a/applications/StructuralMechanicsApplication/custom_elements/truss_element_linear_3D2N.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/truss_element_linear_3D2N.cpp
@@ -261,6 +261,13 @@ void TrussElementLinear3D2N::FinalizeSolutionStep(const ProcessInfo& rCurrentPro
     KRATOS_CATCH("");
 }
 
+double TrussElementLinear3D2N::ReturnTangentModulus1D(const ProcessInfo& rCurrentProcessInfo)
+{
+    KRATOS_TRY
+    return ReturnTangentModulus1D(CalculateLinearStrain(), rCurrentProcessInfo);
+    KRATOS_CATCH("")
+}
+
 
 void TrussElementLinear3D2N::save(Serializer& rSerializer) const
 {

--- a/applications/StructuralMechanicsApplication/custom_elements/truss_element_linear_3D2N.hpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/truss_element_linear_3D2N.hpp
@@ -122,6 +122,9 @@ public:
 
     void FinalizeSolutionStep(const ProcessInfo& rCurrentProcessInfo) override;
 
+    double ReturnTangentModulus1D(const ProcessInfo& rCurrentProcessInfo) override;
+    using TrussElement3D2N::ReturnTangentModulus1D;
+
 private:
 
     friend class Serializer;

--- a/applications/StructuralMechanicsApplication/tests/cpp_tests/test_truss.cpp
+++ b/applications/StructuralMechanicsApplication/tests/cpp_tests/test_truss.cpp
@@ -27,10 +27,10 @@ using namespace Kratos;
 class StubBilinearLaw : public ConstitutiveLaw
 {
 public:
-    // Only implement the interface that is needed by the test
-  StubBilinearLaw(double Strain, double TangentModulus1, double TangentModulus2) :
- mStrain{Strain}, mTangentModuli{TangentModulus1, TangentModulus2}
-  {}
+    // Only implement the interface that is needed by the tests
+    StubBilinearLaw(double Strain, double TangentModulus1, double TangentModulus2) :
+        mStrain{Strain}, mTangentModuli{TangentModulus1, TangentModulus2}
+    {}
 
     ConstitutiveLaw::Pointer Clone() const override
     {
@@ -267,9 +267,8 @@ namespace Testing
         constexpr auto elongation = 0.01;
         constexpr auto tangent_modulus_1 = 2.0e+03;
         constexpr auto tangent_modulus_2 = 1.0e+03;
-        auto p_stub_law = CreateStubBilinearLaw(elongation, length, tangent_modulus_1, tangent_modulus_2);
         auto p_elem_prop = r_model_part.CreateNewProperties(0);
-        p_elem_prop->SetValue(CONSTITUTIVE_LAW, p_stub_law);
+        p_elem_prop->SetValue(CONSTITUTIVE_LAW, CreateStubBilinearLaw(elongation, length, tangent_modulus_1, tangent_modulus_2));
 
         std::vector<ModelPart::IndexType> element_nodes {p_bottom_node->Id(), p_top_node->Id()};
         auto p_element = r_model_part.CreateNewElement("TrussElement3D2N", 1, element_nodes, p_elem_prop);
@@ -295,9 +294,8 @@ namespace Testing
         constexpr auto elongation = 0.01;
         constexpr auto tangent_modulus_1 = 2.0e+03;
         constexpr auto tangent_modulus_2 = 1.0e+03;
-        auto p_stub_law = CreateStubBilinearLaw(elongation, length, tangent_modulus_1, tangent_modulus_2);
         auto p_elem_prop = r_model_part.CreateNewProperties(0);
-        p_elem_prop->SetValue(CONSTITUTIVE_LAW, p_stub_law);
+        p_elem_prop->SetValue(CONSTITUTIVE_LAW, CreateStubBilinearLaw(elongation, length, tangent_modulus_1, tangent_modulus_2));
 
         std::vector<ModelPart::IndexType> element_nodes {p_bottom_node->Id(), p_top_node->Id()};
         auto p_element = r_model_part.CreateNewElement("TrussLinearElement3D2N", 1, element_nodes, p_elem_prop);

--- a/applications/StructuralMechanicsApplication/tests/cpp_tests/test_truss.cpp
+++ b/applications/StructuralMechanicsApplication/tests/cpp_tests/test_truss.cpp
@@ -304,7 +304,7 @@ namespace Testing
         p_bottom_node->FastGetSolutionStepValue(DISPLACEMENT, 0) = array_1d<double, 3>{0.0, 0.0, 0.0};
         p_top_node->FastGetSolutionStepValue(DISPLACEMENT, 0) = array_1d<double, 3>{0.0, 0.0, elongation};
 
-        auto p_truss_element = dynamic_cast<TrussElementLinear3D2N*>(p_element.get());
+        auto p_truss_element = dynamic_cast<TrussElement3D2N*>(p_element.get());
         KRATOS_EXPECT_NE(p_truss_element, nullptr);
         KRATOS_EXPECT_NEAR(tangent_modulus_1, p_truss_element->ReturnTangentModulus1D(r_model_part.GetProcessInfo()), 1.0e-10);
     }

--- a/applications/StructuralMechanicsApplication/tests/cpp_tests/test_truss.cpp
+++ b/applications/StructuralMechanicsApplication/tests/cpp_tests/test_truss.cpp
@@ -70,6 +70,12 @@ std::pair<Node::Pointer, Node::Pointer> CreateEndNodes(ModelPart& rModelPart, do
   return std::make_pair(p_bottom_node, p_top_node);
 }
 
+std::shared_ptr<StubBilinearLaw> CreateStubBilinearLaw(double Elongation, double Length, double TangentModulus1, double TangentModulus2)
+{
+    const auto linear_strain = Elongation / Length;
+    return std::make_shared<StubBilinearLaw>(1.0001 * linear_strain, TangentModulus1, TangentModulus2);
+}
+
 }
 
 
@@ -255,13 +261,12 @@ namespace Testing
         auto [p_bottom_node, p_top_node] = CreateEndNodes(r_model_part, length);
         AddDisplacementDofsElement(r_model_part);
 
-        auto p_elem_prop = r_model_part.CreateNewProperties(0);
         constexpr auto elongation = 0.01;
-        constexpr auto linear_strain = elongation / length;
         constexpr auto tangent_modulus_1 = 2.0e+03;
         constexpr auto tangent_modulus_2 = 1.0e+03;
-        auto p_test_law = std::make_shared<StubBilinearLaw>(1.0001 * linear_strain, tangent_modulus_1, tangent_modulus_2);
-        p_elem_prop->SetValue(CONSTITUTIVE_LAW, p_test_law);
+        auto p_stub_law = CreateStubBilinearLaw(elongation, length, tangent_modulus_1, tangent_modulus_2);
+        auto p_elem_prop = r_model_part.CreateNewProperties(0);
+        p_elem_prop->SetValue(CONSTITUTIVE_LAW, p_stub_law);
 
         std::vector<ModelPart::IndexType> element_nodes {1,2};
         auto p_element = r_model_part.CreateNewElement("TrussElement3D2N", 1, element_nodes, p_elem_prop);
@@ -285,13 +290,12 @@ namespace Testing
         auto [p_bottom_node, p_top_node] = CreateEndNodes(r_model_part, length);
         AddDisplacementDofsElement(r_model_part);
 
-        auto p_elem_prop = r_model_part.CreateNewProperties(0);
         constexpr auto elongation = 0.01;
-        constexpr auto linear_strain = elongation / length;
         constexpr auto tangent_modulus_1 = 2.0e+03;
         constexpr auto tangent_modulus_2 = 1.0e+03;
-        auto p_test_law = std::make_shared<StubBilinearLaw>(1.0001 * linear_strain, tangent_modulus_1, tangent_modulus_2);
-        p_elem_prop->SetValue(CONSTITUTIVE_LAW, p_test_law);
+        auto p_stub_law = CreateStubBilinearLaw(elongation, length, tangent_modulus_1, tangent_modulus_2);
+        auto p_elem_prop = r_model_part.CreateNewProperties(0);
+        p_elem_prop->SetValue(CONSTITUTIVE_LAW, p_stub_law);
 
         std::vector<ModelPart::IndexType> element_nodes {1,2};
         auto p_element = r_model_part.CreateNewElement("TrussLinearElement3D2N", 1, element_nodes, p_elem_prop);

--- a/applications/StructuralMechanicsApplication/tests/cpp_tests/test_truss.cpp
+++ b/applications/StructuralMechanicsApplication/tests/cpp_tests/test_truss.cpp
@@ -16,6 +16,45 @@
 
 #include "custom_elements/truss_element_3D2N.hpp"
 
+namespace
+{
+
+using namespace Kratos;
+
+class BilinearTestLaw : public ConstitutiveLaw
+{
+public:
+    // Only implement the interface that is needed by the test
+    BilinearTestLaw(double Strain, double TangentModulus1, double TangentModulus2) :
+ mStrain{Strain}, mTangentModuli{TangentModulus1, TangentModulus2}
+  {}
+
+    ConstitutiveLaw::Pointer Clone() const override
+    {
+        return std::make_shared<BilinearTestLaw>(*this);
+    }
+
+    SizeType GetStrainSize() const override
+    {
+        return 3;
+    }
+
+    double& CalculateValue(Parameters& rParameterValues, const Variable<double>& rThisVariable, double& rValue) override
+    {
+        KRATOS_ERROR_IF_NOT(rThisVariable == TANGENT_MODULUS);
+
+        rValue = rParameterValues.GetStrainVector()[0] < mStrain ? mTangentModuli[0] : mTangentModuli[1];
+        return rValue;
+    }
+
+private:
+    double mStrain = 0.0;
+    array_1d<double, 2> mTangentModuli{2.0, 1.0};
+};
+
+}
+
+
 namespace Kratos
 {
 namespace Testing
@@ -187,6 +226,41 @@ namespace Testing
         }
 
 
+    }
+
+    KRATOS_TEST_CASE_IN_SUITE(TangentModulusOfTrussElement3D2NUsesGreenLagrangeStrain, KratosStructuralMechanicsFastSuite)
+    {
+        // Set up the model part
+        Model current_model;
+        auto& r_model_part = current_model.CreateModelPart("ModelPart",1);
+        r_model_part.GetProcessInfo().SetValue(DOMAIN_SIZE, 3);
+        r_model_part.AddNodalSolutionStepVariable(DISPLACEMENT);
+
+        // Create two nodes and a truss element
+        constexpr auto length = 2.0;
+        auto p_bottom_node = r_model_part.CreateNewNode(1, 0.0, 0.0, 0.0);
+        auto p_top_node = r_model_part.CreateNewNode(2, 0.0, 0.0, length);
+        AddDisplacementDofsElement(r_model_part);
+
+        auto p_elem_prop = r_model_part.CreateNewProperties(0);
+        constexpr auto elongation = 0.01;
+        constexpr auto linear_strain = elongation / length;
+        constexpr auto tangent_modulus_1 = 2.0e+03;
+        constexpr auto tangent_modulus_2 = 1.0e+03;
+        auto p_test_law = std::make_shared<BilinearTestLaw>(1.0001 * linear_strain, tangent_modulus_1, tangent_modulus_2);
+        p_elem_prop->SetValue(CONSTITUTIVE_LAW, p_test_law);
+
+        std::vector<ModelPart::IndexType> element_nodes {1,2};
+        auto p_element = r_model_part.CreateNewElement("TrussElement3D2N", 1, element_nodes, p_elem_prop);
+        p_element->Initialize(r_model_part.GetProcessInfo());
+
+        // Set the displacements for testing
+        p_bottom_node->FastGetSolutionStepValue(DISPLACEMENT, 0) = array_1d<double, 3>{0.0, 0.0, 0.0};
+        p_top_node->FastGetSolutionStepValue(DISPLACEMENT, 0) = array_1d<double, 3>{0.0, 0.0, elongation};
+
+        auto p_truss_element = dynamic_cast<TrussElement3D2N*>(p_element.get());
+        KRATOS_EXPECT_NE(p_truss_element, nullptr);
+        KRATOS_EXPECT_NEAR(tangent_modulus_2, p_truss_element->ReturnTangentModulus1D(r_model_part.GetProcessInfo()), 1.0e-8);
     }
 
 }

--- a/applications/StructuralMechanicsApplication/tests/cpp_tests/test_truss.cpp
+++ b/applications/StructuralMechanicsApplication/tests/cpp_tests/test_truss.cpp
@@ -53,6 +53,14 @@ private:
     array_1d<double, 2> mTangentModuli{2.0, 1.0};
 };
 
+ModelPart& CreateTestModelPart(Model& rModel)
+{
+  auto&r_result = rModel.CreateModelPart("ModelPart", 1);
+  r_result.GetProcessInfo().SetValue(DOMAIN_SIZE, 3);
+  r_result.AddNodalSolutionStepVariable(DISPLACEMENT);
+  return r_result;
+}
+
 }
 
 
@@ -231,11 +239,8 @@ namespace Testing
 
     KRATOS_TEST_CASE_IN_SUITE(TangentModulusOfTrussElement3D2NUsesGreenLagrangeStrain, KratosStructuralMechanicsFastSuite)
     {
-        // Set up the model part
         Model current_model;
-        auto& r_model_part = current_model.CreateModelPart("ModelPart",1);
-        r_model_part.GetProcessInfo().SetValue(DOMAIN_SIZE, 3);
-        r_model_part.AddNodalSolutionStepVariable(DISPLACEMENT);
+        auto& r_model_part = CreateTestModelPart(current_model);
 
         // Create two nodes and a truss element
         constexpr auto length = 2.0;
@@ -266,37 +271,34 @@ namespace Testing
 
     KRATOS_TEST_CASE_IN_SUITE(TangentModulusOfTrussElementLinear3D2NUsesLinearStrain, KratosStructuralMechanicsFastSuite)
     {
-      // Set up the model part
-      Model current_model;
-      auto& r_model_part = current_model.CreateModelPart("ModelPart",1);
-      r_model_part.GetProcessInfo().SetValue(DOMAIN_SIZE, 3);
-      r_model_part.AddNodalSolutionStepVariable(DISPLACEMENT);
+        Model current_model;
+        auto& r_model_part = CreateTestModelPart(current_model);
 
-      // Create two nodes and a truss element
-      constexpr auto length = 2.0;
-      auto p_bottom_node = r_model_part.CreateNewNode(1, 0.0, 0.0, 0.0);
-      auto p_top_node = r_model_part.CreateNewNode(2, 0.0, 0.0, length);
-      AddDisplacementDofsElement(r_model_part);
+        // Create two nodes and a truss element
+        constexpr auto length = 2.0;
+        auto p_bottom_node = r_model_part.CreateNewNode(1, 0.0, 0.0, 0.0);
+        auto p_top_node = r_model_part.CreateNewNode(2, 0.0, 0.0, length);
+        AddDisplacementDofsElement(r_model_part);
 
-      auto p_elem_prop = r_model_part.CreateNewProperties(0);
-      constexpr auto elongation = 0.01;
-      constexpr auto linear_strain = elongation / length;
-      constexpr auto tangent_modulus_1 = 2.0e+03;
-      constexpr auto tangent_modulus_2 = 1.0e+03;
-      auto p_test_law = std::make_shared<StubBilinearLaw>(1.0001 * linear_strain, tangent_modulus_1, tangent_modulus_2);
-      p_elem_prop->SetValue(CONSTITUTIVE_LAW, p_test_law);
+        auto p_elem_prop = r_model_part.CreateNewProperties(0);
+        constexpr auto elongation = 0.01;
+        constexpr auto linear_strain = elongation / length;
+        constexpr auto tangent_modulus_1 = 2.0e+03;
+        constexpr auto tangent_modulus_2 = 1.0e+03;
+        auto p_test_law = std::make_shared<StubBilinearLaw>(1.0001 * linear_strain, tangent_modulus_1, tangent_modulus_2);
+        p_elem_prop->SetValue(CONSTITUTIVE_LAW, p_test_law);
 
-      std::vector<ModelPart::IndexType> element_nodes {1,2};
-      auto p_element = r_model_part.CreateNewElement("TrussLinearElement3D2N", 1, element_nodes, p_elem_prop);
-      p_element->Initialize(r_model_part.GetProcessInfo());
+        std::vector<ModelPart::IndexType> element_nodes {1,2};
+        auto p_element = r_model_part.CreateNewElement("TrussLinearElement3D2N", 1, element_nodes, p_elem_prop);
+        p_element->Initialize(r_model_part.GetProcessInfo());
 
-      // Set the displacements for testing
-      p_bottom_node->FastGetSolutionStepValue(DISPLACEMENT, 0) = array_1d<double, 3>{0.0, 0.0, 0.0};
-      p_top_node->FastGetSolutionStepValue(DISPLACEMENT, 0) = array_1d<double, 3>{0.0, 0.0, elongation};
+        // Set the displacements for testing
+        p_bottom_node->FastGetSolutionStepValue(DISPLACEMENT, 0) = array_1d<double, 3>{0.0, 0.0, 0.0};
+        p_top_node->FastGetSolutionStepValue(DISPLACEMENT, 0) = array_1d<double, 3>{0.0, 0.0, elongation};
 
-      auto p_truss_element = dynamic_cast<TrussElementLinear3D2N*>(p_element.get());
-      KRATOS_EXPECT_NE(p_truss_element, nullptr);
-      KRATOS_EXPECT_NEAR(tangent_modulus_1, p_truss_element->ReturnTangentModulus1D(r_model_part.GetProcessInfo()), 1.0e-10);
+        auto p_truss_element = dynamic_cast<TrussElementLinear3D2N*>(p_element.get());
+        KRATOS_EXPECT_NE(p_truss_element, nullptr);
+        KRATOS_EXPECT_NEAR(tangent_modulus_1, p_truss_element->ReturnTangentModulus1D(r_model_part.GetProcessInfo()), 1.0e-10);
     }
 
 }

--- a/applications/StructuralMechanicsApplication/tests/cpp_tests/test_truss.cpp
+++ b/applications/StructuralMechanicsApplication/tests/cpp_tests/test_truss.cpp
@@ -39,7 +39,7 @@ public:
 
     SizeType GetStrainSize() const override
     {
-        return 3;
+        return 1;
     }
 
     double& CalculateValue(Parameters& rParameterValues, const Variable<double>& rThisVariable, double& rValue) override
@@ -75,8 +75,8 @@ std::shared_ptr<StubBilinearLaw> CreateStubBilinearLaw(double Elongation, double
     const auto linear_strain = Elongation / Length;
     const auto new_length = Length + Elongation;
     const auto green_lagrange_strain = (new_length * new_length - Length * Length) / (2.0 * Length * Length);
-    const auto mean_strain = 0.5 * (linear_strain + green_lagrange_strain);
-    return std::make_shared<StubBilinearLaw>(mean_strain, TangentModulus1, TangentModulus2);
+    const auto threshold_strain = 0.5 * (linear_strain + green_lagrange_strain);
+    return std::make_shared<StubBilinearLaw>(threshold_strain, TangentModulus1, TangentModulus2);
 }
 
 }
@@ -274,12 +274,12 @@ namespace Testing
         auto p_element = r_model_part.CreateNewElement("TrussElement3D2N", 1, element_nodes, p_elem_prop);
         p_element->Initialize(r_model_part.GetProcessInfo());
 
-        p_bottom_node->FastGetSolutionStepValue(DISPLACEMENT, 0) = array_1d<double, 3>{0.0, 0.0, 0.0};
-        p_top_node->FastGetSolutionStepValue(DISPLACEMENT, 0) = array_1d<double, 3>{0.0, 0.0, elongation};
+        p_bottom_node->FastGetSolutionStepValue(DISPLACEMENT) = array_1d<double, 3>{0.0, 0.0, 0.0};
+        p_top_node->FastGetSolutionStepValue(DISPLACEMENT) = array_1d<double, 3>{0.0, 0.0, elongation};
 
         auto p_truss_element = dynamic_cast<TrussElement3D2N*>(p_element.get());
         KRATOS_EXPECT_NE(p_truss_element, nullptr);
-        KRATOS_EXPECT_NEAR(tangent_modulus_2, p_truss_element->ReturnTangentModulus1D(r_model_part.GetProcessInfo()), 1.0e-8);
+        KRATOS_EXPECT_DOUBLE_EQ(tangent_modulus_2, p_truss_element->ReturnTangentModulus1D(r_model_part.GetProcessInfo()));
     }
 
     KRATOS_TEST_CASE_IN_SUITE(TangentModulusOfTrussElementLinear3D2NUsesLinearStrain, KratosStructuralMechanicsFastSuite)
@@ -301,12 +301,12 @@ namespace Testing
         auto p_element = r_model_part.CreateNewElement("TrussLinearElement3D2N", 1, element_nodes, p_elem_prop);
         p_element->Initialize(r_model_part.GetProcessInfo());
 
-        p_bottom_node->FastGetSolutionStepValue(DISPLACEMENT, 0) = array_1d<double, 3>{0.0, 0.0, 0.0};
-        p_top_node->FastGetSolutionStepValue(DISPLACEMENT, 0) = array_1d<double, 3>{0.0, 0.0, elongation};
+        p_bottom_node->FastGetSolutionStepValue(DISPLACEMENT) = array_1d<double, 3>{0.0, 0.0, 0.0};
+        p_top_node->FastGetSolutionStepValue(DISPLACEMENT) = array_1d<double, 3>{0.0, 0.0, elongation};
 
         auto p_truss_element = dynamic_cast<TrussElement3D2N*>(p_element.get());
         KRATOS_EXPECT_NE(p_truss_element, nullptr);
-        KRATOS_EXPECT_NEAR(tangent_modulus_1, p_truss_element->ReturnTangentModulus1D(r_model_part.GetProcessInfo()), 1.0e-10);
+        KRATOS_EXPECT_DOUBLE_EQ(tangent_modulus_1, p_truss_element->ReturnTangentModulus1D(r_model_part.GetProcessInfo()));
     }
 
 }

--- a/applications/StructuralMechanicsApplication/tests/cpp_tests/test_truss.cpp
+++ b/applications/StructuralMechanicsApplication/tests/cpp_tests/test_truss.cpp
@@ -17,6 +17,8 @@
 #include "custom_elements/truss_element_3D2N.hpp"
 #include "custom_elements/truss_element_linear_3D2N.hpp"
 
+#include <utility>
+
 namespace
 {
 
@@ -59,6 +61,13 @@ ModelPart& CreateTestModelPart(Model& rModel)
   r_result.GetProcessInfo().SetValue(DOMAIN_SIZE, 3);
   r_result.AddNodalSolutionStepVariable(DISPLACEMENT);
   return r_result;
+}
+
+std::pair<Node::Pointer, Node::Pointer> CreateEndNodes(ModelPart& rModelPart, double VerticalDistance)
+{
+  auto p_bottom_node = rModelPart.CreateNewNode(1, 0.0, 0.0, 0.0);
+  auto p_top_node = rModelPart.CreateNewNode(2, 0.0, 0.0, VerticalDistance);
+  return std::make_pair(p_bottom_node, p_top_node);
 }
 
 }
@@ -242,10 +251,8 @@ namespace Testing
         Model current_model;
         auto& r_model_part = CreateTestModelPart(current_model);
 
-        // Create two nodes and a truss element
         constexpr auto length = 2.0;
-        auto p_bottom_node = r_model_part.CreateNewNode(1, 0.0, 0.0, 0.0);
-        auto p_top_node = r_model_part.CreateNewNode(2, 0.0, 0.0, length);
+        auto [p_bottom_node, p_top_node] = CreateEndNodes(r_model_part, length);
         AddDisplacementDofsElement(r_model_part);
 
         auto p_elem_prop = r_model_part.CreateNewProperties(0);
@@ -274,10 +281,8 @@ namespace Testing
         Model current_model;
         auto& r_model_part = CreateTestModelPart(current_model);
 
-        // Create two nodes and a truss element
         constexpr auto length = 2.0;
-        auto p_bottom_node = r_model_part.CreateNewNode(1, 0.0, 0.0, 0.0);
-        auto p_top_node = r_model_part.CreateNewNode(2, 0.0, 0.0, length);
+        auto [p_bottom_node, p_top_node] = CreateEndNodes(r_model_part, length);
         AddDisplacementDofsElement(r_model_part);
 
         auto p_elem_prop = r_model_part.CreateNewProperties(0);

--- a/applications/StructuralMechanicsApplication/tests/cpp_tests/test_truss.cpp
+++ b/applications/StructuralMechanicsApplication/tests/cpp_tests/test_truss.cpp
@@ -22,17 +22,17 @@ namespace
 
 using namespace Kratos;
 
-class BilinearTestLaw : public ConstitutiveLaw
+class StubBilinearLaw : public ConstitutiveLaw
 {
 public:
     // Only implement the interface that is needed by the test
-    BilinearTestLaw(double Strain, double TangentModulus1, double TangentModulus2) :
+  StubBilinearLaw(double Strain, double TangentModulus1, double TangentModulus2) :
  mStrain{Strain}, mTangentModuli{TangentModulus1, TangentModulus2}
   {}
 
     ConstitutiveLaw::Pointer Clone() const override
     {
-        return std::make_shared<BilinearTestLaw>(*this);
+        return std::make_shared<StubBilinearLaw>(*this);
     }
 
     SizeType GetStrainSize() const override
@@ -248,7 +248,7 @@ namespace Testing
         constexpr auto linear_strain = elongation / length;
         constexpr auto tangent_modulus_1 = 2.0e+03;
         constexpr auto tangent_modulus_2 = 1.0e+03;
-        auto p_test_law = std::make_shared<BilinearTestLaw>(1.0001 * linear_strain, tangent_modulus_1, tangent_modulus_2);
+        auto p_test_law = std::make_shared<StubBilinearLaw>(1.0001 * linear_strain, tangent_modulus_1, tangent_modulus_2);
         p_elem_prop->SetValue(CONSTITUTIVE_LAW, p_test_law);
 
         std::vector<ModelPart::IndexType> element_nodes {1,2};
@@ -283,7 +283,7 @@ namespace Testing
       constexpr auto linear_strain = elongation / length;
       constexpr auto tangent_modulus_1 = 2.0e+03;
       constexpr auto tangent_modulus_2 = 1.0e+03;
-      auto p_test_law = std::make_shared<BilinearTestLaw>(1.0001 * linear_strain, tangent_modulus_1, tangent_modulus_2);
+      auto p_test_law = std::make_shared<StubBilinearLaw>(1.0001 * linear_strain, tangent_modulus_1, tangent_modulus_2);
       p_elem_prop->SetValue(CONSTITUTIVE_LAW, p_test_law);
 
       std::vector<ModelPart::IndexType> element_nodes {1,2};


### PR DESCRIPTION
**📝 Description**
For the setup of the tangent modulus, the `TrussElementLinear3D2N` uses `ReturnTangentModulus1D` from its base class `TrussElement3D2N`. `TrussElementLinear3D2N` intends to use a linear strain measure, `TrussElement3D2N` uses a Green-Lagrange strain measure. The `TrussElement3D2N` base class function `ReturnTangentModulus1D` uses Green-Lagrange strain, hence gives wrong results when used from `TrussElementLinear3D2N` in  combination with a nonlinear constitutive law. This PR corrects that.

**🆕 Changelog**
- Extracted common part of `ReturnTangentModulus1D`, which receives an additional argument representing the truss's strain value.
- Made the original member function `ReturnTangentModulus1D` `virtual`, to allow for overriding it by class `TrussElementLinear3D2N`.
- The base class (`TrussElement3D2N`) passes the Green-Lagrange strain to the newly extracted member function, whereas the derived class (`TrussElementLinear3D2N`) passes the linear strain.
- Added two unit tests to demonstrate the effect of the above behavioral changes.