### PR TITLE
[Core][MappingApplication] Make MapperFactory use Registry

### DIFF
--- a/applications/MappingApplication/mapping_application.cpp
+++ b/applications/MappingApplication/mapping_application.cpp
@@ -48,6 +48,14 @@
         (MapperName, Kratos::make_shared<MapperType<                                                  \
         MapperDefinitions::SparseSpaceType,MapperDefinitions::DenseSpaceType>>                        \
         (dummy_model_part, dummy_model_part));                                                        \
+    using TMapperType = Mapper<MapperDefinitions::SparseSpaceType, MapperDefinitions::DenseSpaceType>;  \
+    using MapperPointer = typename TMapperType::Pointer;                                                \
+    MapperPointer p_mapper = Kratos::make_shared<MapperType<                                            \
+            MapperDefinitions::SparseSpaceType,                                                         \
+            MapperDefinitions::DenseSpaceType                                                           \
+        >>(dummy_model_part, dummy_model_part);                                                         \
+    Registry::AddItem<TMapperType>("mappers."+Registry::GetCurrentSource()+"."+MapperName, p_mapper);   \
+    Registry::AddItem<TMapperType>("mappers.all."+std::string(MapperName), p_mapper);                   \
     }
 
 #define KRATOS_REGISTER_MAPPER_WITH_BACKEND(MapperType, MapperName)                                   \
@@ -59,6 +67,15 @@
         MapperDefinitions::SparseSpaceType,MapperDefinitions::DenseSpaceType,MapperBackend<           \
                 MapperDefinitions::SparseSpaceType,MapperDefinitions::DenseSpaceType>>>               \
         (dummy_model_part, dummy_model_part));                                                        \
+    using TMapperType = Mapper<MapperDefinitions::SparseSpaceType, MapperDefinitions::DenseSpaceType>;  \
+    using MapperPointer = typename TMapperType::Pointer;                                                \
+    MapperPointer p_mapper = Kratos::make_shared<MapperType<                                            \
+            MapperDefinitions::SparseSpaceType,                                                         \
+            MapperDefinitions::DenseSpaceType,                                                          \
+            MapperBackend<MapperDefinitions::SparseSpaceType,MapperDefinitions::DenseSpaceType>         \
+        >>(dummy_model_part, dummy_model_part);                                                         \
+    Registry::AddItem<TMapperType>("mappers."+Registry::GetCurrentSource()+"."+MapperName, p_mapper);   \
+    Registry::AddItem<TMapperType>("mappers.all."+std::string(MapperName), p_mapper);                   \
     }
 
 Kratos::KratosApplication* CreateApplication()

--- a/applications/MappingApplication/mapping_application.cpp
+++ b/applications/MappingApplication/mapping_application.cpp
@@ -48,14 +48,6 @@
         (MapperName, Kratos::make_shared<MapperType<                                                  \
         MapperDefinitions::SparseSpaceType,MapperDefinitions::DenseSpaceType>>                        \
         (dummy_model_part, dummy_model_part));                                                        \
-    using TMapperType = Mapper<MapperDefinitions::SparseSpaceType, MapperDefinitions::DenseSpaceType>;  \
-    using MapperPointer = typename TMapperType::Pointer;                                                \
-    MapperPointer p_mapper = Kratos::make_shared<MapperType<                                            \
-            MapperDefinitions::SparseSpaceType,                                                         \
-            MapperDefinitions::DenseSpaceType                                                           \
-        >>(dummy_model_part, dummy_model_part);                                                         \
-    Registry::AddItem<TMapperType>("mappers."+Registry::GetCurrentSource()+"."+MapperName, p_mapper);   \
-    Registry::AddItem<TMapperType>("mappers.all."+std::string(MapperName), p_mapper);                   \
     }
 
 #define KRATOS_REGISTER_MAPPER_WITH_BACKEND(MapperType, MapperName)                                   \
@@ -67,15 +59,6 @@
         MapperDefinitions::SparseSpaceType,MapperDefinitions::DenseSpaceType,MapperBackend<           \
                 MapperDefinitions::SparseSpaceType,MapperDefinitions::DenseSpaceType>>>               \
         (dummy_model_part, dummy_model_part));                                                        \
