### PR TITLE
[GeoMechanicsApplication] Fix hydraulic head time writing

### DIFF
--- a/applications/GeoMechanicsApplication/custom_workflows/geo_output_writer.cpp
+++ b/applications/GeoMechanicsApplication/custom_workflows/geo_output_writer.cpp
@@ -178,7 +178,8 @@ void GeoOutputWriter::CalculateNodalHydraulicHead(ModelPart& rModelPart)
             rGeom[node].SetValue(element_var, NodalHydraulicHead[node]);
         }
     }
-    mGidIO.WriteNodalResultsNonHistorical(element_var, rModelPart.Nodes(), 0);
+
+    mGidIO.WriteNodalResultsNonHistorical(element_var, rModelPart.Nodes(), rModelPart.GetProcessInfo()[TIME]);
 }
 
 void GeoOutputWriter::FinalizeResults() { mGidIO.FinalizeResults(); }

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/test_head_extrapolation_flow_workflow.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/test_head_extrapolation_flow_workflow.cpp
@@ -10,81 +10,112 @@
 //  Main authors:    Jonathan Nuttall
 //
 
-#include <iostream>
 #include <string>
+#include <iostream>
 
 // Project includes
+#include "testing/testing.h"
 #include "custom_workflows/dgeoflow.h"
 #include "flow_stubs.h"
 #include "test_utilities.h"
