### PR TITLE
[Core] Fix Extrapolation in `Table::GetDerivative`

### DIFF
--- a/kratos/includes/table.h
+++ b/kratos/includes/table.h
@@ -446,9 +446,6 @@ public:
     using RecordType = std::pair<TArgumentType, result_row_type>;
     using TableContainerType = std::vector<RecordType>;
 
-    template <typename T>
-    using Variable = Variable<T>;
-
     using XVariableType = Variable<TArgumentType>;
     using YVariableType = Variable<TResultType>;
 

--- a/kratos/includes/table.h
+++ b/kratos/includes/table.h
@@ -11,8 +11,7 @@
 //                   Riccardo Rossi
 //
 
-#if !defined(KRATOS_TABLE_H_INCLUDED )
-#define  KRATOS_TABLE_H_INCLUDED
+#pragma once
 
 // System includes
 #include <string>
@@ -71,11 +70,11 @@ public:
     /// Pointer definition of Table
     KRATOS_CLASS_POINTER_DEFINITION(Table);
 
-    typedef std::array<TResultType, TResultsColumns>  result_row_type;
+    using result_row_type = std::array<TResultType, TResultsColumns>;
 
-    typedef std::pair<TArgumentType, result_row_type> RecordType;
+    using RecordType = std::pair<TArgumentType, result_row_type>;
 
-    typedef std::vector<RecordType> TableContainerType;
+    using TableContainerType = std::vector<RecordType>;
 
     ///@}
     ///@name Life Cycle
@@ -440,17 +439,18 @@ public:
     /// Pointer definition of Table
     KRATOS_CLASS_POINTER_DEFINITION(Table);
 
-    typedef double TResultType;
-    typedef double TArgumentType;
+    using TResultType = double;
+    using TArgumentType = double;
 
-    typedef std::array<TResultType, 1>  result_row_type;
+    using result_row_type = std::array<TResultType, 1>;
+    using RecordType = std::pair<TArgumentType, result_row_type>;
+    using TableContainerType = std::vector<RecordType>;
 
-    typedef std::pair<TArgumentType, result_row_type> RecordType;
+    template <typename T>
+    using Variable = Variable<T>;
 
-    typedef std::vector<RecordType> TableContainerType;
-
-    typedef Variable<TArgumentType> XVariableType;
-    typedef Variable<TResultType> YVariableType;
+    using XVariableType = Variable<TArgumentType>;
+    using YVariableType = Variable<TResultType>;
 
     ///@}
     ///@name Life Cycle
@@ -810,7 +810,7 @@ private:
             for(auto j = i_row->second.begin() ; j != i_row->second.end() ; j++)
                 rSerializer.load("Column", *j);
         }
-   }
+    }
 
 
     ///@}
@@ -865,7 +865,3 @@ inline std::ostream& operator << (std::ostream& rOStream,
 ///@} addtogroup block
 
 }  // namespace Kratos.
-
-#endif // KRATOS_TABLE_H_INCLUDED  defined
-
-

--- a/kratos/includes/table.h
+++ b/kratos/includes/table.h
@@ -48,8 +48,8 @@ namespace Kratos
 ///@}
 ///@name Kratos Classes
 ///@{
-    
-/** 
+
+/**
  * @class Table
  * @ingroup KratosCore
  * @brief This class represents the value of its variable depending to other variable.
@@ -238,7 +238,7 @@ public:
     {
         mData.push_back(RecordType(X,Y));
     }
-    
+
     /**
      * @brief This method clears database
      */
@@ -649,15 +649,13 @@ public:
 
         TResultType result;
         if(X <= mData[0].first)
-            //return Interpolate(X, mData[0].first, mData[0].second[0], mData[1].first, mData[1].second[0], result);
-            return 0.0;
+            return InterpolateDerivative(mData[0].first, mData[0].second[0], mData[1].first, mData[1].second[0], result);
 
         for(std::size_t i = 1 ; i < size ; i++)
             if(X <= mData[i].first)
                 return InterpolateDerivative( mData[i-1].first, mData[i-1].second[0], mData[i].first, mData[i].second[0], result);
 
-        // If it lies outside the table values we will return 0.0.
-        return 0.0;
+        return InterpolateDerivative(mData[size-2].first, mData[size-2].second[0], mData[size-1].first, mData[size-1].second[0], result);
     }
      TResultType& InterpolateDerivative( TArgumentType const& X1, TResultType const& Y1, TArgumentType const& X2, TResultType const& Y2, TResultType& Result) const
     {
@@ -667,7 +665,7 @@ public:
         if (dx < epsilon)
         {
             dx=epsilon;
-            KRATOS_WARNING("") 
+            KRATOS_WARNING("")
             << "*******************************************\n"
             << "*** ATTENTION: SMALL dX WHEN COMPUTING  ***\n"
             << "*** DERIVATIVE FROM TABLE. SET TO 1E-12 ***\n"
@@ -676,7 +674,7 @@ public:
         Result= dy/dx;
         return Result;
     }
-    
+
     /**
      * @brief This method clears database
      */
@@ -684,7 +682,7 @@ public:
     {
         mData.clear();
     }
-    
+
     ///@}
     ///@name Access
     ///@{
@@ -868,6 +866,6 @@ inline std::ostream& operator << (std::ostream& rOStream,
 
 }  // namespace Kratos.
 
-#endif // KRATOS_TABLE_H_INCLUDED  defined 
+#endif // KRATOS_TABLE_H_INCLUDED  defined
 
 


### PR DESCRIPTION
[`Table::GetValue`](https://github.com/KratosMultiphysics/Kratos/blob/1fcc8b51bd533544e02fd01c1f145f56bf88cc5e/kratos/includes/table.h#L511-L520) continues on the last (or first) slope if the input value is out of bounds, but [`Table::GetDerivative`](https://github.com/KratosMultiphysics/Kratos/blob/1fcc8b51bd533544e02fd01c1f145f56bf88cc5e/kratos/includes/table.h#L647-L660) returns `0` in these regions.

This PR makes the behaviour of `Table::GetDerivative` consistent with `Table::GetValue`.