### PR TITLE
[RomApp] Changing default order

### DIFF
--- a/applications/RomApplication/python_scripts/rom_manager.py
+++ b/applications/RomApplication/python_scripts/rom_manager.py
@@ -147,7 +147,7 @@ class RomManager(object):
         self._LaunchTestNeuralNetworkReconstruction( mu_train, mu_validation)
 
 
-    def Test(self, mu_train=[None], mu_test=[None]):
+    def Test(self, mu_test=[None], mu_train=[None]):
         chosen_projection_strategy = self.general_rom_manager_parameters["projection_strategy"].GetString()
         testing_stages = self.general_rom_manager_parameters["rom_stages_to_test"].GetStringArray()
         type_of_decoder = self.general_rom_manager_parameters["type_of_decoder"].GetString()

--- a/applications/RomApplication/python_scripts/rom_manager.py
+++ b/applications/RomApplication/python_scripts/rom_manager.py
@@ -229,7 +229,7 @@ class RomManager(object):
         self._LaunchRunFOM(mu_run)
 
 
-    def RunROM(self, mu_train=[None], mu_run=[None]):
+    def RunROM(self, mu_run=[None], mu_train=[None]):
         chosen_projection_strategy = self.general_rom_manager_parameters["projection_strategy"].GetString()
         type_of_decoder = self.general_rom_manager_parameters["type_of_decoder"].GetString()
         nn_rom_interface = None
@@ -267,7 +267,7 @@ class RomManager(object):
 
 
 
-    def RunHROM(self, mu_train=[None], mu_run=[None], use_full_model_part = False):
+    def RunHROM(self, mu_run=[None], mu_train=[None], use_full_model_part = False):
         chosen_projection_strategy = self.general_rom_manager_parameters["projection_strategy"].GetString()
         type_of_decoder = self.general_rom_manager_parameters["type_of_decoder"].GetString()
         self._LoadSolutionBasis(mu_train)

--- a/applications/RomApplication/tests/test_structural_lspg_rom.py
+++ b/applications/RomApplication/tests/test_structural_lspg_rom.py
@@ -105,7 +105,7 @@ class TestStructuralLSPGRom(KratosUnittest.TestCase):
             rom_manager = RomManager(general_rom_manager_parameters=general_rom_manager_parameters,CustomizeSimulation=CustomizeSimulation,UpdateProjectParameters=UpdateProjectParameters)
             with open('mu_train.json', 'r') as json_file:
                 mu_train = json.load(json_file)
-            rom_manager.RunROM(mu_train, [mu_train[50]])
+            rom_manager.RunROM([mu_train[50]], mu_train)
             # Check results
             expected_output = np.load(expected_output_filename)
             obtained_output = rom_manager.QoI_Run_ROM[0]["displacement"]

--- a/applications/RomApplication/tests/test_structural_rom.py
+++ b/applications/RomApplication/tests/test_structural_rom.py
@@ -105,7 +105,7 @@ class TestStructuralRom(KratosUnittest.TestCase):
             rom_manager = RomManager(general_rom_manager_parameters=general_rom_manager_parameters,CustomizeSimulation=CustomizeSimulation,UpdateProjectParameters=UpdateProjectParameters)
             with open('mu_train.json', 'r') as json_file:
                 mu_train = json.load(json_file)
-            rom_manager.RunROM(mu_train, [mu_train[50]])
+            rom_manager.RunROM([mu_train[50]], mu_train)
             # Check results
             expected_output = np.load(expected_output_filename)
             obtained_output = rom_manager.QoI_Run_ROM[0]["displacement"]


### PR DESCRIPTION
📝 **Description**
This PR modifies the RunROM method by swapping the order of the mu_train and mu_run parameters. 

In the Test and Run methods of the RomManager, it is more intuitive to first input mu_test or mu_run respectively before mu_train. This follows the logical sequence of running the ROM followed by specifying the training parameters if needed. For cases where users are not interested in providing the training parameters (mu_train), they can now simply input the mu_run parameter. 

🛠️ Behavior
Default Parameters: If no parameters are provided, the default behavior will be to **use the basis present in the rom_data folder**.

Keyword Arguments: The order of parameters won't matter if the respective keywords are used. Users can continue to use mu_run mu_test and mu_train as keyword arguments to specify them in any order.

🔄 Example Usage
**Before:**
```python
# Previous usage required to input the mu_run (or test) always with a keyword argument, 
# or to input it after inputting mu_train if no keyword are used.
rom_manager.RunROM(mu_train=[0.1, 0.2], mu_run=[0.3, 0.4])
```

**After:**
```python
# New usage following the updated order
rom_manager.RunROM(mu_run=[0.3, 0.4], mu_train=[0.1, 0.2])

# Only inputting mu_run with no keyword
rom_manager.RunROM([0.3, 0.4])

# Using keyword arguments (order does not matter)
rom_manager.RunROM(mu_train=[0.1, 0.2], mu_run=[0.3, 0.4])
rom_manager.RunROM(mu_run=[0.3, 0.4], mu_train=[0.1, 0.2])
```

This change is backward compatible when using keyword arguments. However, for positional arguments, users will need to adjust their method calls to align with the new parameter order.
