### PR TITLE
[Core][GeoMechanicsApplication] Add a test suite without a kernel to improve performance of GTest runs.

### DIFF
--- a/applications/GeoMechanicsApplication/tests/cpp_tests/geo_mechanics_fast_suite.h
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/geo_mechanics_fast_suite.h
@@ -30,6 +30,10 @@ namespace Kratos::Testing
      KratosLinearSolversApplication::Pointer mpLinearSolversApp;
  };
 
+class KratosGeoMechanicsFastSuiteWithoutKernel : public KratosCoreFastSuiteWithoutKernel
+{
+};
+
  class KratosGeoMechanicsIntegrationSuite : public KratosCoreFastSuite
  {
  public:

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/test_permeability_matrix.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/test_permeability_matrix.cpp
@@ -21,7 +21,7 @@ using namespace Kratos;
 namespace Kratos::Testing
 {
 
-KRATOS_TEST_CASE_IN_SUITE(CalculatePermeabilityMatrix2D3NGivesCorrectResults, KratosGeoMechanicsFastSuite)
+KRATOS_TEST_CASE_IN_SUITE(CalculatePermeabilityMatrix2D3NGivesCorrectResults, KratosGeoMechanicsFastSuiteWithoutKernel)
 {
     // clang-format off
     Matrix GradNpT(3, 2);
@@ -54,7 +54,7 @@ KRATOS_TEST_CASE_IN_SUITE(CalculatePermeabilityMatrix2D3NGivesCorrectResults, Kr
     KRATOS_CHECK_MATRIX_NEAR(PermeabilityMatrix, PMatrix, 1e-12)
 }
 
-KRATOS_TEST_CASE_IN_SUITE(CalculatePermeabilityMatrix3D4NGivesCorrectResults, KratosGeoMechanicsFastSuite)
+KRATOS_TEST_CASE_IN_SUITE(CalculatePermeabilityMatrix3D4NGivesCorrectResults, KratosGeoMechanicsFastSuiteWithoutKernel)
 {
     // clang-format off
     Matrix GradNpT(4, 3);

--- a/applications/GeoMechanicsApplication/tests/run_cpp_unit_tests.py
+++ b/applications/GeoMechanicsApplication/tests/run_cpp_unit_tests.py
@@ -10,7 +10,7 @@ def run():
 
     command = [os.path.join("test", "KratosGeoMechanicsCoreTest")]
     if args.onlyFastSuite:
-        command.append("--gtest_filter=KratosGeoMechanicsFastSuite.*")
+        command.append("--gtest_filter=KratosGeoMechanicsFastSuite*")
 
     return subprocess.run(command).returncode
 

--- a/kratos/tests/test_utilities/test_suite.h
+++ b/kratos/tests/test_utilities/test_suite.h
@@ -60,6 +60,10 @@ class KRATOS_API(KRATOS_TEST_UTILS) KratosCoreFastSuite : public ::testing::Test
         std::vector<KratosApplication::Pointer> mRegisteredApplications;    // List of applications loaded by the suit. TODO: Remove once every test includes its own suit
 };
 
+class KRATOS_API(KRATOS_TEST_UTILS) KratosCoreFastSuiteWithoutKernel : public ::testing::Test
+{
+};
+
 // Define some suits that are needed by core tests
 class KratosSensitivityTestSuite : public KratosCoreFastSuite {};
 class KratosCoreGeometriesFastSuite : public KratosCoreFastSuite {};


### PR DESCRIPTION
**📝 Description**
One of the characteristics of running our unit tests using the GTest suites is that currently every test has a kernel and initializes th applications. However, for the GeoMechanicsApplication, most unit tests are independent of the initialization of the apps, since they test the units in isolation. Therefore, we can achieve a significant speed-up by having a version of the suites without a kernel. We experimented with this idea and could reduce the unit test time for the Geo app by > 75% (~35 sec to ~7.5 sec locally) using this mechanism.

This PR adds a kernel-less test suite to Kratos Core, which is then used as an example in the GeoMechanicsApplication. In this PR one example file is converted to the suite without kernel (for a single test locally, the speed-up is from ~100 ms to < 1 ms)