### PR TITLE
[RomApp] Keeping element children (neighbouring conditions to elements)

### DIFF
--- a/applications/RomApplication/custom_python/add_custom_utilities_to_python.cpp
+++ b/applications/RomApplication/custom_python/add_custom_utilities_to_python.cpp
@@ -67,6 +67,7 @@ void AddCustomUtilitiesToPython(pybind11::module& m)
         .def_static("ProjectRomSolutionIncrementToNodes", &RomAuxiliaryUtilities::ProjectRomSolutionIncrementToNodes)
         .def_static("GetElementIdsInModelPart", &RomAuxiliaryUtilities::GetElementIdsInModelPart)
         .def_static("GetConditionIdsInModelPart", &RomAuxiliaryUtilities::GetConditionIdsInModelPart)
+        .def_static("GetHRomElementChildrenIds", &RomAuxiliaryUtilities::GetHRomElementChildrenIds)
         ;
 }
 

--- a/applications/RomApplication/custom_utilities/rom_auxiliary_utilities.cpp
+++ b/applications/RomApplication/custom_utilities/rom_auxiliary_utilities.cpp
@@ -702,6 +702,35 @@ std::vector<IndexType> RomAuxiliaryUtilities::GetHRomConditionParentsIds(
     return parent_ids;
 }
 
+
+std::vector<IndexType> RomAuxiliaryUtilities::GetHRomElementChildrenIds(
+    const ModelPart& rModelPart,
+    const std::map<std::string, std::map<IndexType, double>>& rHRomWeights)
+{
+    std::vector<IndexType> children_ids;
+    const auto& r_elem_weights = rHRomWeights.at("Elements");
+    const auto& r_cond_weights = rHRomWeights.at("Conditions");
+
+    for (auto it = r_elem_weights.begin(); it != r_elem_weights.end(); ++it) {
+        // Get the condition parent
+        const auto& r_elem = rModelPart.GetElement(it->first + 1); //FIXME: FIX THE + 1 --> WE NEED TO WRITE REAL IDS IN THE WEIGHTS!!
+        KRATOS_WATCH('alive')
+        const auto& r_neigh = r_elem.GetValue(NEIGHBOUR_CONDITIONS);
+        KRATOS_WATCH('still alive')
+        //KRATOS_ERROR_IF(r_neigh.size() == 0) << "Condition "<< r_elem.Id() <<" has no child condition assigned. Check that \'NEIGHBOUR_ELEMENTS\' have been already computed." << std::endl;
+        // #TODO Plenty of elements can have no conditions assigned !!!!!!!!!!
+
+        // Add the parent to the HROM weights
+        // Note that we check if the element child has been already added by the HROM element selection strategy
+        if (r_cond_weights.find(r_neigh[0].Id() - 1) == r_cond_weights.end()) { //FIXME: FIX THE + 1 --> WE NEED TO WRITE REAL IDS IN THE WEIGHTS!!
+            children_ids.push_back(r_neigh[0].Id() - 1); //FIXME: FIX THE + 1 --> WE NEED TO WRITE REAL IDS IN THE WEIGHTS!!
+        }
+    }
+
+    return children_ids;
+}
+
+
 std::vector<IndexType> RomAuxiliaryUtilities::GetHRomConditionParentsIds(
     ModelPart& rModelPart,
     const std::vector<IndexType>& rConditionIds)

--- a/applications/RomApplication/custom_utilities/rom_auxiliary_utilities.h
+++ b/applications/RomApplication/custom_utilities/rom_auxiliary_utilities.h
@@ -146,6 +146,18 @@ public:
         const std::map<std::string, std::map<IndexType, double>>& rHRomWeights);
 
 
+
+    /**
+     fix
+     */
+    static std::vector<IndexType> GetHRomElementChildrenIds(
+        const ModelPart& rModelPart,
+        const std::map<std::string, std::map<IndexType, double>>& rHRomWeights);
+
+
+
+
+
     /**
      * @brief Finds the parent elements for specified condition IDs and decrements their IDs for zero-based indexing.
      * This version executes a process to compute nodal element neighbours for the entire model part, ensuring


### PR DESCRIPTION
**📝 Description**
This PR intents to add the possibility to keep in the HROM model part, for each selected element, its associated conditons

**🆕 Changelog**
- Added GetHRomElementChildrenIds to rom_auxiliary_utilities (based on GetHRomConditionParentsIds)
- Added Foo Application
- Exported GetHRomElementChildrenIds to python
- Added the "include_element_children" flag to hrom_training_utility

**missing**
- cleanup, correct documentation comments
- add test