### PR TITLE
[Core] Add Accessor for Table Derivatives

### DIFF
--- a/kratos/includes/table_derivative_accessor.cpp
+++ b/kratos/includes/table_derivative_accessor.cpp
@@ -1,0 +1,101 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
+//
+
+// System includes
+
+// External includes
+
+// Project includes
+#include "includes/table_derivative_accessor.h"
+#include "includes/properties.h"
+
+namespace Kratos
+{
+
+/***********************************************************************************/
+/***********************************************************************************/
+
+double TableDerivativeAccessor::GetValue(
+    const Variable<double>& rVariable,
+    const Properties& rProperties,
+    const GeometryType& rGeometry,
+    const Vector& rShapeFunctionVector,
+    const ProcessInfo& rProcessInfo
+    ) const
+{
+    return GetValueFromTable(*mpInputVariable, rVariable, rProperties, rGeometry, rShapeFunctionVector, rProcessInfo);
+}
+
+/***********************************************************************************/
+/***********************************************************************************/
+
+double TableDerivativeAccessor::GetValueFromTable(
+        const Variable<double> &rIndependentVariable,
+        const Variable<double> &rDependentVariable,
+        const Properties& rProperties,
+        const GeometryType& rGeometry,
+        const Vector& rShapeFunctionVector,
+        const ProcessInfo& rProcessInfo) const
+{
+    double independent_at_gauss = 0.0;
+    if (mInputVariableType == Globals::DataLocation::NodeHistorical) {
+        for (SizeType i = 0; i < rShapeFunctionVector.size(); ++i) {
+            KRATOS_DEBUG_ERROR_IF_NOT(rGeometry[i].SolutionStepsDataHas(rIndependentVariable)) << "The Variable " << rIndependentVariable.Name() << " is not available at the nodes of the Geometry to retrieve Table values." << std::endl;
+            const double nodal_value = rGeometry[i].FastGetSolutionStepValue(rIndependentVariable);
+            independent_at_gauss += nodal_value * rShapeFunctionVector[i];
+        }
+    } else if (mInputVariableType == Globals::DataLocation::NodeNonHistorical) {
+        for (SizeType i = 0; i < rShapeFunctionVector.size(); ++i) {
+            KRATOS_DEBUG_ERROR_IF_NOT(rGeometry[i].Has(rIndependentVariable)) << "The Variable " << rIndependentVariable.Name() << " is not available at the nodes of the Geometry to retrieve Table values." << std::endl;
+            const double nodal_value = rGeometry[i].GetValue(rIndependentVariable);
+            independent_at_gauss += nodal_value * rShapeFunctionVector[i];
+        }
+    } else if (mInputVariableType == Globals::DataLocation::Element) {
+        KRATOS_DEBUG_ERROR_IF_NOT(rGeometry.Has(rIndependentVariable)) << "The Variable " << rIndependentVariable.Name() << " is not available at the Geometry to retrieve Table values." << std::endl;
+        independent_at_gauss = rGeometry.GetValue(rIndependentVariable);
+    } else {
+        KRATOS_ERROR << "The table_input_variable_type is incorrect or not supported. Types available are : nodal_historical, nodal_non_historical and elemental_non_historical" << std::endl;
+    }
+
+    // Retrieve the dependent variable from the table
+    const auto& r_table = rProperties.GetTable(rIndependentVariable, rDependentVariable);
+    return r_table.GetDerivative(independent_at_gauss);
+}
+
+/***********************************************************************************/
+/***********************************************************************************/
+
+void TableDerivativeAccessor::save(Serializer& rSerializer) const
+{
+    rSerializer.save("InputVariable", mpInputVariable->Name());
+    // // we must do the int cast to be able to compile
+    rSerializer.save("InputVariableType", static_cast<int>(mInputVariableType));
+}
+void TableDerivativeAccessor::load(Serializer& rSerializer)
+{
+    std::string variable_name;
+    rSerializer.load("InputVariable", variable_name);
+    mpInputVariable = static_cast<Variable<double> *>(KratosComponents<VariableData>::pGet(variable_name));
+
+    // // we must do the int cast to be able to compile
+    int enum_value;
+    rSerializer.load("InputVariableType", enum_value);
+    mInputVariableType = static_cast<Globals::DataLocation>(enum_value);
+}
+
+/***********************************************************************************/
+/***********************************************************************************/
+
+Accessor::UniquePointer TableDerivativeAccessor::Clone() const
+{
+    return Kratos::make_unique<TableDerivativeAccessor>(*this);
+}
+
+} // namespace Kratos

