### PR TITLE
[GeoMechanicsApplication] Reuse the nodal extrapolator in U-Pw small strain element

### DIFF
--- a/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_element.cpp
@@ -20,6 +20,117 @@
 #include "custom_utilities/transport_equation_utilities.hpp"
 #include "includes/cfd_variables.h"
 
+namespace
+{
+
+Kratos::BoundedMatrix<double, 4, 4> GetExtrapolationMatrixFor3D4NElement()
+{
+    auto result = Kratos::BoundedMatrix<double, 4, 4>{};
+
+    result(0, 0) = -0.309016988749894905;
+    result(0, 1) = -0.3090169887498949046;
+    result(0, 2) = -0.309016988749894905;
+    result(0, 3) = 1.9270509662496847144;
+
+    result(1, 0) = 1.9270509662496847144;
+    result(1, 1) = -0.30901698874989490481;
+    result(1, 2) = -0.3090169887498949049;
+    result(1, 3) = -0.30901698874989490481;
+
+    result(2, 0) = -0.30901698874989490473;
+    result(2, 1) = 1.9270509662496847143;
+    result(2, 2) = -0.3090169887498949049;
+    result(2, 3) = -0.30901698874989490481;
+
+    result(3, 0) = -0.3090169887498949048;
+    result(3, 1) = -0.30901698874989490471;
+    result(3, 2) = 1.9270509662496847143;
+    result(3, 3) = -0.30901698874989490481;
+
+    return result;
+}
+
+Kratos::BoundedMatrix<double, 8, 8> GetExtrapolationMatrixFor3D8NElement()
+{
+    auto result = Kratos::BoundedMatrix<double, 8, 8>{};
+
+    result(0, 0) = 2.549038105676658;
+    result(0, 1) = -0.6830127018922192;
+    result(0, 2) = 0.18301270189221927;
+    result(0, 3) = -0.6830127018922192;
+    result(0, 4) = -0.6830127018922192;
+    result(0, 5) = 0.18301270189221927;
+    result(0, 6) = -0.04903810567665795;
+    result(0, 7) = 0.18301270189221927;
+
+    result(1, 0) = -0.6830127018922192;
+    result(1, 1) = 2.549038105676658;
+    result(1, 2) = -0.6830127018922192;
+    result(1, 3) = 0.18301270189221927;
+    result(1, 4) = 0.18301270189221927;
+    result(1, 5) = -0.6830127018922192;
+    result(1, 6) = 0.18301270189221927;
+    result(1, 7) = -0.04903810567665795;
+
+    result(2, 0) = 0.18301270189221927;
+    result(2, 1) = -0.6830127018922192;
+    result(2, 2) = 2.549038105676658;
+    result(2, 3) = -0.6830127018922192;
+    result(2, 4) = -0.04903810567665795;
+    result(2, 5) = 0.18301270189221927;
+    result(2, 6) = -0.6830127018922192;
+    result(2, 7) = 0.18301270189221927;
+
+    result(3, 0) = -0.6830127018922192;
+    result(3, 1) = 0.18301270189221927;
+    result(3, 2) = -0.6830127018922192;
+    result(3, 3) = 2.549038105676658;
+    result(3, 4) = 0.18301270189221927;
+    result(3, 5) = -0.04903810567665795;
+    result(3, 6) = 0.18301270189221927;
+    result(3, 7) = -0.6830127018922192;
+
+    result(4, 0) = -0.6830127018922192;
+    result(4, 1) = 0.18301270189221927;
+    result(4, 2) = -0.04903810567665795;
+    result(4, 3) = 0.18301270189221927;
+    result(4, 4) = 2.549038105676658;
+    result(4, 5) = -0.6830127018922192;
+    result(4, 6) = 0.18301270189221927;
+    result(4, 7) = -0.6830127018922192;
+
+    result(5, 0) = 0.18301270189221927;
+    result(5, 1) = -0.6830127018922192;
+    result(5, 2) = 0.18301270189221927;
+    result(5, 3) = -0.04903810567665795;
+    result(5, 4) = -0.6830127018922192;
+    result(5, 5) = 2.549038105676658;
+    result(5, 6) = -0.6830127018922192;
+    result(5, 7) = 0.18301270189221927;
+
+    result(6, 0) = -0.04903810567665795;
+    result(6, 1) = 0.18301270189221927;
+    result(6, 2) = -0.6830127018922192;
+    result(6, 3) = 0.18301270189221927;
+    result(6, 4) = 0.18301270189221927;
+    result(6, 5) = -0.6830127018922192;
+    result(6, 6) = 2.549038105676658;
+    result(6, 7) = -0.6830127018922192;
+
+    result(7, 0) = 0.18301270189221927;
+    result(7, 1) = -0.04903810567665795;
+    result(7, 2) = 0.18301270189221927;
+    result(7, 3) = -0.6830127018922192;
+    result(7, 4) = -0.6830127018922192;
+    result(7, 5) = 0.18301270189221927;
+    result(7, 6) = -0.6830127018922192;
+    result(7, 7) = 2.549038105676658;
+
+    return result;
+}
+
+}
+
 namespace Kratos
 {
 
@@ -1533,146 +1644,28 @@ void UPwSmallStrainElement<TDim, TNumNodes>::CalculateExtrapolationMatrix(Bounde
 {
     KRATOS_TRY
 
-    KRATOS_ERROR << "undefined number of nodes in CalculateExtrapolationMatrix "
-                    "... TNumNodes:"
-                 << TNumNodes << " element: " << this->Id() << std::endl;
+    if constexpr ((TDim == 2u) && ((TNumNodes == 3u) || (TNumNodes == 4u))) {
+        const auto extrapolator = LinearNodalExtrapolator{};
+        const auto result       = extrapolator.CalculateElementExtrapolationMatrix(
+            this->GetGeometry(), this->GetIntegrationMethod());
+        KRATOS_ERROR_IF_NOT(result.size1() == TNumNodes)
+            << "Extrapolation matrix has unexpected number of rows: " << result.size1()
+            << " (expected " << TNumNodes << ")" << std::endl;
+        KRATOS_ERROR_IF_NOT(result.size2() == TNumNodes)
+            << "Extrapolation matrix has unexpected number of columns: " << result.size2()
+            << " (expected " << TNumNodes << ")" << std::endl;
+        rExtrapolationMatrix = result;
+    } else if constexpr ((TDim == 3u) && (TNumNodes == 4u)) {
+        rExtrapolationMatrix = ::GetExtrapolationMatrixFor3D4NElement();
+    } else if constexpr ((TDim == 3u) && (TNumNodes == 8u)) {
+        rExtrapolationMatrix = ::GetExtrapolationMatrixFor3D8NElement();
+    } else {
+        KRATOS_ERROR << "undefined number of nodes in CalculateExtrapolationMatrix "
+                        "... TNumNodes:"
+                     << TNumNodes << " element: " << this->Id() << std::endl;
+    }
 
     KRATOS_CATCH("")
-}
-
-template <>
-void UPwSmallStrainElement<2, 3>::CalculateExtrapolationMatrix(BoundedMatrix<double, 3, 3>& rExtrapolationMatrix)
-{
-    // Triangle_2d_3
-    // GI_GAUSS_2
-    const auto extrapolator = LinearNodalExtrapolator{};
-    const auto result       = extrapolator.CalculateElementExtrapolationMatrix(
-        this->GetGeometry(), this->GetIntegrationMethod());
-    KRATOS_ERROR_IF_NOT(result.size1() == 3)
-        << "Extrapolation matrix has unexpected number of rows: " << result.size1()
-        << " (expected 3)" << std::endl;
-    KRATOS_ERROR_IF_NOT(result.size2() == 3)
-        << "Extrapolation matrix has unexpected number of columns: " << result.size1()
-        << " (expected 3)" << std::endl;
-    rExtrapolationMatrix = result;
-}
-
-template <>
-void UPwSmallStrainElement<2, 4>::CalculateExtrapolationMatrix(BoundedMatrix<double, 4, 4>& rExtrapolationMatrix)
-{
-    // Quadrilateral_2d_4
-    // GI_GAUSS_2
-    const auto extrapolator = LinearNodalExtrapolator{};
-    const auto result       = extrapolator.CalculateElementExtrapolationMatrix(
-        this->GetGeometry(), this->GetIntegrationMethod());
-    KRATOS_ERROR_IF_NOT(result.size1() == 4)
-        << "Extrapolation matrix has unexpected number of rows: " << result.size1()
-        << " (expected 4)" << std::endl;
-    KRATOS_ERROR_IF_NOT(result.size2() == 4)
-        << "Extrapolation matrix has unexpected number of columns: " << result.size1()
-        << " (expected 4)" << std::endl;
-    rExtrapolationMatrix = result;
-}
-
-template <>
-void UPwSmallStrainElement<3, 4>::CalculateExtrapolationMatrix(BoundedMatrix<double, 4, 4>& rExtrapolationMatrix)
-{
-    // Tetrahedra_3d_4
-    // GI_GAUSS_2
-    rExtrapolationMatrix(0, 0) = -0.309016988749894905;
-    rExtrapolationMatrix(0, 1) = -0.3090169887498949046;
-    rExtrapolationMatrix(0, 2) = -0.309016988749894905;
-    rExtrapolationMatrix(0, 3) = 1.9270509662496847144;
-    rExtrapolationMatrix(1, 0) = 1.9270509662496847144;
-    rExtrapolationMatrix(1, 1) = -0.30901698874989490481;
-    rExtrapolationMatrix(1, 2) = -0.3090169887498949049;
-    rExtrapolationMatrix(1, 3) = -0.30901698874989490481;
-    rExtrapolationMatrix(2, 0) = -0.30901698874989490473;
-    rExtrapolationMatrix(2, 1) = 1.9270509662496847143;
-    rExtrapolationMatrix(2, 2) = -0.3090169887498949049;
-    rExtrapolationMatrix(2, 3) = -0.30901698874989490481;
-    rExtrapolationMatrix(3, 0) = -0.3090169887498949048;
-    rExtrapolationMatrix(3, 1) = -0.30901698874989490471;
-    rExtrapolationMatrix(3, 2) = 1.9270509662496847143;
-    rExtrapolationMatrix(3, 3) = -0.30901698874989490481;
-}
-
-template <>
-void UPwSmallStrainElement<3, 8>::CalculateExtrapolationMatrix(BoundedMatrix<double, 8, 8>& rExtrapolationMatrix)
-{
-    // Hexahedra_3d_8
-    // GI_GAUSS_2
-    rExtrapolationMatrix(0, 0) = 2.549038105676658;
-    rExtrapolationMatrix(0, 1) = -0.6830127018922192;
-    rExtrapolationMatrix(0, 2) = 0.18301270189221927;
-    rExtrapolationMatrix(0, 3) = -0.6830127018922192;
-    rExtrapolationMatrix(0, 4) = -0.6830127018922192;
-    rExtrapolationMatrix(0, 5) = 0.18301270189221927;
-    rExtrapolationMatrix(0, 6) = -0.04903810567665795;
-    rExtrapolationMatrix(0, 7) = 0.18301270189221927;
-
-    rExtrapolationMatrix(1, 0) = -0.6830127018922192;
-    rExtrapolationMatrix(1, 1) = 2.549038105676658;
-    rExtrapolationMatrix(1, 2) = -0.6830127018922192;
-    rExtrapolationMatrix(1, 3) = 0.18301270189221927;
-    rExtrapolationMatrix(1, 4) = 0.18301270189221927;
-    rExtrapolationMatrix(1, 5) = -0.6830127018922192;
-    rExtrapolationMatrix(1, 6) = 0.18301270189221927;
-    rExtrapolationMatrix(1, 7) = -0.04903810567665795;
-
-    rExtrapolationMatrix(2, 0) = 0.18301270189221927;
-    rExtrapolationMatrix(2, 1) = -0.6830127018922192;
-    rExtrapolationMatrix(2, 2) = 2.549038105676658;
-    rExtrapolationMatrix(2, 3) = -0.6830127018922192;
-    rExtrapolationMatrix(2, 4) = -0.04903810567665795;
-    rExtrapolationMatrix(2, 5) = 0.18301270189221927;
-    rExtrapolationMatrix(2, 6) = -0.6830127018922192;
-    rExtrapolationMatrix(2, 7) = 0.18301270189221927;
-
-    rExtrapolationMatrix(3, 0) = -0.6830127018922192;
-    rExtrapolationMatrix(3, 1) = 0.18301270189221927;
-    rExtrapolationMatrix(3, 2) = -0.6830127018922192;
-    rExtrapolationMatrix(3, 3) = 2.549038105676658;
-    rExtrapolationMatrix(3, 4) = 0.18301270189221927;
-    rExtrapolationMatrix(3, 5) = -0.04903810567665795;
-    rExtrapolationMatrix(3, 6) = 0.18301270189221927;
-    rExtrapolationMatrix(3, 7) = -0.6830127018922192;
-
-    rExtrapolationMatrix(4, 0) = -0.6830127018922192;
-    rExtrapolationMatrix(4, 1) = 0.18301270189221927;
-    rExtrapolationMatrix(4, 2) = -0.04903810567665795;
-    rExtrapolationMatrix(4, 3) = 0.18301270189221927;
-    rExtrapolationMatrix(4, 4) = 2.549038105676658;
-    rExtrapolationMatrix(4, 5) = -0.6830127018922192;
-    rExtrapolationMatrix(4, 6) = 0.18301270189221927;
-    rExtrapolationMatrix(4, 7) = -0.6830127018922192;
-
-    rExtrapolationMatrix(5, 0) = 0.18301270189221927;
-    rExtrapolationMatrix(5, 1) = -0.6830127018922192;
-    rExtrapolationMatrix(5, 2) = 0.18301270189221927;
-    rExtrapolationMatrix(5, 3) = -0.04903810567665795;
-    rExtrapolationMatrix(5, 4) = -0.6830127018922192;
-    rExtrapolationMatrix(5, 5) = 2.549038105676658;
-    rExtrapolationMatrix(5, 6) = -0.6830127018922192;
-    rExtrapolationMatrix(5, 7) = 0.18301270189221927;
-
-    rExtrapolationMatrix(6, 0) = -0.04903810567665795;
-    rExtrapolationMatrix(6, 1) = 0.18301270189221927;
-    rExtrapolationMatrix(6, 2) = -0.6830127018922192;
-    rExtrapolationMatrix(6, 3) = 0.18301270189221927;
-    rExtrapolationMatrix(6, 4) = 0.18301270189221927;
-    rExtrapolationMatrix(6, 5) = -0.6830127018922192;
-    rExtrapolationMatrix(6, 6) = 2.549038105676658;
-    rExtrapolationMatrix(6, 7) = -0.6830127018922192;
-
-    rExtrapolationMatrix(7, 0) = 0.18301270189221927;
-    rExtrapolationMatrix(7, 1) = -0.04903810567665795;
-    rExtrapolationMatrix(7, 2) = 0.18301270189221927;
-    rExtrapolationMatrix(7, 3) = -0.6830127018922192;
-    rExtrapolationMatrix(7, 4) = -0.6830127018922192;
-    rExtrapolationMatrix(7, 5) = 0.18301270189221927;
-    rExtrapolationMatrix(7, 6) = -0.6830127018922192;
-    rExtrapolationMatrix(7, 7) = 2.549038105676658;
 }
 
 template <unsigned int TDim, unsigned int TNumNodes>

--- a/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_element.cpp
@@ -15,6 +15,7 @@
 #include "custom_elements/U_Pw_small_strain_element.hpp"
 #include "custom_utilities/constitutive_law_utilities.hpp"
 #include "custom_utilities/equation_of_motion_utilities.h"
+#include "custom_utilities/linear_nodal_extrapolator.h"
 #include "custom_utilities/math_utilities.h"
 #include "custom_utilities/transport_equation_utilities.hpp"
 #include "includes/cfd_variables.h"
@@ -1542,20 +1543,19 @@ void UPwSmallStrainElement<TDim, TNumNodes>::CalculateExtrapolationMatrix(Bounde
 template <>
 void UPwSmallStrainElement<2, 3>::CalculateExtrapolationMatrix(BoundedMatrix<double, 3, 3>& rExtrapolationMatrix)
 {
-    // The matrix contains the shape functions at each GP evaluated at each
-    // node. Rows: nodes Columns: GP
-
     // Triangle_2d_3
     // GI_GAUSS_2
-    rExtrapolationMatrix(0, 0) = 1.6666666666666666666;
-    rExtrapolationMatrix(0, 1) = -0.33333333333333333333;
-    rExtrapolationMatrix(0, 2) = -0.33333333333333333333;
-    rExtrapolationMatrix(1, 0) = -0.33333333333333333333;
-    rExtrapolationMatrix(1, 1) = 1.6666666666666666666;
-    rExtrapolationMatrix(1, 2) = -0.33333333333333333333;
-    rExtrapolationMatrix(2, 0) = -0.33333333333333333333;
-    rExtrapolationMatrix(2, 1) = -0.33333333333333333333;
-    rExtrapolationMatrix(2, 2) = 1.6666666666666666666;
+
+    LinearNodalExtrapolator extrapolator;
+    const auto              result = extrapolator.CalculateElementExtrapolationMatrix(
+        this->GetGeometry(), this->GetIntegrationMethod());
+    KRATOS_ERROR_IF_NOT(result.size1() == 3)
+        << "Extrapolation matrix has unexpected number of rows: " << result.size1()
+        << " (expected 3)" << std::endl;
+    KRATOS_ERROR_IF_NOT(result.size2() == 3)
+        << "Extrapolation matrix has unexpected number of columns: " << result.size1()
+        << " (expected 3)" << std::endl;
+    rExtrapolationMatrix = result;
 }
 
 template <>

--- a/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_element.cpp
@@ -1545,9 +1545,8 @@ void UPwSmallStrainElement<2, 3>::CalculateExtrapolationMatrix(BoundedMatrix<dou
 {
     // Triangle_2d_3
     // GI_GAUSS_2
-
-    LinearNodalExtrapolator extrapolator;
-    const auto              result = extrapolator.CalculateElementExtrapolationMatrix(
+    const auto extrapolator = LinearNodalExtrapolator{};
+    const auto result       = extrapolator.CalculateElementExtrapolationMatrix(
         this->GetGeometry(), this->GetIntegrationMethod());
     KRATOS_ERROR_IF_NOT(result.size1() == 3)
         << "Extrapolation matrix has unexpected number of rows: " << result.size1()
@@ -1563,22 +1562,16 @@ void UPwSmallStrainElement<2, 4>::CalculateExtrapolationMatrix(BoundedMatrix<dou
 {
     // Quadrilateral_2d_4
     // GI_GAUSS_2
-    rExtrapolationMatrix(0, 0) = 1.8660254037844386;
-    rExtrapolationMatrix(0, 1) = -0.5;
-    rExtrapolationMatrix(0, 2) = 0.13397459621556132;
-    rExtrapolationMatrix(0, 3) = -0.5;
-    rExtrapolationMatrix(1, 0) = -0.5;
-    rExtrapolationMatrix(1, 1) = 1.8660254037844386;
-    rExtrapolationMatrix(1, 2) = -0.5;
-    rExtrapolationMatrix(1, 3) = 0.13397459621556132;
-    rExtrapolationMatrix(2, 0) = 0.13397459621556132;
-    rExtrapolationMatrix(2, 1) = -0.5;
-    rExtrapolationMatrix(2, 2) = 1.8660254037844386;
-    rExtrapolationMatrix(2, 3) = -0.5;
-    rExtrapolationMatrix(3, 0) = -0.5;
-    rExtrapolationMatrix(3, 1) = 0.13397459621556132;
-    rExtrapolationMatrix(3, 2) = -0.5;
-    rExtrapolationMatrix(3, 3) = 1.8660254037844386;
+    const auto extrapolator = LinearNodalExtrapolator{};
+    const auto result       = extrapolator.CalculateElementExtrapolationMatrix(
+        this->GetGeometry(), this->GetIntegrationMethod());
+    KRATOS_ERROR_IF_NOT(result.size1() == 4)
+        << "Extrapolation matrix has unexpected number of rows: " << result.size1()
+        << " (expected 4)" << std::endl;
+    KRATOS_ERROR_IF_NOT(result.size2() == 4)
+        << "Extrapolation matrix has unexpected number of columns: " << result.size1()
+        << " (expected 4)" << std::endl;
+    rExtrapolationMatrix = result;
 }
 
 template <>

--- a/applications/GeoMechanicsApplication/tests/test_elements.py
+++ b/applications/GeoMechanicsApplication/tests/test_elements.py
@@ -28,12 +28,8 @@ class KratosGeoMechanicsElementTypeTests(KratosUnittest.TestCase):
         bottom_node_ids = [5, 7, 9]
         self.assert_linear_elastic_block(simulation, output_file_path, top_node_nbrs, n_dim, bottom_node_ids)
 
-        reader = test_helper.GiDOutputFileReader()
-        output_data = reader.read_output_from(output_file_path)
-        end_time = 1.0
-        nodal_stress_tensors = test_helper.GiDOutputFileReader.nodal_values_at_time("NODAL_CAUCHY_STRESS_TENSOR", end_time, output_data, bottom_node_ids)
-        for stress_tensor in nodal_stress_tensors:
-            self.assertAlmostEqual(stress_tensor[1], -1e4)
+        output_data = self.fetchOutputFromFile(output_file_path)
+        self.assertVerticalStressAtBottomNodes(output_data, bottom_node_ids)
 
     def test_triangle_3n_rebuild_level_0(self):
         test_name = 'test_triangle_3n_rebuild_0'
@@ -45,6 +41,9 @@ class KratosGeoMechanicsElementTypeTests(KratosUnittest.TestCase):
         n_dim = 2
         bottom_node_ids = [5, 7, 9]
         self.assert_linear_elastic_block(simulation, output_file_path, top_node_nbrs, n_dim, bottom_node_ids)
+
+        output_data = self.fetchOutputFromFile(output_file_path)
+        self.assertVerticalStressAtBottomNodes(output_data, bottom_node_ids)
 
     def test_triangle_6n(self):
         test_name = 'test_triangle_6n'
@@ -90,6 +89,9 @@ class KratosGeoMechanicsElementTypeTests(KratosUnittest.TestCase):
         bottom_node_ids = [5, 7, 9]
         self.assert_linear_elastic_block(simulation, output_file_path, top_node_nbrs, n_dim, bottom_node_ids)
 
+        output_data = self.fetchOutputFromFile(output_file_path)
+        self.assertVerticalStressAtBottomNodes(output_data, bottom_node_ids)
+
     def test_triangle_6n_fic(self):
         test_name = 'test_triangle_6n_fic'
         file_path = test_helper.get_file_path(os.path.join('.', test_name + '.gid'))
@@ -112,12 +114,8 @@ class KratosGeoMechanicsElementTypeTests(KratosUnittest.TestCase):
         bottom_node_ids = [5, 7, 9]
         self.assert_linear_elastic_block(simulation, output_file_path, top_node_nbrs, n_dim, bottom_node_ids)
 
-        reader = test_helper.GiDOutputFileReader()
-        output_data = reader.read_output_from(output_file_path)
-        end_time = 1.0
-        nodal_stress_tensors = test_helper.GiDOutputFileReader.nodal_values_at_time("NODAL_CAUCHY_STRESS_TENSOR", end_time, output_data, bottom_node_ids)
-        for stress_tensor in nodal_stress_tensors:
-            self.assertAlmostEqual(stress_tensor[1], -1e4)
+        output_data = self.fetchOutputFromFile(output_file_path)
+        self.assertVerticalStressAtBottomNodes(output_data, bottom_node_ids)
 
     def test_quad_8n(self):
         test_name = 'test_quad_8n'
@@ -140,6 +138,9 @@ class KratosGeoMechanicsElementTypeTests(KratosUnittest.TestCase):
         n_dim = 3
         bottom_node_ids = [11, 12, 17, 20, 22, 23, 25, 26, 27]
         self.assert_linear_elastic_block(simulation, output_file_path, top_node_nbrs, n_dim, bottom_node_ids)
+
+        output_data = self.fetchOutputFromFile(output_file_path)
+        self.assertVerticalStressAtBottomNodes(output_data, bottom_node_ids)
 
     def test_tetra_10n(self):
         test_name = 'test_tetra_10n'
@@ -230,6 +231,16 @@ class KratosGeoMechanicsElementTypeTests(KratosUnittest.TestCase):
         if n_dim >= 3:
             for z_displacement in z_displacements:
                 self.assertAlmostEqual(0.0, z_displacement)
+
+    def fetchOutputFromFile(self, output_file_path):
+        reader = test_helper.GiDOutputFileReader()
+        return reader.read_output_from(output_file_path)
+
+    def assertVerticalStressAtBottomNodes(self, output_data, bottom_node_ids):
+        end_time = 1.0
+        nodal_stress_tensors = test_helper.GiDOutputFileReader.nodal_values_at_time("NODAL_CAUCHY_STRESS_TENSOR", end_time, output_data, bottom_node_ids)
+        for stress_tensor in nodal_stress_tensors:
+            self.assertAlmostEqual(stress_tensor[1], -1e4)
 
 if __name__ == '__main__':
     KratosUnittest.main()

--- a/applications/GeoMechanicsApplication/tests/test_elements.py
+++ b/applications/GeoMechanicsApplication/tests/test_elements.py
@@ -25,10 +25,10 @@ class KratosGeoMechanicsElementTypeTests(KratosUnittest.TestCase):
         output_file_path = os.path.join(file_path, f"{test_name}.post.res")
         top_node_nbrs = [0, 1, 5]
         n_dim = 2
-        bottom_node_ids = [5, 7, 9]
-        self.assert_linear_elastic_block(simulation, output_file_path, top_node_nbrs, n_dim, bottom_node_ids)
+        self.assert_linear_elastic_block(simulation, output_file_path, top_node_nbrs, n_dim)
 
         output_data = self.fetchOutputFromFile(output_file_path)
+        bottom_node_ids = [5, 7, 9]
         self.assertVerticalStressAtBottomNodes(output_data, bottom_node_ids)
 
     def test_triangle_3n_rebuild_level_0(self):
@@ -39,10 +39,10 @@ class KratosGeoMechanicsElementTypeTests(KratosUnittest.TestCase):
         output_file_path = os.path.join(file_path, "test_triangle_3n.post.res")
         top_node_nbrs = [0, 1, 5]
         n_dim = 2
-        bottom_node_ids = [5, 7, 9]
-        self.assert_linear_elastic_block(simulation, output_file_path, top_node_nbrs, n_dim, bottom_node_ids)
+        self.assert_linear_elastic_block(simulation, output_file_path, top_node_nbrs, n_dim)
 
         output_data = self.fetchOutputFromFile(output_file_path)
+        bottom_node_ids = [5, 7, 9]
         self.assertVerticalStressAtBottomNodes(output_data, bottom_node_ids)
 
     def test_triangle_6n(self):
@@ -53,8 +53,7 @@ class KratosGeoMechanicsElementTypeTests(KratosUnittest.TestCase):
         output_file_path = os.path.join(file_path, f"{test_name}.post.res")
         top_node_nbrs = [0, 2, 4, 9, 15]
         n_dim = 2
-        bottom_node_ids = [17, 18, 22, 24, 25]
-        self.assert_linear_elastic_block(simulation, output_file_path, top_node_nbrs, n_dim, bottom_node_ids)
+        self.assert_linear_elastic_block(simulation, output_file_path, top_node_nbrs, n_dim)
 
     def test_triangle_10n(self):
         test_name = 'test_triangle_10n'
@@ -64,8 +63,7 @@ class KratosGeoMechanicsElementTypeTests(KratosUnittest.TestCase):
         output_file_path = os.path.join(file_path, f"{test_name}.post.res")
         top_node_nbrs = [9, 8, 7, 6]
         n_dim = 2
-        bottom_node_ids = [1, 2, 3, 4]
-        self.assert_linear_elastic_block(simulation, output_file_path, top_node_nbrs, n_dim, bottom_node_ids)
+        self.assert_linear_elastic_block(simulation, output_file_path, top_node_nbrs, n_dim)
 
     def test_triangle_15n(self):
         test_name = 'test_triangle_15n'
@@ -75,8 +73,7 @@ class KratosGeoMechanicsElementTypeTests(KratosUnittest.TestCase):
         output_file_path = os.path.join(file_path, f"{test_name}.post.res")
         top_node_nbrs = [12, 11, 10, 9, 8]
         n_dim = 2
-        bottom_node_ids = [1, 2, 3, 4, 5]
-        self.assert_linear_elastic_block(simulation, output_file_path, top_node_nbrs, n_dim, bottom_node_ids)
+        self.assert_linear_elastic_block(simulation, output_file_path, top_node_nbrs, n_dim)
 
     def test_triangle_3n_fic(self):
         test_name = 'test_triangle_3n_fic'
@@ -86,10 +83,10 @@ class KratosGeoMechanicsElementTypeTests(KratosUnittest.TestCase):
         output_file_path = os.path.join(file_path, f"{test_name}.post.res")
         top_node_nbrs = [0, 1, 5]
         n_dim = 2
-        bottom_node_ids = [5, 7, 9]
-        self.assert_linear_elastic_block(simulation, output_file_path, top_node_nbrs, n_dim, bottom_node_ids)
+        self.assert_linear_elastic_block(simulation, output_file_path, top_node_nbrs, n_dim)
 
         output_data = self.fetchOutputFromFile(output_file_path)
+        bottom_node_ids = [5, 7, 9]
         self.assertVerticalStressAtBottomNodes(output_data, bottom_node_ids)
 
     def test_triangle_6n_fic(self):
@@ -100,8 +97,7 @@ class KratosGeoMechanicsElementTypeTests(KratosUnittest.TestCase):
         output_file_path = os.path.join(file_path, f"{test_name}.post.res")
         top_node_nbrs = [0, 2, 4, 9, 15]
         n_dim = 2
-        bottom_node_ids = [17, 18, 22, 24, 25]
-        self.assert_linear_elastic_block(simulation, output_file_path, top_node_nbrs, n_dim, bottom_node_ids)
+        self.assert_linear_elastic_block(simulation, output_file_path, top_node_nbrs, n_dim)
 
     def test_quad_4n(self):
         test_name = 'test_quad_4n'
@@ -111,10 +107,10 @@ class KratosGeoMechanicsElementTypeTests(KratosUnittest.TestCase):
         output_file_path = os.path.join(file_path, f"{test_name}.post.res")
         top_node_nbrs = [0, 1, 5]
         n_dim = 2
-        bottom_node_ids = [5, 7, 9]
-        self.assert_linear_elastic_block(simulation, output_file_path, top_node_nbrs, n_dim, bottom_node_ids)
+        self.assert_linear_elastic_block(simulation, output_file_path, top_node_nbrs, n_dim)
 
         output_data = self.fetchOutputFromFile(output_file_path)
+        bottom_node_ids = [5, 7, 9]
         self.assertVerticalStressAtBottomNodes(output_data, bottom_node_ids)
 
     def test_quad_8n(self):
@@ -125,8 +121,7 @@ class KratosGeoMechanicsElementTypeTests(KratosUnittest.TestCase):
         output_file_path = os.path.join(file_path, f"{test_name}.post.res")
         top_node_nbrs = [0, 2, 4, 8, 12]
         n_dim = 2
-        bottom_node_ids = [14, 15, 18, 20, 21]
-        self.assert_linear_elastic_block(simulation, output_file_path, top_node_nbrs, n_dim, bottom_node_ids)
+        self.assert_linear_elastic_block(simulation, output_file_path, top_node_nbrs, n_dim)
 
     def test_tetra_4n(self):
         test_name = 'test_tetra_4n'
@@ -136,10 +131,10 @@ class KratosGeoMechanicsElementTypeTests(KratosUnittest.TestCase):
         output_file_path = os.path.join(file_path, f"{test_name}.post.res")
         top_node_nbrs = [0, 2, 9, 3, 6, 13, 8, 14, 20]
         n_dim = 3
-        bottom_node_ids = [11, 12, 17, 20, 22, 23, 25, 26, 27]
-        self.assert_linear_elastic_block(simulation, output_file_path, top_node_nbrs, n_dim, bottom_node_ids)
+        self.assert_linear_elastic_block(simulation, output_file_path, top_node_nbrs, n_dim)
 
         output_data = self.fetchOutputFromFile(output_file_path)
+        bottom_node_ids = [11, 12, 17, 20, 22, 23, 25, 26, 27]
         self.assertVerticalStressAtBottomNodes(output_data, bottom_node_ids)
 
     def test_tetra_10n(self):
@@ -154,11 +149,10 @@ class KratosGeoMechanicsElementTypeTests(KratosUnittest.TestCase):
                          27, 34, 41, 64, 94,
                          51, 56, 74, 95, 110]
         n_dim = 3
-        bottom_node_ids = [53, 58, 63, 64, 74, 76, 83, 84, 88, 91, 94, 98, 99, 104, 106, 110, 112, 113, 115, 118, 119, 121, 122, 124, 125]
-        self.assert_linear_elastic_block(simulation, output_file_path, top_node_nbrs, n_dim, bottom_node_ids)
+        self.assert_linear_elastic_block(simulation, output_file_path, top_node_nbrs, n_dim)
 
 
-    def assert_linear_elastic_block(self, simulation, output_file_path, top_node_nbrs, n_dim, bottom_node_ids):
+    def assert_linear_elastic_block(self, simulation, output_file_path, top_node_nbrs, n_dim):
         """
         Assert results of a linear elastic block. The sides of the block can move freely in vertical direction and are
         fixed in horizontal direction. The bottom of the block is fixed. On top of the block, a load of 10kN/m2 is

--- a/applications/GeoMechanicsApplication/tests/test_elements.py
+++ b/applications/GeoMechanicsApplication/tests/test_elements.py
@@ -227,8 +227,9 @@ class KratosGeoMechanicsElementTypeTests(KratosUnittest.TestCase):
     def assertVerticalStressAtBottomNodes(self, output_data, bottom_node_ids):
         end_time = 1.0
         nodal_stress_tensors = test_helper.GiDOutputFileReader.nodal_values_at_time("NODAL_CAUCHY_STRESS_TENSOR", end_time, output_data, bottom_node_ids)
+        expected_stress_yy = -1e4
         for stress_tensor in nodal_stress_tensors:
-            self.assertAlmostEqual(stress_tensor[1], -1e4)
+            self.assertAlmostEqual(stress_tensor[1], expected_stress_yy)
 
 if __name__ == '__main__':
     KratosUnittest.main()

--- a/applications/GeoMechanicsApplication/tests/test_elements.py
+++ b/applications/GeoMechanicsApplication/tests/test_elements.py
@@ -26,6 +26,14 @@ class KratosGeoMechanicsElementTypeTests(KratosUnittest.TestCase):
         n_dim = 2
         self.assert_linear_elastic_block(simulation, top_node_nbrs, n_dim)
 
+        reader = test_helper.GiDOutputFileReader()
+        output_data = reader.read_output_from(os.path.join(file_path, f"{test_name}.post.res"))
+        end_time = 1.0
+        bottom_node_ids = [5, 7, 9]
+        nodal_stress_tensors = test_helper.GiDOutputFileReader.nodal_values_at_time("NODAL_CAUCHY_STRESS_TENSOR", end_time, output_data, bottom_node_ids)
+        for stress_tensor in nodal_stress_tensors:
+            self.assertAlmostEqual(stress_tensor[1], -1e4)
+
     def test_triangle_3n_rebuild_level_0(self):
         test_name = 'test_triangle_3n_rebuild_0'
         file_path = test_helper.get_file_path(os.path.join('.', test_name + '.gid'))

--- a/applications/GeoMechanicsApplication/tests/test_elements.py
+++ b/applications/GeoMechanicsApplication/tests/test_elements.py
@@ -97,6 +97,14 @@ class KratosGeoMechanicsElementTypeTests(KratosUnittest.TestCase):
         n_dim = 2
         self.assert_linear_elastic_block(simulation, top_node_nbrs, n_dim)
 
+        reader = test_helper.GiDOutputFileReader()
+        output_data = reader.read_output_from(os.path.join(file_path, f"{test_name}.post.res"))
+        end_time = 1.0
+        bottom_node_ids = [5, 7, 9]
+        nodal_stress_tensors = test_helper.GiDOutputFileReader.nodal_values_at_time("NODAL_CAUCHY_STRESS_TENSOR", end_time, output_data, bottom_node_ids)
+        for stress_tensor in nodal_stress_tensors:
+            self.assertAlmostEqual(stress_tensor[1], -1e4)
+
     def test_quad_8n(self):
         test_name = 'test_quad_8n'
         file_path = test_helper.get_file_path(os.path.join('.', test_name + '.gid'))

--- a/applications/GeoMechanicsApplication/tests/test_elements.py
+++ b/applications/GeoMechanicsApplication/tests/test_elements.py
@@ -22,14 +22,15 @@ class KratosGeoMechanicsElementTypeTests(KratosUnittest.TestCase):
         file_path = test_helper.get_file_path(os.path.join('.', test_name + '.gid'))
         simulation = test_helper.run_kratos(file_path)
 
+        output_file_path = os.path.join(file_path, f"{test_name}.post.res")
         top_node_nbrs = [0, 1, 5]
         n_dim = 2
-        self.assert_linear_elastic_block(simulation, top_node_nbrs, n_dim)
+        bottom_node_ids = [5, 7, 9]
+        self.assert_linear_elastic_block(simulation, output_file_path, top_node_nbrs, n_dim, bottom_node_ids)
 
         reader = test_helper.GiDOutputFileReader()
-        output_data = reader.read_output_from(os.path.join(file_path, f"{test_name}.post.res"))
+        output_data = reader.read_output_from(output_file_path)
         end_time = 1.0
-        bottom_node_ids = [5, 7, 9]
         nodal_stress_tensors = test_helper.GiDOutputFileReader.nodal_values_at_time("NODAL_CAUCHY_STRESS_TENSOR", end_time, output_data, bottom_node_ids)
         for stress_tensor in nodal_stress_tensors:
             self.assertAlmostEqual(stress_tensor[1], -1e4)
@@ -39,68 +40,81 @@ class KratosGeoMechanicsElementTypeTests(KratosUnittest.TestCase):
         file_path = test_helper.get_file_path(os.path.join('.', test_name + '.gid'))
         simulation = test_helper.run_kratos(file_path)
 
+        output_file_path = os.path.join(file_path, "test_triangle_3n.post.res")
         top_node_nbrs = [0, 1, 5]
         n_dim = 2
-        self.assert_linear_elastic_block(simulation, top_node_nbrs, n_dim)
+        bottom_node_ids = [5, 7, 9]
+        self.assert_linear_elastic_block(simulation, output_file_path, top_node_nbrs, n_dim, bottom_node_ids)
 
     def test_triangle_6n(self):
         test_name = 'test_triangle_6n'
         file_path = test_helper.get_file_path(os.path.join('.', test_name + '.gid'))
         simulation = test_helper.run_kratos(file_path)
 
+        output_file_path = os.path.join(file_path, f"{test_name}.post.res")
         top_node_nbrs = [0, 2, 4, 9, 15]
         n_dim = 2
-        self.assert_linear_elastic_block(simulation, top_node_nbrs, n_dim)
+        bottom_node_ids = [17, 18, 22, 24, 25]
+        self.assert_linear_elastic_block(simulation, output_file_path, top_node_nbrs, n_dim, bottom_node_ids)
 
     def test_triangle_10n(self):
         test_name = 'test_triangle_10n'
         file_path = test_helper.get_file_path(os.path.join('.', test_name + '.gid'))
         simulation = test_helper.run_kratos(file_path)
 
+        output_file_path = os.path.join(file_path, f"{test_name}.post.res")
         top_node_nbrs = [9, 8, 7, 6]
         n_dim = 2
-        self.assert_linear_elastic_block(simulation, top_node_nbrs, n_dim)
+        bottom_node_ids = [1, 2, 3, 4]
+        self.assert_linear_elastic_block(simulation, output_file_path, top_node_nbrs, n_dim, bottom_node_ids)
 
     def test_triangle_15n(self):
         test_name = 'test_triangle_15n'
         file_path = test_helper.get_file_path(os.path.join('.', test_name + '.gid'))
         simulation = test_helper.run_kratos(file_path)
 
+        output_file_path = os.path.join(file_path, f"{test_name}.post.res")
         top_node_nbrs = [12, 11, 10, 9, 8]
         n_dim = 2
-        self.assert_linear_elastic_block(simulation, top_node_nbrs, n_dim)
+        bottom_node_ids = [1, 2, 3, 4, 5]
+        self.assert_linear_elastic_block(simulation, output_file_path, top_node_nbrs, n_dim, bottom_node_ids)
 
     def test_triangle_3n_fic(self):
         test_name = 'test_triangle_3n_fic'
         file_path = test_helper.get_file_path(os.path.join('.', test_name + '.gid'))
         simulation = test_helper.run_kratos(file_path)
 
+        output_file_path = os.path.join(file_path, f"{test_name}.post.res")
         top_node_nbrs = [0, 1, 5]
         n_dim = 2
-        self.assert_linear_elastic_block(simulation, top_node_nbrs, n_dim)
+        bottom_node_ids = [5, 7, 9]
+        self.assert_linear_elastic_block(simulation, output_file_path, top_node_nbrs, n_dim, bottom_node_ids)
 
     def test_triangle_6n_fic(self):
         test_name = 'test_triangle_6n_fic'
         file_path = test_helper.get_file_path(os.path.join('.', test_name + '.gid'))
         simulation = test_helper.run_kratos(file_path)
 
+        output_file_path = os.path.join(file_path, f"{test_name}.post.res")
         top_node_nbrs = [0, 2, 4, 9, 15]
         n_dim = 2
-        self.assert_linear_elastic_block(simulation, top_node_nbrs, n_dim)
+        bottom_node_ids = [17, 18, 22, 24, 25]
+        self.assert_linear_elastic_block(simulation, output_file_path, top_node_nbrs, n_dim, bottom_node_ids)
 
     def test_quad_4n(self):
         test_name = 'test_quad_4n'
         file_path = test_helper.get_file_path(os.path.join('.', test_name + '.gid'))
         simulation = test_helper.run_kratos(file_path)
 
+        output_file_path = os.path.join(file_path, f"{test_name}.post.res")
         top_node_nbrs = [0, 1, 5]
         n_dim = 2
-        self.assert_linear_elastic_block(simulation, top_node_nbrs, n_dim)
+        bottom_node_ids = [5, 7, 9]
+        self.assert_linear_elastic_block(simulation, output_file_path, top_node_nbrs, n_dim, bottom_node_ids)
 
         reader = test_helper.GiDOutputFileReader()
-        output_data = reader.read_output_from(os.path.join(file_path, f"{test_name}.post.res"))
+        output_data = reader.read_output_from(output_file_path)
         end_time = 1.0
-        bottom_node_ids = [5, 7, 9]
         nodal_stress_tensors = test_helper.GiDOutputFileReader.nodal_values_at_time("NODAL_CAUCHY_STRESS_TENSOR", end_time, output_data, bottom_node_ids)
         for stress_tensor in nodal_stress_tensors:
             self.assertAlmostEqual(stress_tensor[1], -1e4)
@@ -110,34 +124,40 @@ class KratosGeoMechanicsElementTypeTests(KratosUnittest.TestCase):
         file_path = test_helper.get_file_path(os.path.join('.', test_name + '.gid'))
         simulation = test_helper.run_kratos(file_path)
 
+        output_file_path = os.path.join(file_path, f"{test_name}.post.res")
         top_node_nbrs = [0, 2, 4, 8, 12]
         n_dim = 2
-        self.assert_linear_elastic_block(simulation, top_node_nbrs, n_dim)
+        bottom_node_ids = [14, 15, 18, 20, 21]
+        self.assert_linear_elastic_block(simulation, output_file_path, top_node_nbrs, n_dim, bottom_node_ids)
 
     def test_tetra_4n(self):
         test_name = 'test_tetra_4n'
         file_path = test_helper.get_file_path(os.path.join('.', test_name + '.gid'))
         simulation = test_helper.run_kratos(file_path)
 
+        output_file_path = os.path.join(file_path, f"{test_name}.post.res")
         top_node_nbrs = [0, 2, 9, 3, 6, 13, 8, 14, 20]
         n_dim = 3
-        self.assert_linear_elastic_block(simulation, top_node_nbrs, n_dim)
+        bottom_node_ids = [11, 12, 17, 20, 22, 23, 25, 26, 27]
+        self.assert_linear_elastic_block(simulation, output_file_path, top_node_nbrs, n_dim, bottom_node_ids)
 
     def test_tetra_10n(self):
         test_name = 'test_tetra_10n'
         file_path = test_helper.get_file_path(os.path.join('.', test_name + '.gid'))
         simulation = test_helper.run_kratos(file_path)
 
+        output_file_path = os.path.join(file_path, f"{test_name}.post.res")
         top_node_nbrs = [0, 3, 9, 28, 53,
                          1, 6, 13, 32,
                          10, 15, 21, 44, 76,
                          27, 34, 41, 64, 94,
                          51, 56, 74, 95, 110]
         n_dim = 3
-        self.assert_linear_elastic_block(simulation, top_node_nbrs, n_dim)
+        bottom_node_ids = [53, 58, 63, 64, 74, 76, 83, 84, 88, 91, 94, 98, 99, 104, 106, 110, 112, 113, 115, 118, 119, 121, 122, 124, 125]
+        self.assert_linear_elastic_block(simulation, output_file_path, top_node_nbrs, n_dim, bottom_node_ids)
 
 
-    def assert_linear_elastic_block(self,simulation, top_node_nbrs, n_dim):
+    def assert_linear_elastic_block(self, simulation, output_file_path, top_node_nbrs, n_dim, bottom_node_ids):
         """
         Assert results of a linear elastic block. The sides of the block can move freely in vertical direction and are
         fixed in horizontal direction. The bottom of the block is fixed. On top of the block, a load of 10kN/m2 is
@@ -148,6 +168,8 @@ class KratosGeoMechanicsElementTypeTests(KratosUnittest.TestCase):
         :param n_dim: number of dimensions
         :return:
         """
+        self.assertTrue(os.path.exists(output_file_path))
+
         total_stresses = test_helper.get_total_stress_tensor(simulation)
         total_stresses_xx = [integration_point[0,0] for element in total_stresses for integration_point in element]
         if n_dim >= 2:

--- a/applications/GeoMechanicsApplication/tests/test_elements.py
+++ b/applications/GeoMechanicsApplication/tests/test_elements.py
@@ -22,12 +22,11 @@ class KratosGeoMechanicsElementTypeTests(KratosUnittest.TestCase):
         file_path = test_helper.get_file_path(os.path.join('.', test_name + '.gid'))
         simulation = test_helper.run_kratos(file_path)
 
-        output_file_path = os.path.join(file_path, f"{test_name}.post.res")
+        output_data = self.fetchOutputFromFile(os.path.join(file_path, f"{test_name}.post.res"))
         top_node_nbrs = [0, 1, 5]
         n_dim = 2
-        self.assert_linear_elastic_block(simulation, output_file_path, top_node_nbrs, n_dim)
+        self.assert_linear_elastic_block(simulation, output_data, top_node_nbrs, n_dim)
 
-        output_data = self.fetchOutputFromFile(output_file_path)
         bottom_node_ids = [5, 7, 9]
         self.assertVerticalStressAtBottomNodes(output_data, bottom_node_ids)
 
@@ -36,12 +35,11 @@ class KratosGeoMechanicsElementTypeTests(KratosUnittest.TestCase):
         file_path = test_helper.get_file_path(os.path.join('.', test_name + '.gid'))
         simulation = test_helper.run_kratos(file_path)
 
-        output_file_path = os.path.join(file_path, "test_triangle_3n.post.res")
+        output_data = self.fetchOutputFromFile(os.path.join(file_path, "test_triangle_3n.post.res"))
         top_node_nbrs = [0, 1, 5]
         n_dim = 2
-        self.assert_linear_elastic_block(simulation, output_file_path, top_node_nbrs, n_dim)
+        self.assert_linear_elastic_block(simulation, output_data, top_node_nbrs, n_dim)
 
-        output_data = self.fetchOutputFromFile(output_file_path)
         bottom_node_ids = [5, 7, 9]
         self.assertVerticalStressAtBottomNodes(output_data, bottom_node_ids)
 
@@ -50,42 +48,41 @@ class KratosGeoMechanicsElementTypeTests(KratosUnittest.TestCase):
         file_path = test_helper.get_file_path(os.path.join('.', test_name + '.gid'))
         simulation = test_helper.run_kratos(file_path)
 
-        output_file_path = os.path.join(file_path, f"{test_name}.post.res")
+        output_data = self.fetchOutputFromFile(os.path.join(file_path, f"{test_name}.post.res"))
         top_node_nbrs = [0, 2, 4, 9, 15]
         n_dim = 2
-        self.assert_linear_elastic_block(simulation, output_file_path, top_node_nbrs, n_dim)
+        self.assert_linear_elastic_block(simulation, output_data, top_node_nbrs, n_dim)
 
     def test_triangle_10n(self):
         test_name = 'test_triangle_10n'
         file_path = test_helper.get_file_path(os.path.join('.', test_name + '.gid'))
         simulation = test_helper.run_kratos(file_path)
 
-        output_file_path = os.path.join(file_path, f"{test_name}.post.res")
+        output_data = self.fetchOutputFromFile(os.path.join(file_path, f"{test_name}.post.res"))
         top_node_nbrs = [9, 8, 7, 6]
         n_dim = 2
-        self.assert_linear_elastic_block(simulation, output_file_path, top_node_nbrs, n_dim)
+        self.assert_linear_elastic_block(simulation, output_data, top_node_nbrs, n_dim)
 
     def test_triangle_15n(self):
         test_name = 'test_triangle_15n'
         file_path = test_helper.get_file_path(os.path.join('.', test_name + '.gid'))
         simulation = test_helper.run_kratos(file_path)
 
-        output_file_path = os.path.join(file_path, f"{test_name}.post.res")
+        output_data = self.fetchOutputFromFile(os.path.join(file_path, f"{test_name}.post.res"))
         top_node_nbrs = [12, 11, 10, 9, 8]
         n_dim = 2
-        self.assert_linear_elastic_block(simulation, output_file_path, top_node_nbrs, n_dim)
+        self.assert_linear_elastic_block(simulation, output_data, top_node_nbrs, n_dim)
 
     def test_triangle_3n_fic(self):
         test_name = 'test_triangle_3n_fic'
         file_path = test_helper.get_file_path(os.path.join('.', test_name + '.gid'))
         simulation = test_helper.run_kratos(file_path)
 
-        output_file_path = os.path.join(file_path, f"{test_name}.post.res")
+        output_data = self.fetchOutputFromFile(os.path.join(file_path, f"{test_name}.post.res"))
         top_node_nbrs = [0, 1, 5]
         n_dim = 2
-        self.assert_linear_elastic_block(simulation, output_file_path, top_node_nbrs, n_dim)
+        self.assert_linear_elastic_block(simulation, output_data, top_node_nbrs, n_dim)
 
-        output_data = self.fetchOutputFromFile(output_file_path)
         bottom_node_ids = [5, 7, 9]
         self.assertVerticalStressAtBottomNodes(output_data, bottom_node_ids)
 
@@ -94,22 +91,21 @@ class KratosGeoMechanicsElementTypeTests(KratosUnittest.TestCase):
         file_path = test_helper.get_file_path(os.path.join('.', test_name + '.gid'))
         simulation = test_helper.run_kratos(file_path)
 
-        output_file_path = os.path.join(file_path, f"{test_name}.post.res")
+        output_data = self.fetchOutputFromFile(os.path.join(file_path, f"{test_name}.post.res"))
         top_node_nbrs = [0, 2, 4, 9, 15]
         n_dim = 2
-        self.assert_linear_elastic_block(simulation, output_file_path, top_node_nbrs, n_dim)
+        self.assert_linear_elastic_block(simulation, output_data, top_node_nbrs, n_dim)
 
     def test_quad_4n(self):
         test_name = 'test_quad_4n'
         file_path = test_helper.get_file_path(os.path.join('.', test_name + '.gid'))
         simulation = test_helper.run_kratos(file_path)
 
-        output_file_path = os.path.join(file_path, f"{test_name}.post.res")
+        output_data = self.fetchOutputFromFile(os.path.join(file_path, f"{test_name}.post.res"))
         top_node_nbrs = [0, 1, 5]
         n_dim = 2
-        self.assert_linear_elastic_block(simulation, output_file_path, top_node_nbrs, n_dim)
+        self.assert_linear_elastic_block(simulation, output_data, top_node_nbrs, n_dim)
 
-        output_data = self.fetchOutputFromFile(output_file_path)
         bottom_node_ids = [5, 7, 9]
         self.assertVerticalStressAtBottomNodes(output_data, bottom_node_ids)
 
@@ -118,22 +114,21 @@ class KratosGeoMechanicsElementTypeTests(KratosUnittest.TestCase):
         file_path = test_helper.get_file_path(os.path.join('.', test_name + '.gid'))
         simulation = test_helper.run_kratos(file_path)
 
-        output_file_path = os.path.join(file_path, f"{test_name}.post.res")
+        output_data = self.fetchOutputFromFile(os.path.join(file_path, f"{test_name}.post.res"))
         top_node_nbrs = [0, 2, 4, 8, 12]
         n_dim = 2
-        self.assert_linear_elastic_block(simulation, output_file_path, top_node_nbrs, n_dim)
+        self.assert_linear_elastic_block(simulation, output_data, top_node_nbrs, n_dim)
 
     def test_tetra_4n(self):
         test_name = 'test_tetra_4n'
         file_path = test_helper.get_file_path(os.path.join('.', test_name + '.gid'))
         simulation = test_helper.run_kratos(file_path)
 
-        output_file_path = os.path.join(file_path, f"{test_name}.post.res")
+        output_data = self.fetchOutputFromFile(os.path.join(file_path, f"{test_name}.post.res"))
         top_node_nbrs = [0, 2, 9, 3, 6, 13, 8, 14, 20]
         n_dim = 3
-        self.assert_linear_elastic_block(simulation, output_file_path, top_node_nbrs, n_dim)
+        self.assert_linear_elastic_block(simulation, output_data, top_node_nbrs, n_dim)
 
-        output_data = self.fetchOutputFromFile(output_file_path)
         bottom_node_ids = [11, 12, 17, 20, 22, 23, 25, 26, 27]
         self.assertVerticalStressAtBottomNodes(output_data, bottom_node_ids)
 
@@ -142,17 +137,17 @@ class KratosGeoMechanicsElementTypeTests(KratosUnittest.TestCase):
         file_path = test_helper.get_file_path(os.path.join('.', test_name + '.gid'))
         simulation = test_helper.run_kratos(file_path)
 
-        output_file_path = os.path.join(file_path, f"{test_name}.post.res")
+        output_data = self.fetchOutputFromFile(os.path.join(file_path, f"{test_name}.post.res"))
         top_node_nbrs = [0, 3, 9, 28, 53,
                          1, 6, 13, 32,
                          10, 15, 21, 44, 76,
                          27, 34, 41, 64, 94,
                          51, 56, 74, 95, 110]
         n_dim = 3
-        self.assert_linear_elastic_block(simulation, output_file_path, top_node_nbrs, n_dim)
+        self.assert_linear_elastic_block(simulation, output_data, top_node_nbrs, n_dim)
 
 
-    def assert_linear_elastic_block(self, simulation, output_file_path, top_node_nbrs, n_dim):
+    def assert_linear_elastic_block(self, simulation, output_data, top_node_nbrs, n_dim):
         """
         Assert results of a linear elastic block. The sides of the block can move freely in vertical direction and are
         fixed in horizontal direction. The bottom of the block is fixed. On top of the block, a load of 10kN/m2 is
@@ -163,8 +158,6 @@ class KratosGeoMechanicsElementTypeTests(KratosUnittest.TestCase):
         :param n_dim: number of dimensions
         :return:
         """
-        self.assertTrue(os.path.exists(output_file_path))
-
         total_stresses = test_helper.get_total_stress_tensor(simulation)
         total_stresses_xx = [integration_point[0,0] for element in total_stresses for integration_point in element]
         if n_dim >= 2:
@@ -179,7 +172,8 @@ class KratosGeoMechanicsElementTypeTests(KratosUnittest.TestCase):
         if n_dim >= 3:
             effective_stresses_zz = [integration_point[2,2] for element in effective_stresses for integration_point in element]
 
-        displacements = test_helper.get_displacement(simulation)
+        end_time = 1.0
+        displacements = test_helper.GiDOutputFileReader.nodal_values_at_time("DISPLACEMENT", end_time, output_data)
         x_displacements = [displacement[0] for displacement in displacements]
         if n_dim >= 2:
             y_displacements = [displacement[1] for displacement in displacements]

--- a/applications/GeoMechanicsApplication/tests/test_quad_4n.gid/ProjectParameters.json
+++ b/applications/GeoMechanicsApplication/tests/test_quad_4n.gid/ProjectParameters.json
@@ -90,8 +90,8 @@
                         "node_output":         false,
                         "skin_output":         false,
                         "plane_output":        [],
-                        "nodal_results":       ["DISPLACEMENT","TOTAL_DISPLACEMENT","ROTATION","WATER_PRESSURE","REACTION","REACTION_WATER_PRESSURE","POINT_LOAD","LINE_LOAD","SURFACE_LOAD","NORMAL_CONTACT_STRESS","TANGENTIAL_CONTACT_STRESS","NORMAL_FLUID_FLUX","VOLUME_ACCELERATION","NODAL_CAUCHY_STRESS_TENSOR","NODAL_DAMAGE_VARIABLE","NODAL_JOINT_WIDTH","NODAL_JOINT_DAMAGE"],
-                        "gauss_point_results": ["MOMENT","FORCE","GREEN_LAGRANGE_STRAIN_TENSOR","CAUCHY_STRESS_TENSOR","TOTAL_STRESS_TENSOR","VON_MISES_STRESS","FLUID_FLUX_VECTOR","PERMEABILITY_MATRIX","DAMAGE_VARIABLE","JOINT_WIDTH","LOCAL_STRESS_VECTOR","LOCAL_RELATIVE_DISPLACEMENT_VECTOR","LOCAL_FLUID_FLUX_VECTOR","LOCAL_PERMEABILITY_MATRIX"]
+                        "nodal_results":       ["DISPLACEMENT","NODAL_CAUCHY_STRESS_TENSOR"],
+                        "gauss_point_results": ["GREEN_LAGRANGE_STRAIN_TENSOR","CAUCHY_STRESS_TENSOR","TOTAL_STRESS_TENSOR"]
                     },
                     "point_data_configuration":  []
                 }

--- a/applications/GeoMechanicsApplication/tests/test_quad_4n.gid/ProjectParameters.json
+++ b/applications/GeoMechanicsApplication/tests/test_quad_4n.gid/ProjectParameters.json
@@ -80,7 +80,7 @@
                         "gidpost_flags":       {
                             "WriteDeformedMeshFlag": "WriteUndeformed",
                             "WriteConditionsFlag":   "WriteElementsOnly",
-                            "GiDPostMode":           "GiD_PostBinary",
+                            "GiDPostMode":           "GiD_PostAscii",
                             "MultiFileFlag":         "SingleFile"
                         },
                         "file_label":          "step",

--- a/applications/GeoMechanicsApplication/tests/test_quad_8n.gid/ProjectParameters.json
+++ b/applications/GeoMechanicsApplication/tests/test_quad_8n.gid/ProjectParameters.json
@@ -90,8 +90,8 @@
                         "node_output":         false,
                         "skin_output":         false,
                         "plane_output":        [],
-                        "nodal_results":       ["DISPLACEMENT","TOTAL_DISPLACEMENT","ROTATION","WATER_PRESSURE","REACTION","REACTION_WATER_PRESSURE","POINT_LOAD","LINE_LOAD","SURFACE_LOAD","NORMAL_CONTACT_STRESS","TANGENTIAL_CONTACT_STRESS","NORMAL_FLUID_FLUX","VOLUME_ACCELERATION","NODAL_CAUCHY_STRESS_TENSOR","NODAL_DAMAGE_VARIABLE","NODAL_JOINT_WIDTH","NODAL_JOINT_DAMAGE"],
-                        "gauss_point_results": ["MOMENT","FORCE","GREEN_LAGRANGE_STRAIN_TENSOR","CAUCHY_STRESS_TENSOR","TOTAL_STRESS_TENSOR","VON_MISES_STRESS","FLUID_FLUX_VECTOR","PERMEABILITY_MATRIX","DAMAGE_VARIABLE","JOINT_WIDTH","LOCAL_STRESS_VECTOR","LOCAL_RELATIVE_DISPLACEMENT_VECTOR","LOCAL_FLUID_FLUX_VECTOR","LOCAL_PERMEABILITY_MATRIX"]
+                        "nodal_results":       ["DISPLACEMENT"],
+                        "gauss_point_results": ["GREEN_LAGRANGE_STRAIN_TENSOR","CAUCHY_STRESS_TENSOR","TOTAL_STRESS_TENSOR"]
                     },
                     "point_data_configuration":  []
                 }

--- a/applications/GeoMechanicsApplication/tests/test_quad_8n.gid/ProjectParameters.json
+++ b/applications/GeoMechanicsApplication/tests/test_quad_8n.gid/ProjectParameters.json
@@ -80,7 +80,7 @@
                         "gidpost_flags":       {
                             "WriteDeformedMeshFlag": "WriteUndeformed",
                             "WriteConditionsFlag":   "WriteElementsOnly",
-                            "GiDPostMode":           "GiD_PostBinary",
+                            "GiDPostMode":           "GiD_PostAscii",
                             "MultiFileFlag":         "SingleFile"
                         },
                         "file_label":          "step",

--- a/applications/GeoMechanicsApplication/tests/test_tetra_10n.gid/ProjectParameters.json
+++ b/applications/GeoMechanicsApplication/tests/test_tetra_10n.gid/ProjectParameters.json
@@ -90,8 +90,8 @@
                         "node_output":         false,
                         "skin_output":         false,
                         "plane_output":        [],
-                        "nodal_results":       ["DISPLACEMENT","TOTAL_DISPLACEMENT","ROTATION","WATER_PRESSURE","REACTION","REACTION_WATER_PRESSURE","POINT_LOAD","LINE_LOAD","SURFACE_LOAD","NORMAL_CONTACT_STRESS","TANGENTIAL_CONTACT_STRESS","NORMAL_FLUID_FLUX","VOLUME_ACCELERATION","NODAL_CAUCHY_STRESS_TENSOR","NODAL_DAMAGE_VARIABLE","NODAL_JOINT_WIDTH","NODAL_JOINT_DAMAGE"],
-                        "gauss_point_results": ["MOMENT","FORCE","GREEN_LAGRANGE_STRAIN_TENSOR","CAUCHY_STRESS_TENSOR","TOTAL_STRESS_TENSOR","VON_MISES_STRESS","FLUID_FLUX_VECTOR","PERMEABILITY_MATRIX","DAMAGE_VARIABLE","JOINT_WIDTH","LOCAL_STRESS_VECTOR","LOCAL_RELATIVE_DISPLACEMENT_VECTOR","LOCAL_FLUID_FLUX_VECTOR","LOCAL_PERMEABILITY_MATRIX"]
+                        "nodal_results":       ["DISPLACEMENT"],
+                        "gauss_point_results": ["GREEN_LAGRANGE_STRAIN_TENSOR","CAUCHY_STRESS_TENSOR","TOTAL_STRESS_TENSOR"]
                     },
                     "point_data_configuration":  []
                 }

--- a/applications/GeoMechanicsApplication/tests/test_tetra_10n.gid/ProjectParameters.json
+++ b/applications/GeoMechanicsApplication/tests/test_tetra_10n.gid/ProjectParameters.json
@@ -80,7 +80,7 @@
                         "gidpost_flags":       {
                             "WriteDeformedMeshFlag": "WriteUndeformed",
                             "WriteConditionsFlag":   "WriteElementsOnly",
-                            "GiDPostMode":           "GiD_PostBinary",
+                            "GiDPostMode":           "GiD_PostAscii",
                             "MultiFileFlag":         "SingleFile"
                         },
                         "file_label":          "step",

--- a/applications/GeoMechanicsApplication/tests/test_tetra_4n.gid/ProjectParameters.json
+++ b/applications/GeoMechanicsApplication/tests/test_tetra_4n.gid/ProjectParameters.json
@@ -90,8 +90,8 @@
                         "node_output":         false,
                         "skin_output":         false,
                         "plane_output":        [],
-                        "nodal_results":       ["DISPLACEMENT","TOTAL_DISPLACEMENT","ROTATION","WATER_PRESSURE","REACTION","REACTION_WATER_PRESSURE","POINT_LOAD","LINE_LOAD","SURFACE_LOAD","NORMAL_CONTACT_STRESS","TANGENTIAL_CONTACT_STRESS","NORMAL_FLUID_FLUX","VOLUME_ACCELERATION","NODAL_CAUCHY_STRESS_TENSOR","NODAL_DAMAGE_VARIABLE","NODAL_JOINT_WIDTH","NODAL_JOINT_DAMAGE"],
-                        "gauss_point_results": ["MOMENT","FORCE","GREEN_LAGRANGE_STRAIN_TENSOR","CAUCHY_STRESS_TENSOR","TOTAL_STRESS_TENSOR","VON_MISES_STRESS","FLUID_FLUX_VECTOR","PERMEABILITY_MATRIX","DAMAGE_VARIABLE","JOINT_WIDTH","LOCAL_STRESS_VECTOR","LOCAL_RELATIVE_DISPLACEMENT_VECTOR","LOCAL_FLUID_FLUX_VECTOR","LOCAL_PERMEABILITY_MATRIX"]
+                        "nodal_results":       ["DISPLACEMENT","NODAL_CAUCHY_STRESS_TENSOR"],
+                        "gauss_point_results": ["GREEN_LAGRANGE_STRAIN_TENSOR","CAUCHY_STRESS_TENSOR","TOTAL_STRESS_TENSOR"]
                     },
                     "point_data_configuration":  []
                 }

--- a/applications/GeoMechanicsApplication/tests/test_tetra_4n.gid/ProjectParameters.json
+++ b/applications/GeoMechanicsApplication/tests/test_tetra_4n.gid/ProjectParameters.json
@@ -80,7 +80,7 @@
                         "gidpost_flags":       {
                             "WriteDeformedMeshFlag": "WriteUndeformed",
                             "WriteConditionsFlag":   "WriteElementsOnly",
-                            "GiDPostMode":           "GiD_PostBinary",
+                            "GiDPostMode":           "GiD_PostAscii",
                             "MultiFileFlag":         "SingleFile"
                         },
                         "file_label":          "step",

--- a/applications/GeoMechanicsApplication/tests/test_triangle_10n.gid/ProjectParameters.json
+++ b/applications/GeoMechanicsApplication/tests/test_triangle_10n.gid/ProjectParameters.json
@@ -90,8 +90,8 @@
                         "node_output":         false,
                         "skin_output":         false,
                         "plane_output":        [],
-                        "nodal_results":       ["DISPLACEMENT","TOTAL_DISPLACEMENT","ROTATION","WATER_PRESSURE","REACTION","REACTION_WATER_PRESSURE","POINT_LOAD","LINE_LOAD","SURFACE_LOAD","NORMAL_CONTACT_STRESS","TANGENTIAL_CONTACT_STRESS","NORMAL_FLUID_FLUX","VOLUME_ACCELERATION","NODAL_CAUCHY_STRESS_TENSOR","NODAL_DAMAGE_VARIABLE","NODAL_JOINT_WIDTH","NODAL_JOINT_DAMAGE"],
-                        "gauss_point_results": ["MOMENT","FORCE","GREEN_LAGRANGE_STRAIN_TENSOR","CAUCHY_STRESS_TENSOR","TOTAL_STRESS_TENSOR","VON_MISES_STRESS","FLUID_FLUX_VECTOR","PERMEABILITY_MATRIX","DAMAGE_VARIABLE","JOINT_WIDTH","LOCAL_STRESS_VECTOR","LOCAL_RELATIVE_DISPLACEMENT_VECTOR","LOCAL_FLUID_FLUX_VECTOR","LOCAL_PERMEABILITY_MATRIX"]
+                        "nodal_results":       ["DISPLACEMENT"],
+                        "gauss_point_results": ["GREEN_LAGRANGE_STRAIN_TENSOR","CAUCHY_STRESS_TENSOR","TOTAL_STRESS_TENSOR"]
                     },
                     "point_data_configuration":  []
                 }

--- a/applications/GeoMechanicsApplication/tests/test_triangle_15n.gid/ProjectParameters.json
+++ b/applications/GeoMechanicsApplication/tests/test_triangle_15n.gid/ProjectParameters.json
@@ -90,8 +90,8 @@
                         "node_output":         false,
                         "skin_output":         false,
                         "plane_output":        [],
-                        "nodal_results":       ["DISPLACEMENT","TOTAL_DISPLACEMENT","ROTATION","WATER_PRESSURE","REACTION","REACTION_WATER_PRESSURE","POINT_LOAD","LINE_LOAD","SURFACE_LOAD","NORMAL_CONTACT_STRESS","TANGENTIAL_CONTACT_STRESS","NORMAL_FLUID_FLUX","VOLUME_ACCELERATION","NODAL_CAUCHY_STRESS_TENSOR","NODAL_DAMAGE_VARIABLE","NODAL_JOINT_WIDTH","NODAL_JOINT_DAMAGE"],
-                        "gauss_point_results": ["MOMENT","FORCE","GREEN_LAGRANGE_STRAIN_TENSOR","CAUCHY_STRESS_TENSOR","TOTAL_STRESS_TENSOR","VON_MISES_STRESS","FLUID_FLUX_VECTOR","PERMEABILITY_MATRIX","DAMAGE_VARIABLE","JOINT_WIDTH","LOCAL_STRESS_VECTOR","LOCAL_RELATIVE_DISPLACEMENT_VECTOR","LOCAL_FLUID_FLUX_VECTOR","LOCAL_PERMEABILITY_MATRIX"]
+                        "nodal_results":       ["DISPLACEMENT"],
+                        "gauss_point_results": ["GREEN_LAGRANGE_STRAIN_TENSOR","CAUCHY_STRESS_TENSOR","TOTAL_STRESS_TENSOR"]
                     },
                     "point_data_configuration":  []
                 }

--- a/applications/GeoMechanicsApplication/tests/test_triangle_3n.gid/ProjectParameters.json
+++ b/applications/GeoMechanicsApplication/tests/test_triangle_3n.gid/ProjectParameters.json
@@ -90,8 +90,8 @@
                         "node_output":         false,
                         "skin_output":         false,
                         "plane_output":        [],
-                        "nodal_results":       ["DISPLACEMENT","TOTAL_DISPLACEMENT","ROTATION","WATER_PRESSURE","REACTION","REACTION_WATER_PRESSURE","POINT_LOAD","LINE_LOAD","SURFACE_LOAD","NORMAL_CONTACT_STRESS","TANGENTIAL_CONTACT_STRESS","NORMAL_FLUID_FLUX","VOLUME_ACCELERATION","NODAL_CAUCHY_STRESS_TENSOR","NODAL_DAMAGE_VARIABLE","NODAL_JOINT_WIDTH","NODAL_JOINT_DAMAGE"],
-                        "gauss_point_results": ["MOMENT","FORCE","GREEN_LAGRANGE_STRAIN_TENSOR","CAUCHY_STRESS_TENSOR","TOTAL_STRESS_TENSOR","VON_MISES_STRESS","FLUID_FLUX_VECTOR","PERMEABILITY_MATRIX","DAMAGE_VARIABLE","JOINT_WIDTH","LOCAL_STRESS_VECTOR","LOCAL_RELATIVE_DISPLACEMENT_VECTOR","LOCAL_FLUID_FLUX_VECTOR","LOCAL_PERMEABILITY_MATRIX"]
+                        "nodal_results":       ["DISPLACEMENT","NODAL_CAUCHY_STRESS_TENSOR"],
+                        "gauss_point_results": ["GREEN_LAGRANGE_STRAIN_TENSOR","CAUCHY_STRESS_TENSOR","TOTAL_STRESS_TENSOR"]
                     },
                     "point_data_configuration":  []
                 }

--- a/applications/GeoMechanicsApplication/tests/test_triangle_3n.gid/ProjectParameters.json
+++ b/applications/GeoMechanicsApplication/tests/test_triangle_3n.gid/ProjectParameters.json
@@ -80,7 +80,7 @@
                         "gidpost_flags":       {
                             "WriteDeformedMeshFlag": "WriteUndeformed",
                             "WriteConditionsFlag":   "WriteElementsOnly",
-                            "GiDPostMode":           "GiD_PostBinary",
+                            "GiDPostMode":           "GiD_PostAscii",
                             "MultiFileFlag":         "SingleFile"
                         },
                         "file_label":          "step",

--- a/applications/GeoMechanicsApplication/tests/test_triangle_3n_fic.gid/ProjectParameters.json
+++ b/applications/GeoMechanicsApplication/tests/test_triangle_3n_fic.gid/ProjectParameters.json
@@ -90,8 +90,8 @@
                         "node_output":         false,
                         "skin_output":         false,
                         "plane_output":        [],
-                        "nodal_results":       ["DISPLACEMENT","TOTAL_DISPLACEMENT","ROTATION","WATER_PRESSURE","REACTION","REACTION_WATER_PRESSURE","POINT_LOAD","LINE_LOAD","SURFACE_LOAD","NORMAL_CONTACT_STRESS","TANGENTIAL_CONTACT_STRESS","NORMAL_FLUID_FLUX","VOLUME_ACCELERATION","NODAL_CAUCHY_STRESS_TENSOR","NODAL_DAMAGE_VARIABLE","NODAL_JOINT_WIDTH","NODAL_JOINT_DAMAGE"],
-                        "gauss_point_results": ["MOMENT","FORCE","GREEN_LAGRANGE_STRAIN_TENSOR","CAUCHY_STRESS_TENSOR","TOTAL_STRESS_TENSOR","VON_MISES_STRESS","FLUID_FLUX_VECTOR","PERMEABILITY_MATRIX","DAMAGE_VARIABLE","JOINT_WIDTH","LOCAL_STRESS_VECTOR","LOCAL_RELATIVE_DISPLACEMENT_VECTOR","LOCAL_FLUID_FLUX_VECTOR","LOCAL_PERMEABILITY_MATRIX"]
+                        "nodal_results":       ["DISPLACEMENT","NODAL_CAUCHY_STRESS_TENSOR"],
+                        "gauss_point_results": ["GREEN_LAGRANGE_STRAIN_TENSOR","CAUCHY_STRESS_TENSOR","TOTAL_STRESS_TENSOR"]
                     },
                     "point_data_configuration":  []
                 }

--- a/applications/GeoMechanicsApplication/tests/test_triangle_3n_fic.gid/ProjectParameters.json
+++ b/applications/GeoMechanicsApplication/tests/test_triangle_3n_fic.gid/ProjectParameters.json
@@ -80,7 +80,7 @@
                         "gidpost_flags":       {
                             "WriteDeformedMeshFlag": "WriteUndeformed",
                             "WriteConditionsFlag":   "WriteElementsOnly",
-                            "GiDPostMode":           "GiD_PostBinary",
+                            "GiDPostMode":           "GiD_PostAscii",
                             "MultiFileFlag":         "SingleFile"
                         },
                         "file_label":          "step",

--- a/applications/GeoMechanicsApplication/tests/test_triangle_3n_rebuild_0.gid/ProjectParameters.json
+++ b/applications/GeoMechanicsApplication/tests/test_triangle_3n_rebuild_0.gid/ProjectParameters.json
@@ -91,8 +91,8 @@
                         "node_output":         false,
                         "skin_output":         false,
                         "plane_output":        [],
-                        "nodal_results":       ["DISPLACEMENT","TOTAL_DISPLACEMENT","ROTATION","WATER_PRESSURE","REACTION","REACTION_WATER_PRESSURE","POINT_LOAD","LINE_LOAD","SURFACE_LOAD","NORMAL_CONTACT_STRESS","TANGENTIAL_CONTACT_STRESS","NORMAL_FLUID_FLUX","VOLUME_ACCELERATION","NODAL_CAUCHY_STRESS_TENSOR","NODAL_DAMAGE_VARIABLE","NODAL_JOINT_WIDTH","NODAL_JOINT_DAMAGE"],
-                        "gauss_point_results": ["MOMENT","FORCE","GREEN_LAGRANGE_STRAIN_TENSOR","CAUCHY_STRESS_TENSOR","TOTAL_STRESS_TENSOR","VON_MISES_STRESS","FLUID_FLUX_VECTOR","PERMEABILITY_MATRIX","DAMAGE_VARIABLE","JOINT_WIDTH","LOCAL_STRESS_VECTOR","LOCAL_RELATIVE_DISPLACEMENT_VECTOR","LOCAL_FLUID_FLUX_VECTOR","LOCAL_PERMEABILITY_MATRIX"]
+                        "nodal_results":       ["DISPLACEMENT","NODAL_CAUCHY_STRESS_TENSOR"],
+                        "gauss_point_results": ["GREEN_LAGRANGE_STRAIN_TENSOR","CAUCHY_STRESS_TENSOR","TOTAL_STRESS_TENSOR"]
                     },
                     "point_data_configuration":  []
                 }

--- a/applications/GeoMechanicsApplication/tests/test_triangle_3n_rebuild_0.gid/ProjectParameters.json
+++ b/applications/GeoMechanicsApplication/tests/test_triangle_3n_rebuild_0.gid/ProjectParameters.json
@@ -81,7 +81,7 @@
                         "gidpost_flags":       {
                             "WriteDeformedMeshFlag": "WriteUndeformed",
                             "WriteConditionsFlag":   "WriteElementsOnly",
-                            "GiDPostMode":           "GiD_PostBinary",
+                            "GiDPostMode":           "GiD_PostAscii",
                             "MultiFileFlag":         "SingleFile"
                         },
                         "file_label":          "step",

--- a/applications/GeoMechanicsApplication/tests/test_triangle_6n.gid/ProjectParameters.json
+++ b/applications/GeoMechanicsApplication/tests/test_triangle_6n.gid/ProjectParameters.json
@@ -90,8 +90,8 @@
                         "node_output":         false,
                         "skin_output":         false,
                         "plane_output":        [],
-                        "nodal_results":       ["DISPLACEMENT","TOTAL_DISPLACEMENT","ROTATION","WATER_PRESSURE","REACTION","REACTION_WATER_PRESSURE","POINT_LOAD","LINE_LOAD","SURFACE_LOAD","NORMAL_CONTACT_STRESS","TANGENTIAL_CONTACT_STRESS","NORMAL_FLUID_FLUX","VOLUME_ACCELERATION","NODAL_CAUCHY_STRESS_TENSOR","NODAL_DAMAGE_VARIABLE","NODAL_JOINT_WIDTH","NODAL_JOINT_DAMAGE"],
-                        "gauss_point_results": ["MOMENT","FORCE","GREEN_LAGRANGE_STRAIN_TENSOR","CAUCHY_STRESS_TENSOR","TOTAL_STRESS_TENSOR","VON_MISES_STRESS","FLUID_FLUX_VECTOR","PERMEABILITY_MATRIX","DAMAGE_VARIABLE","JOINT_WIDTH","LOCAL_STRESS_VECTOR","LOCAL_RELATIVE_DISPLACEMENT_VECTOR","LOCAL_FLUID_FLUX_VECTOR","LOCAL_PERMEABILITY_MATRIX"]
+                        "nodal_results":       ["DISPLACEMENT"],
+                        "gauss_point_results": ["GREEN_LAGRANGE_STRAIN_TENSOR","CAUCHY_STRESS_TENSOR","TOTAL_STRESS_TENSOR"]
                     },
                     "point_data_configuration":  []
                 }

--- a/applications/GeoMechanicsApplication/tests/test_triangle_6n.gid/ProjectParameters.json
+++ b/applications/GeoMechanicsApplication/tests/test_triangle_6n.gid/ProjectParameters.json
@@ -80,7 +80,7 @@
                         "gidpost_flags":       {
                             "WriteDeformedMeshFlag": "WriteUndeformed",
                             "WriteConditionsFlag":   "WriteElementsOnly",
-                            "GiDPostMode":           "GiD_PostBinary",
+                            "GiDPostMode":           "GiD_PostAscii",
                             "MultiFileFlag":         "SingleFile"
                         },
                         "file_label":          "step",

--- a/applications/GeoMechanicsApplication/tests/test_triangle_6n_fic.gid/ProjectParameters.json
+++ b/applications/GeoMechanicsApplication/tests/test_triangle_6n_fic.gid/ProjectParameters.json
@@ -90,8 +90,8 @@
                         "node_output":         false,
                         "skin_output":         false,
                         "plane_output":        [],
-                        "nodal_results":       ["DISPLACEMENT","TOTAL_DISPLACEMENT","ROTATION","WATER_PRESSURE","REACTION","REACTION_WATER_PRESSURE","POINT_LOAD","LINE_LOAD","SURFACE_LOAD","NORMAL_CONTACT_STRESS","TANGENTIAL_CONTACT_STRESS","NORMAL_FLUID_FLUX","VOLUME_ACCELERATION","NODAL_CAUCHY_STRESS_TENSOR","NODAL_DAMAGE_VARIABLE","NODAL_JOINT_WIDTH","NODAL_JOINT_DAMAGE"],
-                        "gauss_point_results": ["MOMENT","FORCE","GREEN_LAGRANGE_STRAIN_TENSOR","CAUCHY_STRESS_TENSOR","TOTAL_STRESS_TENSOR","VON_MISES_STRESS","FLUID_FLUX_VECTOR","PERMEABILITY_MATRIX","DAMAGE_VARIABLE","JOINT_WIDTH","LOCAL_STRESS_VECTOR","LOCAL_RELATIVE_DISPLACEMENT_VECTOR","LOCAL_FLUID_FLUX_VECTOR","LOCAL_PERMEABILITY_MATRIX"]
+                        "nodal_results":       ["DISPLACEMENT"],
+                        "gauss_point_results": ["GREEN_LAGRANGE_STRAIN_TENSOR","CAUCHY_STRESS_TENSOR","TOTAL_STRESS_TENSOR"]
                     },
                     "point_data_configuration":  []
                 }

--- a/applications/GeoMechanicsApplication/tests/test_triangle_6n_fic.gid/ProjectParameters.json
+++ b/applications/GeoMechanicsApplication/tests/test_triangle_6n_fic.gid/ProjectParameters.json
@@ -80,7 +80,7 @@
                         "gidpost_flags":       {
                             "WriteDeformedMeshFlag": "WriteUndeformed",
                             "WriteConditionsFlag":   "WriteElementsOnly",
-                            "GiDPostMode":           "GiD_PostBinary",
+                            "GiDPostMode":           "GiD_PostAscii",
                             "MultiFileFlag":         "SingleFile"
                         },
                         "file_label":          "step",


### PR DESCRIPTION
**📝 Description**
Replace the hard-coded extrapolation matrices for U-Pw small strain elements by requesting the nodal extrapolator to calculate the extrapolation matrices. Note that at present, the nodal extrapolator supports triangles and quadrilaterals only. And since the member functions of the U-Pw small strain element support linear elements only, this PR considers linear triangles and linear quadrilaterals only.

Furthermore, existing integration tests have been extended to cover the changes made.

**🆕 Changelog**
- Member functions `CalculateExtrapolationMatrix` of class `UPwSmallStrainElement` for linear triangles and linear quadrilaterals no longer return hard-coded matrices. Instead, they now use a linear nodal extrapolator to carry out their task.
- Existing test cases in file `test_elements.py` for linear elements (triangles, quadrilaterals, tetrahedra, and hexahedra) now also check the vertical stress component at the bottom nodes. For tetrahedra and hexahedra, it covers untouched code.
- All test cases in file `test_elements.py` now retrieve the displacement field at the end time from a GiD output file rather than from the analysis database. Unfortunately, I couldn't extend that approach to the stress and strain tensors, since writing such output to GiD output files is not supported for neither 15-noded triangles nor 10-noded tetrahedra.
- Cleaned up the lists of requested output items. We now only ask for the output items that we actually check. This will help with code coverage analysis, since previously code appeared to be covered whereas it wasn't. Most output items were actually calculated (which results in line hits when performing code coverage analysis), but the computed values were simply not checked. Therefore, we only ask for `NODAL_CAUCHY_STRESS_TENSOR` when the test involves linear elements.
- GiD output files have to be text files in order to process them with our test tools. Where previously binary output files were requested, we now ask for ASCII files.