### PR TITLE
[Rom app] Fix HROM usage with rom manager

### DIFF
--- a/applications/RomApplication/python_scripts/hrom_training_utility.py
+++ b/applications/RomApplication/python_scripts/hrom_training_utility.py
@@ -135,7 +135,7 @@ class HRomTrainingUtility(object):
     def map_element_ids_to_numpy_indexes(self, this_modelpart_element_ids):
         this_modelpart_indexes_numpy = []
         for elem_id in this_modelpart_element_ids:
-            this_modelpart_indexes_numpy.append(self.condition_id_to_numpy_index_mapping[elem_id])
+            this_modelpart_indexes_numpy.append(self.element_id_to_numpy_index_mapping[elem_id])
         return np.array(this_modelpart_indexes_numpy)
 
 
@@ -347,7 +347,6 @@ class HRomTrainingUtility(object):
 
                 # Call the GetConditionIdsNotInHRomModelPart function
                 new_conditions = KratosROM.RomAuxiliaryUtilities.GetConditionIdsNotInHRomModelPart(
-                    root_model_part, # The complete model part
                     conditions_to_include_model_part, # The model part containing the conditions to be included
                     hrom_weights)
 
@@ -384,6 +383,7 @@ class HRomTrainingUtility(object):
 
                 # Call the GetNodalNeighbouringElementIdsNotInHRom function
                 new_nodal_neighbours = KratosROM.RomAuxiliaryUtilities.GetNodalNeighbouringElementIdsNotInHRom(
+                    root_model_part, # The complete model part
                     nodal_neighbours_model_part, # The model part containing the nodal neighbouring elements to be included
                     hrom_weights)
 

--- a/applications/RomApplication/python_scripts/rom_manager.py
+++ b/applications/RomApplication/python_scripts/rom_manager.py
@@ -45,9 +45,6 @@ class RomManager(object):
         if chosen_projection_strategy == "galerkin":
             if type_of_decoder =="ann_enhanced":
                 if any(item == "ROM" for item in training_stages):
-                    if self.rom_training_parameters["Parameters"]["print_singular_values"].GetBool() == False:
-                        err_msg = f'Data preparation for ann_enhanced ROM requires "print_singular_values" option to be True in the ROM parameters.'
-                        raise Exception(err_msg)
                     self._LaunchTrainROM(mu_train)
                     self._LaunchFOM(mu_validation) #What to do here with the gid and vtk results?
                     self.TrainAnnEnhancedROM(mu_train,mu_validation)
@@ -75,9 +72,6 @@ class RomManager(object):
         elif chosen_projection_strategy == "lspg":
             if type_of_decoder =="ann_enhanced":
                 if any(item == "ROM" for item in training_stages):
-                    if self.rom_training_parameters["Parameters"]["print_singular_values"].GetBool() == False:
-                        err_msg = f'Data preparation for ann_enhanced ROM requires "print_singular_values" option to be True in the ROM parameters.'
-                        raise Exception(err_msg)
                     self._LaunchTrainROM(mu_train)
                     self._LaunchFOM(mu_validation) #What to do here with the gid and vtk results?
                     self.TrainAnnEnhancedROM(mu_train,mu_validation)

--- a/applications/RomApplication/python_scripts/rom_manager.py
+++ b/applications/RomApplication/python_scripts/rom_manager.py
@@ -694,6 +694,7 @@ class RomManager(object):
 
 
     def _AddHromParametersToRomParameters(self,f):
+        f["hrom_settings"]["hrom_format"] = self.general_rom_manager_parameters["HROM"]["hrom_format"].GetString()
         f["hrom_settings"]["element_selection_type"] = self.general_rom_manager_parameters["HROM"]["element_selection_type"].GetString()
         f["hrom_settings"]["element_selection_svd_truncation_tolerance"] = self.general_rom_manager_parameters["HROM"]["element_selection_svd_truncation_tolerance"].GetDouble()
         f["hrom_settings"]["constraint_sum_weights"] = self.general_rom_manager_parameters["HROM"]["constraint_sum_weights"].GetBool()
