### PR TITLE
[Poro] Added license file and updated README

### DIFF
--- a/applications/PoromechanicsApplication/README.md
+++ b/applications/PoromechanicsApplication/README.md
@@ -28,4 +28,6 @@ Mises)
 damage model with the insertion of interface elements after remeshing
 with GiD
 
+- GiD GUI available in [KratosPoroGiDInterface](https://github.com/ipouplana/KratosPoroGiDInterface)
+
 

--- a/applications/PoromechanicsApplication/license.txt
+++ b/applications/PoromechanicsApplication/license.txt
@@ -1,0 +1,20 @@
+Kratos Poromechanics Application
+
+Copyright (c) 2016, Ignasi de Pouplana, CIMNE (International Center for Numerical Methods in Engineering)
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+	-	Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+	-	Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer
+		in the documentation and/or other materials provided with the distribution.
+	-	All advertising materials mentioning features or use of this software must display the following acknowledgement:
+			This product includes Kratos Multi-Physics technology.
+	-	Neither the name of the CIMNE nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ''AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDERS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.


### PR DESCRIPTION
**📝 Description**
The license file was missing. This PR adds it. Also, the README has been updated to include a link to the public GiD GUI of the Poromechanics Application.

**🆕 Changelog**
- Added license.txt file
- Added link to the Poromechanics GiD GUI in the README
