### PR TITLE
[CI] Add support for importing runtime dependencies in gtest test suites

### DIFF
--- a/applications/FluidDynamicsApplication/fluid_dynamics_application.cpp
+++ b/applications/FluidDynamicsApplication/fluid_dynamics_application.cpp
@@ -28,6 +28,11 @@
 #include "fluid_dynamics_application.h"
 #include "includes/variables.h"
 
+Kratos::KratosApplication * CreateApplication()
+{
+    return new Kratos::KratosFluidDynamicsApplication();
+}
+
 namespace Kratos
 {
 

--- a/applications/FluidDynamicsApplication/fluid_dynamics_application.h
+++ b/applications/FluidDynamicsApplication/fluid_dynamics_application.h
@@ -115,6 +115,8 @@
 // Adjoint fluid conditions
 #include "custom_conditions/adjoint_monolithic_wall_condition.h"
 
+extern "C" KRATOS_API(FLUID_DYNAMICS_APPLICATION) Kratos::KratosApplication * CreateApplication();
+
 namespace Kratos
 {
 ///@addtogroup FluidDynamicsApplication

--- a/applications/LinearSolversApplication/linear_solvers_application.cpp
+++ b/applications/LinearSolversApplication/linear_solvers_application.cpp
@@ -27,6 +27,11 @@
 #include "mkl_service.h"
 #endif
 
+Kratos::KratosApplication* CreateApplication()
+{
+    return new Kratos::KratosLinearSolversApplication();
+}
+
 namespace Kratos
 {
 

--- a/applications/LinearSolversApplication/linear_solvers_application.h
+++ b/applications/LinearSolversApplication/linear_solvers_application.h
@@ -18,6 +18,10 @@
 #include "includes/define.h"
 #include "includes/kratos_application.h"
 
+/// @brief Helper method to initialize the application when loading the library directly
+/// @return An application instance
+extern "C" KRATOS_API(LINEARSOLVERS_APPLICATION) Kratos::KratosApplication* CreateApplication();
+
 namespace Kratos
 {
 

--- a/applications/MappingApplication/mapping_application.cpp
+++ b/applications/MappingApplication/mapping_application.cpp
@@ -61,6 +61,11 @@
         (dummy_model_part, dummy_model_part));                                                        \
     }
 
+Kratos::KratosApplication* CreateApplication()
+{
+    return new Kratos::KratosMappingApplication();
+}
+
 namespace Kratos
 {
 

--- a/applications/MappingApplication/mapping_application.h
+++ b/applications/MappingApplication/mapping_application.h
@@ -25,6 +25,9 @@
 #include "custom_searching/interface_object.h"
 #include "custom_modelers/mapping_geometries_modeler.h"
 
+/// @brief Helper method to initialize the application when loading the library directly
+/// @return An application instance
+extern "C" KRATOS_API(MAPPING_APPLICATION) Kratos::KratosApplication* CreateApplication();
 namespace Kratos
 {
 

--- a/cmake_modules/KratosGTest.cmake
+++ b/cmake_modules/KratosGTest.cmake
@@ -22,6 +22,8 @@ macro(kratos_add_gtests)
             endif()
         endif()
 
+        set(KRATOS_ADD_GTEST_SOURCES ${KRATOS_ADD_GTEST_SOURCES} ${KRATOS_BASE_FOLDER}/kratos/testing/runtime_dependency_handler.cpp)
+
         add_executable("${KRATOS_ADD_GTEST_TARGET}Test" ${KRATOS_ADD_GTEST_SOURCES} ${KRATOS_GTEST_MAIN_SOURCE})
         target_link_libraries("${KRATOS_ADD_GTEST_TARGET}Test" ${KRATOS_ADD_GTEST_TARGET} KratosCoreTestUtilities "${TESTING_MPI_UTILITIES}" GTest::gmock_main)
         set_target_properties("${KRATOS_ADD_GTEST_TARGET}Test" PROPERTIES COMPILE_DEFINITIONS "KRATOS_TEST_CORE=IMPORT,API")

--- a/kratos/testing/runtime_dependency_handler.cpp
+++ b/kratos/testing/runtime_dependency_handler.cpp
@@ -16,7 +16,7 @@ void RuntimeDependencyHandler::LoadDependency(const std::string& rApplicationNam
 {
     auto found = mLoadedLibraries.find(rApplicationName);
     if (found == mLoadedLibraries.end()) {
-        #ifdef _WIN32
+        #ifdef KRATOS_COMPILED_IN_WINDOWS
         const std::string lib_file = rLibraryName+".dll";
         LibraryHandle library = LoadLibrary(TEXT(lib_file.c_str()));
         #else
@@ -38,7 +38,7 @@ RuntimeDependencyHandler::ApplicationMap RuntimeDependencyHandler::CreateApplica
 
     for (auto& r_loaded: mLoadedLibraries) {
         LibraryHandle library = r_loaded.second;
-        #ifdef _WIN32
+        #ifdef KRATOS_COMPILED_IN_WINDOWS
         auto p_create_app = reinterpret_cast<CreateApplicationPointer>(GetProcAddress(library, "CreateApplication"));
         #else
         auto p_create_app = reinterpret_cast<CreateApplicationPointer>(dlsym(library, "CreateApplication"));
@@ -55,7 +55,7 @@ void RuntimeDependencyHandler::ReleaseDependencies()
 {
     for (auto iter = mLoadedLibraries.begin(); iter != mLoadedLibraries.end(); ++iter)
     {
-        #ifdef _WIN32
+        #ifdef KRATOS_COMPILED_IN_WINDOWS
         FreeLibrary(iter->second);
         #else
         dlclose(iter->second);

--- a/kratos/testing/runtime_dependency_handler.cpp
+++ b/kratos/testing/runtime_dependency_handler.cpp
@@ -1,0 +1,68 @@
+#include "runtime_dependency_handler.h"
+
+namespace Kratos::Testing {
+
+
+RuntimeDependencyHandler::RuntimeDependencyHandler() {}
+
+
+RuntimeDependencyHandler::~RuntimeDependencyHandler()
+{
+    ReleaseDependencies();
+}
+
+
+void RuntimeDependencyHandler::LoadDependency(const std::string& rApplicationName, const std::string& rLibraryName)
+{
+    auto found = mLoadedLibraries.find(rApplicationName);
+    if (found == mLoadedLibraries.end()) {
+        #ifdef _WIN32
+        const std::string lib_file = rLibraryName+".dll";
+        LibraryHandle library = LoadLibrary(TEXT(lib_file.c_str()));
+        #else
+        const std::string lib_file = "lib"+rLibraryName+".so";
+        LibraryHandle library = dlopen(lib_file.c_str(), RTLD_NOW|RTLD_GLOBAL);
+        #endif
+        KRATOS_ERROR_IF(library == nullptr) << "Could not load runtime dependency library " << rLibraryName << std::endl;
+        mLoadedLibraries.insert_or_assign(rApplicationName, library);
+    }
+}
+
+
+RuntimeDependencyHandler::ApplicationMap RuntimeDependencyHandler::CreateApplications()
+{
+    using KratosApplication = Kratos::KratosApplication;
+    typedef KratosApplication* (*CreateApplicationPointer)();
+
+    ApplicationMap applications;
+
+    for (auto& r_loaded: mLoadedLibraries) {
+        LibraryHandle library = r_loaded.second;
+        #ifdef _WIN32
+        auto p_create_app = reinterpret_cast<CreateApplicationPointer>(GetProcAddress(library, "CreateApplication"));
+        #else
+        auto p_create_app = reinterpret_cast<CreateApplicationPointer>(dlsym(library, "CreateApplication"));
+        #endif
+        KRATOS_ERROR_IF(p_create_app == nullptr) << "Could not find CreateApplication method for runtime dependency library " << r_loaded.first << std::endl;
+        applications.insert({r_loaded.first, KratosApplication::Pointer((*p_create_app)())});
+    }
+
+    return applications;
+}
+
+
+void RuntimeDependencyHandler::ReleaseDependencies()
+{
+    for (auto iter = mLoadedLibraries.begin(); iter != mLoadedLibraries.end(); ++iter)
+    {
+        #ifdef _WIN32
+        FreeLibrary(iter->second);
+        #else
+        dlclose(iter->second);
+        #endif
+    }
+
+    mLoadedLibraries.clear();
+}
+
+}

--- a/kratos/testing/runtime_dependency_handler.h
+++ b/kratos/testing/runtime_dependency_handler.h
@@ -14,7 +14,7 @@
 #pragma once
 
 #include <unordered_map>
-#ifdef _WIN32
+#ifdef KRATOS_COMPILED_IN_WINDOWS
 #define NOMINMAX
 #include <windows.h>
 #undef NOMINMAX
@@ -45,7 +45,7 @@ public:
 
 private:
 
-    #ifdef _WIN32
+    #ifdef KRATOS_COMPILED_IN_WINDOWS
     using LibraryHandle = HINSTANCE;
     #else
     using LibraryHandle = void*;

--- a/kratos/testing/runtime_dependency_handler.h
+++ b/kratos/testing/runtime_dependency_handler.h
@@ -1,0 +1,58 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
+//
+//  Main authors:    Jordi Cotela Dalmau
+//
+//
+
+#pragma once
+
+#include <unordered_map>
+#ifdef _WIN32
+#define NOMINMAX
+#include <windows.h>
+#undef NOMINMAX
+#else
+#include <dlfcn.h>
+#endif
+
+#include "includes/define.h"
+#include "includes/kernel.h"
+
+namespace Kratos::Testing {
+
+class RuntimeDependencyHandler
+{
+public:
+
+    using ApplicationMap = std::unordered_map<std::string, Kratos::KratosApplication::Pointer>;
+
+    RuntimeDependencyHandler();
+
+    ~RuntimeDependencyHandler();
+
+    void LoadDependency(const std::string& rApplicationName, const std::string& rLibraryName);
+
+    ApplicationMap CreateApplications();
+
+    void ReleaseDependencies();
+
+private:
+
+    #ifdef _WIN32
+    using LibraryHandle = HINSTANCE;
+    #else
+    using LibraryHandle = void*;
+    #endif
+
+    std::unordered_map<std::string, LibraryHandle> mLoadedLibraries = {};
+
+};
+
+}

--- a/kratos/testing/testing.h
+++ b/kratos/testing/testing.h
@@ -313,7 +313,7 @@ class KRATOS_API(KRATOS_TEST_UTILS) RuntimeDependencyExample: public KratosCoreF
 {
 public:
     RuntimeDependencyExample(): KratosCoreFastSuite() {
-        // Needs to be a member, so that it has the same lifetime as the suite
+        // The list of applications has to be a member, so that it has the same lifetime as the suite
         mRuntimeDependencyApplications = mRuntimeDependencies.CreateApplications();
         for (auto& r_dependency: mRuntimeDependencyApplications) {
             std::cout << "Registering " << r_dependency.first << std::endl;
@@ -324,7 +324,7 @@ public:
     static void SetUpTestSuite() {
         // Dependencies should have a CreateApplication function to allow programatic import
         // The second argument is the library name, the extension (and the "lib" prefix, if needed) is added internally
-        mRuntimeDependencies.LoadDependency("FluidDynamicsApplication", "KratosFluidDynamicsCore");
+        mRuntimeDependencies.LoadDependency("LinearSolversApplication", "KratosLinearSolversCore");
     }
 
     static void TearDownTestSuite() {

--- a/kratos/testing/testing.h
+++ b/kratos/testing/testing.h
@@ -24,6 +24,7 @@
 #include "includes/expect.h"                    // Includes the expects from gtest and gmock adapted to kratos checks.
 #include "includes/data_communicator.h"
 #include "testing/test_skipped_exception.h"     // Macros and exception class used to skip tests.
+#include "testing/runtime_dependency_handler.h"
 
 #define KRATOS_TEST_CASE(A) TEST_F(KratosCoreFastSuite, A)
 #define KRATOS_TEST_CASE_IN_SUITE(A, B) TEST_F(B, A)
@@ -306,5 +307,37 @@ class ShallowWaterApplicationFastSuite : public KratosCoreFastSuite {};
 class KratosMappingApplicationMPITestSuite : public KratosCoreFastSuite {};
 
 KRATOS_API(KRATOS_TEST_UTILS) DataCommunicator& GetDefaultDataCommunicator();
+
+
+class KRATOS_API(KRATOS_TEST_UTILS) RuntimeDependencyExample: public KratosCoreFastSuite
+{
+public:
+    RuntimeDependencyExample(): KratosCoreFastSuite() {
+        // Needs to be a member, so that it has the same lifetime as the suite
+        mRuntimeDependencyApplications = mRuntimeDependencies.CreateApplications();
+        for (auto& r_dependency: mRuntimeDependencyApplications) {
+            std::cout << "Registering " << r_dependency.first << std::endl;
+            this->ImportApplicationIntoKernel(r_dependency.second);
+        }
+    }
+
+    static void SetUpTestSuite() {
+        // Dependencies should have a CreateApplication function to allow programatic import
+        // The second argument is the library name, the extension (and the "lib" prefix, if needed) is added internally
+        mRuntimeDependencies.LoadDependency("FluidDynamicsApplication", "KratosFluidDynamicsCore");
+    }
+
+    static void TearDownTestSuite() {
+        mRuntimeDependencies.ReleaseDependencies();
+    }
+
+private:
+
+    std::unordered_map<std::string, KratosApplication::Pointer> mRuntimeDependencyApplications;
+
+    static RuntimeDependencyHandler mRuntimeDependencies;
+};
+
+
 
 } // namespace Kratos::Testing


### PR DESCRIPTION
**📝 Description**
Adds a RuntimeDepenedencyHandler class to manage runtime dependencies in test suites. See testing.h for an example of how to use it.

Note that this approach requires that the imported lilbraries have a CreateApplication method defined with the right visibility.

