### PR TITLE
[OptApp] Introduce GetInfluencingModelPart

### DIFF
--- a/applications/OptimizationApplication/python_scripts/responses/combined_response_function.py
+++ b/applications/OptimizationApplication/python_scripts/responses/combined_response_function.py
@@ -47,7 +47,7 @@ class CombinedResponseFunction(ResponseFunction):
         for response_params in parameters["combining_responses"].values():
             response_params.ValidateAndAssignDefaults(default_settings["combining_responses"].values()[0])
             response_name = response_params["response_name"].GetString()
-            
+
             if response_name not in [response.GetName() for response in optimization_problem.GetListOfResponses()]:
                 raise RuntimeError(f"\"{response_name}\" not found in the optimization problem. Please check whether this reponse is defined before the \"{self.GetName()}\".")
 
@@ -66,24 +66,10 @@ class CombinedResponseFunction(ResponseFunction):
             variables_list.extend(response.GetImplementedPhysicalKratosVariables())
         return list(set(variables_list))
 
-    def GetEvaluatedModelPart(self) -> Kratos.ModelPart:
-        if all([response.GetEvaluatedModelPart() != None for response, _ in self.list_of_responses]):
-            raise RuntimeError(f"Mixing of adjoint and direct responses are prohibited.")
-
-        if self.model_part == None:
-            evaluated_model_part_names = [response.GetEvaluatedModelPart().FullName() for response, _ in self.list_of_responses]
-            model_part_operation = ModelPartOperation(self.model, ModelPartOperation.OperationType.UNION, f"response_{self.GetName()}", evaluated_model_part_names, False)
-            self.model_part = model_part_operation.GetModelPart()
-        return self.model_part
-
-    def GetAnalysisModelPart(self) -> Kratos.ModelPart:
-        if all([response.GetAnalysisModelPart() != None for response, _ in self.list_of_responses]):
-            raise RuntimeError(f"Mixing of adjoint and direct responses are prohibited.")
-
-        if self.model_part == None:
-            evaluated_model_part_names = [response.GetAnalysisModelPart().FullName() for response, _ in self.list_of_responses]
-            model_part_operation = ModelPartOperation(self.model, ModelPartOperation.OperationType.UNION, f"response_{self.GetName()}", evaluated_model_part_names, False)
-            self.model_part = model_part_operation.GetModelPart()
+    def GetInfluencingModelPart(self) -> Kratos.ModelPart:
+        influencing_model_part_names = [response.GetInfluencingModelPart().FullName() for response, _ in self.list_of_responses]
+        model_part_operation = ModelPartOperation(self.model, ModelPartOperation.OperationType.UNION, f"response_{self.GetName()}", influencing_model_part_names, False)
+        self.model_part = model_part_operation.GetModelPart()
         return self.model_part
 
     def Initialize(self) -> None:

--- a/applications/OptimizationApplication/python_scripts/responses/discrete_value_residual_response_function.py
+++ b/applications/OptimizationApplication/python_scripts/responses/discrete_value_residual_response_function.py
@@ -69,13 +69,10 @@ class DiscreteValueResidualResponseFunction(ResponseFunction):
     def GetImplementedPhysicalKratosVariables(self) -> 'list[SupportedSensitivityFieldVariableTypes]':
         return [self.variable]
 
-    def GetEvaluatedModelPart(self) -> Kratos.ModelPart:
+    def GetInfluencingModelPart(self) -> Kratos.ModelPart:
         if self.model_part is None:
             raise RuntimeError("Please call DiscreteValueResidualResponseFunction::Initialize first.")
         return self.model_part
-
-    def GetAnalysisModelPart(self) -> None:
-        return None
 
     def Initialize(self) -> None:
         self.model_part = self.model_part_operation.GetModelPart()

--- a/applications/OptimizationApplication/python_scripts/responses/geometric_centroid_deviation_response_function.py
+++ b/applications/OptimizationApplication/python_scripts/responses/geometric_centroid_deviation_response_function.py
@@ -38,13 +38,10 @@ class GeometricCentroidDeviationResponseFunction(ResponseFunction):
     def GetImplementedPhysicalKratosVariables(self) -> 'list[SupportedSensitivityFieldVariableTypes]':
         return [KratosOA.SHAPE]
 
-    def GetEvaluatedModelPart(self) -> Kratos.ModelPart:
+    def GetInfluencingModelPart(self) -> Kratos.ModelPart:
         if self.model_part is None:
             raise RuntimeError("Please call GeometricCentroidDeviationResponseFunction::Initialize first.")
         return self.model_part
