### PR TITLE
[GeoMechanicsApplication] Cleanup of the head extrapolation unit tests

### DIFF
--- a/applications/GeoMechanicsApplication/tests/cpp_tests/test_head_extrapolation_flow_workflow.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/test_head_extrapolation_flow_workflow.cpp
@@ -10,112 +10,82 @@
 //  Main authors:    Jonathan Nuttall
 //
 
-#include <string>
 #include <iostream>
+#include <string>
 
 // Project includes
 #include "custom_workflows/dgeoflow.h"
 #include "flow_stubs.h"
 #include "geo_mechanics_fast_suite.h"
 #include "test_utilities.h"
+#include "testing/testing.h"
+
+namespace
+{
+
+using namespace Kratos;
+using namespace Kratos::Testing;
+
+const auto workingDirectory = std::filesystem::path{"."} / "applications" / "GeoMechanicsApplication" /
+                              "tests" / "test_head_extrapolation_custom_workflow_flow";
+
+int RunTestCase(int test_case_number)
+{
+    const auto projectFile = std::string{"ProjectParameters_"} + std::to_string(test_case_number) + ".json";
+
+    auto execute = KratosExecute();
+
+    const KratosExecute::CriticalHeadInfo  critical_head_info(0, 0, 0);
+    const KratosExecute::CallBackFunctions call_back_functions(
+        &flow_stubs::emptyLog, &flow_stubs::emptyProgress, &flow_stubs::emptyLog, &flow_stubs::emptyCancel);
+
+    return execute.ExecuteFlowAnalysis(workingDirectory.generic_string(), projectFile,
+                                       critical_head_info, "", call_back_functions);
+}
+
+void CompareResults(int test_case_number)
+{
+    const auto original =
+        (workingDirectory / ("test_head_extrapolate_" + std::to_string(test_case_number) + ".orig.res"))
+            .generic_string();
+    const auto result =
+        (workingDirectory / ("test_head_extrapolate_" + std::to_string(test_case_number) + ".post.res"))
+            .generic_string();
+
+    KRATOS_EXPECT_TRUE(TestUtilities::CompareFiles(original, result))
+}
+}
+
 
 namespace Kratos::Testing
 {
 
 KRATOS_TEST_CASE_IN_SUITE(CalculateExtrapolatedHeadFlow_1, KratosGeoMechanicsIntegrationSuite)
 {
-    auto workingDirectory = "./applications/GeoMechanicsApplication/tests/test_head_extrapolation_custom_workflow_flow";
-    auto projectFile = "ProjectParameters_1.json";
-
-    auto execute = Kratos::KratosExecute();
-
-    const Kratos::KratosExecute::CriticalHeadInfo critical_head_info(0, 0, 0);
-    const Kratos::KratosExecute::CallBackFunctions call_back_functions(&flow_stubs::emptyLog,
-                                                                 &flow_stubs::emptyProgress,
-                                                                 &flow_stubs::emptyLog,
-                                                                 &flow_stubs::emptyCancel);
-
-    const int status = execute.ExecuteFlowAnalysis(workingDirectory, projectFile, critical_head_info, "", call_back_functions);
-
-    KRATOS_EXPECT_EQ(status, 0);
-
-    // output_files
-    std::string original = (std::string) workingDirectory + "/test_head_extrapolate_1.orig.res";
-    std::string result = (std::string) workingDirectory + "/test_head_extrapolate_1.post.res";
-
-    KRATOS_EXPECT_TRUE(TestUtilities::CompareFiles(original, result))
+    constexpr auto test_case_number = 1;
+    KRATOS_EXPECT_EQ(RunTestCase(test_case_number), 0);
+    CompareResults(test_case_number);
 }
 
- KRATOS_TEST_CASE_IN_SUITE(CalculateExtrapolatedHeadFlow_2, KratosGeoMechanicsIntegrationSuite)
+KRATOS_TEST_CASE_IN_SUITE(CalculateExtrapolatedHeadFlow_2, KratosGeoMechanicsIntegrationSuite)
 {
-    auto workingDirectory = "./applications/GeoMechanicsApplication/tests/test_head_extrapolation_custom_workflow_flow";
-    auto projectFile = "ProjectParameters_2.json";
-
-    auto execute = Kratos::KratosExecute();
-
-    const Kratos::KratosExecute::CriticalHeadInfo critical_head_info(0, 0, 0);
-    const Kratos::KratosExecute::CallBackFunctions call_back_functions(&flow_stubs::emptyLog,
-                                                                 &flow_stubs::emptyProgress,
-                                                                 &flow_stubs::emptyLog,
-                                                                 &flow_stubs::emptyCancel);
-
-    const int status = execute.ExecuteFlowAnalysis(workingDirectory, projectFile, critical_head_info, "", call_back_functions);
-
-    KRATOS_EXPECT_EQ(status, 0);
-
-    // output_files
-    std::string original = (std::string) workingDirectory + "/test_head_extrapolate_2.orig.res";
-    std::string result = (std::string) workingDirectory + "/test_head_extrapolate_2.post.res";
-
-    KRATOS_EXPECT_TRUE(TestUtilities::CompareFiles(original, result))
+    constexpr auto test_case_number = 2;
+    KRATOS_EXPECT_EQ(RunTestCase(test_case_number), 0);
+    CompareResults(test_case_number);
 }
 
 KRATOS_TEST_CASE_IN_SUITE(CalculateExtrapolatedHeadFlow_3, KratosGeoMechanicsIntegrationSuite)
 {
-    auto workingDirectory = "./applications/GeoMechanicsApplication/tests/test_head_extrapolation_custom_workflow_flow";
-    auto projectFile = "ProjectParameters_3.json";
-
-    auto execute = Kratos::KratosExecute();
-
-    const Kratos::KratosExecute::CriticalHeadInfo critical_head_info(0, 0, 0);
-    const Kratos::KratosExecute::CallBackFunctions call_back_functions(&flow_stubs::emptyLog,
-                                                                 &flow_stubs::emptyProgress,
-                                                                 &flow_stubs::emptyLog,
-                                                                 &flow_stubs::emptyCancel);
-
-    const int status = execute.ExecuteFlowAnalysis(workingDirectory, projectFile, critical_head_info, "", call_back_functions);
-
-    KRATOS_EXPECT_EQ(status, 0);
-
-    // output_files
-    std::string original = (std::string) workingDirectory + "/test_head_extrapolate_3.orig.res";
-    std::string result = (std::string) workingDirectory + "/test_head_extrapolate_3.post.res";
-
-    KRATOS_EXPECT_TRUE(TestUtilities::CompareFiles(original, result))
+    constexpr auto test_case_number = 3;
+    KRATOS_EXPECT_EQ(RunTestCase(test_case_number), 0);
+    CompareResults(test_case_number);
 }
 
 KRATOS_TEST_CASE_IN_SUITE(CalculateExtrapolatedHeadFlow_4, KratosGeoMechanicsIntegrationSuite)
 {
-    auto workingDirectory = "./applications/GeoMechanicsApplication/tests/test_head_extrapolation_custom_workflow_flow";
-    auto projectFile = "ProjectParameters_4.json";
-
-    auto execute = Kratos::KratosExecute();
-
-    const Kratos::KratosExecute::CriticalHeadInfo critical_head_info(0, 0, 0);
-    const Kratos::KratosExecute::CallBackFunctions call_back_functions(&flow_stubs::emptyLog,
-                                                                 &flow_stubs::emptyProgress,
-                                                                 &flow_stubs::emptyLog,
-                                                                 &flow_stubs::emptyCancel);
-
-    const int status = execute.ExecuteFlowAnalysis(workingDirectory, projectFile, critical_head_info, "", call_back_functions);
-
-    KRATOS_EXPECT_EQ(status, 0);
-
-    // output_files
-    std::string original = (std::string) workingDirectory + "/test_head_extrapolate_4.orig.res";
-    std::string result = (std::string) workingDirectory + "/test_head_extrapolate_4.post.res";
-
-    KRATOS_EXPECT_TRUE(TestUtilities::CompareFiles(original, result))
+    constexpr auto test_case_number = 4;
+    KRATOS_EXPECT_EQ(RunTestCase(test_case_number), 0);
+    CompareResults(test_case_number);
 }
 
-}
+} // namespace Kratos::Testing

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/test_head_extrapolation_flow_workflow.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/test_head_extrapolation_flow_workflow.cpp
@@ -10,7 +10,7 @@
 //  Main authors:    Jonathan Nuttall
 //
 
