### PR TITLE
[GeoMechanicsApplication] ApplyConstantPhreaticMultiLinePressureProcess checks size of coordinates

### DIFF
--- a/applications/GeoMechanicsApplication/custom_processes/apply_constant_phreatic_multi_line_pressure_process.cpp
+++ b/applications/GeoMechanicsApplication/custom_processes/apply_constant_phreatic_multi_line_pressure_process.cpp
@@ -82,8 +82,11 @@ void ApplyConstantPhreaticMultiLinePressureProcess::ValidateCoordinates(const Pa
         KRATOS_ERROR << "The Horizontal Elements Coordinates are not ordered." << rParameters << std::endl;
     }
 
-    KRATOS_ERROR_IF(GravityDirectionCoordinates().empty()) << "Coordinates in gravity direction must not be empty" << std::endl;
-    KRATOS_ERROR_IF(HorizontalDirectionCoordinates().empty()) << "Coordinates in horizontal direction must not be empty" << std::endl;
+    KRATOS_ERROR_IF(GravityDirectionCoordinates().size() < 2)
+        << "At least two coordinates in gravity direction must be given, but got "
+        << GravityDirectionCoordinates().size() << std::endl;
+    KRATOS_ERROR_IF(HorizontalDirectionCoordinates().empty())
+        << "Coordinates in horizontal direction must not be empty" << std::endl;
 }
 
 void ApplyConstantPhreaticMultiLinePressureProcess::InitializeCoordinates(const Parameters& rParameters)

--- a/applications/GeoMechanicsApplication/custom_processes/apply_constant_phreatic_multi_line_pressure_process.cpp
+++ b/applications/GeoMechanicsApplication/custom_processes/apply_constant_phreatic_multi_line_pressure_process.cpp
@@ -83,6 +83,7 @@ void ApplyConstantPhreaticMultiLinePressureProcess::ValidateCoordinates(const Pa
     }
 
     KRATOS_ERROR_IF(GravityDirectionCoordinates().empty()) << "Coordinates in gravity direction must not be empty" << std::endl;
+    KRATOS_ERROR_IF(HorizontalDirectionCoordinates().empty()) << "Coordinates in horizontal direction must not be empty" << std::endl;
 }
 
 void ApplyConstantPhreaticMultiLinePressureProcess::InitializeCoordinates(const Parameters& rParameters)

--- a/applications/GeoMechanicsApplication/custom_processes/apply_constant_phreatic_multi_line_pressure_process.cpp
+++ b/applications/GeoMechanicsApplication/custom_processes/apply_constant_phreatic_multi_line_pressure_process.cpp
@@ -85,8 +85,9 @@ void ApplyConstantPhreaticMultiLinePressureProcess::ValidateCoordinates(const Pa
     KRATOS_ERROR_IF(GravityDirectionCoordinates().size() < 2)
         << "At least two coordinates in gravity direction must be given, but got "
         << GravityDirectionCoordinates().size() << std::endl;
-    KRATOS_ERROR_IF(HorizontalDirectionCoordinates().empty())
-        << "Coordinates in horizontal direction must not be empty" << std::endl;
+    KRATOS_ERROR_IF(HorizontalDirectionCoordinates().size() < 2)
+        << "At least two coordinates in horizontal direction must be given, but got "
+        << HorizontalDirectionCoordinates().size() << std::endl;
 }
 
 void ApplyConstantPhreaticMultiLinePressureProcess::InitializeCoordinates(const Parameters& rParameters)