--- a/kratos/includes/table_derivative_accessor.h
+++ b/kratos/includes/table_derivative_accessor.h
@@ -1,0 +1,171 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
+//
+
+# pragma once
+
+// System includes
+
+// External includes
+
+// Project includes
+#include "includes/accessor.h"
+
+namespace Kratos
+{
+///@addtogroup KratosCore
+///@{
+
+///@name Kratos Classes
+///@{
+
+/**
+ * @class TableDerivativeAccessor
+ * @ingroup Kratos Core
+ * @brief This class looks up a variable from the derivative of a table.
+ * @brief The tables are supposed to relate double <-> double type entities.
+ * @brief The input variable is suposed to be a nodally accesible one (either historical or not)
+ */
+class KRATOS_API(KRATOS_CORE) TableDerivativeAccessor : public Accessor
+{
+public:
+    ///@name Type Definitions
+    ///@{
+
+    /// Geometry type definition
+    using GeometryType = Geometry<Node>;
+
+    /// Variable type
+    using VariableType = Variable<double>;
+
+    /// BaseType
+    using BaseType = Accessor;
+
+    using DataLocation = Globals::DataLocation;
+
+    using SizeType = std::size_t;
+
+    /// Pointer definition of TableDerivativeAccessor
+    KRATOS_CLASS_POINTER_DEFINITION(TableDerivativeAccessor);
+
+    ///@}
+    ///@name Life Cycle
+    ///@{
+    TableDerivativeAccessor()
+    {}
+
+    /// Custom constructor
+    TableDerivativeAccessor(VariableType& rInputVariable, const std::string& rInputVariableType = "node_historical")
+        : mpInputVariable(&rInputVariable)
+    {
+        // We initialize the variable type only once
+        if (rInputVariableType == "node_historical") {
+            mInputVariableType = Globals::DataLocation::NodeHistorical;
+        } else if (rInputVariableType == "node_non_historical") {
+            mInputVariableType = Globals::DataLocation::NodeNonHistorical;
+        } else if (rInputVariableType == "element") {
+            mInputVariableType = Globals::DataLocation::Element;
+        } else {
+            KRATOS_ERROR << "The table_input_variable_type is incorrect or not supported. Types available are : 'node_historical', 'node_non_historical' and 'element'" << std::endl;
+        }
+    }
+
+    /// Copy constructor
+    TableDerivativeAccessor(const TableDerivativeAccessor& rOther)
+    : BaseType(rOther),
+        mpInputVariable(rOther.mpInputVariable),
+        mInputVariableType(rOther.mInputVariableType)
+    {}
+
+    ///@}
+    ///@name Operations
+    ///@{
+
+    /**
+     * @brief Custom method to retrieve double type properties
+     * @param rVariable The variable considered (double type properties)
+     * @param rProperties The properties considered
+     * @param rGeometry The geometry considered
+     * @param rShapeFunctionVector The shape function of the GP considered
+     * @param rProcessInfo The process info considered
+     * @return The double type properties
+     */
+    double GetValue(
+        const Variable<double>& rVariable,
+        const Properties& rProperties,
+        const GeometryType& rGeometry,
+        const Vector& rShapeFunctionVector,
+        const ProcessInfo& rProcessInfo
+        ) const override;
+
+    /**
+     * @brief This computes a material property according to a certain
+     * nodal Variable<double> table
+     */
+    double GetValueFromTable(
+        const Variable<double>& rIndependentVariable,
+        const Variable<double>& rDependentVariable,
+        const Properties& rProperties,
+        const GeometryType& rGeometry,
+        const Vector& rShapeFunctionVector,
+        const ProcessInfo& rProcessInfo) const;
+
+
+    /**
+     * @brief Returns the member input variable
+     */
+    VariableType& GetInputVariable() const
+    {
+        return *mpInputVariable;
+    }
+
+    // Getting a pointer to the class
+    Accessor::UniquePointer Clone() const override;
+
+    ///@}
+    ///@name Input and output
+    ///@{
+
+    /// Turn back information as a string.
+    std::string Info() const override
+    {
+        std::stringstream buffer;
+        buffer << "TableDerivativeAccessor" ;
+
+        return buffer.str();
+    }
+
+    /// Print information about this object.
+    void PrintInfo(std::ostream& rOStream) const override {rOStream << "TableDerivativeAccessor";}
+
+    /// Print object's data.
+    void PrintData(std::ostream& rOStream) const override {rOStream << "TableDerivativeAccessor class";}
+
+    ///@}
+
+private:
+
+    ///@name Member Variables
+    ///@{
+
+    VariableType* mpInputVariable;
+    Globals::DataLocation mInputVariableType = Globals::DataLocation::NodeHistorical; // NodalHistorical by default
+
+    friend class Serializer;
+
+    void save(Serializer &rSerializer) const override;
+
+    void load(Serializer &rSerializer) override;
+
+}; // class
+///@}
+
+///@} addtogroup block
+
+} // namespace Kratos

