### PR TITLE
[Core] GiD output default print to layer 0

### DIFF
--- a/kratos/includes/gid_mesh_container.h
+++ b/kratos/includes/gid_mesh_container.h
@@ -174,7 +174,7 @@ public:
                             nodes_id[1] = (it)->GetGeometry() [1].Id();
                             nodes_id[2] = (it)->GetGeometry() [2].Id();
                         }
-                        const int elem_layer = it->HasProperties() ? it->GetProperties().Id() : 0;
+                        const unsigned int elem_layer = it->HasProperties() ? it->GetProperties().Id() : 0;
                         nodes_id[ (it)->GetGeometry().size()]= elem_layer + 1;
 
                         if (it->IsActive())

--- a/kratos/includes/gid_mesh_container.h
+++ b/kratos/includes/gid_mesh_container.h
@@ -106,11 +106,7 @@ public:
             for ( ModelPart::ElementsContainerType::iterator it = mMeshElements.begin();
                     it != mMeshElements.end(); ++it )
             {
-                KRATOS_DEBUG_ERROR_IF_NOT((it)->HasProperties()) << "Element #"
-                    << (it)->Id() << " does not have Properties and hence cannot "
-                    << "be used with the GiD-Output" << std::endl;
-
-                int prop_id = (it)->GetProperties().Id();
+                const int prop_id = it->HasProperties() ? it->GetProperties().Id() : 0;
                 if (max_id < prop_id) max_id = prop_id;
             }
             if (max_id > 10000)
@@ -122,7 +118,7 @@ public:
             for ( ModelPart::ElementsContainerType::iterator it = mMeshElements.begin();
                     it != mMeshElements.end(); ++it )
             {
-                int prop_id = (it)->GetProperties().Id();
+                const int prop_id = it->HasProperties() ? (it)->GetProperties().Id() : 0;
                 elements_per_layer[prop_id] += 1;
             }
             //std::cout << "start printing elements" <<std::endl;
@@ -178,10 +174,11 @@ public:
                             nodes_id[1] = (it)->GetGeometry() [1].Id();
                             nodes_id[2] = (it)->GetGeometry() [2].Id();
                         }
-                        nodes_id[ (it)->GetGeometry().size()]= (it)->GetProperties().Id()+1;
+                        const int elem_layer = it->HasProperties() ? it->GetProperties().Id() : 0;
+                        nodes_id[ (it)->GetGeometry().size()]= elem_layer + 1;
 
                         if (it->IsActive())
-                            if ((it)->GetProperties().Id()==current_layer)
+                            if (elem_layer == current_layer)
                                 GiD_fWriteElementMat ( MeshFile, (it)->Id(), nodes_id);
 
                     }
@@ -199,7 +196,7 @@ public:
             for ( ModelPart::ConditionsContainerType::iterator it = mMeshConditions.begin();
                     it != mMeshConditions.end(); ++it )
             {
-                int prop_id = (it)->GetProperties().Id();
+                const int prop_id = it->HasProperties() ? (it)->GetProperties().Id() : 0;
                 if (max_id < prop_id) max_id = prop_id;
             }
             if (max_id > 10000)
@@ -209,11 +206,7 @@ public:
             for ( ModelPart::ConditionsContainerType::iterator it = mMeshConditions.begin();
                     it != mMeshConditions.end(); ++it )
             {
-                KRATOS_DEBUG_ERROR_IF_NOT((it)->HasProperties()) << "Condition #"
-                    << (it)->Id() << " does not have Properties and hence cannot "
-                    << "be used with the GiD-Output" << std::endl;
-
-                int prop_id = (it)->GetProperties().Id();
+                const int prop_id = it->HasProperties() ? it->GetProperties().Id() : 0;
                 conditions_per_layer[prop_id] += 1;
             }
             //std::cout << "start printing conditions" <<std::endl;
@@ -280,10 +273,11 @@ public:
                             nodes_id[18] = (it)->GetGeometry() [14].Id();
                             nodes_id[19] = (it)->GetGeometry() [15].Id();
                         }
-                        nodes_id[ (it)->GetGeometry().size()]= (it)->GetProperties().Id()+1;
+                        const int cond_layer = it->HasProperties() ? it->GetProperties().Id() : 0;
+                        nodes_id[(it)->GetGeometry().size()]= cond_layer + 1;
 
                         if (it->IsActive())
-                            if ((it)->GetProperties().Id()==current_layer)
+                            if (cond_layer == current_layer)
                                 GiD_fWriteElementMat ( MeshFile, (it)->Id(), nodes_id);
                     }
                     delete [] nodes_id;

--- a/kratos/includes/gid_mesh_container.h
+++ b/kratos/includes/gid_mesh_container.h
@@ -273,7 +273,7 @@ public:
                             nodes_id[18] = (it)->GetGeometry() [14].Id();
                             nodes_id[19] = (it)->GetGeometry() [15].Id();
                         }
-                        const unsinged int cond_layer = it->HasProperties() ? it->GetProperties().Id() : 0;
+                        const unsigned int cond_layer = it->HasProperties() ? it->GetProperties().Id() : 0;
                         nodes_id[(it)->GetGeometry().size()]= cond_layer + 1;
 
                         if (it->IsActive())

--- a/kratos/includes/gid_mesh_container.h
+++ b/kratos/includes/gid_mesh_container.h
@@ -273,7 +273,7 @@ public:
                             nodes_id[18] = (it)->GetGeometry() [14].Id();
                             nodes_id[19] = (it)->GetGeometry() [15].Id();
                         }
-                        const int cond_layer = it->HasProperties() ? it->GetProperties().Id() : 0;
+                        const unsinged int cond_layer = it->HasProperties() ? it->GetProperties().Id() : 0;
                         nodes_id[(it)->GetGeometry().size()]= cond_layer + 1;
 
                         if (it->IsActive())


### PR DESCRIPTION
**📝 Description**
So far, our standard GiD output maps the entities properties to the GiD postprocess layers. So far everything worked as a charm as we always created a "fake" 0 Id. `Properties`, which were assigned by default  to all elements and conditions. These fake properties are eventually substituted by the corresponding materials json.

Now that we are progressively switching to geometry-based input, these fake properties make no longer sense, so they can (should) be removed from the mdpa. The point, is that there might be elements and conditions that do not need properties (e.g. the potential flow ones). Hence, if we remove the "fake" 0 properties these cannot be print in GiD. In this PR I'm avoiding this by defaulting the print to GiD layer 0 if there are no properties, rather than throwing an error.

@jginternational this should solve most of your current issues.
