### PR TITLE
[RomApplication] [Fast PR] Change the size allocation of phi_elemental and psi_elemental

### DIFF
--- a/applications/RomApplication/custom_utilities/rom_residuals_utility.h
+++ b/applications/RomApplication/custom_utilities/rom_residuals_utility.h
@@ -122,8 +122,8 @@ namespace Kratos
                         //assemble the elemental contribution - here is where the ROM acts
                         //compute the elemental reduction matrix phi_elemental
                         const auto& r_geom = it_el->GetGeometry();
-                        if(phi_elemental.size1() != elem_dofs.size() || phi_elemental.size2() != mRomDofs)
-                            phi_elemental.resize(elem_dofs.size(), mRomDofs,false);
+                        if(phi_elemental.size1() != rhs_contribution.size() || phi_elemental.size2() != mRomDofs)
+                            phi_elemental.resize(rhs_contribution.size(), mRomDofs,false);
                         RomAuxiliaryUtilities::GetPhiElemental(phi_elemental, elem_dofs, r_geom, mMapPhi);
                         noalias(row(matrix_residuals, k)) = prod(trans(phi_elemental), rhs_contribution); // The size of the residual will vary only when using more ROM modes, one row per condition
                     }
@@ -190,8 +190,8 @@ namespace Kratos
                         //assemble the elemental contribution - here is where the ROM acts
                         //compute the elemental reduction matrix phi_elemental
                         const auto& r_geom = it_el->GetGeometry();
-                        if(psi_elemental.size1() != elem_dofs.size() || psi_elemental.size2() != mPetrovGalerkinRomDofs)
-                            psi_elemental.resize(elem_dofs.size(), mPetrovGalerkinRomDofs,false);
+                        if(psi_elemental.size1() != rhs_contribution.size() || psi_elemental.size2() != mPetrovGalerkinRomDofs)
+                            psi_elemental.resize(rhs_contribution.size(), mPetrovGalerkinRomDofs,false);
                         RomAuxiliaryUtilities::GetPsiElemental(psi_elemental, elem_dofs, r_geom, mMapPhi);
                         noalias(row(matrix_residuals, k)) = prod(trans(psi_elemental), rhs_contribution); // The size of the residual will vary only when using more ROM modes, one row per condition
                     }


### PR DESCRIPTION
**📝 Description**

This fast PR proposes to change the size allocation of _phi_elemental_ and _psi_elemental from _elem_dofs.size()_ to _rhs_contribution.size()_.

This is because in transonic potential cases it is necessary to calculate the density at an upwind point for each element located in a supersonic region. Since the supersonic regions are not known _a priori_, and may vary during the calculation procedure, an upwind element is associated to each element mesh. 

As a result, the finite element data structure needs to be enriched and here the elemental systems are extended (from _number_of_degrees_of_freedom_ to _number_of_degrees_of_freedom_ + 1) to contain additions to upwind nodes, only for those elements whose local mach number is greater than a certain _critical_mach_.

I think this is very specific for this case, but I don't think it will be a problem in a normal case and will broaden the use of the application.

**🆕 Changelog**

- Updated _rom_residuals_utility.h_