-#include "testing/testing.h"
-
-namespace
-{
-
-using namespace Kratos;
-using namespace Kratos::Testing;
-
-const auto workingDirectory = std::filesystem::path{"."} / "applications" / "GeoMechanicsApplication" /
-                              "tests" / "test_head_extrapolation_custom_workflow_flow";
-
-int RunTestCase(int test_case_number)
-{
-    const auto projectFile = std::string{"ProjectParameters_"} + std::to_string(test_case_number) + ".json";
-
-    auto execute = KratosExecute();
-
-    const KratosExecute::CriticalHeadInfo  critical_head_info(0, 0, 0);
-    const KratosExecute::CallBackFunctions call_back_functions(
-        &flow_stubs::emptyLog, &flow_stubs::emptyProgress, &flow_stubs::emptyLog, &flow_stubs::emptyCancel);
-
-    return execute.ExecuteFlowAnalysis(workingDirectory.generic_string(), projectFile,
-                                       critical_head_info, "", call_back_functions);
-}
-
-void CompareResults(int test_case_number)
-{
-    const auto original =
-        (workingDirectory / ("test_head_extrapolate_" + std::to_string(test_case_number) + ".orig.res"))
-            .generic_string();
-    const auto result =
-        (workingDirectory / ("test_head_extrapolate_" + std::to_string(test_case_number) + ".post.res"))
-            .generic_string();
-
-    KRATOS_EXPECT_TRUE(TestUtilities::CompareFiles(original, result))
-}
-}
-
 
 namespace Kratos::Testing
 {
 
 KRATOS_TEST_CASE_IN_SUITE(CalculateExtrapolatedHeadFlow_1, KratosGeoMechanicsIntegrationSuite)
 {
-    constexpr auto test_case_number = 1;
-    KRATOS_EXPECT_EQ(RunTestCase(test_case_number), 0);
-    CompareResults(test_case_number);
+    auto workingDirectory = "./applications/GeoMechanicsApplication/tests/test_head_extrapolation_custom_workflow_flow";
+    auto projectFile = "ProjectParameters_1.json";
+
+    auto execute = Kratos::KratosExecute();
+
+    const Kratos::KratosExecute::CriticalHeadInfo critical_head_info(0, 0, 0);
+    const Kratos::KratosExecute::CallBackFunctions call_back_functions(&flow_stubs::emptyLog,
+                                                                 &flow_stubs::emptyProgress,
+                                                                 &flow_stubs::emptyLog,
+                                                                 &flow_stubs::emptyCancel);
+
+    const int status = execute.ExecuteFlowAnalysis(workingDirectory, projectFile, critical_head_info, "", call_back_functions);
+
+    KRATOS_EXPECT_EQ(status, 0);
+
+    // output_files
+    std::string original = (std::string) workingDirectory + "/test_head_extrapolate_1.orig.res";
+    std::string result = (std::string) workingDirectory + "/test_head_extrapolate_1.post.res";
+
+    KRATOS_EXPECT_TRUE(TestUtilities::CompareFiles(original, result))
 }
 
-KRATOS_TEST_CASE_IN_SUITE(CalculateExtrapolatedHeadFlow_2, KratosGeoMechanicsIntegrationSuite)
+ KRATOS_TEST_CASE_IN_SUITE(CalculateExtrapolatedHeadFlow_2, KratosGeoMechanicsIntegrationSuite)
 {
-    constexpr auto test_case_number = 2;
-    KRATOS_EXPECT_EQ(RunTestCase(test_case_number), 0);
-    CompareResults(test_case_number);
+    auto workingDirectory = "./applications/GeoMechanicsApplication/tests/test_head_extrapolation_custom_workflow_flow";
+    auto projectFile = "ProjectParameters_2.json";
+
+    auto execute = Kratos::KratosExecute();
+
+    const Kratos::KratosExecute::CriticalHeadInfo critical_head_info(0, 0, 0);
+    const Kratos::KratosExecute::CallBackFunctions call_back_functions(&flow_stubs::emptyLog,
+                                                                 &flow_stubs::emptyProgress,
+                                                                 &flow_stubs::emptyLog,
+                                                                 &flow_stubs::emptyCancel);
+
+    const int status = execute.ExecuteFlowAnalysis(workingDirectory, projectFile, critical_head_info, "", call_back_functions);
+
+    KRATOS_EXPECT_EQ(status, 0);
+
+    // output_files
+    std::string original = (std::string) workingDirectory + "/test_head_extrapolate_2.orig.res";
+    std::string result = (std::string) workingDirectory + "/test_head_extrapolate_2.post.res";
+
+    KRATOS_EXPECT_TRUE(TestUtilities::CompareFiles(original, result))
 }
 
 KRATOS_TEST_CASE_IN_SUITE(CalculateExtrapolatedHeadFlow_3, KratosGeoMechanicsIntegrationSuite)
 {
-    constexpr auto test_case_number = 3;
-    KRATOS_EXPECT_EQ(RunTestCase(test_case_number), 0);
-    CompareResults(test_case_number);
+    auto workingDirectory = "./applications/GeoMechanicsApplication/tests/test_head_extrapolation_custom_workflow_flow";
+    auto projectFile = "ProjectParameters_3.json";
+
+    auto execute = Kratos::KratosExecute();
+
+    const Kratos::KratosExecute::CriticalHeadInfo critical_head_info(0, 0, 0);
+    const Kratos::KratosExecute::CallBackFunctions call_back_functions(&flow_stubs::emptyLog,
+                                                                 &flow_stubs::emptyProgress,
+                                                                 &flow_stubs::emptyLog,
+                                                                 &flow_stubs::emptyCancel);
+
+    const int status = execute.ExecuteFlowAnalysis(workingDirectory, projectFile, critical_head_info, "", call_back_functions);
+
+    KRATOS_EXPECT_EQ(status, 0);
+
+    // output_files
+    std::string original = (std::string) workingDirectory + "/test_head_extrapolate_3.orig.res";
+    std::string result = (std::string) workingDirectory + "/test_head_extrapolate_3.post.res";
+
+    KRATOS_EXPECT_TRUE(TestUtilities::CompareFiles(original, result))
 }
 
 KRATOS_TEST_CASE_IN_SUITE(CalculateExtrapolatedHeadFlow_4, KratosGeoMechanicsIntegrationSuite)
 {
-    constexpr auto test_case_number = 4;
-    KRATOS_EXPECT_EQ(RunTestCase(test_case_number), 0);
-    CompareResults(test_case_number);
+    auto workingDirectory = "./applications/GeoMechanicsApplication/tests/test_head_extrapolation_custom_workflow_flow";
+    auto projectFile = "ProjectParameters_4.json";
+
+    auto execute = Kratos::KratosExecute();
+
+    const Kratos::KratosExecute::CriticalHeadInfo critical_head_info(0, 0, 0);
+    const Kratos::KratosExecute::CallBackFunctions call_back_functions(&flow_stubs::emptyLog,
+                                                                 &flow_stubs::emptyProgress,
+                                                                 &flow_stubs::emptyLog,
+                                                                 &flow_stubs::emptyCancel);
+
+    const int status = execute.ExecuteFlowAnalysis(workingDirectory, projectFile, critical_head_info, "", call_back_functions);
+
+    KRATOS_EXPECT_EQ(status, 0);
+
+    // output_files
+    std::string original = (std::string) workingDirectory + "/test_head_extrapolate_4.orig.res";
+    std::string result = (std::string) workingDirectory + "/test_head_extrapolate_4.post.res";
+
+    KRATOS_EXPECT_TRUE(TestUtilities::CompareFiles(original, result))
 }
 
-} // namespace Kratos::Testing
+}

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/test_head_extrapolation_flow_workflow.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/test_head_extrapolation_flow_workflow.cpp
@@ -10,112 +10,81 @@
 //  Main authors:    Jonathan Nuttall
 //
 
