### PR TITLE
[GeoMechanicsApplication] Moved large include from header to source

### DIFF
--- a/applications/GeoMechanicsApplication/custom_conditions/T_microclimate_flux_condition.cpp
+++ b/applications/GeoMechanicsApplication/custom_conditions/T_microclimate_flux_condition.cpp
@@ -19,6 +19,7 @@
 #include "micro_climate_constants.h"
 
 #include <boost/numeric/ublas/vector_expression.hpp>
+#include <numeric>
 
 namespace Kratos
 {

--- a/applications/GeoMechanicsApplication/custom_conditions/general_U_Pw_diff_order_condition.cpp
+++ b/applications/GeoMechanicsApplication/custom_conditions/general_U_Pw_diff_order_condition.cpp
@@ -16,6 +16,7 @@
 #include "geometries/line_2d_4.h"
 #include "geometries/quadrilateral_3d_4.h"
 #include "geometries/triangle_3d_3.h"
+#include <geometries/line_2d_3.h>
 
 // Project includes
 #include "custom_conditions/general_U_Pw_diff_order_condition.hpp"

--- a/applications/GeoMechanicsApplication/custom_conditions/general_U_Pw_diff_order_condition.cpp
+++ b/applications/GeoMechanicsApplication/custom_conditions/general_U_Pw_diff_order_condition.cpp
@@ -13,10 +13,10 @@
 //
 
 #include "geometries/line_2d_2.h"
+#include "geometries/line_2d_3.h"
 #include "geometries/line_2d_4.h"
 #include "geometries/quadrilateral_3d_4.h"
 #include "geometries/triangle_3d_3.h"
-#include <geometries/line_2d_3.h>
 
 // Project includes
 #include "custom_conditions/general_U_Pw_diff_order_condition.hpp"

--- a/applications/GeoMechanicsApplication/custom_conditions/line_normal_load_2D_diff_order_condition.cpp
+++ b/applications/GeoMechanicsApplication/custom_conditions/line_normal_load_2D_diff_order_condition.cpp
@@ -14,6 +14,7 @@
 
 // Project includes
 #include "custom_conditions/line_normal_load_2D_diff_order_condition.hpp"
+#include "includes/variables.h"
 
 namespace Kratos
 {

--- a/applications/GeoMechanicsApplication/custom_conditions/surface_normal_load_3D_diff_order_condition.cpp
+++ b/applications/GeoMechanicsApplication/custom_conditions/surface_normal_load_3D_diff_order_condition.cpp
@@ -14,6 +14,7 @@
 
 // Project includes
 #include "custom_conditions/surface_normal_load_3D_diff_order_condition.hpp"
+#include "includes/variables.h"
 #include "utilities/math_utils.h"
 
 namespace Kratos

--- a/applications/GeoMechanicsApplication/custom_constitutive/thermal_dispersion_law.cpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/thermal_dispersion_law.cpp
@@ -15,6 +15,8 @@
 #include "custom_constitutive/thermal_dispersion_law.h"
 #include "custom_retention/retention_law_factory.h"
 #include "geo_mechanics_application_variables.h"
+#include "includes/properties.h"
+#include "includes/variables.h"
 
 namespace Kratos
 {

--- a/applications/GeoMechanicsApplication/custom_constitutive/thermal_filter_law.cpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/thermal_filter_law.cpp
@@ -13,6 +13,7 @@
 
 #include "custom_constitutive/thermal_filter_law.h"
 #include "geo_mechanics_application_variables.h"
+#include "includes/properties.h"
 
 namespace Kratos
 {

--- a/applications/GeoMechanicsApplication/custom_constitutive/thermal_law.h
+++ b/applications/GeoMechanicsApplication/custom_constitutive/thermal_law.h
@@ -20,6 +20,8 @@
 namespace Kratos
 {
 
+class Properties;
+
 class KRATOS_API(GEO_MECHANICS_APPLICATION) GeoThermalLaw
 {
 public:

--- a/applications/GeoMechanicsApplication/custom_elements/U_Pw_base_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/U_Pw_base_element.cpp
@@ -15,6 +15,7 @@
 #include "custom_elements/U_Pw_base_element.hpp"
 #include "custom_utilities/dof_utilities.h"
 #include "custom_utilities/equation_of_motion_utilities.h"
+#include "utilities/geometry_utilities.h"
 
 namespace Kratos
 {

--- a/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_element.cpp
@@ -17,6 +17,7 @@
 #include "custom_utilities/equation_of_motion_utilities.h"
 #include "custom_utilities/math_utilities.h"
 #include "custom_utilities/transport_equation_utilities.hpp"
+#include "includes/cfd_variables.h"
 
 namespace Kratos
 {

--- a/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_interface_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_interface_element.cpp
@@ -16,6 +16,7 @@
 #include "custom_utilities/constitutive_law_utilities.hpp"
 #include "custom_utilities/transport_equation_utilities.hpp"
 #include <custom_utilities/stress_strain_utilities.h>
+#include "includes/cfd_variables.h"
 
 namespace Kratos
 {

--- a/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_link_interface_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_link_interface_element.cpp
@@ -14,6 +14,7 @@
 // Application includes
 #include "custom_elements/U_Pw_small_strain_link_interface_element.hpp"
 #include "custom_utilities/constitutive_law_utilities.hpp"
+#include "includes/cfd_variables.h"
 
 namespace Kratos
 {

--- a/applications/GeoMechanicsApplication/custom_elements/small_strain_U_Pw_diff_order_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/small_strain_U_Pw_diff_order_element.cpp
@@ -18,6 +18,8 @@
 #include "geometries/tetrahedra_3d_4.h"
 #include "geometries/triangle_2d_10.h"
 #include "geometries/triangle_2d_3.h"
+#include "geometries/triangle_2d_6.h"
+#include "includes/cfd_variables.h"
 #include "utilities/math_utils.h"
 
 // Application includes

--- a/applications/GeoMechanicsApplication/custom_elements/steady_state_Pw_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/steady_state_Pw_element.cpp
@@ -13,6 +13,7 @@
 // Application includes
 #include "custom_elements/steady_state_Pw_element.hpp"
 #include "custom_utilities/transport_equation_utilities.hpp"
+#include "includes/cfd_variables.h"
 
 namespace Kratos
 {

--- a/applications/GeoMechanicsApplication/custom_elements/steady_state_Pw_interface_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/steady_state_Pw_interface_element.cpp
@@ -12,6 +12,7 @@
 
 // Application includes
 #include "custom_elements/steady_state_Pw_interface_element.hpp"
+#include "includes/cfd_variables.h"
 
 namespace Kratos
 {

--- a/applications/GeoMechanicsApplication/custom_elements/transient_Pw_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/transient_Pw_element.cpp
@@ -14,6 +14,7 @@
 #include "custom_elements/transient_Pw_element.hpp"
 #include "custom_utilities/dof_utilities.h"
 #include "custom_utilities/transport_equation_utilities.hpp"
+#include "includes/cfd_variables.h"
 
 namespace Kratos
 {

--- a/applications/GeoMechanicsApplication/custom_elements/transient_Pw_interface_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/transient_Pw_interface_element.cpp
@@ -16,6 +16,7 @@
 #include "custom_utilities/interface_element_utilities.hpp"
 #include "custom_utilities/transport_equation_utilities.hpp"
 #include "geo_mechanics_application_variables.h"
+#include "includes/cfd_variables.h"
 
 namespace Kratos
 {

--- a/applications/GeoMechanicsApplication/custom_elements/transient_Pw_line_element.h
+++ b/applications/GeoMechanicsApplication/custom_elements/transient_Pw_line_element.h
@@ -18,6 +18,7 @@
 #include "custom_utilities/element_utilities.hpp"
 #include "custom_utilities/transport_equation_utilities.hpp"
 #include "geo_mechanics_application_variables.h"
+#include "includes/cfd_variables.h"
 #include "includes/element.h"
 #include "includes/serializer.h"
 

--- a/applications/GeoMechanicsApplication/custom_processes/apply_c_phi_reduction_process.cpp
+++ b/applications/GeoMechanicsApplication/custom_processes/apply_c_phi_reduction_process.cpp
@@ -15,6 +15,7 @@
 // Project includes
 #include "custom_processes/apply_c_phi_reduction_process.h"
 #include "utilities/math_utils.h"
+#include "includes/model_part.h"
 
 namespace Kratos
 {

--- a/applications/GeoMechanicsApplication/custom_processes/apply_c_phi_reduction_process.h
+++ b/applications/GeoMechanicsApplication/custom_processes/apply_c_phi_reduction_process.h
@@ -16,6 +16,7 @@
 
 // Project includes
 #include "geo_mechanics_application_variables.h"
+#include "includes/element.h"
 
 // Application includes
 #include "includes/kratos_export_api.h"

--- a/applications/GeoMechanicsApplication/custom_processes/apply_component_table_process.hpp
+++ b/applications/GeoMechanicsApplication/custom_processes/apply_component_table_process.hpp
@@ -17,6 +17,7 @@
 #include "includes/kratos_parameters.h"
 #include "includes/table.h"
 #include "processes/process.h"
+#include "includes/model_part.h"
 
 #include "geo_mechanics_application_variables.h"
 

--- a/applications/GeoMechanicsApplication/custom_processes/apply_constant_boundary_hydrostatic_pressure_process.hpp
+++ b/applications/GeoMechanicsApplication/custom_processes/apply_constant_boundary_hydrostatic_pressure_process.hpp
@@ -14,6 +14,7 @@
 
 #include "includes/kratos_flags.h"
 #include "includes/kratos_parameters.h"
+#include "includes/model_part.h"
 #include "processes/process.h"
 
 #include "geo_mechanics_application_variables.h"

--- a/applications/GeoMechanicsApplication/custom_processes/apply_constant_phreatic_multi_line_pressure_process.cpp
+++ b/applications/GeoMechanicsApplication/custom_processes/apply_constant_phreatic_multi_line_pressure_process.cpp
@@ -11,6 +11,7 @@
 //                   Jonathan Nuttall
 
 #include "apply_constant_phreatic_multi_line_pressure_process.h"
+#include "includes/model_part.h"
 
 namespace Kratos
 {

--- a/applications/GeoMechanicsApplication/custom_processes/apply_constant_phreatic_multi_line_pressure_process.h
+++ b/applications/GeoMechanicsApplication/custom_processes/apply_constant_phreatic_multi_line_pressure_process.h
@@ -22,6 +22,9 @@
 namespace Kratos
 {
 
+class ModelPart;
+class Node;
+
 class KRATOS_API(GEO_MECHANICS_APPLICATION) ApplyConstantPhreaticMultiLinePressureProcess : public Process
 {
 public:

--- a/applications/GeoMechanicsApplication/custom_processes/apply_phreatic_multi_line_pressure_table_process.cpp
+++ b/applications/GeoMechanicsApplication/custom_processes/apply_phreatic_multi_line_pressure_table_process.cpp
@@ -12,6 +12,7 @@
 
 #include "apply_phreatic_multi_line_pressure_table_process.h"
 #include "geo_mechanics_application_variables.h"
+#include "includes/model_part.h"
 
 namespace Kratos
 {

--- a/applications/GeoMechanicsApplication/custom_processes/calculate_incremental_displacement_process.cpp
+++ b/applications/GeoMechanicsApplication/custom_processes/calculate_incremental_displacement_process.cpp
@@ -11,6 +11,9 @@
 //
 #include "calculate_incremental_displacement_process.h"
 #include "geo_mechanics_application_variables.h"
+#include "includes/model_part.h"
+#include "includes/node.h"
+#include "includes/variables.h"
 
 namespace Kratos
 {

--- a/applications/GeoMechanicsApplication/custom_utilities/equation_of_motion_utilities.cpp
+++ b/applications/GeoMechanicsApplication/custom_utilities/equation_of_motion_utilities.cpp
@@ -15,6 +15,7 @@
 // Application includes
 #include "custom_utilities/equation_of_motion_utilities.h"
 #include "custom_utilities/element_utilities.hpp"
+#include "utilities/geometry_utilities.h"
 
 namespace Kratos
 {

--- a/applications/GeoMechanicsApplication/custom_utilities/transport_equation_utilities.hpp
+++ b/applications/GeoMechanicsApplication/custom_utilities/transport_equation_utilities.hpp
@@ -18,6 +18,7 @@
 #include "custom_retention/retention_law.h"
 #include "custom_utilities/stress_strain_utilities.h"
 #include "geo_mechanics_application_variables.h"
+#include "includes/variables.h"
 
 namespace Kratos
 {

--- a/applications/GeoMechanicsApplication/geo_mechanics_application_variables.h
+++ b/applications/GeoMechanicsApplication/geo_mechanics_application_variables.h
@@ -20,7 +20,6 @@
 // Project includes
 #include "geo_mechanics_application_constants.h"
 #include "includes/define.h"
-#include "includes/kratos_application.h"
 #include "structural_mechanics_application_variables.h"
 #include <string>
 

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/geo_mechanics_fast_suite.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/geo_mechanics_fast_suite.cpp
@@ -12,6 +12,8 @@
 //
 
 #include "geo_mechanics_fast_suite.h"
+#include "geo_mechanics_application.h"
+#include "linear_solvers_application.h"
 
 namespace Kratos::Testing
 {

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/geo_mechanics_fast_suite.h
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/geo_mechanics_fast_suite.h
@@ -13,22 +13,26 @@
 
 #pragma once
 
-#include "geo_mechanics_application.h"
-#include "linear_solvers_application.h"
 #include "testing/testing.h"
+
+namespace Kratos
+{
+class KratosGeoMechanicsApplication;
+class KratosLinearSolversApplication;
+} // namespace Kratos
 
 namespace Kratos::Testing
 {
 
- class KratosGeoMechanicsFastSuite : public KratosCoreFastSuite
- {
- public:
-     KratosGeoMechanicsFastSuite();
+class KratosGeoMechanicsFastSuite : public KratosCoreFastSuite
+{
+public:
+    KratosGeoMechanicsFastSuite();
 
- private:
-     KratosGeoMechanicsApplication::Pointer mpGeoApp;
-     KratosLinearSolversApplication::Pointer mpLinearSolversApp;
- };
+private:
+   std::shared_ptr<KratosGeoMechanicsApplication>  mpGeoApp;
+   std::shared_ptr<KratosLinearSolversApplication> mpLinearSolversApp;
+};
 
 class KratosGeoMechanicsFastSuiteWithoutKernel : public KratosCoreFastSuiteWithoutKernel
 {
@@ -36,14 +40,14 @@ public:
     KratosGeoMechanicsFastSuiteWithoutKernel();
 };
 
- class KratosGeoMechanicsIntegrationSuite : public KratosCoreFastSuite
- {
- public:
-     KratosGeoMechanicsIntegrationSuite();
+class KratosGeoMechanicsIntegrationSuite : public KratosCoreFastSuite
+{
+public:
+    KratosGeoMechanicsIntegrationSuite();
 
- private:
-     KratosGeoMechanicsApplication::Pointer mpGeoApp;
-     KratosLinearSolversApplication::Pointer mpLinearSolversApp;
- };
+private:
+    std::shared_ptr<KratosGeoMechanicsApplication>  mpGeoApp;
+    std::shared_ptr<KratosLinearSolversApplication> mpLinearSolversApp;
+};
 
 } // namespace Kratos::Testing

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/test_equation_of_motion.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/test_equation_of_motion.cpp
@@ -10,8 +10,8 @@
 //  Main authors:    Gennady Markelov
 //
 
-#include "custom_utilities/element_utilities.hpp"
 #include "custom_utilities/equation_of_motion_utilities.h"
+#include "geo_mechanics_application_variables.h"
 #include "geo_mechanics_fast_suite.h"
 #include "tests/cpp_tests/test_utilities/model_setup_utilities.h"
 #include <boost/numeric/ublas/assignment.hpp>


### PR DESCRIPTION
**📝 Description**
This PR makes sure not all unit tests (which include the geo_mechanics_fast_suite.h) also include the linear solver application and geomechanics application headers, to improve compilation times