### PR TITLE
[FastPR][Core] Add model-parameters constructor to variational redistance

### DIFF
--- a/applications/TrilinosApplication/custom_python/add_trilinos_processes_to_python.cpp
+++ b/applications/TrilinosApplication/custom_python/add_trilinos_processes_to_python.cpp
@@ -42,6 +42,14 @@ template<unsigned int TDim> using TrilinosVariationalDistanceCalculation = Varia
 template< class TBinder, unsigned int TDim > void DistanceCalculatorConstructionHelper(TBinder& rBinder)
 {
     rBinder.def(py::init([](
+        Epetra_MpiComm& rCommunicator, Model& rModel,TrilinosLinearSolverType::Pointer pLinearSolver, Parameters ThisParameters)
+        {
+            constexpr int row_size_guess = TDim == 2 ? 15 : 40;
+            auto p_builder_solver = Kratos::make_shared<TrilinosBlockBuilderAndSolver<TrilinosSparseSpaceType, TrilinosLocalSpaceType, TrilinosLinearSolverType > >(
+                rCommunicator, row_size_guess, pLinearSolver);
+            return Kratos::make_shared<TrilinosVariationalDistanceCalculation<TDim>>(rModel, pLinearSolver, p_builder_solver, ThisParameters);
+        }));
+    rBinder.def(py::init([](
         Epetra_MpiComm& rComm,ModelPart& rModelPart,TrilinosLinearSolverType::Pointer pLinearSolver,
         unsigned int MaxIter,Flags TheFlags)
         {

--- a/applications/TrilinosApplication/tests/test_trilinos_redistance.py
+++ b/applications/TrilinosApplication/tests/test_trilinos_redistance.py
@@ -50,16 +50,13 @@ class TestTrilinosRedistance(KratosUnittest.TestCase):
         trilinos_linear_solver = trilinos_linear_solver_factory.ConstructSolver(
             KratosMultiphysics.Parameters("""{"solver_type" : "amesos" }"""))
 
-        epetra_comm = TrilinosApplication.CreateEpetraCommunicator(KratosMultiphysics.DataCommunicator.GetDefault())
+        epetra_comm = TrilinosApplication.CreateEpetraCommunicator(self.model_part.GetCommunicator().GetDataCommunicator())
 
-        max_iterations = 2
-        TrilinosApplication.TrilinosVariationalDistanceCalculationProcess3D(
-            epetra_comm,
-            self.model_part,
-            trilinos_linear_solver,
-            max_iterations,
-            (KratosMultiphysics.VariationalDistanceCalculationProcess3D.CALCULATE_EXACT_DISTANCES_TO_PLANE).AsFalse()
-            ).Execute()
+        settings = KratosMultiphysics.Parameters("""{
+            "model_part_name" : "Main",
+            "max_iterations" : 2
+        }""")
+        TrilinosApplication.TrilinosVariationalDistanceCalculationProcess3D(epetra_comm, self.current_model, trilinos_linear_solver, settings).Execute()
 
         # Check the obtained values
         max_distance = -1.0

--- a/kratos/processes/variational_distance_calculation_process.h
+++ b/kratos/processes/variational_distance_calculation_process.h
@@ -13,8 +13,7 @@
 //
 
 
-#if !defined(KRATOS_VARIATIONAL_DISTANCE_CALCULATION_PROCESS_INCLUDED )
-#define  KRATOS_VARIATIONAL_DISTANCE_CALCULATION_PROCESS_INCLUDED
+#pragma once
 
 // System includes
 #include <string>
@@ -120,6 +119,73 @@ public:
      distance_calculator.Execute()
      */
 
+    /**
+     * @brief Construct a new Variational Distance Calculation Process object
+     * This process recomputes the distance function mantaining the zero of the existing distance distribution, stored in DISTANCE
+     * For this reason the DISTANCE should be initialized to values distinct from zero in at least some portions of the domain
+     * Alternatively, the DISTANCE shall be fixed to zero at least on some nodes, and the process will compute a positive distance
+     * respecting that zero
+     * @param rModel The model container
+     * @param pLinearSolver Pointer to the linear solver to be used internally
+     * @param ThisParameters Process settings to be validated
+     */
+    VariationalDistanceCalculationProcess(
+        Model& rModel,
+        typename TLinearSolver::Pointer pLinearSolver,
+        Parameters ThisParameters)
+        : VariationalDistanceCalculationProcess(
+            rModel,
+            pLinearSolver,
+            Kratos::make_shared<ResidualBasedBlockBuilderAndSolver<TSparseSpace, TDenseSpace, TLinearSolver> >(pLinearSolver),
+            ThisParameters)
+    {
+    }
+
+    /**
+     * @brief Construct a new Variational Distance Calculation Process object
+     * This process recomputes the distance function mantaining the zero of the existing distance distribution, stored in DISTANCE
+     * For this reason the DISTANCE should be initialized to values distinct from zero in at least some portions of the domain
+     * Alternatively, the DISTANCE shall be fixed to zero at least on some nodes, and the process will compute a positive distance
+     * respecting that zero
+     * Note that this constructor with custom builder and solver is to be used in the trilinos version, since the trilinos builder and
+     * solver needs additional data (the EpetraComm).
+     * @param rModel The model container
+     * @param pLinearSolver Pointer to the linear solver to be used internally
+     * @param pBuilderAndSolver Pointer to the custom linear and solver to be used internally
+     * @param ThisParameters Process settings to be validated
+     */
+    VariationalDistanceCalculationProcess(
+        Model& rModel,
+        typename TLinearSolver::Pointer pLinearSolver,
+        BuilderSolverPointerType pBuilderAndSolver,
+        Parameters ThisParameters)
+        : mDistancePartIsInitialized(false)
+        , mrModel(rModel)
+        , mrBaseModelPart(rModel.GetModelPart(ThisParameters["model_part_name"].GetString()))
+    {
+        // Check and assign settings
+        ThisParameters.ValidateAndAssignDefaults(GetDefaultParameters());
+        if (ThisParameters["calculate_exact_distances_to_plane"].GetBool()) {
+            mOptions = CALCULATE_EXACT_DISTANCES_TO_PLANE;
+        } else {
+            mOptions = CALCULATE_EXACT_DISTANCES_TO_PLANE.AsFalse();
+        }
+        mMaxIterations = ThisParameters["max_iterations"].GetInt();
+        mAuxModelPartName = ThisParameters["auxiliary_model_part_name"].GetString();
+        mCoefficient1 = ThisParameters["variational_redistance_coefficient_1"].GetDouble();
+        mCoefficient2 = ThisParameters["variational_redistance_coefficient_2"].GetDouble();
+
+        // Check that the process input is valid
+        ValidateInput();
+
+        // Generate an auxilary model part and populate it by elements of type DistanceCalculationElementSimplex
+        ReGenerateDistanceModelPart(mrBaseModelPart);
+
+        // Set provided builder and solver and initialize the solution strategy
+        InitializeSolutionStrategy(pBuilderAndSolver);
+        mpSolvingStrategy->SetEchoLevel(ThisParameters["echo_level"].GetInt());
+    }
+
     VariationalDistanceCalculationProcess(
         ModelPart& rBaseModelPart,
         typename TLinearSolver::Pointer pLinearSolver,
@@ -139,6 +205,8 @@ public:
         mCoefficient2(Coefficient2)
     {
         KRATOS_TRY
+
+        KRATOS_WARNING("VariationalDistanceCalculationProcess") << "This constructor is deprecated, please use the Parameters-based one." << std::endl;
 
         ValidateInput();
 
@@ -181,6 +249,8 @@ public:
         mCoefficient2(Coefficient2)
     {
         KRATOS_TRY
+
+        KRATOS_WARNING("VariationalDistanceCalculationProcess") << "This constructor is deprecated, please use the Parameters-based one." << std::endl;
 
         ValidateInput();
 
@@ -358,6 +428,21 @@ public:
 
         mpSolvingStrategy->Clear();
 
+    }
+
+    const Parameters GetDefaultParameters() const override
+    {
+        Parameters default_parameters = Parameters(R"({
+            "model_part_name" : "",
+            "auxiliary_model_part_name" : "RedistanceCalculationPart",
+            "echo_level" : 0,
+            "max_iterations" : 10,
+            "calculate_exact_distances_to_plane" : false,
+            "variational_redistance_coefficient_1" : 0.01,
+            "variational_redistance_coefficient_2" : 0.1
+        })");
+
+        return default_parameters;
     }
 
     ///@}
@@ -673,4 +758,3 @@ inline std::ostream& operator << (std::ostream& rOStream,
 
 }  // namespace Kratos.
 
-#endif // KRATOS_VARIATIONAL_DISTANCE_CALCULATION_PROCESS_INCLUDED  defined

--- a/kratos/python/add_processes_to_python.cpp
+++ b/kratos/python/add_processes_to_python.cpp
@@ -312,6 +312,7 @@ void  AddProcessesToPython(pybind11::module& m)
     orientation_check_interface.attr("COMPUTE_CONDITION_NORMALS") = &TetrahedralMeshOrientationCheck::COMPUTE_CONDITION_NORMALS;
 
     py::class_<VariationalDistanceCalculationProcess<2,SparseSpaceType,LocalSpaceType,LinearSolverType>, VariationalDistanceCalculationProcess<2,SparseSpaceType,LocalSpaceType,LinearSolverType>::Pointer, Process>(m,"VariationalDistanceCalculationProcess2D")
+            .def(py::init<Model&, LinearSolverType::Pointer, Parameters>())
             .def(py::init<ModelPart&, LinearSolverType::Pointer>())
             .def(py::init<ModelPart&, LinearSolverType::Pointer, unsigned int>())
             .def(py::init<ModelPart&, LinearSolverType::Pointer, unsigned int, Flags>())
@@ -321,6 +322,7 @@ void  AddProcessesToPython(pybind11::module& m)
             .def_readonly_static("CALCULATE_EXACT_DISTANCES_TO_PLANE", &VariationalDistanceCalculationProcess<2,SparseSpaceType,LocalSpaceType,LinearSolverType>::CALCULATE_EXACT_DISTANCES_TO_PLANE)
     ;
     py::class_<VariationalDistanceCalculationProcess<3,SparseSpaceType,LocalSpaceType,LinearSolverType>, VariationalDistanceCalculationProcess<3,SparseSpaceType,LocalSpaceType,LinearSolverType>::Pointer, Process>(m,"VariationalDistanceCalculationProcess3D")
+            .def(py::init<Model&, LinearSolverType::Pointer, Parameters>())
             .def(py::init<ModelPart&, LinearSolverType::Pointer>())
             .def(py::init<ModelPart&, LinearSolverType::Pointer, unsigned int>())
             .def(py::init<ModelPart&, LinearSolverType::Pointer, unsigned int, Flags>())

--- a/kratos/tests/test_redistance.py
+++ b/kratos/tests/test_redistance.py
@@ -33,8 +33,11 @@ class TestRedistance(KratosUnittest.TestCase):
 
         model_part.CloneTimeStep(1.0)
 
-        max_iterations = 2
-        KratosMultiphysics.VariationalDistanceCalculationProcess3D(model_part, linear_solver, max_iterations).Execute()
+        settings = KratosMultiphysics.Parameters("""{
+            "model_part_name" : "Main",
+            "max_iterations" : 2
+        }""")
+        KratosMultiphysics.VariationalDistanceCalculationProcess3D(current_model, linear_solver, settings).Execute()
 
         max_distance = -1.0
         min_distance = +1.0
@@ -71,12 +74,12 @@ class TestRedistance(KratosUnittest.TestCase):
 
         model_part.CloneTimeStep(1.0)
 
-        max_iterations = 2
-        KratosMultiphysics.VariationalDistanceCalculationProcess2D(
-            model_part,
-            linear_solver,
-            max_iterations,
-            KratosMultiphysics.VariationalDistanceCalculationProcess2D.CALCULATE_EXACT_DISTANCES_TO_PLANE).Execute()
+        settings = KratosMultiphysics.Parameters("""{
+            "model_part_name" : "Main",
+            "max_iterations" : 2,
+            "calculate_exact_distances_to_plane" : true
+        }""")
+        KratosMultiphysics.VariationalDistanceCalculationProcess2D(current_model, linear_solver, settings).Execute()
 
         for node in model_part.Nodes:
             self.assertAlmostEqual(node.GetSolutionStepValue(KratosMultiphysics.DISTANCE), node.Y - free_surface_level, 10 )
@@ -106,12 +109,12 @@ class TestRedistance(KratosUnittest.TestCase):
 
         model_part.CloneTimeStep(1.0)
 
-        max_iterations = 2
-        KratosMultiphysics.VariationalDistanceCalculationProcess3D(
-            model_part,
-            linear_solver,
-            max_iterations,
-            KratosMultiphysics.VariationalDistanceCalculationProcess3D.CALCULATE_EXACT_DISTANCES_TO_PLANE).Execute()
+        settings = KratosMultiphysics.Parameters("""{
+            "model_part_name" : "Main",
+            "max_iterations" : 2,
+            "calculate_exact_distances_to_plane" : true
+        }""")
+        KratosMultiphysics.VariationalDistanceCalculationProcess3D(current_model, linear_solver, settings).Execute()
 
         for node in model_part.Nodes:
             self.assertAlmostEqual(node.GetSolutionStepValue(KratosMultiphysics.DISTANCE), node.Y - free_surface_level, 10 )


### PR DESCRIPTION
**📝 Description**
Following our standards, in this PR I'm adding a model-parameters (and linear solver as required in this case) constructor to the variational redistancing processes. I took the chance to also add a deprecation warning to the old ones. Tests have been updated accordingly.