-#include <string>
 #include <iostream>
+#include <string>
 
 // Project includes
-#include "testing/testing.h"
 #include "custom_workflows/dgeoflow.h"
 #include "flow_stubs.h"
 #include "test_utilities.h"
+#include "testing/testing.h"
+
+namespace
+{
+
+using namespace Kratos;
+using namespace Kratos::Testing;
+
+const auto workingDirectory = std::filesystem::path{"."} / "applications" / "GeoMechanicsApplication" /
+                              "tests" / "test_head_extrapolation_custom_workflow_flow";
+
+int RunTestCase(int test_case_number)
+{
+    const auto projectFile = std::string{"ProjectParameters_"} + std::to_string(test_case_number) + ".json";
+
+    auto execute = KratosExecute();
+
+    const KratosExecute::CriticalHeadInfo  critical_head_info(0, 0, 0);
+    const KratosExecute::CallBackFunctions call_back_functions(
+        &flow_stubs::emptyLog, &flow_stubs::emptyProgress, &flow_stubs::emptyLog, &flow_stubs::emptyCancel);
+
+    return execute.ExecuteFlowAnalysis(workingDirectory.generic_string(), projectFile,
+                                       critical_head_info, "", call_back_functions);
+}
+
+void CompareResults(int test_case_number)
+{
+    const auto original =
+        (workingDirectory / ("test_head_extrapolate_" + std::to_string(test_case_number) + ".orig.res"))
+            .generic_string();
+    const auto result =
+        (workingDirectory / ("test_head_extrapolate_" + std::to_string(test_case_number) + ".post.res"))
+            .generic_string();
+
+    KRATOS_EXPECT_TRUE(TestUtilities::CompareFiles(original, result))
+}
+}
+
 
 namespace Kratos::Testing
 {
 
 KRATOS_TEST_CASE_IN_SUITE(CalculateExtrapolatedHeadFlow_1, KratosGeoMechanicsIntegrationSuite)
 {
-    auto workingDirectory = "./applications/GeoMechanicsApplication/tests/test_head_extrapolation_custom_workflow_flow";
-    auto projectFile = "ProjectParameters_1.json";
-
-    auto execute = Kratos::KratosExecute();
-
-    const Kratos::KratosExecute::CriticalHeadInfo critical_head_info(0, 0, 0);
-    const Kratos::KratosExecute::CallBackFunctions call_back_functions(&flow_stubs::emptyLog,
-                                                                 &flow_stubs::emptyProgress,
-                                                                 &flow_stubs::emptyLog,
-                                                                 &flow_stubs::emptyCancel);
-
-    const int status = execute.ExecuteFlowAnalysis(workingDirectory, projectFile, critical_head_info, "", call_back_functions);
-
-    KRATOS_EXPECT_EQ(status, 0);
-
-    // output_files
-    std::string original = (std::string) workingDirectory + "/test_head_extrapolate_1.orig.res";
-    std::string result = (std::string) workingDirectory + "/test_head_extrapolate_1.post.res";
-
-    KRATOS_EXPECT_TRUE(TestUtilities::CompareFiles(original, result))
+    constexpr auto test_case_number = 1;
+    KRATOS_EXPECT_EQ(RunTestCase(test_case_number), 0);
+    CompareResults(test_case_number);
 }
 
- KRATOS_TEST_CASE_IN_SUITE(CalculateExtrapolatedHeadFlow_2, KratosGeoMechanicsIntegrationSuite)
+KRATOS_TEST_CASE_IN_SUITE(CalculateExtrapolatedHeadFlow_2, KratosGeoMechanicsIntegrationSuite)
 {
-    auto workingDirectory = "./applications/GeoMechanicsApplication/tests/test_head_extrapolation_custom_workflow_flow";
-    auto projectFile = "ProjectParameters_2.json";
-
-    auto execute = Kratos::KratosExecute();
-
-    const Kratos::KratosExecute::CriticalHeadInfo critical_head_info(0, 0, 0);
-    const Kratos::KratosExecute::CallBackFunctions call_back_functions(&flow_stubs::emptyLog,
-                                                                 &flow_stubs::emptyProgress,
-                                                                 &flow_stubs::emptyLog,
-                                                                 &flow_stubs::emptyCancel);
-
-    const int status = execute.ExecuteFlowAnalysis(workingDirectory, projectFile, critical_head_info, "", call_back_functions);
-
-    KRATOS_EXPECT_EQ(status, 0);
-
-    // output_files
-    std::string original = (std::string) workingDirectory + "/test_head_extrapolate_2.orig.res";
-    std::string result = (std::string) workingDirectory + "/test_head_extrapolate_2.post.res";
-
-    KRATOS_EXPECT_TRUE(TestUtilities::CompareFiles(original, result))
+    constexpr auto test_case_number = 2;
+    KRATOS_EXPECT_EQ(RunTestCase(test_case_number), 0);
+    CompareResults(test_case_number);
 }
 
 KRATOS_TEST_CASE_IN_SUITE(CalculateExtrapolatedHeadFlow_3, KratosGeoMechanicsIntegrationSuite)
 {
-    auto workingDirectory = "./applications/GeoMechanicsApplication/tests/test_head_extrapolation_custom_workflow_flow";
-    auto projectFile = "ProjectParameters_3.json";
-
-    auto execute = Kratos::KratosExecute();
-
-    const Kratos::KratosExecute::CriticalHeadInfo critical_head_info(0, 0, 0);
-    const Kratos::KratosExecute::CallBackFunctions call_back_functions(&flow_stubs::emptyLog,
-                                                                 &flow_stubs::emptyProgress,
-                                                                 &flow_stubs::emptyLog,
-                                                                 &flow_stubs::emptyCancel);
-
-    const int status = execute.ExecuteFlowAnalysis(workingDirectory, projectFile, critical_head_info, "", call_back_functions);
-
-    KRATOS_EXPECT_EQ(status, 0);
-
-    // output_files
-    std::string original = (std::string) workingDirectory + "/test_head_extrapolate_3.orig.res";
-    std::string result = (std::string) workingDirectory + "/test_head_extrapolate_3.post.res";
-
-    KRATOS_EXPECT_TRUE(TestUtilities::CompareFiles(original, result))
+    constexpr auto test_case_number = 3;
+    KRATOS_EXPECT_EQ(RunTestCase(test_case_number), 0);
+    CompareResults(test_case_number);
 }
 
 KRATOS_TEST_CASE_IN_SUITE(CalculateExtrapolatedHeadFlow_4, KratosGeoMechanicsIntegrationSuite)
 {
-    auto workingDirectory = "./applications/GeoMechanicsApplication/tests/test_head_extrapolation_custom_workflow_flow";
-    auto projectFile = "ProjectParameters_4.json";
-
-    auto execute = Kratos::KratosExecute();
-
-    const Kratos::KratosExecute::CriticalHeadInfo critical_head_info(0, 0, 0);
-    const Kratos::KratosExecute::CallBackFunctions call_back_functions(&flow_stubs::emptyLog,
-                                                                 &flow_stubs::emptyProgress,
-                                                                 &flow_stubs::emptyLog,
-                                                                 &flow_stubs::emptyCancel);
-
-    const int status = execute.ExecuteFlowAnalysis(workingDirectory, projectFile, critical_head_info, "", call_back_functions);
-
-    KRATOS_EXPECT_EQ(status, 0);
-
-    // output_files
-    std::string original = (std::string) workingDirectory + "/test_head_extrapolate_4.orig.res";
-    std::string result = (std::string) workingDirectory + "/test_head_extrapolate_4.post.res";
-
-    KRATOS_EXPECT_TRUE(TestUtilities::CompareFiles(original, result))
+    constexpr auto test_case_number = 4;
+    KRATOS_EXPECT_EQ(RunTestCase(test_case_number), 0);
+    CompareResults(test_case_number);
 }
 
-}
+} // namespace Kratos::Testing