--- a/kratos/utilities/read_and_set_accessors_utilities.cpp
+++ b/kratos/utilities/read_and_set_accessors_utilities.cpp
@@ -17,6 +17,7 @@
 
 // Project includes
 #include "utilities/read_and_set_accessors_utilities.h"
+#include "includes/table_derivative_accessor.h"
 
 namespace Kratos {
 
@@ -34,27 +35,37 @@ void ReadAndSetAccessorsUtilities::ReadAndSetAccessors(
         // Loop over the accessors list
         for (auto iter = accessors.begin(); iter != accessors.end(); ++iter) {
             auto accessor_param = accessors.GetValue(iter.name());
-            
+
+            // Independent Variable
+            std::string input_var_name = accessor_param["properties"]["table_input_variable"].GetString();
+            Variable<double> *p_input_var = static_cast<Variable<double> *>(KratosComponents<VariableData>::pGet(input_var_name));
+
+            // Dependent Variable
+            std::string output_var_name = accessor_param["properties"]["table_output_variable"].GetString();
+            const auto& r_output_var  = KratosComponents<Variable<double>>().Get(output_var_name);
+
+            // We set the variable type of the input variable (node_historical, node_non_historical and element)
+            std::string input_var_type = accessor_param["properties"].Has("table_input_variable_type") ? accessor_param["properties"]["table_input_variable_type"].GetString() : "node_historical";
+
+            KRATOS_ERROR_IF(rProperty.HasAccessor(r_output_var)) << "You are trying to add an Accessor between " << input_var_name << " and " << output_var_name << " which already exists..." << std::endl;
+
+            std::unique_ptr<Accessor> p_accessor;
+
             // Table Accessor
-            if (accessor_param["accessor_type"].GetString() == "table_accessor") {
-                // Independent Variable
-                std::string input_var_name = accessor_param["properties"]["table_input_variable"].GetString();
-                Variable<double> *p_input_var = static_cast<Variable<double> *>(KratosComponents<VariableData>::pGet(input_var_name));
-
-                // Dependent Variable
-                std::string output_var_name = accessor_param["properties"]["table_output_variable"].GetString();
-                const auto& r_output_var  = KratosComponents<Variable<double>>().Get(output_var_name);
-
-                // We set the variable type of the input variable (node_historical, node_non_historical and element)
-                std::string input_var_type = accessor_param["properties"].Has("table_input_variable_type") ? accessor_param["properties"]["table_input_variable_type"].GetString() : "node_historical";
-
-                KRATOS_ERROR_IF(rProperty.HasAccessor(r_output_var)) << "You are trying to add an TableAccessor between " << input_var_name << " and " << output_var_name << " which already exists..." << std::endl;
-
-                rProperty.SetAccessor(r_output_var, (TableAccessor(*p_input_var, input_var_type)).Clone());
+            const std::string accessor_type_name = accessor_param["accessor_type"].GetString();
+            if (accessor_type_name == "table_accessor") {
+                p_accessor = std::unique_ptr<Accessor>(new TableAccessor(*p_input_var, input_var_type));
+            } else if (accessor_type_name == "table_derivative_accessor") {
+                p_accessor = std::unique_ptr<Accessor>(new TableDerivativeAccessor(*p_input_var, input_var_type));
             } else {
                 // No more accessors implemented currently
-                KRATOS_ERROR << "This Accessor type is not available, only TableAccessor is ready for now" << std::endl;
+                KRATOS_ERROR << "This Accessor type is not available, options are:\n"
+                             << "- TableAccessor\n"
+                             << "- TableDerivativeAccessor"
+                             << std::endl;
             }
+
+            rProperty.SetAccessor(r_output_var, std::move(p_accessor));
         }
     }
 }


### PR DESCRIPTION
Add an `Accessor` that fetches the derivatives from a table instead of the values. Example use case is getting stiffnesses from a displacement-force table.