@@ -955,20 +956,20 @@ class RomManager(object):
                 }
             },
             "HROM":{
-                "hrom_format": "numpy",
+                "hrom_format": "numpy",                            //  "json", "numpy"
                 "element_selection_type": "empirical_cubature",
                 "element_selection_svd_truncation_tolerance": 1.0e-6,
-                "constraint_sum_weights": true,
-                "svd_type": "numpy_rsvd",
+                "constraint_sum_weights": true,                   // if true, then sum(w) = num_elems (this avoids trivial solutions sum(w)=0)
+                "svd_type": "numpy_rsvd",                         //  "numpy_svd", "numpy_rsvd"
                 "create_hrom_visualization_model_part" : true,
-                "include_elements_model_parts_list": [],
-                "include_conditions_model_parts_list": [],
-                "initial_candidate_elements_model_part_list" : [],
-                "initial_candidate_conditions_model_part_list" : [],
+                "include_elements_model_parts_list": [],          //The elements of the submodel parts included in this list will be considered in the HROM model part
+                "include_conditions_model_parts_list": [],         //The conditions of the submodel parts included in this list will be considered in the HROM model part
+                "initial_candidate_elements_model_part_list" : [],        //These elements will be given priority when creating the HROM model part
+                "initial_candidate_conditions_model_part_list" : [],       //These conditions will be given priority when creating the HROM model part
                 "include_nodal_neighbouring_elements_model_parts_list":[],
-                "include_minimum_condition": false,
-                "include_condition_parents": false,
-                "echo_level" : 0
+                "include_minimum_condition": false,       // if true, keep at least one condition per submodelpart
+                "include_condition_parents": false,       // if true, when a condition is chosen by the ECM algorithm, the parent element is also included
+                "echo_level" : 0                          // if >0, get hrom training status promts
             }
         }""")
 

--- a/applications/RomApplication/tests/structural_static_test_files/HROM/rom_data/RomParameters.json
+++ b/applications/RomApplication/tests/structural_static_test_files/HROM/rom_data/RomParameters.json
@@ -17,13 +17,18 @@
     "hrom_settings": {
         "hrom_format": "numpy",
         "element_selection_type": "empirical_cubature",
-        "element_selection_svd_truncation_tolerance": 0.0,
+        "element_selection_svd_truncation_tolerance": 1e-06,
         "create_hrom_visualization_model_part": true,
         "echo_level": 0,
         "include_condition_parents": false,
         "initial_candidate_elements_model_part_list": [],
         "initial_candidate_conditions_model_part_list": [],
-        "constraint_sum_weights": true
+        "constraint_sum_weights": true,
+        "svd_type": "numpy_rsvd",
+        "include_elements_model_parts_list": [],
+        "include_conditions_model_parts_list": [],
+        "include_nodal_neighbouring_elements_model_parts_list": [],
+        "include_minimum_condition": false
     },
     "nodal_modes": {
         "1": [

--- a/applications/RomApplication/tests/structural_static_test_files/ROM/rom_data/RomParameters.json
+++ b/applications/RomApplication/tests/structural_static_test_files/ROM/rom_data/RomParameters.json
@@ -16,13 +16,18 @@
     },
     "hrom_settings": {
         "element_selection_type": "empirical_cubature",
-        "element_selection_svd_truncation_tolerance": 0.0,
+        "element_selection_svd_truncation_tolerance": 1e-06,
         "create_hrom_visualization_model_part": true,
         "echo_level": 0,
         "include_condition_parents": false,
         "initial_candidate_elements_model_part_list": [],
         "initial_candidate_conditions_model_part_list": [],
-        "constraint_sum_weights": true
+        "constraint_sum_weights": true,
+        "svd_type": "numpy_rsvd",
+        "include_elements_model_parts_list": [],
+        "include_conditions_model_parts_list": [],
+        "include_nodal_neighbouring_elements_model_parts_list": [],
+        "include_minimum_condition": false
     },
     "nodal_modes": {
         "1": [

--- a/applications/RomApplication/tests/structural_static_test_files/ROM/rom_data/RomParameters.json
+++ b/applications/RomApplication/tests/structural_static_test_files/ROM/rom_data/RomParameters.json
@@ -27,7 +27,8 @@
         "include_elements_model_parts_list": [],
         "include_conditions_model_parts_list": [],
         "include_nodal_neighbouring_elements_model_parts_list": [],
-        "include_minimum_condition": false
+        "include_minimum_condition": false,
+        "hrom_format": "numpy"
     },
     "nodal_modes": {
         "1": [


### PR DESCRIPTION
**📝 Description**
The HROM parameters pased to the RomManager were not being taken into account.

This PR adds the necessary changes to take into account all parameters passed to the RomManager in the field:

`general_rom_manager_parameters["HROM"]
`


**🆕 Changelog**
- Only using general_rom_manager_parameters, no more two parameters objects for ROM and HROM 
- Fixed bug in hrom training utility in 
     - KratosROM.RomAuxiliaryUtilities.GetConditionIdsNotInHRomModelPart method call
     - KratosROM.RomAuxiliaryUtilities.GetNodalNeighbouringElementIdsNotInHRom method call
     - map_element_ids_to_numpy_indexes object