### PR TITLE
[Core] Fixed the calculation of the table's derivative outside its domain

### DIFF
--- a/kratos/includes/table.h
+++ b/kratos/includes/table.h
@@ -649,15 +649,13 @@ public:
 
         TResultType result;
         if(X <= mData[0].first)
-            //return Interpolate(X, mData[0].first, mData[0].second[0], mData[1].first, mData[1].second[0], result);
-            return 0.0;
+            return InterpolateDerivative(mData[0].first, mData[0].second[0], mData[1].first, mData[1].second[0], result);
 
         for(std::size_t i = 1 ; i < size ; i++)
             if(X <= mData[i].first)
                 return InterpolateDerivative( mData[i-1].first, mData[i-1].second[0], mData[i].first, mData[i].second[0], result);
 
-        // If it lies outside the table values we will return 0.0.
-        return 0.0;
+        return InterpolateDerivative(mData[size-2].first, mData[size-2].second[0], mData[size-1].first, mData[size-1].second[0], result);
     }
      TResultType& InterpolateDerivative( TArgumentType const& X1, TResultType const& Y1, TArgumentType const& X2, TResultType const& Y2, TResultType& Result) const
     {

--- a/kratos/tests/cpp_tests/sources/test_table.cpp
+++ b/kratos/tests/cpp_tests/sources/test_table.cpp
@@ -80,4 +80,18 @@ KRATOS_TEST_CASE_IN_SUITE(NamesOfXAndYInTableSpecialization, KratosCoreFastSuite
     KRATOS_EXPECT_EQ(table.NameOfY(), "Bar");
 }
 
+KRATOS_TEST_CASE_IN_SUITE(TableDerivativeUsesExtrapolationWhenOutsideOfDomain, KratosCoreFastSuite)
+{
+    Table<double, double> table;
+    table.PushBack(0.0, 0.0);
+    table.PushBack(1.0, 2.0);
+    table.PushBack(3.0, 3.0);
+
+    constexpr auto abs_tolerance = 1.0e-08;
+    KRATOS_EXPECT_NEAR(table.GetDerivative(-2.0), 2.0, abs_tolerance); // before first point in table
+    KRATOS_EXPECT_NEAR(table.GetDerivative(0.0), 2.0, abs_tolerance); // at first point in table
+    KRATOS_EXPECT_NEAR(table.GetDerivative(3.0), 0.5, abs_tolerance); // at last point in table
+    KRATOS_EXPECT_NEAR(table.GetDerivative(5.0), 0.5, abs_tolerance); // beyond last point in table
+}
+
 }  // namespace Kratos::Testing.


### PR DESCRIPTION
**📝 Description**
When the derivative of a table was requested at a point outside of the table's domain, it always returned 0. This was inconsistent with the behavior of member `GetValue`, which extrapolates using either the first line segment or the last line segment. The calculation of the table's derivative has been made consistent now. The change is covered by a unit test.