--- a/applications/GeoMechanicsApplication/custom_processes/apply_constant_phreatic_multi_line_pressure_process.cpp
+++ b/applications/GeoMechanicsApplication/custom_processes/apply_constant_phreatic_multi_line_pressure_process.cpp
@@ -81,6 +81,8 @@ void ApplyConstantPhreaticMultiLinePressureProcess::ValidateCoordinates(const Pa
     if (!std::is_sorted(HorizontalDirectionCoordinates().begin(), HorizontalDirectionCoordinates().end())) {
         KRATOS_ERROR << "The Horizontal Elements Coordinates are not ordered." << rParameters << std::endl;
     }
+
+    KRATOS_ERROR_IF(GravityDirectionCoordinates().empty()) << "Coordinates in gravity direction must not be empty" << std::endl;
 }
 
 void ApplyConstantPhreaticMultiLinePressureProcess::InitializeCoordinates(const Parameters& rParameters)

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/test_apply_constant_phreatic_multi_line_pressure_process.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/test_apply_constant_phreatic_multi_line_pressure_process.cpp
@@ -1,0 +1,43 @@
+// KRATOS___
+//     //   ) )
+//    //         ___      ___
+//   //  ____  //___) ) //   ) )
+//  //    / / //       //   / /
+// ((____/ / ((____   ((___/ /  MECHANICS
+//
+//  License:         geo_mechanics_application/license.txt
+//
+//  Main authors:    Anne van de Graaf
+//
+#include "containers/model.h"
+#include "custom_processes/apply_constant_phreatic_multi_line_pressure_process.h"
+#include "geo_mechanics_fast_suite.h"
+#include "includes/checks.h"
+
+using namespace Kratos;
+
+namespace Kratos::Testing
+{
+
+KRATOS_TEST_CASE_IN_SUITE(ApplyConstantPhreaticMultiLinePressureProcessThrowsWhenCoordinatesInGravityDirectionAreEmpty,
+                          KratosGeoMechanicsFastSuiteWithoutKernel)
+{
+    auto  model        = Model{};
+    auto& r_model_part = model.CreateModelPart("foo");
+
+    const auto test_parameters = Parameters{R"(
+            {
+                "model_part_name": "foo",
+                "variable_name": "WATER_PRESSURE",
+                "x_coordinates": [0.0, 1.0],
+                "y_coordinates": [],
+				"z_coordinates": [0.0, 0.0],
+                "gravity_direction": 1
+            }  )"};
+
+    KRATOS_EXPECT_EXCEPTION_IS_THROWN(
+        (ApplyConstantPhreaticMultiLinePressureProcess{r_model_part, test_parameters}),
+        "Coordinates in gravity direction must not be empty")
+}
+
+} // namespace Kratos::Testing

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/test_apply_constant_phreatic_multi_line_pressure_process.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/test_apply_constant_phreatic_multi_line_pressure_process.cpp
@@ -19,13 +19,13 @@ using namespace Kratos;
 namespace Kratos::Testing
 {
 
-KRATOS_TEST_CASE_IN_SUITE(ApplyConstantPhreaticMultiLinePressureProcessThrowsWhenCoordinatesInGravityDirectionAreEmpty,
+KRATOS_TEST_CASE_IN_SUITE(ApplyConstantPhreaticMultiLinePressureProcessThrowsWhenLessThanTwoCoordinatesInGravityDirectionAreGiven,
                           KratosGeoMechanicsFastSuiteWithoutKernel)
 {
     auto  model        = Model{};
     auto& r_model_part = model.CreateModelPart("foo");
 
-    const auto test_parameters = Parameters{R"(
+    auto test_parameters = Parameters{R"(
             {
                 "model_part_name": "foo",
                 "variable_name": "WATER_PRESSURE",
@@ -37,7 +37,13 @@ KRATOS_TEST_CASE_IN_SUITE(ApplyConstantPhreaticMultiLinePressureProcessThrowsWhe
 
     KRATOS_EXPECT_EXCEPTION_IS_THROWN(
         (ApplyConstantPhreaticMultiLinePressureProcess{r_model_part, test_parameters}),
-        "Coordinates in gravity direction must not be empty")
+        "At least two coordinates in gravity direction must be given, but got 0")
+
+    test_parameters.RemoveValue("y_coordinates");
+    test_parameters.AddVector("y_coordinates", ScalarVector{1, 0.0});
+    KRATOS_EXPECT_EXCEPTION_IS_THROWN(
+        (ApplyConstantPhreaticMultiLinePressureProcess{r_model_part, test_parameters}),
+        "At least two coordinates in gravity direction must be given, but got 1")
 }
 
 KRATOS_TEST_CASE_IN_SUITE(ApplyConstantPhreaticMultiLinePressureProcessThrowsWhenHorizontalCoordinatesAreEmpty, KratosGeoMechanicsFastSuiteWithoutKernel)

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/test_apply_constant_phreatic_multi_line_pressure_process.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/test_apply_constant_phreatic_multi_line_pressure_process.cpp
@@ -47,7 +47,7 @@ KRATOS_TEST_CASE_IN_SUITE(ApplyConstantPhreaticMultiLinePressureProcessThrowsWhe
                 "variable_name": "WATER_PRESSURE",
                 "x_coordinates": [0.0, 1.0],
                 "y_coordinates": [],
-				"z_coordinates": [0.0, 0.0],
+                "z_coordinates": [0.0, 0.0],
                 "gravity_direction": 1
             }  )"};
 
@@ -73,7 +73,7 @@ KRATOS_TEST_CASE_IN_SUITE(ApplyConstantPhreaticMultiLinePressureProcessThrowsWhe
                 "variable_name": "WATER_PRESSURE",
                 "x_coordinates": [],
                 "y_coordinates": [0.0, 1.0],
-				"z_coordinates": [0.0, 0.0],
+                "z_coordinates": [0.0, 0.0],
                 "gravity_direction": 1,
                 "out_of_plane_direction": 2
             }  )"};
@@ -100,7 +100,7 @@ KRATOS_TEST_CASE_IN_SUITE(ApplyConstantPhreaticMultiLinePressureProcessDoesNotTh
                 "variable_name": "WATER_PRESSURE",
                 "x_coordinates": [0.0, 1.0],
                 "y_coordinates": [1.0, 2.0],
-				"z_coordinates": [0.0, 0.0],
+                "z_coordinates": [0.0, 0.0],
                 "gravity_direction": 1
             }  )"};
 
@@ -125,7 +125,7 @@ KRATOS_TEST_CASE_IN_SUITE(ApplyConstantPhreaticMultiLinePressureProcessDoesNotTh
                 "variable_name": "WATER_PRESSURE",
                 "x_coordinates": [1.0, 2.0],
                 "y_coordinates": [0.0, 1.0],
-				"z_coordinates": [0.0, 0.0],
+                "z_coordinates": [0.0, 0.0],
                 "gravity_direction": 1,
                 "out_of_plane_direction": 2
             }  )"};

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/test_apply_constant_phreatic_multi_line_pressure_process.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/test_apply_constant_phreatic_multi_line_pressure_process.cpp
@@ -39,10 +39,9 @@ namespace Kratos::Testing
 KRATOS_TEST_CASE_IN_SUITE(ApplyConstantPhreaticMultiLinePressureProcessThrowsWhenLessThanTwoCoordinatesInGravityDirectionAreGiven,
                           KratosGeoMechanicsFastSuiteWithoutKernel)
 {
-    auto  model        = Model{};
-    auto& r_model_part = model.CreateModelPart("foo");
-
-    auto test_parameters = Parameters{R"(
+    auto  model           = Model{};
+    auto& r_model_part    = model.CreateModelPart("foo");
+    auto  test_parameters = Parameters{R"(
             {
                 "model_part_name": "foo",
                 "variable_name": "WATER_PRESSURE",
@@ -66,10 +65,9 @@ KRATOS_TEST_CASE_IN_SUITE(ApplyConstantPhreaticMultiLinePressureProcessThrowsWhe
 KRATOS_TEST_CASE_IN_SUITE(ApplyConstantPhreaticMultiLinePressureProcessThrowsWhenLessThanTwoCoordinatesInHorizontalDirectionAreGiven,
                           KratosGeoMechanicsFastSuiteWithoutKernel)
 {
-    auto  model        = Model{};
-    auto& r_model_part = model.CreateModelPart("foo");
-
-    auto test_parameters = Parameters{R"(
+    auto  model           = Model{};
+    auto& r_model_part    = model.CreateModelPart("foo");
+    auto  test_parameters = Parameters{R"(
             {
                 "model_part_name": "foo",
                 "variable_name": "WATER_PRESSURE",
@@ -111,6 +109,32 @@ KRATOS_TEST_CASE_IN_SUITE(ApplyConstantPhreaticMultiLinePressureProcessDoesNotTh
 
     test_parameters.RemoveValue("y_coordinates");
     test_parameters.AddVector("y_coordinates", ScalarVector{5, 1.0});
+
+    KRATOS_EXPECT_TRUE(CanCreateInstanceOfApplyConstantPhreaticMultiLinePressureProcessWithoutFailure(
+        r_model_part, test_parameters))
+}
+
+KRATOS_TEST_CASE_IN_SUITE(ApplyConstantPhreaticMultiLinePressureProcessDoesNotThrowWhenAtLeastTwoCoordinatesInHorizontalDirectionAreGiven,
+                          KratosGeoMechanicsFastSuiteWithoutKernel)
+{
+    auto  model           = Model{};
+    auto& r_model_part    = model.CreateModelPart("foo");
+    auto  test_parameters = Parameters{R"(
+            {
+                "model_part_name": "foo",
+                "variable_name": "WATER_PRESSURE",
+                "x_coordinates": [1.0, 2.0],
+                "y_coordinates": [0.0, 1.0],
+				"z_coordinates": [0.0, 0.0],
+                "gravity_direction": 1,
+                "out_of_plane_direction": 2
+            }  )"};
+
+    KRATOS_EXPECT_TRUE(CanCreateInstanceOfApplyConstantPhreaticMultiLinePressureProcessWithoutFailure(
+        r_model_part, test_parameters))
+
+    test_parameters.RemoveValue("x_coordinates");
+    test_parameters.AddVector("x_coordinates", ScalarVector{5, 1.0});
 
     KRATOS_EXPECT_TRUE(CanCreateInstanceOfApplyConstantPhreaticMultiLinePressureProcessWithoutFailure(
         r_model_part, test_parameters))

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/test_apply_constant_phreatic_multi_line_pressure_process.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/test_apply_constant_phreatic_multi_line_pressure_process.cpp
@@ -46,12 +46,13 @@ KRATOS_TEST_CASE_IN_SUITE(ApplyConstantPhreaticMultiLinePressureProcessThrowsWhe
         "At least two coordinates in gravity direction must be given, but got 1")
 }
 
-KRATOS_TEST_CASE_IN_SUITE(ApplyConstantPhreaticMultiLinePressureProcessThrowsWhenHorizontalCoordinatesAreEmpty, KratosGeoMechanicsFastSuiteWithoutKernel)
+KRATOS_TEST_CASE_IN_SUITE(ApplyConstantPhreaticMultiLinePressureProcessThrowsWhenLessThanTwoCoordinatesInHorizontalDirectionAreGiven,
+                          KratosGeoMechanicsFastSuiteWithoutKernel)
 {
     auto  model        = Model{};
     auto& r_model_part = model.CreateModelPart("foo");
 
-    const auto test_parameters = Parameters{R"(
+    auto test_parameters = Parameters{R"(
             {
                 "model_part_name": "foo",
                 "variable_name": "WATER_PRESSURE",
@@ -64,7 +65,13 @@ KRATOS_TEST_CASE_IN_SUITE(ApplyConstantPhreaticMultiLinePressureProcessThrowsWhe
 
     KRATOS_EXPECT_EXCEPTION_IS_THROWN(
         (ApplyConstantPhreaticMultiLinePressureProcess{r_model_part, test_parameters}),
-        "Coordinates in horizontal direction must not be empty")
+        "At least two coordinates in horizontal direction must be given, but got 0")
+
+    test_parameters.RemoveValue("x_coordinates");
+    test_parameters.AddVector("x_coordinates", ScalarVector{1, 0.0});
+    KRATOS_EXPECT_EXCEPTION_IS_THROWN(
+        (ApplyConstantPhreaticMultiLinePressureProcess{r_model_part, test_parameters}),
+        "At least two coordinates in horizontal direction must be given, but got 1")
 }
 
 } // namespace Kratos::Testing

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/test_apply_constant_phreatic_multi_line_pressure_process.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/test_apply_constant_phreatic_multi_line_pressure_process.cpp
@@ -40,4 +40,25 @@ KRATOS_TEST_CASE_IN_SUITE(ApplyConstantPhreaticMultiLinePressureProcessThrowsWhe
         "Coordinates in gravity direction must not be empty")
 }
 
+KRATOS_TEST_CASE_IN_SUITE(ApplyConstantPhreaticMultiLinePressureProcessThrowsWhenHorizontalCoordinatesAreEmpty, KratosGeoMechanicsFastSuiteWithoutKernel)
+{
+    auto  model        = Model{};
+    auto& r_model_part = model.CreateModelPart("foo");
+
+    const auto test_parameters = Parameters{R"(
+            {
+                "model_part_name": "foo",
+                "variable_name": "WATER_PRESSURE",
+                "x_coordinates": [],
+                "y_coordinates": [0.0, 1.0],
+				"z_coordinates": [0.0, 0.0],
+                "gravity_direction": 1,
+                "out_of_plane_direction": 2
+            }  )"};
+
+    KRATOS_EXPECT_EXCEPTION_IS_THROWN(
+        (ApplyConstantPhreaticMultiLinePressureProcess{r_model_part, test_parameters}),
+        "Coordinates in horizontal direction must not be empty")
+}
+
 } // namespace Kratos::Testing

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/test_apply_constant_phreatic_multi_line_pressure_process.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/test_apply_constant_phreatic_multi_line_pressure_process.cpp
@@ -16,6 +16,23 @@
 
 using namespace Kratos;
 
+namespace
+{
+
+bool CanCreateInstanceOfApplyConstantPhreaticMultiLinePressureProcessWithoutFailure(ModelPart& rModelPart,
+                                                                                    const Parameters& rProcessParameters)
+{
+    try {
+        ApplyConstantPhreaticMultiLinePressureProcess{rModelPart, rProcessParameters};
+    } catch (const Exception&) {
+        return false;
+    }
+
+    return true;
+}
+
+} // namespace
+
 namespace Kratos::Testing
 {
 
@@ -72,6 +89,31 @@ KRATOS_TEST_CASE_IN_SUITE(ApplyConstantPhreaticMultiLinePressureProcessThrowsWhe
     KRATOS_EXPECT_EXCEPTION_IS_THROWN(
         (ApplyConstantPhreaticMultiLinePressureProcess{r_model_part, test_parameters}),
         "At least two coordinates in horizontal direction must be given, but got 1")
+}
+
+KRATOS_TEST_CASE_IN_SUITE(ApplyConstantPhreaticMultiLinePressureProcessDoesNotThrowWhenAtLeastTwoCoordinatesInGravityDirectionAreGiven,
+                          KratosGeoMechanicsFastSuiteWithoutKernel)
+{
+    auto  model           = Model{};
+    auto& r_model_part    = model.CreateModelPart("foo");
+    auto  test_parameters = Parameters{R"(
+            {
+                "model_part_name": "foo",
+                "variable_name": "WATER_PRESSURE",
+                "x_coordinates": [0.0, 1.0],
+                "y_coordinates": [1.0, 2.0],
+				"z_coordinates": [0.0, 0.0],
+                "gravity_direction": 1
+            }  )"};
+
+    KRATOS_EXPECT_TRUE(CanCreateInstanceOfApplyConstantPhreaticMultiLinePressureProcessWithoutFailure(
+        r_model_part, test_parameters))
+
+    test_parameters.RemoveValue("y_coordinates");
+    test_parameters.AddVector("y_coordinates", ScalarVector{5, 1.0});
+
+    KRATOS_EXPECT_TRUE(CanCreateInstanceOfApplyConstantPhreaticMultiLinePressureProcessWithoutFailure(
+        r_model_part, test_parameters))
 }
 
 } // namespace Kratos::Testing


### PR DESCRIPTION
**📝 Description**
When an instance of class `ApplyConstantPhreaticMultiLinePressureProcess` is created, at least two coordinates must be supplied for both the gravity direction and the horizontal direction. Each direction is indicated by a zero-based index: 0 -> `x_coordinates`, 1 -> `y_coordinates`, and 2 -> `z_coordinates`. When there are too few coordinates supplied, an exception is thrown.
