### PR TITLE
[RomApp] Passing parameters vector mu to CustomizeSimulation in RomManager

### DIFF
--- a/applications/RomApplication/python_scripts/rom_manager.py
+++ b/applications/RomApplication/python_scripts/rom_manager.py
@@ -385,7 +385,7 @@ class RomManager(object):
                 self.UpdateMaterialParametersFile(materials_file_name, mu)
                 model = KratosMultiphysics.Model()
                 analysis_stage_class = self._GetAnalysisStageClass(parameters_copy)
-                simulation = self.CustomizeSimulation(analysis_stage_class,model,parameters_copy)
+                simulation = self.CustomizeSimulation(analysis_stage_class,model,parameters_copy, mu)
                 if NonConvergedSolutionsGathering:
                     simulation = self.ActivateNonconvergedSolutionsGathering(simulation)
                 simulation.Run()
@@ -452,7 +452,7 @@ class RomManager(object):
                 self.UpdateMaterialParametersFile(materials_file_name, mu)
                 model = KratosMultiphysics.Model()
                 analysis_stage_class = type(SetUpSimulationInstance(model, parameters_copy, nn_rom_interface=nn_rom_interface))
-                simulation = self.CustomizeSimulation(analysis_stage_class,model,parameters_copy)
+                simulation = self.CustomizeSimulation(analysis_stage_class,model,parameters_copy, mu)
 
                 simulation.Run()
                 self.data_base.add_to_database("QoI_ROM", mu, simulation.GetFinalData())
@@ -485,7 +485,7 @@ class RomManager(object):
                     self.UpdateMaterialParametersFile(materials_file_name, mu)
                     model = KratosMultiphysics.Model()
                     analysis_stage_class = type(SetUpSimulationInstance(model, parameters_copy))
-                    simulation = self.CustomizeSimulation(analysis_stage_class,model,parameters_copy)
+                    simulation = self.CustomizeSimulation(analysis_stage_class,model,parameters_copy, mu)
                     simulation.Run()
                     PetrovGalerkinTrainingUtility = simulation.GetPetrovGalerkinTrainUtility()
                     pretrov_galerkin_matrix = PetrovGalerkinTrainingUtility._GetSnapshotsMatrix() #TODO is the best way of extracting the Projected Residuals calling the HROM residuals utility?
@@ -526,7 +526,7 @@ class RomManager(object):
                     self.UpdateMaterialParametersFile(materials_file_name, mu)
                     model = KratosMultiphysics.Model()
                     analysis_stage_class = type(SetUpSimulationInstance(model, parameters_copy))
-                    simulation = self.CustomizeSimulation(analysis_stage_class,model,parameters_copy)
+                    simulation = self.CustomizeSimulation(analysis_stage_class,model,parameters_copy, mu)
                     simulation.Run()
                     ResidualProjected = simulation.GetHROM_utility()._GetResidualsProjectedMatrix() #TODO flush intermediately the residuals projected to cope with large models.
                     self.data_base.add_to_database("ResidualsProjected", mu, ResidualProjected )
@@ -578,7 +578,7 @@ class RomManager(object):
                 self.UpdateMaterialParametersFile(materials_file_name, mu)
                 model = KratosMultiphysics.Model()
                 analysis_stage_class = type(SetUpSimulationInstance(model, parameters_copy))
-                simulation = self.CustomizeSimulation(analysis_stage_class,model,parameters_copy)
+                simulation = self.CustomizeSimulation(analysis_stage_class,model,parameters_copy, mu)
                 simulation.Run()
                 self.data_base.add_to_database("QoI_HROM", mu, simulation.GetFinalData())
                 for process in simulation._GetListOfOutputProcesses():
@@ -603,7 +603,7 @@ class RomManager(object):
             self.UpdateMaterialParametersFile(materials_file_name, mu)
             model = KratosMultiphysics.Model()
             analysis_stage_class = self._GetAnalysisStageClass(parameters_copy)