--- a/applications/GeoMechanicsApplication/tests/test_head_extrapolation_custom_workflow_flow/test_head_extrapolate_1.orig.res
+++ b/applications/GeoMechanicsApplication/tests/test_head_extrapolation_custom_workflow_flow/test_head_extrapolate_1.orig.res
@@ -6,7 +6,7 @@ Natural Coordinates: Given
 0.666667 0.166667
 0.166667 0.666667
 End GaussPoints
-Result "HYDRAULIC_HEAD" "Kratos" 0 Scalar OnNodes
+Result "HYDRAULIC_HEAD" "Kratos" 1 Scalar OnNodes
 Values
 1 1
 2 1

--- a/applications/GeoMechanicsApplication/tests/test_head_extrapolation_custom_workflow_flow/test_head_extrapolate_2.orig.res
+++ b/applications/GeoMechanicsApplication/tests/test_head_extrapolation_custom_workflow_flow/test_head_extrapolate_2.orig.res
@@ -6,7 +6,7 @@ Natural Coordinates: Given
 0.666667 0.166667
 0.166667 0.666667
 End GaussPoints
-Result "HYDRAULIC_HEAD" "Kratos" 0 Scalar OnNodes
+Result "HYDRAULIC_HEAD" "Kratos" 1 Scalar OnNodes
 Values
 1 0
 2 0.0714286

