### PR TITLE
[RomApp] Take into account non converged solutions in Linear and NonLinear (ANN-Enhanced) Decoders

### DIFF
--- a/applications/RomApplication/python_scripts/rom_manager.py
+++ b/applications/RomApplication/python_scripts/rom_manager.py
@@ -365,7 +365,7 @@ class RomManager(object):
         This method should be parallel capable
         """
         self._LaunchFOM(mu_train)
-        self._LauchComputeSolutionBasis(mu_train)
+        self._LaunchComputeSolutionBasis(mu_train)
 
 
 
@@ -401,7 +401,7 @@ class RomManager(object):
 
 
 
-    def _LauchComputeSolutionBasis(self, mu_train):
+    def _LaunchComputeSolutionBasis(self, mu_train):
         in_database, hash_basis = self.data_base.check_if_in_database("RightBasis", mu_train)
         if not in_database:
             BasisOutputProcess = self.InitializeDummySimulationForBasisOutputProcess()

--- a/applications/RomApplication/python_scripts/rom_manager.py
+++ b/applications/RomApplication/python_scripts/rom_manager.py
@@ -405,7 +405,10 @@ class RomManager(object):
         in_database, hash_basis = self.data_base.check_if_in_database("RightBasis", mu_train)
         if not in_database:
             BasisOutputProcess = self.InitializeDummySimulationForBasisOutputProcess()
-            u,sigma = BasisOutputProcess._ComputeSVD(self.data_base.get_snapshots_matrix_from_database(mu_train)) #Calling the RomOutput Process for creating the RomParameter.json
+            if self.general_rom_manager_parameters["ROM"]["use_non_converged_sols"].GetBool():
+                u,sigma = BasisOutputProcess._ComputeSVD(self.data_base.get_snapshots_matrix_from_database(mu_train, table_name='NonconvergedFOM')) #TODO this might be too large for single opeartion, add partitioned svd
+            else:
+                u,sigma = BasisOutputProcess._ComputeSVD(self.data_base.get_snapshots_matrix_from_database(mu_train, table_name='FOM'))
             BasisOutputProcess._PrintRomBasis(u, sigma) #Calling the RomOutput Process for creating the RomParameter.json
             self.data_base.add_to_database("RightBasis", mu_train, u )
             self.data_base.add_to_database("SingularValues_Solution", mu_train, sigma )


### PR DESCRIPTION
**📝 Description**
This PR allows to take into account the nonconverged solutions when this parameters is true  

`general_rom_manager_parameters["ROM"]["use_non_converged_sols"].GetBool()
`

In future PRs we should include other types of SVDs, e.g. partitioned or parallel methods, to be used with the RomManager for cases where matrices are too large to fit in fast memory. 


**🆕 Changelog**
- Changed method **_LaunchComputeSolutionBasis** in RomManager to consider nonconversed solutions
- Changed **_GetTrainingData** method in rom_nn_trainer.py to simplify the inclusion of nonconverged solutions while training a neural network
- Fixed a typo in the RomManager