-#include <iostream>
+#include <filesystem>
 #include <string>
 
 // Project includes
@@ -28,33 +28,30 @@ using namespace Kratos::Testing;
 const auto workingDirectory = std::filesystem::path{"."} / "applications" / "GeoMechanicsApplication" /
                               "tests" / "test_head_extrapolation_custom_workflow_flow";
 
-int RunTestCase(int test_case_number)
+int RunTestCase(int TestCaseNumber)
 {
-    const auto projectFile = std::string{"ProjectParameters_"} + std::to_string(test_case_number) + ".json";
-
-    auto execute = KratosExecute();
+    const auto projectFile = std::string{"ProjectParameters_"} + std::to_string(TestCaseNumber) + ".json";
 
     const KratosExecute::CriticalHeadInfo  critical_head_info(0, 0, 0);
     const KratosExecute::CallBackFunctions call_back_functions(
         &flow_stubs::emptyLog, &flow_stubs::emptyProgress, &flow_stubs::emptyLog, &flow_stubs::emptyCancel);
 
-    return execute.ExecuteFlowAnalysis(workingDirectory.generic_string(), projectFile,
-                                       critical_head_info, "", call_back_functions);
+    return KratosExecute().ExecuteFlowAnalysis(workingDirectory.generic_string(), projectFile,
+                                               critical_head_info, "", call_back_functions);
 }
 
-void CompareResults(int test_case_number)
+void CompareResults(int TestCaseNumber)
 {
     const auto original =
-        (workingDirectory / ("test_head_extrapolate_" + std::to_string(test_case_number) + ".orig.res"))
+        (workingDirectory / ("test_head_extrapolate_" + std::to_string(TestCaseNumber) + ".orig.res"))
             .generic_string();
     const auto result =
-        (workingDirectory / ("test_head_extrapolate_" + std::to_string(test_case_number) + ".post.res"))
+        (workingDirectory / ("test_head_extrapolate_" + std::to_string(TestCaseNumber) + ".post.res"))
             .generic_string();
 
     KRATOS_EXPECT_TRUE(TestUtilities::CompareFiles(original, result))
 }
-}
-
+} // namespace
 
 namespace Kratos::Testing
 {

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/test_head_extrapolation_flow_workflow.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/test_head_extrapolation_flow_workflow.cpp
@@ -18,7 +18,6 @@
 #include "flow_stubs.h"
 #include "geo_mechanics_fast_suite.h"
 #include "test_utilities.h"
-#include "testing/testing.h"
 
 namespace
 {


### PR DESCRIPTION
**📝 Description**
Minor cleanup effort for the unit tests in `test_head_extrapolation_workflow.cpp`. I did the clean-up before, but didn't want to introduce more merge conflicts for the ci/gtests branch. Now that is done, this can be merged