### PR TITLE
[ConvDiff] [Structural] SBM elements: Fix to get correct nodes of face

### DIFF
--- a/applications/ConvectionDiffusionApplication/custom_elements/laplacian_shifted_boundary_element.cpp
+++ b/applications/ConvectionDiffusionApplication/custom_elements/laplacian_shifted_boundary_element.cpp
@@ -110,7 +110,7 @@ void LaplacianShiftedBoundaryElement<TDim>::CalculateLocalSystem(
                 // Get the current surrogate face geometry information
                 const auto& r_sur_bd_geom = r_boundaries[sur_bd_id];
                 const unsigned int n_bd_points = r_sur_bd_geom.PointsNumber();
-                const DenseVector<std::size_t> sur_bd_local_ids = row(nodes_in_faces, sur_bd_id);
+                const DenseVector<std::size_t> sur_bd_local_ids = column(nodes_in_faces, sur_bd_id);
                 const auto& r_sur_bd_N = r_sur_bd_geom.ShapeFunctionsValues(GeometryData::IntegrationMethod::GI_GAUSS_1);
 
                 // Get the surrogate boundary average conductivity
@@ -190,7 +190,7 @@ void LaplacianShiftedBoundaryElement<TDim>::CalculateLeftHandSide(
                 // Get the current surrogate face geometry information
                 const auto& r_sur_bd_geom = r_boundaries[sur_bd_id];
                 const unsigned int n_bd_points = r_sur_bd_geom.PointsNumber();
-                const DenseVector<std::size_t> sur_bd_local_ids = row(nodes_in_faces, sur_bd_id);
+                const DenseVector<std::size_t> sur_bd_local_ids = column(nodes_in_faces, sur_bd_id);
                 const auto& r_sur_bd_N = r_sur_bd_geom.ShapeFunctionsValues(GeometryData::IntegrationMethod::GI_GAUSS_1);
 
                 // Get the surrogate boundary average conductivity
@@ -274,7 +274,7 @@ void LaplacianShiftedBoundaryElement<TDim>::CalculateRightHandSide(
                 // Get the current surrogate face geometry information
                 const auto& r_sur_bd_geom = r_boundaries[sur_bd_id];
                 const unsigned int n_bd_points = r_sur_bd_geom.PointsNumber();
-                const DenseVector<std::size_t> sur_bd_local_ids = row(nodes_in_faces, sur_bd_id);
+                const DenseVector<std::size_t> sur_bd_local_ids = column(nodes_in_faces, sur_bd_id);
                 const auto& r_sur_bd_N = r_sur_bd_geom.ShapeFunctionsValues(GeometryData::IntegrationMethod::GI_GAUSS_1);
 
                 // Get the surrogate boundary average conductivity

--- a/applications/StructuralMechanicsApplication/custom_elements/small_displacement_shifted_boundary_element.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/small_displacement_shifted_boundary_element.cpp
@@ -113,7 +113,7 @@ void SmallDisplacementShiftedBoundaryElement<TDim>::CalculateLocalSystem(
                 // Get the current surrogate face geometry information
                 const auto& r_sur_bd_geom = r_boundaries[sur_bd_id];
                 const unsigned int n_bd_points = r_sur_bd_geom.PointsNumber();
-                const DenseVector<std::size_t> sur_bd_local_ids = row(nodes_in_faces, sur_bd_id);
+                const DenseVector<std::size_t> sur_bd_local_ids = column(nodes_in_faces, sur_bd_id);
                 const auto& r_sur_bd_N = r_sur_bd_geom.ShapeFunctionsValues(GeometryData::IntegrationMethod::GI_GAUSS_1);
 
                 // Get the gradient of the node contrary to the surrogate face
@@ -203,7 +203,7 @@ void SmallDisplacementShiftedBoundaryElement<TDim>::CalculateLeftHandSide(
                 // Get the current surrogate face geometry information
                 const auto& r_sur_bd_geom = r_boundaries[sur_bd_id];
                 const unsigned int n_bd_points = r_sur_bd_geom.PointsNumber();
-                const DenseVector<std::size_t> sur_bd_local_ids = row(nodes_in_faces, sur_bd_id);
+                const DenseVector<std::size_t> sur_bd_local_ids = column(nodes_in_faces, sur_bd_id);
                 const auto& r_sur_bd_N = r_sur_bd_geom.ShapeFunctionsValues(GeometryData::IntegrationMethod::GI_GAUSS_1);
 
                 // Get the gradient of the node contrary to the surrogate face
@@ -292,7 +292,7 @@ void SmallDisplacementShiftedBoundaryElement<TDim>::CalculateRightHandSide(
                 // Get the current surrogate face geometry information
                 const auto& r_sur_bd_geom = r_boundaries[sur_bd_id];
                 const unsigned int n_bd_points = r_sur_bd_geom.PointsNumber();
-                const DenseVector<std::size_t> sur_bd_local_ids = row(nodes_in_faces, sur_bd_id);
+                const DenseVector<std::size_t> sur_bd_local_ids = column(nodes_in_faces, sur_bd_id);
                 const auto& r_sur_bd_N = r_sur_bd_geom.ShapeFunctionsValues(GeometryData::IntegrationMethod::GI_GAUSS_1);
 
                 // Get the gradient of the node contrary to the surrogate face


### PR DESCRIPTION
**📝 Description**
In both shifted-boundary elements - laplacian of `ConvectionDiffusionApplication` and small displacement of `StructuralMechanicsApplication` - `NodesInFaces` of the repective geometry is called in order to get the elemental node numbers of each face giving a matrix `nodes_in_faces`. The columns of the matrix `nodes_in_faces` refer to the faces and the first row refers to the nodes contrary to the respective face. 

As a consequence, `column(nodes_in_faces, face_id)` should be used to retrieve the correct node order of  a specific face. So far `row(nodes_in_faces, face_id)` was used, which works for triangles, where the matrix is symmetric, but not in the general case. Therefore, this PR replaces `row` with `column`.

**🆕 Changelog**
- Fixed `LaplacianShiftedBoundaryElement` to get correct nodes of face using column of `nodes_in_faces`
- Fixed `SmallDisplacementShiftedBoundaryElement` to get correct nodes of face using column of `nodes_in_faces`