-            simulation = self.CustomizeSimulation(analysis_stage_class,model,parameters_copy)
+            simulation = self.CustomizeSimulation(analysis_stage_class,model,parameters_copy, mu)
             simulation.Run()
             self.QoI_Run_FOM.append(simulation.GetFinalData())
 
@@ -621,7 +621,7 @@ class RomManager(object):
             self.UpdateMaterialParametersFile(materials_file_name, mu)
             model = KratosMultiphysics.Model()
             analysis_stage_class = type(SetUpSimulationInstance(model, parameters_copy, nn_rom_interface=nn_rom_interface))
-            simulation = self.CustomizeSimulation(analysis_stage_class,model,parameters_copy)
+            simulation = self.CustomizeSimulation(analysis_stage_class,model,parameters_copy, mu)
             simulation.Run()
             self.QoI_Run_ROM.append(simulation.GetFinalData())
 
@@ -643,7 +643,7 @@ class RomManager(object):
             self.UpdateMaterialParametersFile(materials_file_name, mu)
             model = KratosMultiphysics.Model()
             analysis_stage_class = type(SetUpSimulationInstance(model, parameters_copy))
-            simulation = self.CustomizeSimulation(analysis_stage_class,model,parameters_copy)
+            simulation = self.CustomizeSimulation(analysis_stage_class,model,parameters_copy, mu)
             simulation.Run()
             self.QoI_Run_HROM.append(simulation.GetFinalData())
 
@@ -968,11 +968,11 @@ class RomManager(object):
         self.hrom_training_parameters = self.SetHromTrainingParameters()
 
 
-    def DefaultCustomizeSimulation(self, cls, global_model, parameters):
+    def DefaultCustomizeSimulation(self, cls, global_model, parameters, mu=None):
         # Default function that does nothing special
         class DefaultCustomSimulation(cls):
-            def _init_(self, model, project_parameters):
-                super()._init_(model, project_parameters)
+            def __init__(self, model, project_parameters):
+                super().__init__(model, project_parameters)
 
             def Initialize(self):
                 super().Initialize()

--- a/applications/RomApplication/tests/test_structural_lspg_rom.py
+++ b/applications/RomApplication/tests/test_structural_lspg_rom.py
@@ -12,7 +12,7 @@ from KratosMultiphysics.RomApplication.rom_manager import RomManager
 from pathlib import Path
 import json
 
-def CustomizeSimulation(cls, global_model, parameters):
+def CustomizeSimulation(cls, global_model, parameters, mu=None):
 
     class CustomSimulation(cls):
 

--- a/applications/RomApplication/tests/test_structural_rom.py
+++ b/applications/RomApplication/tests/test_structural_rom.py
@@ -12,7 +12,7 @@ from KratosMultiphysics.RomApplication.rom_manager import RomManager
 from pathlib import Path
 import json
 
-def CustomizeSimulation(cls, global_model, parameters):
+def CustomizeSimulation(cls, global_model, parameters, mu=None):
 
     class CustomSimulation(cls):
 

--- a/applications/RomApplication/tests/test_thermal_lspg_rom.py
+++ b/applications/RomApplication/tests/test_thermal_lspg_rom.py
@@ -11,7 +11,7 @@ if kratos_utilities.CheckIfApplicationsAvailable("ConvectionDiffusionApplication
 from KratosMultiphysics.RomApplication.rom_manager import RomManager
 from pathlib import Path
 
-def CustomizeSimulation(cls, global_model, parameters):
+def CustomizeSimulation(cls, global_model, parameters, mu = None):
 
     class CustomSimulation(cls):
 


### PR DESCRIPTION
**📝 Description**
This PR enhances the RomManager by enabling the passing of a list of parameters, mu, to each simulation. This modification allows for customized behavior based on the specific parameters provided.

Additionally, the function responsible for creating the custom analysis stage class now accepts an extra parameter compared to the standard simulation function.

**🆕 Changelog**
- Added the mu parameter to each method of the RomManager to pass the simulation parameters.
- Updated the CustomizeSimulation function in the tests to accommodate the mu parameter.