-
-    def GetAnalysisModelPart(self) -> None:
-        return None
 
     def Initialize(self) -> None:
         self.model_part = self.model_part_operation.GetModelPart()

--- a/applications/OptimizationApplication/python_scripts/responses/linear_strain_energy_response_function.py
+++ b/applications/OptimizationApplication/python_scripts/responses/linear_strain_energy_response_function.py
@@ -53,12 +53,7 @@ class LinearStrainEnergyResponseFunction(ResponseFunction):
     def Finalize(self) -> None:
         pass
 
-    def GetEvaluatedModelPart(self) -> Kratos.ModelPart:
-        if self.model_part is None:
-            raise RuntimeError("Please call LinearStrainEnergyResponseFunction::Initialize first.")
-        return self.model_part
-
-    def GetAnalysisModelPart(self) -> Kratos.ModelPart:
+    def GetInfluencingModelPart(self) -> Kratos.ModelPart:
         return self.primal_analysis_execution_policy_decorator.GetAnalysisModelPart()
 
     def CalculateValue(self) -> float:

--- a/applications/OptimizationApplication/python_scripts/responses/mass_response_function.py
+++ b/applications/OptimizationApplication/python_scripts/responses/mass_response_function.py
@@ -52,13 +52,10 @@ class MassResponseFunction(ResponseFunction):
     def Finalize(self) -> None:
         pass
 
-    def GetEvaluatedModelPart(self) -> Kratos.ModelPart:
+    def GetInfluencingModelPart(self) -> Kratos.ModelPart:
         if self.model_part is None:
             raise RuntimeError("Please call MassResponseFunction::Initialize first.")
         return self.model_part
-
-    def GetAnalysisModelPart(self) -> None:
-        return None
 
     def CalculateValue(self) -> float:
         return KratosOA.ResponseUtils.MassResponseUtils.CalculateValue(self.model_part)

--- a/applications/OptimizationApplication/python_scripts/responses/response_function.py
+++ b/applications/OptimizationApplication/python_scripts/responses/response_function.py
@@ -103,8 +103,8 @@ class ResponseFunction(ABC):
                response value is computed.) Therefore, in this case, this method should return the
                evaluated model part.
             2. Responses with adjoint system solve: The value of the response can be influenced by
-                changing quantities in the adjoint model part (There may or may not be an intersection between
-                the evaluated and adjoint model parts). Therefore, in this case, this method should return the
+                changing quantities in the adjoint/primal model part (Evaluated model part needs to have
+                intersection with the adjoint/primal model part). Therefore, in this case, this method should return the
                 adjoint analysis model part.
 
         Returns:

--- a/applications/OptimizationApplication/python_scripts/responses/response_function.py
+++ b/applications/OptimizationApplication/python_scripts/responses/response_function.py
@@ -94,22 +94,20 @@ class ResponseFunction(ABC):
         pass
 
     @abstractmethod
-    def GetEvaluatedModelPart(self) -> Kratos.ModelPart:
-        """Returns the model part for which this response is computed on.
+    def GetInfluencingModelPart(self) -> Kratos.ModelPart:
+        """Returns the model part which influences the computation of the response value.
+
+        Following two cases are considered:
+            1. Responses without adjoint system solve: The value of the response can only be influenced by
+               changing the quantities in the evaluated model part (evaluated model part is the one which the
+               response value is computed.) Therefore, in this case, this method should return the
+               evaluated model part.
+            2. Responses with adjoint system solve: The value of the response can be influenced by
+                changing quantities in the adjoint model part (There may or may not be an intersection between
+                the evaluated and adjoint model parts). Therefore, in this case, this method should return the
+                adjoint analysis model part.
 
         Returns:
