### PR TITLE
[GeoMechanicsApplication] Clean up truss elements

### DIFF
--- a/applications/GeoMechanicsApplication/custom_elements/geo_cable_element.hpp
+++ b/applications/GeoMechanicsApplication/custom_elements/geo_cable_element.hpp
@@ -48,7 +48,6 @@ public:
     using VectorType     = Element::VectorType;
 
     using FullDofMatrixType = typename GeoTrussElementBase<TDim, TNumNodes>::FullDofMatrixType;
-    using FullDofVectorType = typename GeoTrussElementBase<TDim, TNumNodes>::FullDofVectorType;
 
     using GeoTrussElementBase<TDim, TNumNodes>::mpConstitutiveLaw;
     using GeoTrussElement<TDim, TNumNodes>::mInternalStressesFinalizedPrevious;

--- a/applications/GeoMechanicsApplication/custom_elements/geo_linear_truss_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/geo_linear_truss_element.cpp
@@ -279,13 +279,7 @@ void GeoLinearTrussElement<TDim, TNumNodes>::FinalizeSolutionStep(const ProcessI
 {
     KRATOS_TRY
 
-    ConstitutiveLaw::Parameters Values(this->GetGeometry(), this->GetProperties(), rCurrentProcessInfo);
-    Vector temp_strain = ZeroVector(1);
-    Vector temp_stress = ZeroVector(1);
-    temp_strain[0]     = this->CalculateLinearStrain();
-    Values.SetStrainVector(temp_strain);
-    Values.SetStressVector(temp_stress);
-    mpConstitutiveLaw->FinalizeMaterialResponse(Values, ConstitutiveLaw::StressMeasure_PK2);
+    this->FinalizeMaterialResponse(this->CalculateLinearStrain(), rCurrentProcessInfo);
 
     mInternalStressesFinalized = mInternalStresses + mInternalStressesFinalizedPrevious;
 

--- a/applications/GeoMechanicsApplication/custom_elements/geo_truss_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/geo_truss_element.cpp
@@ -76,7 +76,7 @@ void GeoTrussElement<TDim, TNumNodes>::Initialize(const ProcessInfo& rCurrentPro
 {
     KRATOS_TRY
 
-    GeoTrussElementBase<TDim, TNumNodes>::Initialize(rCurrentProcessInfo);
+    BaseType::Initialize(rCurrentProcessInfo);
 
     if (rCurrentProcessInfo.Has(RESET_DISPLACEMENTS)) {
         bool ResetDisplacement = rCurrentProcessInfo[RESET_DISPLACEMENTS];
@@ -241,7 +241,7 @@ void GeoTrussElement<TDim, TNumNodes>::FinalizeSolutionStep(const ProcessInfo& r
 {
     KRATOS_TRY
 
-    GeoTrussElementBase<TDim, TNumNodes>::FinalizeSolutionStep(rCurrentProcessInfo);
+    BaseType::FinalizeSolutionStep(rCurrentProcessInfo);
     mInternalStressesFinalized = mInternalStresses + mInternalStressesFinalizedPrevious;
 
     KRATOS_CATCH("")

--- a/applications/GeoMechanicsApplication/custom_elements/geo_truss_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/geo_truss_element.cpp
@@ -108,8 +108,7 @@ void GeoTrussElement<TDim, TNumNodes>::CalculateOnIntegrationPoints(const Variab
         Vector strain = ZeroVector(TDim);
         strain[0]     = this->CalculateGreenLagrangeStrain();
         rOutput[0]    = strain;
-    }
-    if (rVariable == PK2_STRESS_VECTOR) {
+    } else if (rVariable == PK2_STRESS_VECTOR) {
         ConstitutiveLaw::Parameters Values(this->GetGeometry(), this->GetProperties(), rCurrentProcessInfo);
         Vector temp_strain = ZeroVector(1);
         temp_strain[0]     = this->CalculateGreenLagrangeStrain();
@@ -122,22 +121,12 @@ void GeoTrussElement<TDim, TNumNodes>::CalculateOnIntegrationPoints(const Variab
             temp_internal_stresses[i] += mInternalStressesFinalizedPrevious[i];
 
         rOutput[0] = temp_internal_stresses;
-    }
-    if (rVariable == CAUCHY_STRESS_VECTOR) {
-        ConstitutiveLaw::Parameters Values(this->GetGeometry(), this->GetProperties(), rCurrentProcessInfo);
-        Vector temp_strain = ZeroVector(1);
-        temp_strain[0]     = this->CalculateGreenLagrangeStrain();
-        Values.SetStrainVector(temp_strain);
-        array_1d<double, 3> temp_internal_stresses = ZeroVector(3);
-        mpConstitutiveLaw->CalculateValue(Values, FORCE, temp_internal_stresses);
+    } else if (rVariable == CAUCHY_STRESS_VECTOR) {
+        CalculateOnIntegrationPoints(PK2_STRESS_VECTOR, rOutput, rCurrentProcessInfo);
 
-        for (unsigned int i = 0; i < TDim; ++i)
-            temp_internal_stresses[i] += mInternalStressesFinalizedPrevious[i];
-
-        const double l  = StructuralMechanicsElementUtilities::CalculateCurrentLength3D2N(*this);
-        const double L0 = StructuralMechanicsElementUtilities::CalculateReferenceLength3D2N(*this);
-
-        rOutput[0] = temp_internal_stresses * l / L0;
+        const auto l  = StructuralMechanicsElementUtilities::CalculateCurrentLength3D2N(*this);
+        const auto L0 = StructuralMechanicsElementUtilities::CalculateReferenceLength3D2N(*this);
+        rOutput[0] *= (l / L0);
     }
 
     KRATOS_CATCH("")

--- a/applications/GeoMechanicsApplication/custom_elements/geo_truss_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/geo_truss_element.cpp
@@ -227,7 +227,8 @@ void GeoTrussElement<TDim, TNumNodes>::FinalizeSolutionStep(const ProcessInfo& r
 {
     KRATOS_TRY
 
-    BaseType::FinalizeSolutionStep(rCurrentProcessInfo);
+    this->FinalizeMaterialResponse(this->CalculateGreenLagrangeStrain(), rCurrentProcessInfo);
+
     mInternalStressesFinalized = mInternalStresses + mInternalStressesFinalizedPrevious;
 
     KRATOS_CATCH("")

--- a/applications/GeoMechanicsApplication/custom_elements/geo_truss_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/geo_truss_element.cpp
@@ -124,9 +124,7 @@ void GeoTrussElement<TDim, TNumNodes>::CalculateOnIntegrationPoints(const Variab
         rOutput[0] = temp_internal_stresses;
     }
     if (rVariable == CAUCHY_STRESS_VECTOR) {
-        ProcessInfo temp_process_information;
-
-        ConstitutiveLaw::Parameters Values(this->GetGeometry(), this->GetProperties(), temp_process_information);
+        ConstitutiveLaw::Parameters Values(this->GetGeometry(), this->GetProperties(), rCurrentProcessInfo);
         Vector temp_strain = ZeroVector(1);
         temp_strain[0]     = this->CalculateGreenLagrangeStrain();
         Values.SetStrainVector(temp_strain);

--- a/applications/GeoMechanicsApplication/custom_elements/geo_truss_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/geo_truss_element.cpp
@@ -59,12 +59,6 @@ Element::Pointer GeoTrussElement<TDim, TNumNodes>::Create(IndexType             
 
 //----------------------------------------------------------------------------------------
 template <unsigned int TDim, unsigned int TNumNodes>
-GeoTrussElement<TDim, TNumNodes>::~GeoTrussElement()
-{
-}
-
-//----------------------------------------------------------------------------------------
-template <unsigned int TDim, unsigned int TNumNodes>
 void GeoTrussElement<TDim, TNumNodes>::ResetConstitutiveLaw()
 {
     KRATOS_TRY

--- a/applications/GeoMechanicsApplication/custom_elements/geo_truss_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/geo_truss_element.cpp
@@ -150,7 +150,7 @@ void GeoTrussElement<TDim, TNumNodes>::CalculateOnIntegrationPoints(const Variab
 template <unsigned int TDim, unsigned int TNumNodes>
 void GeoTrussElement<TDim, TNumNodes>::CalculateOnIntegrationPoints(const Variable<array_1d<double, 3>>& rVariable,
                                                                     std::vector<array_1d<double, 3>>& rOutput,
-                                                                    const ProcessInfo& rCurrentProcessInfo)
+                                                                    const ProcessInfo&)
 {
     KRATOS_TRY
 
@@ -239,7 +239,7 @@ void GeoTrussElement<TDim, TNumNodes>::UpdateInternalForces(BoundedVector<double
 template <unsigned int TDim, unsigned int TNumNodes>
 void GeoTrussElement<TDim, TNumNodes>::FinalizeSolutionStep(const ProcessInfo& rCurrentProcessInfo)
 {
-    KRATOS_TRY;
+    KRATOS_TRY
 
     GeoTrussElementBase<TDim, TNumNodes>::FinalizeSolutionStep(rCurrentProcessInfo);
     mInternalStressesFinalized = mInternalStresses + mInternalStressesFinalizedPrevious;

--- a/applications/GeoMechanicsApplication/custom_elements/geo_truss_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/geo_truss_element.cpp
@@ -44,8 +44,7 @@ Element::Pointer GeoTrussElement<TDim, TNumNodes>::Create(IndexType             
                                                           NodesArrayType const&   rThisNodes,
                                                           PropertiesType::Pointer pProperties) const
 {
-    const GeometryType& rGeom = this->GetGeometry();
-    return Kratos::make_intrusive<GeoTrussElement>(NewId, rGeom.Create(rThisNodes), pProperties);
+    return make_intrusive<GeoTrussElement>(NewId, this->GetGeometry().Create(rThisNodes), pProperties);
 }
 
 //----------------------------------------------------------------------------------------
@@ -54,7 +53,7 @@ Element::Pointer GeoTrussElement<TDim, TNumNodes>::Create(IndexType             
                                                           GeometryType::Pointer   pGeom,
                                                           PropertiesType::Pointer pProperties) const
 {
-    return Kratos::make_intrusive<GeoTrussElement>(NewId, pGeom, pProperties);
+    return make_intrusive<GeoTrussElement>(NewId, pGeom, pProperties);
 }
 
 //----------------------------------------------------------------------------------------

--- a/applications/GeoMechanicsApplication/custom_elements/geo_truss_element.hpp
+++ b/applications/GeoMechanicsApplication/custom_elements/geo_truss_element.hpp
@@ -58,8 +58,6 @@ public:
     GeoTrussElement(IndexType NewId, GeometryType::Pointer pGeometry);
     GeoTrussElement(IndexType NewId, GeometryType::Pointer pGeometry, PropertiesType::Pointer pProperties);
 
-    ~GeoTrussElement() override;
-
     /**
      * @brief Creates a new element
      * @param NewId The Id of the new created element

--- a/applications/GeoMechanicsApplication/custom_elements/geo_truss_element.hpp
+++ b/applications/GeoMechanicsApplication/custom_elements/geo_truss_element.hpp
@@ -49,8 +49,6 @@ public:
     using SizeType          = Element::SizeType;
     using MatrixType        = Element::MatrixType;
     using VectorType        = Element::VectorType;
-    using FullDofMatrixType = typename GeoTrussElementBase<TDim, TNumNodes>::FullDofMatrixType;
-    using FullDofVectorType = typename GeoTrussElementBase<TDim, TNumNodes>::FullDofVectorType;
 
     using GeoTrussElementBase<TDim, TNumNodes>::mpConstitutiveLaw;
 

--- a/applications/GeoMechanicsApplication/custom_elements/geo_truss_element_base.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/geo_truss_element_base.cpp
@@ -1051,21 +1051,15 @@ void GeoTrussElementBase<2, 2>::CalculateElasticStiffnessMatrix(MatrixType& rEla
     KRATOS_CATCH("")
 }
 
-//----------------------------------------------------------------------------------------
 template <unsigned int TDim, unsigned int TNumNodes>
-void GeoTrussElementBase<TDim, TNumNodes>::FinalizeSolutionStep(const ProcessInfo& rCurrentProcessInfo)
+void GeoTrussElementBase<TDim, TNumNodes>::FinalizeMaterialResponse(double Strain, const ProcessInfo& rCurrentProcessInfo)
 {
-    KRATOS_TRY;
-
-    ConstitutiveLaw::Parameters Values(GetGeometry(), GetProperties(), rCurrentProcessInfo);
-    Vector                      temp_strain = ZeroVector(1);
-    Vector                      temp_stress = ZeroVector(1);
-    temp_strain[0]                          = CalculateGreenLagrangeStrain();
-    Values.SetStrainVector(temp_strain);
-    Values.SetStressVector(temp_stress);
-    mpConstitutiveLaw->FinalizeMaterialResponse(Values, ConstitutiveLaw::StressMeasure_PK2);
-
-    KRATOS_CATCH("")
+    auto values = ConstitutiveLaw::Parameters(this->GetGeometry(), this->GetProperties(), rCurrentProcessInfo);
+    auto temp_strain = Vector{ScalarVector(1, Strain)};
+    auto temp_stress = Vector{ZeroVector(1)};
+    values.SetStrainVector(temp_strain);
+    values.SetStressVector(temp_stress);
+    mpConstitutiveLaw->FinalizeMaterialResponse(values, ConstitutiveLaw::StressMeasure_PK2);
 }
 
 //----------------------------------------------------------------------------------------

--- a/applications/GeoMechanicsApplication/custom_elements/geo_truss_element_base.hpp
+++ b/applications/GeoMechanicsApplication/custom_elements/geo_truss_element_base.hpp
@@ -206,7 +206,8 @@ public:
 
     double ReturnTangentModulus1D(const ProcessInfo& rCurrentProcessInfo);
 
-    void FinalizeSolutionStep(const ProcessInfo& rCurrentProcessInfo) override;
+protected:
+    void FinalizeMaterialResponse(double Strain, const ProcessInfo& rCurrentProcessInfo);
 
 private:
     /**


### PR DESCRIPTION
**📝 Description**
Minor clean up of the truss element code.

**🆕 Changelog**
- Extracted duplicated code of member `FinalizeSolutionStep` and moved it to a new member `FinalizeMaterialResponse`. The latter receives the appropriate strain measure to carry out its task. Also its implementation has been slightly simplified.
- Eliminated duplicated code for calculating the Cauchy stress vector.
- Applied the rule of zero to class `GeoTrussElement`.
- Removed unused aliases.
- Removed an unneeded intermediate variable.
- Use alias `BaseType` when appropriate.
- Unnamed an unused function parameter.
- Removed an empty statement.
