### PR TITLE
[GeoMechanicsApplication] Fixed an OpenMP issue for running the extrapolation process with multiple cores

### DIFF
--- a/applications/GeoMechanicsApplication/custom_processes/geo_extrapolate_integration_point_values_to_nodes_process.h
+++ b/applications/GeoMechanicsApplication/custom_processes/geo_extrapolate_integration_point_values_to_nodes_process.h
@@ -67,7 +67,7 @@ private:
     std::vector<const Variable<Vector>*>              mVectorVariables;
     std::vector<const Variable<Matrix>*>              mMatrixVariables;
     const Variable<double>&                           mrAverageVariable       = NODAL_AREA;
-    mutable std::map<SizeType, Matrix>                mExtrapolationMatrixMap = {};
+    std::map<SizeType, Matrix>                        mExtrapolationMatrixMap = {};
     std::unique_ptr<NodalExtrapolator>                mpExtrapolator;
     std::map<const Variable<Vector>*, Vector>         mZeroValuesOfVectorVariables;
     std::map<const Variable<Matrix>*, Matrix>         mZeroValuesOfMatrixVariables;
@@ -99,7 +99,7 @@ private:
                                             const Variable<T>& rVariable,
                                             const Matrix&      rExtrapolationMatrix,
                                             SizeType           NumberOfIntegrationPoints,
-                                            const U&           rAtomicAddOperation)
+                                            const U&           rAtomicAddOperation) const
     {
         auto&          r_this_geometry = rElement.GetGeometry();
         std::vector<T> values_on_integration_points(NumberOfIntegrationPoints);
@@ -119,12 +119,12 @@ private:
         }
     }
 
-    const Matrix&      GetExtrapolationMatrix(const Element& rElement) const;
-    [[nodiscard]] bool ExtrapolationMatrixIsCachedFor(const Element& rElement) const;
-    void CacheExtrapolationMatrixFor(const Element& rElement, const Matrix& rExtrapolationMatrix) const;
-    const Matrix& GetCachedExtrapolationMatrixFor(const Element& rElement) const;
+    void CacheExtrapolationMatricesForElements();
+    void CacheExtrapolationMatrixFor(const Element& rElement, const Matrix& rExtrapolationMatrix);
+    [[nodiscard]] bool          ExtrapolationMatrixIsCachedFor(const Element& rElement) const;
+    [[nodiscard]] const Matrix& GetCachedExtrapolationMatrixFor(const Element& rElement) const;
 
-    void AddIntegrationPointContributionsForAllVariables(Element& rElem, const Matrix& rExtrapolationMatrix);
+    void AddIntegrationPointContributionsForAllVariables(Element& rElem, const Matrix& rExtrapolationMatrix) const;
 };
 
 } // namespace Kratos.

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/test_geo_extrapolate_integration_point_values_to_nodes_process.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/test_geo_extrapolate_integration_point_values_to_nodes_process.cpp
@@ -218,8 +218,7 @@ KRATOS_TEST_CASE_IN_SUITE(TestExtrapolationProcess_ExtrapolatesCorrectlyForLinea
     KRATOS_EXPECT_VECTOR_NEAR(actual_values, expected_values, 1e-6)
 }
 
-// KRATOS_TEST_CASE_IN_SUITE(TestExtrapolationProcess_ExtrapolatesMatrixCorrectlyForLinearFields, KratosGeoMechanicsFastSuite)
-[[maybe_unused]] void TestExtrapolatesMatrixCorrectlyForLinearFields()
+KRATOS_TEST_CASE_IN_SUITE(TestExtrapolationProcess_ExtrapolatesMatrixCorrectlyForLinearFields, KratosGeoMechanicsFastSuite)
 {
     //   This test uses the following two-element system.
     //   4------3------6
@@ -262,8 +261,7 @@ KRATOS_TEST_CASE_IN_SUITE(TestExtrapolationProcess_ExtrapolatesCorrectlyForLinea
     }
 }
 
-// KRATOS_TEST_CASE_IN_SUITE(TestExtrapolationProcess_ExtrapolatesVectorCorrectlyForLinearFields, KratosGeoMechanicsFastSuite)
-[[maybe_unused]] void TestExtrapolatesVectorCorrectlyForLinearFields()
+KRATOS_TEST_CASE_IN_SUITE(TestExtrapolationProcess_ExtrapolatesVectorCorrectlyForLinearFields, KratosGeoMechanicsFastSuite)
 {
     //   This test uses the following two-element system.
     //   4------3------6

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/test_geo_extrapolate_integration_point_values_to_nodes_process.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/test_geo_extrapolate_integration_point_values_to_nodes_process.cpp
@@ -13,8 +13,8 @@
 #include "containers/model.h"
 #include "custom_processes/geo_extrapolate_integration_point_values_to_nodes_process.h"
 #include "geo_mechanics_application_variables.h"
-#include "geometries/quadrilateral_2d_4.h"
 #include "geo_mechanics_fast_suite.h"
+#include "geometries/quadrilateral_2d_4.h"
 
 namespace Kratos::Testing
 {


### PR DESCRIPTION
**📝 Description**
This PR fixes an OpenMP issue, which came to light when running the extrapolation process with multiple cores. It turned out we were writing to the cache in a `block_for_each` loop, which is run in parallel. This resulted into issues, either by simulataneous writing to the same memory, or writing and reading at the same time.