-            Kratos.ModelPart: Response function model part.
-        """
-        pass
-
-    @abstractmethod
-    def GetAnalysisModelPart(self) -> 'Union[Kratos.ModelPart, None]':
-        """Returns the analysis model part if exists. Otherwise returns None.
-
-        This method returns the analysis model part if an analysis is used (as in Adjoint case)
-        to compute the gradients. If it is not the case, then None should be returned.
-
-        Returns:
-            Union[Kratos.ModelPart, None]: Analysis model part if used, otherwise None
+            Kratos.ModelPart: Response function model part which influences the response value.
         """
         pass

--- a/applications/OptimizationApplication/python_scripts/responses/response_routine.py
+++ b/applications/OptimizationApplication/python_scripts/responses/response_routine.py
@@ -49,13 +49,8 @@ class ResponseRoutine:
         for control in self.__master_control.GetListOfControls():
             # check whether control has keys given by required gradients
             if set(control.GetPhysicalKratosVariables()).intersection(self.__required_physical_gradients.keys()):
-                # check whether there is an intersection of model parts between respones domain and control domain.
-                #   1. in the case where response does not require an analysis, then intersection between evaluated and control domain is checked.
-                #   2. in the case where response require an analysis, then intersection between analysis and control domain is checked.
-                if self.__response.GetAnalysisModelPart() is None:
-                    checked_model_part: Kratos.ModelPart = self.__response.GetEvaluatedModelPart()
-                else:
-                    checked_model_part: Kratos.ModelPart = self.__response.GetAnalysisModelPart()
+                # check whether there is an intersection of model parts between response influencial domain and control domain.
+                checked_model_part: Kratos.ModelPart = self.__response.GetInfluencingModelPart()
 
                 if Kratos.ModelPartOperationUtilities.HasIntersection([checked_model_part, control.GetEmptyField().GetModelPart()]):
                     self.__contributing_controls_list.append(control)

--- a/applications/OptimizationApplication/tests/process_tests/test_optimization_problem_ascii_output_process.py
+++ b/applications/OptimizationApplication/tests/process_tests/test_optimization_problem_ascii_output_process.py
@@ -26,9 +26,7 @@ class TestOptimizationProblemAsciiOutputProcess(kratos_unittest.TestCase):
             pass
         def Finalize(self) -> None:
             pass
-        def GetAnalysisModelPart(self) -> Kratos.ModelPart:
-            return None
-        def GetEvaluatedModelPart(self) -> Kratos.ModelPart:
+        def GetInfluencingModelPart(self) -> Kratos.ModelPart:
             return None
         def GetImplementedPhysicalKratosVariables(self) -> 'list[SupportedSensitivityFieldVariableTypes]':
             return []

--- a/applications/OptimizationApplication/tests/process_tests/test_optimization_problem_vtu_output_process.py
+++ b/applications/OptimizationApplication/tests/process_tests/test_optimization_problem_vtu_output_process.py
@@ -29,9 +29,7 @@ class TestOptimizationProblemVtuOutputProcess(kratos_unittest.TestCase):
             pass
         def Finalize(self) -> None:
             pass
-        def GetAnalysisModelPart(self) -> Kratos.ModelPart:
-            return None
-        def GetEvaluatedModelPart(self) -> Kratos.ModelPart:
+        def GetInfluencingModelPart(self) -> Kratos.ModelPart:
             return None
         def GetImplementedPhysicalKratosVariables(self) -> 'list[SupportedSensitivityFieldVariableTypes]':
             return []

--- a/applications/OptimizationApplication/tests/test_component_data_view.py
+++ b/applications/OptimizationApplication/tests/test_component_data_view.py
@@ -20,9 +20,7 @@ class TestComponentDataView(kratos_unittest.TestCase):
             pass
         def GetImplementedPhysicalKratosVariables(self) -> 'list[SupportedSensitivityFieldVariableTypes]':
             return None
-        def GetAnalysisModelPart(self) -> Kratos.ModelPart:
-            return None
-        def GetEvaluatedModelPart(self) -> Kratos.ModelPart:
+        def GetInfluencingModelPart(self) -> Kratos.ModelPart:
             return None
         def CalculateValue(self) -> float:
             return 0.0


### PR DESCRIPTION
**📝 Description**
This PR introduces `ResponseFunction::GetInfluencingModelPart` method which returns the model part which can influence the response value.
1. In the case of responses without adjoints, this returns the evaluated model part to compute the reponse value.
2. In the case of responses with adjoints, this returns the adjoint model part because change in adjoint model part can influence the response value (evaluated model part always has a intersection with the adjoint/primal model part).

This removes the confusion we had with `GetAnalysisModelPart` and `GetEvaluatedModelPart`, in the case "1", the `GetAnalysisModelPart` is returning None.

This is required to develop more flexible combination methods with arithmetic operators for `ResponseFunction`, which is coming up in next few PRs to have full flexibility in combining different responses.

This will remove the Incompatibility in combining reponses with and without adjoint formulations (FYI: @talhah-ansari)

**🆕 Changelog**
- Removed `ResponseFunction::GetAnalysisModelPart`
- Removed `ResponseFunction::GetEvaluatedModelPart`
- Added `GetInfluencingModelPart`