-    using TMapperType = Mapper<MapperDefinitions::SparseSpaceType, MapperDefinitions::DenseSpaceType>;  \
-    using MapperPointer = typename TMapperType::Pointer;                                                \
-    MapperPointer p_mapper = Kratos::make_shared<MapperType<                                            \
-            MapperDefinitions::SparseSpaceType,                                                         \
-            MapperDefinitions::DenseSpaceType,                                                          \
-            MapperBackend<MapperDefinitions::SparseSpaceType,MapperDefinitions::DenseSpaceType>         \
-        >>(dummy_model_part, dummy_model_part);                                                         \
-    Registry::AddItem<TMapperType>("mappers."+Registry::GetCurrentSource()+"."+MapperName, p_mapper);   \
-    Registry::AddItem<TMapperType>("mappers.all."+std::string(MapperName), p_mapper);                   \
     }
 
 Kratos::KratosApplication* CreateApplication()

--- a/applications/MappingApplication/mpi_extension/custom_utilities/mapper_factory_mpi.cpp
+++ b/applications/MappingApplication/mpi_extension/custom_utilities/mapper_factory_mpi.cpp
@@ -27,15 +27,6 @@ namespace Kratos {
 typedef typename MPIMapperDefinitions::SparseSpaceType SparseSpaceType;
 typedef typename MPIMapperDefinitions::DenseSpaceType  DenseSpaceType;
 
-template<>
-std::unordered_map<std::string, typename Mapper<SparseSpaceType, DenseSpaceType>::Pointer>& MapperFactory<SparseSpaceType,
-    DenseSpaceType>::GetRegisteredMappersList()
-{
-    static std::unordered_map<std::string, typename Mapper<SparseSpaceType, DenseSpaceType>::Pointer> registered_mappers;
-
-    return registered_mappers;
-}
-
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 // Class template instantiation
 template class MapperFactory< SparseSpaceType, DenseSpaceType >;

--- a/kratos/factories/mapper_factory.cpp
+++ b/kratos/factories/mapper_factory.cpp
@@ -27,15 +27,6 @@ namespace Kratos {
 typedef typename MapperDefinitions::SparseSpaceType SparseSpaceType;
 typedef typename MapperDefinitions::DenseSpaceType  DenseSpaceType;
 
-template<>
-std::unordered_map<std::string, typename Mapper<SparseSpaceType, DenseSpaceType>::Pointer>& MapperFactory<SparseSpaceType,
-    DenseSpaceType>::GetRegisteredMappersList()
-{
-    static std::unordered_map<std::string, typename Mapper<SparseSpaceType, DenseSpaceType>::Pointer> registered_mappers;
-
-    return registered_mappers;
-}
-
     /* // CommRank is used as input bcs the MyPID function of the non-MPI MapperCommunicator is used
     // since this function is called before the MapperMPICommunicato is initialized
     void CheckInterfaceModelParts(const int CommRank)

--- a/kratos/factories/mapper_factory.h
+++ b/kratos/factories/mapper_factory.h
@@ -24,6 +24,7 @@
 // Project includes
 #include "includes/define.h"
 #include "includes/kratos_parameters.h"
+#include "includes/registry.h"
 #include "containers/model.h"
 
 #include "mappers/mapper.h"
@@ -74,27 +75,27 @@ public:
         KRATOS_ERROR_IF(TSparseSpace::IsDistributed() && !r_interface_model_part_origin.IsDistributed() && !r_interface_model_part_destination.IsDistributed()) << "Trying to construct a MPI Mapper without a distributed ModelPart. Please use \"CreateMapper\" instead!" << std::endl;
 
         const std::string mapper_name = MapperSettings["mapper_type"].GetString();
+        const std::string mapper_path = GetPath(mapper_name);
 
-        const auto& mapper_list = GetRegisteredMappersList();
+        if (Registry::HasItem(mapper_path)) {
 
-        if (mapper_list.find(mapper_name) != mapper_list.end()) {
             // Removing Parameters that are not needed by the Mapper
             MapperSettings.RemoveValue("mapper_type");
             MapperSettings.RemoveValue("interface_submodel_part_origin");
             MapperSettings.RemoveValue("interface_submodel_part_destination");
 
-            // TODO check why this works, Clone currently returns a unique ptr!!!
-            return mapper_list.at(mapper_name)->Clone(r_interface_model_part_origin,
-                                                      r_interface_model_part_destination,
-                                                      MapperSettings);
+            return Registry::GetValue<Mapper<TSparseSpace, TDenseSpace>>(mapper_path).Clone(
+                r_interface_model_part_origin, r_interface_model_part_destination, MapperSettings);
         }
         else {
             std::stringstream err_msg;
             err_msg << "The requested Mapper \"" << mapper_name <<"\" is not not available!\n"
                     << "The following Mappers are available:" << std::endl;
 
-            for (auto const& registered_mapper : mapper_list)
-                err_msg << "\t" << registered_mapper.first << "\n";
+            auto& r_mappers = Registry::GetItem(GetPath());
+            for (auto i_key = r_mappers.KeyConstBegin(); i_key != r_mappers.KeyConstEnd(); ++i_key) {
+                err_msg << "\t" << *i_key << "\n";
+            }
 
             KRATOS_ERROR << err_msg.str() << std::endl;
         }
@@ -156,6 +157,18 @@ private:
 
     /// Default constructor.
     MapperFactory() {}
+
+    static std::string GetPath() {
+        if constexpr (TSparseSpace::IsDistributed()) {
+            return std::string("mappers.all.mpi");
+        }
+        return std::string("mappers.all");
+    }
+
+    static std::string GetPath(const std::string& rName)
+    {
+        return GetPath() + "." + rName;
+    }
 
     static ModelPart& GetInterfaceModelPart(ModelPart& rModelPart,
                                             const Parameters InterfaceParameters,

--- a/kratos/factories/mapper_factory.h
+++ b/kratos/factories/mapper_factory.h
@@ -104,8 +104,9 @@ public:
     static void Register(const std::string& rMapperName,
                   typename Mapper<TSparseSpace, TDenseSpace>::Pointer pMapperPrototype)
     {
-        GetRegisteredMappersList().insert(
-            std::make_pair(rMapperName, pMapperPrototype));
+        using MapperType = Mapper<TSparseSpace, TDenseSpace>;
+        Registry::AddItem<MapperType>("mappers."+Registry::GetCurrentSource()+"."+rMapperName, pMapperPrototype);
+        Registry::AddItem<MapperType>("mappers.all."+rMapperName, pMapperPrototype);
     }
 
     static bool HasMapper(const std::string& rMapperName)

--- a/kratos/includes/kratos_application.h
+++ b/kratos/includes/kratos_application.h
@@ -129,7 +129,7 @@ class KRATOS_API(KRATOS_CORE) KratosApplication {
           mpModelers(rOther.mpModelers) {}
 
     /// Destructor.
-    virtual ~KratosApplication() 
+    virtual ~KratosApplication()
     {
         // This must be commented until tests have been fixed.
         DeregisterCommonComponents();
@@ -152,7 +152,7 @@ class KRATOS_API(KRATOS_CORE) KratosApplication {
 
     /**
      * @brief This method is used to unregister common components of the application.
-     * @details This method is used to unregister common components of the application. 
+     * @details This method is used to unregister common components of the application.
      * The list of unregistered components are the ones exposed in the common KratosComponents interface:
      * - Geometries
      * - Elements
@@ -168,6 +168,12 @@ class KRATOS_API(KRATOS_CORE) KratosApplication {
      * @details This method is used to unregister specific application components.
      */
     virtual void DeregisterApplication();
+
+    /**
+     * @brief This method is used to unregister mappers registered by the application..
+     * @details This method is used to unregister mappers registered by the application..
+     */
+    void DeregisterMappers();
 
     ///////////////////////////////////////////////////////////////////
     void RegisterVariables();  // This contains the whole list of common variables in the Kratos Core

--- a/kratos/sources/kratos_application.cpp
+++ b/kratos/sources/kratos_application.cpp
@@ -122,7 +122,7 @@ KratosApplication::KratosApplication(const std::string& ApplicationName)
       mpModelers(KratosComponents<Modeler>::pGetComponents()),
       mpRegisteredObjects(&(Serializer::GetRegisteredObjects())),
       mpRegisteredObjectsName(&(Serializer::GetRegisteredObjectsName())) {
-        
+
         Registry::SetCurrentSource(mApplicationName);
 
         for (auto component : {"geometries", "elements", "conditions", "constraints", "modelers", "constitutive_laws"}) {
@@ -355,7 +355,7 @@ void KratosApplication::DeregisterComponent(std::string const & rComponentName) 
     }
 }
 
-void KratosApplication::DeregisterCommonComponents() 
+void KratosApplication::DeregisterCommonComponents()
 {
     KRATOS_INFO("") << "Deregistering " << mApplicationName << std::endl;
 
@@ -368,8 +368,23 @@ void KratosApplication::DeregisterCommonComponents()
 }
 
 void KratosApplication::DeregisterApplication() {
+    DeregisterMappers();
     // DeregisterLinearSolvers();
     // DeregisterPreconditioners();
+}
+
+void KratosApplication::DeregisterMappers() {
+    const std::string path = "mappers."+mApplicationName;
+    if (Registry::HasItem(path)) {
+        auto& r_mappers = Registry::GetItem(path);
+        // Iterate over items at path. For each item, remove it from the mappers.all branch too
+        for (auto i_key = r_mappers.KeyConstBegin(); i_key != r_mappers.KeyConstEnd(); ++i_key) {
+            KRATOS_INFO("") << "Deregistering mappers.all." << *i_key << std::endl;
+            Registry::RemoveItem("mappers.all."+*i_key);
+        }
+        KRATOS_INFO("") << "Deregistering " << mApplicationName << " mappers" << std::endl;
+        Registry::RemoveItem(path);
+    }
 }
 
 }  // namespace Kratos.

--- a/kratos/sources/kratos_application.cpp
+++ b/kratos/sources/kratos_application.cpp
@@ -374,6 +374,19 @@ void KratosApplication::DeregisterApplication() {
 }
 
 void KratosApplication::DeregisterMappers() {
+    // Unload the mpi branch first to avoid having a special case later
+    const std::string mpi_path = "mappers."+mApplicationName+".mpi";
+    if (Registry::HasItem(mpi_path)) {
+        auto& r_mappers = Registry::GetItem(mpi_path);
+        // Iterate over items at path. For each item, remove it from the mappers.all.mpi branch too
+        for (auto i_key = r_mappers.KeyConstBegin(); i_key != r_mappers.KeyConstEnd(); ++i_key) {
+            KRATOS_INFO("") << "Deregistering mappers.all.mpi." << *i_key << std::endl;
+            Registry::RemoveItem("mappers.all.mpi."+*i_key);
+        }
+        KRATOS_INFO("") << "Deregistering " << mApplicationName << " MPI mappers" << std::endl;
+        Registry::RemoveItem(mpi_path);
+    }
+
     const std::string path = "mappers."+mApplicationName;
     if (Registry::HasItem(path)) {
         auto& r_mappers = Registry::GetItem(path);

--- a/kratos/sources/kratos_application.cpp
+++ b/kratos/sources/kratos_application.cpp
@@ -380,10 +380,8 @@ void KratosApplication::DeregisterMappers() {
         auto& r_mappers = Registry::GetItem(mpi_path);
         // Iterate over items at path. For each item, remove it from the mappers.all.mpi branch too
         for (auto i_key = r_mappers.KeyConstBegin(); i_key != r_mappers.KeyConstEnd(); ++i_key) {
-            KRATOS_INFO("") << "Deregistering mappers.all.mpi." << *i_key << std::endl;
             Registry::RemoveItem("mappers.all.mpi."+*i_key);
         }
-        KRATOS_INFO("") << "Deregistering " << mApplicationName << " MPI mappers" << std::endl;
         Registry::RemoveItem(mpi_path);
     }
 
@@ -392,10 +390,8 @@ void KratosApplication::DeregisterMappers() {
         auto& r_mappers = Registry::GetItem(path);
         // Iterate over items at path. For each item, remove it from the mappers.all branch too
         for (auto i_key = r_mappers.KeyConstBegin(); i_key != r_mappers.KeyConstEnd(); ++i_key) {
-            KRATOS_INFO("") << "Deregistering mappers.all." << *i_key << std::endl;
             Registry::RemoveItem("mappers.all."+*i_key);
         }
-        KRATOS_INFO("") << "Deregistering " << mApplicationName << " mappers" << std::endl;
         Registry::RemoveItem(path);
     }
 }


### PR DESCRIPTION
**📝 Description**
Refactoring the MapperFactory in order to use the Registry infrastructure instead of its internal registered_mappers list.

The motivation for the change is related to the new gtests and the need to load application dependencies dynamically. Consider a test suite that loads MappingApplication as a runtime dependency (because the tested application does not have compile-time dependencies to it and does not link to it)

1. Kratos Core imported (including MapperFactory)
2. MappingApplication imported dynamically on SetUpTestSuite
3. For each test:
 3.1 Mappers registered in MapperFactory on each test start (when the test suite imports its dependencies in the kernel)
 3.2 Test run
 3.3 Applications de-registered
4. MappingApplication unloaded on TearDownTestSuite
5. MapperFactory mapper list deallocated, but the mapper class definitions are no longer available -> Memory error

If the MapperFactory uses the registry instead, mappers are automatically registered when MapperApplication is de-registered in 3.3, so the deallocation in 5 is no longer a problem.

**🆕 Changelog**
- MapperFactory uses Registry to hold registered mappers instead of an internal static variable.
