### PR TITLE
[Potential Flow App] [Fast PR] Changing the use of radians to degrees

### DIFF
--- a/applications/CompressiblePotentialFlowApplication/python_scripts/apply_far_field_process.py
+++ b/applications/CompressiblePotentialFlowApplication/python_scripts/apply_far_field_process.py
@@ -19,6 +19,9 @@ class ApplyFarFieldProcess(KratosMultiphysics.Process):
     def __init__(self, Model, settings ):
         KratosMultiphysics.Process.__init__(self)
 
+        if not settings.Has("angle_of_attack_units"):
+            KratosMultiphysics.Logger.PrintWarning("ApplyFarFieldProcess", "'angle of attack_units' is not provided. Using 'radians' as default angle of attack unit.")
+
         default_parameters = KratosMultiphysics.Parameters( """
             {
                 "model_part_name":"",

--- a/applications/CompressiblePotentialFlowApplication/python_scripts/apply_far_field_process.py
+++ b/applications/CompressiblePotentialFlowApplication/python_scripts/apply_far_field_process.py
@@ -66,7 +66,7 @@ class ApplyFarFieldProcess(KratosMultiphysics.Process):
         self.free_stream_velocity = KratosMultiphysics.Vector(3)
 
         if self.angle_of_attack_units == "radians":
-            KratosMultiphysics.Logger.PrintWarning("ApplyFarFieldProcess", " Using 'radians' as default angle of attack unit.")
+            KratosMultiphysics.Logger.PrintWarning("ApplyFarFieldProcess", " Using 'radians' as angle of attack unit. This will be deprecated soon.")
         elif self.angle_of_attack_units == "degrees":
             self.angle_of_attack = self.angle_of_attack*math.pi/180
 

--- a/applications/CompressiblePotentialFlowApplication/python_scripts/apply_far_field_process.py
+++ b/applications/CompressiblePotentialFlowApplication/python_scripts/apply_far_field_process.py
@@ -63,17 +63,17 @@ class ApplyFarFieldProcess(KratosMultiphysics.Process):
         self.domain_size = self.fluid_model_part.ProcessInfo.GetValue(KratosMultiphysics.DOMAIN_SIZE)
         if self.domain_size == 2:
             # By convention 2D airfoils are in the xy plane
-            self.free_stream_velocity[0] = round(self.u_inf*math.cos(self.angle_of_attack),8)
-            self.free_stream_velocity[1] = round(self.u_inf*math.sin(self.angle_of_attack),8)
+            self.free_stream_velocity[0] = round(self.u_inf*math.cos(self.angle_of_attack*math.pi/180),8)
+            self.free_stream_velocity[1] = round(self.u_inf*math.sin(self.angle_of_attack*math.pi/180),8)
             self.free_stream_velocity[2] = 0.0
         else: # self.domain_size == 3
             # By convention 3D wings and aircrafts:
             # y axis along the span
             # z axis pointing upwards
             # TODO: Add sideslip angle beta
-            self.free_stream_velocity[0] = round(self.u_inf*math.cos(self.angle_of_attack),8)
+            self.free_stream_velocity[0] = round(self.u_inf*math.cos(self.angle_of_attack*math.pi/180),8)
             self.free_stream_velocity[1] = 0.0
-            self.free_stream_velocity[2] = round(self.u_inf*math.sin(self.angle_of_attack),8)
+            self.free_stream_velocity[2] = round(self.u_inf*math.sin(self.angle_of_attack*math.pi/180),8)
 
         self.free_stream_velocity_direction = self.free_stream_velocity / self.u_inf
 


### PR DESCRIPTION
**📝 Description**

This fast PR is to propose changing the use of radians to degrees in the angle of attack in the application. I think this way is more intuitive and clear for the user.

For this, only the conversion factor is added in _apply_far_field_process.py_ when is calculated the velocity components, since the variable _ANGLE_OF_ATTACK_ itself does not exist here.

**🆕 Changelog**
- Updated __apply_far_field_process.py_
