### PR TITLE
[Hotfix][Structural] Call Initialize() before Check() in patch tests

### DIFF
--- a/applications/StructuralMechanicsApplication/tests/test_patch_test_cr_beam.py
+++ b/applications/StructuralMechanicsApplication/tests/test_patch_test_cr_beam.py
@@ -131,7 +131,7 @@ class BasePatchTestCrBeam3D2N(KratosUnittest.TestCase):
                                                                 reform_step_dofs,
                                                                 move_mesh_flag)
         strategy.SetEchoLevel(0)
-
+        strategy.Initialize()
         strategy.Check()
         strategy.Solve()
 

--- a/applications/StructuralMechanicsApplication/tests/test_patch_test_membrane.py
+++ b/applications/StructuralMechanicsApplication/tests/test_patch_test_membrane.py
@@ -804,7 +804,7 @@ def _set_up_dynamic_solver(mp):
                                                                     reform_step_dofs,
                                                                     move_mesh_flag)
     strategy.SetEchoLevel(0)
-
+    strategy.Initialize()
     strategy.Check()
     return strategy
 

--- a/applications/StructuralMechanicsApplication/tests/test_patch_test_shells.py
+++ b/applications/StructuralMechanicsApplication/tests/test_patch_test_shells.py
@@ -106,7 +106,7 @@ class TestPatchTestShells(KratosUnittest.TestCase):
                                                                   calculate_norm_dx,
                                                                   move_mesh_flag)
         strategy.SetEchoLevel(0)
-
+        strategy.Initialize()
         strategy.Check()
         strategy.Solve()
 

--- a/applications/StructuralMechanicsApplication/tests/test_patch_test_shells_orthotropic.py
+++ b/applications/StructuralMechanicsApplication/tests/test_patch_test_shells_orthotropic.py
@@ -140,7 +140,7 @@ class TestPatchTestShellsOrthotropic(KratosUnittest.TestCase):
                                                                         reform_step_dofs,
                                                                         move_mesh_flag)
         strategy.SetEchoLevel(0)
-
+        strategy.Initialize()
         strategy.Check()
         strategy.Solve()
 

--- a/applications/StructuralMechanicsApplication/tests/test_patch_test_shells_stress.py
+++ b/applications/StructuralMechanicsApplication/tests/test_patch_test_shells_stress.py
@@ -107,7 +107,7 @@ class TestPatchTestShellsStressRec(KratosUnittest.TestCase):
                                                                         reform_step_dofs,
                                                                         move_mesh_flag)
         strategy.SetEchoLevel(0)
-
+        strategy.Initialize()
         strategy.Check()
         strategy.Solve()
 

--- a/applications/StructuralMechanicsApplication/tests/test_patch_test_small_displacement_mixed_volumetric_strain.py
+++ b/applications/StructuralMechanicsApplication/tests/test_patch_test_small_displacement_mixed_volumetric_strain.py
@@ -118,6 +118,7 @@ class TestPatchTestSmallDisplacementMixedVolumetricStrain(KratosUnittest.TestCas
             calculate_norm_dx,
             move_mesh_flag)
         strategy.SetEchoLevel(0)
+        strategy.Initialize()
         strategy.Check()
 
         # Solve the problem

--- a/applications/StructuralMechanicsApplication/tests/test_patch_test_small_strain_bbar.py
+++ b/applications/StructuralMechanicsApplication/tests/test_patch_test_small_strain_bbar.py
@@ -117,7 +117,7 @@ class TestPatchTestSmallStrainBbar(KratosUnittest.TestCase):
                                                                             reform_step_dofs,
                                                                             move_mesh_flag)
         strategy.SetEchoLevel(0)
-
+        strategy.Initialize()
         strategy.Check()
         strategy.Solve()
 


### PR DESCRIPTION
**📝 Description**
This PR adds a call to the strategy `Initialize` before the `Check` in the `StructuralMechanicsApplication` Python patch tests. Note that this is required as the `Check` may need some of the stuff done in the `Initialize`. Also note that this is consistent to the way we do it in the `AnalysisStage`.

PD: This is the source of the random fails in #12527.