--- a/applications/GeoMechanicsApplication/tests/test_head_extrapolation_custom_workflow_flow/test_head_extrapolate_3.orig.res
+++ b/applications/GeoMechanicsApplication/tests/test_head_extrapolation_custom_workflow_flow/test_head_extrapolate_3.orig.res
@@ -6,7 +6,7 @@ Natural Coordinates: Given
 0.666667 0.166667
 0.166667 0.666667
 End GaussPoints
-Result "HYDRAULIC_HEAD" "Kratos" 0 Scalar OnNodes
+Result "HYDRAULIC_HEAD" "Kratos" 1 Scalar OnNodes
 Values
 1 -1
 2 -0.857143

--- a/applications/GeoMechanicsApplication/tests/test_head_extrapolation_custom_workflow_flow/test_head_extrapolate_4.orig.res
+++ b/applications/GeoMechanicsApplication/tests/test_head_extrapolation_custom_workflow_flow/test_head_extrapolate_4.orig.res
@@ -6,7 +6,7 @@ Natural Coordinates: Given
 0.666667 0.166667
 0.166667 0.666667
 End GaussPoints
-Result "HYDRAULIC_HEAD" "Kratos" 0 Scalar OnNodes
+Result "HYDRAULIC_HEAD" "Kratos" 1 Scalar OnNodes
 Values
 1 1
 2 0.928571


### PR DESCRIPTION
**📝 Description**
For the Hydraulic head, the time was not used to label the output in the .res files. This PR rectifies that and changes the related tests.