### PR TITLE
[FastPR][Core] Remove mesh_id warnings from AssignVectorByDirection processes

### DIFF
--- a/applications/CableNetApplication/tests/sliding_element/ProjectParameters.json
+++ b/applications/CableNetApplication/tests/sliding_element/ProjectParameters.json
@@ -55,7 +55,6 @@
             "check"         : "DirectorVectorNonZero direction",
             "process_name"  : "AssignVectorByDirectionToConditionProcess",
             "Parameters"    : {
-                "mesh_id"         : 0,
                 "model_part_name" : "Structure.PointLoad3D_Load_on_points_Auto1",
                 "variable_name"   : "POINT_LOAD",
                 "modulus"         : "10000*t",

--- a/applications/MeshingApplication/tests/mmg_lagrangian_test/beam2D_line_load_test_parameters.json
+++ b/applications/MeshingApplication/tests/mmg_lagrangian_test/beam2D_line_load_test_parameters.json
@@ -54,7 +54,6 @@
             "check"         : "DirectorVectorNonZero direction",
             "process_name"  : "AssignVectorByDirectionToConditionProcess",
             "Parameters"    : {
-                "mesh_id"         : 0,
                 "model_part_name" : "Structure.LineLoad2D_Load_on_lines_Auto1",
                 "variable_name"   : "LINE_LOAD",
                 "modulus"         : -1.0e7,

--- a/applications/OptimizationApplication/tests/algorithm_tests/nlopt_tests/mma_shell_thickness_opt/primal_parameters.json
+++ b/applications/OptimizationApplication/tests/algorithm_tests/nlopt_tests/mma_shell_thickness_opt/primal_parameters.json
@@ -63,7 +63,6 @@
                 "help": "This process fixes the selected components of a given vector variable",
                 "process_name": "AssignVectorByDirectionToConditionProcess",
                 "Parameters": {
-                    "mesh_id": 0,
                     "model_part_name": "shell.surface_load",
                     "variable_name": "SURFACE_LOAD",
                     "modulus": 1000.0,

--- a/applications/OptimizationApplication/tests/mat_opt_test/primal_parameters.json
+++ b/applications/OptimizationApplication/tests/mat_opt_test/primal_parameters.json
@@ -43,7 +43,7 @@
                         "block_size": 1,
                         "use_block_matrices_if_possible" : true,
                         "coarse_enough" : 5000
-        },        
+        },
         "rotation_dofs"                   : false,
         "volumetric_strain_dofs"          : false
     },
@@ -78,7 +78,6 @@
             "help"                  : "This process fixes the selected components of a given vector variable",
             "process_name"          : "AssignVectorByDirectionToConditionProcess",
             "Parameters"            : {
-                "mesh_id"         : 0,
                 "model_part_name" : "Structure.center_load",
                 "variable_name"   : "POINT_LOAD",
                 "modulus"         : 2000,
@@ -90,7 +89,6 @@
             "help"                  : "This process fixes the selected components of a given vector variable",
             "process_name"          : "AssignVectorByDirectionToConditionProcess",
             "Parameters"            : {
-                "mesh_id"         : 0,
                 "model_part_name" : "Structure.side_loads",
                 "variable_name"   : "POINT_LOAD",
                 "modulus"         : 2000,

--- a/applications/OptimizationApplication/tests/mdpas/algorithms_test_input/unconstraint/primal_parameters.json
+++ b/applications/OptimizationApplication/tests/mdpas/algorithms_test_input/unconstraint/primal_parameters.json
@@ -103,7 +103,6 @@
                 "help": "This process fixes the selected components of a given vector variable",
                 "process_name": "AssignVectorByDirectionToConditionProcess",
                 "Parameters": {
-                    "mesh_id": 0,
                     "model_part_name": "Structure.center_load",
                     "variable_name": "POINT_LOAD",
                     "modulus": 2000,

--- a/applications/OptimizationApplication/tests/responses_tests/linear_strain_energy_test/primal_parameters.json
+++ b/applications/OptimizationApplication/tests/responses_tests/linear_strain_energy_test/primal_parameters.json
@@ -88,7 +88,6 @@
                 "help": "This process fixes the selected components of a given vector variable",
                 "process_name": "AssignVectorByDirectionToConditionProcess",
                 "Parameters": {
-                    "mesh_id": 0,
                     "model_part_name": "Structure.side_loads",
                     "variable_name": "POINT_LOAD",
                     "modulus": 2000,

--- a/applications/OptimizationApplication/tests/shell-shape-opt-test/primal_parameters.json
+++ b/applications/OptimizationApplication/tests/shell-shape-opt-test/primal_parameters.json
@@ -36,7 +36,7 @@
                                 "block_size": 1,
                                 "use_block_matrices_if_possible" : true,
                                 "coarse_enough" : 5000
-                            } 
+                            }
     },
     "processes": {
         "constraints_process_list" : [{
@@ -57,7 +57,6 @@
             "help"                  : "This process fixes the selected components of a given vector variable",
             "process_name"          : "AssignVectorByDirectionToConditionProcess",
             "Parameters"            : {
-                "mesh_id"         : 0,
                 "model_part_name" : "shell.surface_load",
                 "variable_name"   : "SURFACE_LOAD",
                 "modulus"         : 1000.0,
@@ -77,7 +76,7 @@
             }
         }]
     },
-    
+
     "output_processes" : {
         "vtk_output" : [{
             "python_module" : "vtk_output_process",

--- a/applications/OptimizationApplication/tests/shell-thickness-opt-test/primal_parameters.json
+++ b/applications/OptimizationApplication/tests/shell-thickness-opt-test/primal_parameters.json
@@ -36,7 +36,7 @@
                                 "block_size": 1,
                                 "use_block_matrices_if_possible" : true,
                                 "coarse_enough" : 5000
-                            } 
+                            }
     },
     "processes": {
         "constraints_process_list" : [{
@@ -57,7 +57,6 @@
             "help"                  : "This process fixes the selected components of a given vector variable",
             "process_name"          : "AssignVectorByDirectionToConditionProcess",
             "Parameters"            : {
-                "mesh_id"         : 0,
                 "model_part_name" : "shell.surface_load",
                 "variable_name"   : "SURFACE_LOAD",
                 "modulus"         : 1000.0,
@@ -77,7 +76,7 @@
             }
         }]
     },
-    
+
     "output_processes" : {
         "vtk_output" : [{
             "python_module" : "vtk_output_process",

--- a/applications/OptimizationApplication/tests/top_opt_test/primal_parameters.json
+++ b/applications/OptimizationApplication/tests/top_opt_test/primal_parameters.json
@@ -43,7 +43,7 @@
                         "block_size": 1,
                         "use_block_matrices_if_possible" : true,
                         "coarse_enough" : 5000
-        },        
+        },
         "rotation_dofs"                   : false,
         "volumetric_strain_dofs"          : false
     },
@@ -66,7 +66,6 @@
             "help"                  : "This process fixes the selected components of a given vector variable",
             "process_name"          : "AssignVectorByDirectionToConditionProcess",
             "Parameters"            : {
-                "mesh_id"         : 0,
                 "model_part_name" : "Structure.surface_load",
                 "variable_name"   : "SURFACE_LOAD",
                 "modulus"         : 1e-3,

--- a/applications/ShapeOptimizationApplication/tests/opt_process_eigenfrequency_test/primal_parameters.json
+++ b/applications/ShapeOptimizationApplication/tests/opt_process_eigenfrequency_test/primal_parameters.json
@@ -54,7 +54,6 @@
             "check"         : "DirectorVectorNonZero direction",
             "process_name"  : "AssignVectorByDirectionToConditionProcess",
             "Parameters"    : {
-                "mesh_id"         : 0,
                 "model_part_name" : "structure.PointLoad3D_load_point",
                 "variable_name"   : "POINT_LOAD",
                 "modulus"         : 10000.0,

--- a/applications/ShapeOptimizationApplication/tests/opt_process_min_max/primal_parameters.json
+++ b/applications/ShapeOptimizationApplication/tests/opt_process_min_max/primal_parameters.json
@@ -46,7 +46,6 @@
             "check"         : "DirectorVectorNonZero direction",
             "process_name"  : "AssignVectorByDirectionToConditionProcess",
             "Parameters"    : {
-                "mesh_id"         : 0,
                 "model_part_name" : "structure.PointLoad3D_load_point",
                 "variable_name"   : "POINT_LOAD",
                 "modulus"         : 10000.0,

--- a/applications/ShapeOptimizationApplication/tests/opt_process_shell_test/primal_parameters.json
+++ b/applications/ShapeOptimizationApplication/tests/opt_process_shell_test/primal_parameters.json
@@ -66,7 +66,6 @@
             "check"         : "DirectorVectorNonZero direction",
             "process_name"  : "AssignVectorByDirectionToConditionProcess",
             "Parameters"    : {
-                "mesh_id"         : 0,
                 "model_part_name" : "structure.load_point",
                 "variable_name"   : "POINT_LOAD",
                 "modulus"         : 1.0,

--- a/applications/ShapeOptimizationApplication/tests/opt_process_solid_test/primal_parameters.json
+++ b/applications/ShapeOptimizationApplication/tests/opt_process_solid_test/primal_parameters.json
@@ -53,7 +53,6 @@
             "check"         : "DirectorVectorNonZero direction",
             "process_name"  : "AssignVectorByDirectionToConditionProcess",
             "Parameters"    : {
-                "mesh_id"         : 0,
                 "model_part_name" : "structure.PointLoad3D_load_point",
                 "variable_name"   : "POINT_LOAD",
                 "modulus"         : 10000.0,

--- a/applications/ShapeOptimizationApplication/tests/opt_process_stress_test/primal_parameters.json
+++ b/applications/ShapeOptimizationApplication/tests/opt_process_stress_test/primal_parameters.json
@@ -46,7 +46,6 @@
             "check"         : "DirectorVectorNonZero direction",
             "process_name"  : "AssignVectorByDirectionToConditionProcess",
             "Parameters"    : {
-                "mesh_id"         : 0,
                 "model_part_name" : "structure.PointLoad3D_load_point",
                 "variable_name"   : "POINT_LOAD",
                 "modulus"         : 10000.0,

--- a/applications/ShapeOptimizationApplication/tests/opt_process_weighted_eigenfrequency_test/primal_parameters.json
+++ b/applications/ShapeOptimizationApplication/tests/opt_process_weighted_eigenfrequency_test/primal_parameters.json
@@ -54,7 +54,6 @@
             "check"         : "DirectorVectorNonZero direction",
             "process_name"  : "AssignVectorByDirectionToConditionProcess",
             "Parameters"    : {
-                "mesh_id"         : 0,
                 "model_part_name" : "structure.PointLoad3D_load_point",
                 "variable_name"   : "POINT_LOAD",
                 "modulus"         : 10000.0,

--- a/applications/ShapeOptimizationApplication/tests/sensitivity_verification_process_test/primal_parameters.json
+++ b/applications/ShapeOptimizationApplication/tests/sensitivity_verification_process_test/primal_parameters.json
@@ -47,7 +47,6 @@
             "check"         : "DirectorVectorNonZero direction",
             "process_name"  : "AssignVectorByDirectionToConditionProcess",
             "Parameters"    : {
-                "mesh_id"         : 0,
                 "model_part_name" : "structure.PointLoad3D_load_point",
                 "variable_name"   : "POINT_LOAD",
                 "modulus"         : 10000.0,

--- a/applications/StructuralMechanicsApplication/tests/adjoint_sensitivity_analysis_tests/adjoint_shell_structure_3d3n/linear_shell_test_local_stress_adjoint_parameters.json
+++ b/applications/StructuralMechanicsApplication/tests/adjoint_sensitivity_analysis_tests/adjoint_shell_structure_3d3n/linear_shell_test_local_stress_adjoint_parameters.json
@@ -65,7 +65,6 @@
         "check"         : "DirectorVectorNonZero direction",
         "process_name"  : "AssignModulusAndDirectionToConditionsProcess",
         "Parameters"    : {
-            "mesh_id"         : 0,
             "model_part_name" : "Structure.PointLoad3D_NODES",
             "variable_name"   : "POINT_LOAD",
             "modulus"         : 10.0,

--- a/applications/StructuralMechanicsApplication/tests/adjoint_sensitivity_analysis_tests/adjoint_shell_structure_3d3n/linear_shell_test_nodal_disp_adjoint_parameters.json
+++ b/applications/StructuralMechanicsApplication/tests/adjoint_sensitivity_analysis_tests/adjoint_shell_structure_3d3n/linear_shell_test_nodal_disp_adjoint_parameters.json
@@ -64,7 +64,6 @@
         "check"         : "DirectorVectorNonZero direction",
         "process_name"  : "AssignModulusAndDirectionToConditionsProcess",
         "Parameters"    : {
-            "mesh_id"         : 0,
             "model_part_name" : "Structure.PointLoad3D_NODES",
             "variable_name"   : "POINT_LOAD",
             "modulus"         : 10.0,

--- a/applications/StructuralMechanicsApplication/tests/adjoint_sensitivity_analysis_tests/adjoint_shell_structure_3d3n/linear_shell_test_parameters.json
+++ b/applications/StructuralMechanicsApplication/tests/adjoint_sensitivity_analysis_tests/adjoint_shell_structure_3d3n/linear_shell_test_parameters.json
@@ -70,7 +70,6 @@
         "check"         : "DirectorVectorNonZero direction",
         "process_name"  : "AssignModulusAndDirectionToConditionsProcess",
         "Parameters"    : {
-            "mesh_id"         : 0,
             "model_part_name" : "Structure.PointLoad3D_NODES",
             "variable_name"   : "POINT_LOAD",
             "modulus"         : 10.0,

--- a/applications/StructuralMechanicsApplication/tests/adjoint_sensitivity_analysis_tests/adjoint_shell_structure_3d3n/linear_shell_test_strain_energy_adjoint_parameters.json
+++ b/applications/StructuralMechanicsApplication/tests/adjoint_sensitivity_analysis_tests/adjoint_shell_structure_3d3n/linear_shell_test_strain_energy_adjoint_parameters.json
@@ -61,7 +61,6 @@
         "check"         : "DirectorVectorNonZero direction",
         "process_name"  : "AssignModulusAndDirectionToConditionsProcess",
         "Parameters"    : {
-            "mesh_id"         : 0,
             "model_part_name" : "Structure.PointLoad3D_NODES",
             "variable_name"   : "POINT_LOAD",
             "modulus"         : 10.0,

--- a/applications/StructuralMechanicsApplication/tests/beam_test/dynamic_3D2NBeamCr_test_parameters.json
+++ b/applications/StructuralMechanicsApplication/tests/beam_test/dynamic_3D2NBeamCr_test_parameters.json
@@ -86,7 +86,6 @@
         "kratos_module" : "KratosMultiphysics",
         "process_name"          : "AssignVectorByDirectionToConditionProcess",
         "Parameters"            : {
-            "mesh_id"         : 0,
             "model_part_name" : "Structure.PointLoad3D_neumann",
             "variable_name"   : "POINT_LOAD",
             "modulus"          : 100000,

--- a/applications/StructuralMechanicsApplication/tests/beam_test/linear_3D2NBeamCr_test_parameters.json
+++ b/applications/StructuralMechanicsApplication/tests/beam_test/linear_3D2NBeamCr_test_parameters.json
@@ -72,7 +72,6 @@
         "kratos_module" : "KratosMultiphysics",
         "process_name"          : "AssignVectorByDirectionToConditionProcess",
         "Parameters"            : {
-            "mesh_id"         : 0,
             "model_part_name" : "Structure.PointLoad3D_neumann",
             "variable_name"   : "POINT_LOAD",
             "modulus"          : 400000,

--- a/applications/StructuralMechanicsApplication/tests/beam_test/semi_rigid_linear_3D2NBeamCr_test_parameters.json
+++ b/applications/StructuralMechanicsApplication/tests/beam_test/semi_rigid_linear_3D2NBeamCr_test_parameters.json
@@ -97,7 +97,6 @@
         "kratos_module" : "KratosMultiphysics",
         "process_name"          : "AssignVectorByDirectionToConditionProcess",
         "Parameters"            : {
-            "mesh_id"         : 0,
             "model_part_name" : "Structure.PointLoad3D_neumann",
             "variable_name"   : "POINT_LOAD",
             "modulus"          : 400000,

--- a/applications/StructuralMechanicsApplication/tests/harmonic_analysis_test/harmonic_analysis_test_eigenproblem_parameters.json
+++ b/applications/StructuralMechanicsApplication/tests/harmonic_analysis_test/harmonic_analysis_test_eigenproblem_parameters.json
@@ -44,7 +44,6 @@
         "check"         : "DirectorVectorNonZero direction",
         "process_name"  : "AssignModulusAndDirectionToConditionsProcess",
         "Parameters"    : {
-            "mesh_id"         : 0,
             "model_part_name" : "Structure.PointLoad3D_load",
             "variable_name"   : "POINT_LOAD",
             "modulus"         : 1.0,

--- a/applications/StructuralMechanicsApplication/tests/harmonic_analysis_test/harmonic_analysis_test_parameters.json
+++ b/applications/StructuralMechanicsApplication/tests/harmonic_analysis_test/harmonic_analysis_test_parameters.json
@@ -55,7 +55,6 @@
         "check"         : "DirectorVectorNonZero direction",
         "process_name"  : "AssignModulusAndDirectionToConditionsProcess",
         "Parameters"    : {
-            "mesh_id"         : 0,
             "model_part_name" : "Structure.PointLoad3D_load",
             "variable_name"   : "POINT_LOAD",
             "modulus"         : 1.0,

--- a/applications/StructuralMechanicsApplication/tests/patch_test/small_disp/patch_test_2D_shear_qua_parameters.json
+++ b/applications/StructuralMechanicsApplication/tests/patch_test/small_disp/patch_test_2D_shear_qua_parameters.json
@@ -64,7 +64,6 @@
             "check"         : "DirectorVectorNonZero direction",
             "process_name"  : "AssignVectorByDirectionToConditionProcess",
             "Parameters"    : {
-                "mesh_id"         : 0,
                 "model_part_name" : "Structure.LineLoad2D_Load_on_lines_Auto2",
                 "variable_name"   : "LINE_LOAD",
                 "modulus"         : 1.0,
@@ -78,7 +77,6 @@
             "check"         : "DirectorVectorNonZero direction",
             "process_name"  : "AssignVectorByDirectionToConditionProcess",
             "Parameters"    : {
-                "mesh_id"         : 0,
                 "model_part_name" : "Structure.LineLoad2D_Load_on_lines_Auto3",
                 "variable_name"   : "LINE_LOAD",
                 "modulus"         : 1.0,
@@ -92,7 +90,6 @@
             "check"         : "DirectorVectorNonZero direction",
             "process_name"  : "AssignVectorByDirectionToConditionProcess",
             "Parameters"    : {
-                "mesh_id"         : 0,
                 "model_part_name" : "Structure.LineLoad2D_Load_on_lines_Auto4",
                 "variable_name"   : "LINE_LOAD",
                 "modulus"         : 1.0,
@@ -106,7 +103,6 @@
             "check"         : "DirectorVectorNonZero direction",
             "process_name"  : "AssignVectorByDirectionToConditionProcess",
             "Parameters"    : {
-                "mesh_id"         : 0,
                 "model_part_name" : "Structure.LineLoad2D_Load_on_lines_Auto5",
                 "variable_name"   : "LINE_LOAD",
                 "modulus"         : 1.0,

--- a/applications/StructuralMechanicsApplication/tests/patch_test/small_disp/patch_test_2D_shear_tri_parameters.json
+++ b/applications/StructuralMechanicsApplication/tests/patch_test/small_disp/patch_test_2D_shear_tri_parameters.json
@@ -63,7 +63,6 @@
         "check"         : "DirectorVectorNonZero direction",
         "process_name"  : "AssignVectorByDirectionToConditionProcess",
         "Parameters"    : {
-            "mesh_id"         : 0,
             "model_part_name" : "Structure.LineLoad2D_Load_on_lines_Auto2",
             "variable_name"   : "LINE_LOAD",
             "modulus"         : 1.0,
@@ -77,7 +76,6 @@
         "check"         : "DirectorVectorNonZero direction",
         "process_name"  : "AssignVectorByDirectionToConditionProcess",
         "Parameters"    : {
-            "mesh_id"         : 0,
             "model_part_name" : "Structure.LineLoad2D_Load_on_lines_Auto3",
             "variable_name"   : "LINE_LOAD",
             "modulus"         : 1.0,
@@ -91,7 +89,6 @@
         "check"         : "DirectorVectorNonZero direction",
         "process_name"  : "AssignVectorByDirectionToConditionProcess",
         "Parameters"    : {
-            "mesh_id"         : 0,
             "model_part_name" : "Structure.LineLoad2D_Load_on_lines_Auto4",
             "variable_name"   : "LINE_LOAD",
             "modulus"         : 1.0,
@@ -105,7 +102,6 @@
         "check"         : "DirectorVectorNonZero direction",
         "process_name"  : "AssignVectorByDirectionToConditionProcess",
         "Parameters"    : {
-            "mesh_id"         : 0,
             "model_part_name" : "Structure.LineLoad2D_Load_on_lines_Auto5",
             "variable_name"   : "LINE_LOAD",
             "modulus"         : 1.0,

--- a/applications/StructuralMechanicsApplication/tests/patch_test/small_disp/patch_test_2D_tension_qua_parameters.json
+++ b/applications/StructuralMechanicsApplication/tests/patch_test/small_disp/patch_test_2D_tension_qua_parameters.json
@@ -63,7 +63,6 @@
         "check"         : "DirectorVectorNonZero direction",
         "process_name"  : "AssignVectorByDirectionToConditionProcess",
         "Parameters"    : {
-            "mesh_id"         : 0,
             "model_part_name" : "Structure.LineLoad2D_Load_on_lines_Auto1",
             "variable_name"   : "LINE_LOAD",
             "modulus"         : 1.0,

--- a/applications/StructuralMechanicsApplication/tests/patch_test/small_disp/patch_test_2D_tension_tri_parameters.json
+++ b/applications/StructuralMechanicsApplication/tests/patch_test/small_disp/patch_test_2D_tension_tri_parameters.json
@@ -63,7 +63,6 @@
         "check"         : "DirectorVectorNonZero direction",
         "process_name"  : "AssignVectorByDirectionToConditionProcess",
         "Parameters"    : {
-            "mesh_id"         : 0,
             "model_part_name" : "Structure.LineLoad2D_Load_on_lines_Auto1",
             "variable_name"   : "LINE_LOAD",
             "modulus"         : 1.0,

--- a/applications/StructuralMechanicsApplication/tests/patch_test/small_disp/patch_test_3D_shear_hexa_parameters.json
+++ b/applications/StructuralMechanicsApplication/tests/patch_test/small_disp/patch_test_3D_shear_hexa_parameters.json
@@ -75,7 +75,6 @@
         "check"         : "DirectorVectorNonZero direction",
         "process_name"  : "AssignVectorByDirectionToConditionProcess",
         "Parameters"    : {
-            "mesh_id"         : 0,
             "model_part_name" : "Structure.SurfaceLoad3D_Load_on_surfaces_Auto2",
             "variable_name"   : "SURFACE_LOAD",
             "modulus"         : 1.0,
@@ -89,7 +88,6 @@
         "check"         : "DirectorVectorNonZero direction",
         "process_name"  : "AssignVectorByDirectionToConditionProcess",
         "Parameters"    : {
-            "mesh_id"         : 0,
             "model_part_name" : "Structure.SurfaceLoad3D_Load_on_surfaces_Auto3",
             "variable_name"   : "SURFACE_LOAD",
             "modulus"         : 1.0,
@@ -103,7 +101,6 @@
         "check"         : "DirectorVectorNonZero direction",
         "process_name"  : "AssignVectorByDirectionToConditionProcess",
         "Parameters"    : {
-            "mesh_id"         : 0,
             "model_part_name" : "Structure.SurfaceLoad3D_Load_on_surfaces_Auto4",
             "variable_name"   : "SURFACE_LOAD",
             "modulus"         : 1.0,
@@ -117,7 +114,6 @@
         "check"         : "DirectorVectorNonZero direction",
         "process_name"  : "AssignVectorByDirectionToConditionProcess",
         "Parameters"    : {
-            "mesh_id"         : 0,
             "model_part_name" : "Structure.SurfaceLoad3D_Load_on_surfaces_Auto5",
             "variable_name"   : "SURFACE_LOAD",
             "modulus"         : 1.0,

--- a/applications/StructuralMechanicsApplication/tests/patch_test/small_disp/patch_test_3D_shear_tetra_parameters.json
+++ b/applications/StructuralMechanicsApplication/tests/patch_test/small_disp/patch_test_3D_shear_tetra_parameters.json
@@ -75,7 +75,6 @@
         "check"         : "DirectorVectorNonZero direction",
         "process_name"  : "AssignVectorByDirectionToConditionProcess",
         "Parameters"    : {
-            "mesh_id"         : 0,
             "model_part_name" : "Structure.SurfaceLoad3D_Load_on_surfaces_Auto2",
             "variable_name"   : "SURFACE_LOAD",
             "modulus"         : 1.0,
@@ -89,7 +88,6 @@
         "check"         : "DirectorVectorNonZero direction",
         "process_name"  : "AssignVectorByDirectionToConditionProcess",
         "Parameters"    : {
-            "mesh_id"         : 0,
             "model_part_name" : "Structure.SurfaceLoad3D_Load_on_surfaces_Auto3",
             "variable_name"   : "SURFACE_LOAD",
             "modulus"         : 1.0,
@@ -103,7 +101,6 @@
         "check"         : "DirectorVectorNonZero direction",
         "process_name"  : "AssignVectorByDirectionToConditionProcess",
         "Parameters"    : {
-            "mesh_id"         : 0,
             "model_part_name" : "Structure.SurfaceLoad3D_Load_on_surfaces_Auto4",
             "variable_name"   : "SURFACE_LOAD",
             "modulus"         : 1.0,
@@ -117,7 +114,6 @@
         "check"         : "DirectorVectorNonZero direction",
         "process_name"  : "AssignVectorByDirectionToConditionProcess",
         "Parameters"    : {
-            "mesh_id"         : 0,
             "model_part_name" : "Structure.SurfaceLoad3D_Load_on_surfaces_Auto5",
             "variable_name"   : "SURFACE_LOAD",
             "modulus"         : 1.0,

--- a/applications/StructuralMechanicsApplication/tests/patch_test/small_disp/patch_test_3D_tension_hexa_parameters.json
+++ b/applications/StructuralMechanicsApplication/tests/patch_test/small_disp/patch_test_3D_tension_hexa_parameters.json
@@ -75,7 +75,6 @@
         "check"         : "DirectorVectorNonZero direction",
         "process_name"  : "AssignVectorByDirectionToConditionProcess",
         "Parameters"    : {
-            "mesh_id"         : 0,
             "model_part_name" : "Structure.SurfaceLoad3D_Load_on_surfaces_Auto1",
             "variable_name"   : "SURFACE_LOAD",
             "modulus"         : 1.0,

--- a/applications/StructuralMechanicsApplication/tests/patch_test/small_disp/patch_test_3D_tension_tetra_parameters.json
+++ b/applications/StructuralMechanicsApplication/tests/patch_test/small_disp/patch_test_3D_tension_tetra_parameters.json
@@ -75,7 +75,6 @@
         "check"         : "DirectorVectorNonZero direction",
         "process_name"  : "AssignVectorByDirectionToConditionProcess",
         "Parameters"    : {
-            "mesh_id"         : 0,
             "model_part_name" : "Structure.SurfaceLoad3D_Load_on_surfaces_Auto1",
             "variable_name"   : "SURFACE_LOAD",
             "modulus"         : 1.0,

--- a/applications/StructuralMechanicsApplication/tests/patch_test/small_disp_shifted_boundary/patch_test_2D_tension_tri_shifted_boundary_parameters.json
+++ b/applications/StructuralMechanicsApplication/tests/patch_test/small_disp_shifted_boundary/patch_test_2D_tension_tri_shifted_boundary_parameters.json
@@ -32,7 +32,6 @@
             "check"         : "DirectorVectorNonZero direction",
             "process_name"  : "AssignVectorByDirectionToConditionProcess",
             "Parameters"    : {
-                "mesh_id"         : 0,
                 "model_part_name" : "Structure.LineLoad2D_Load_on_lines_Auto1",
                 "variable_name"   : "LINE_LOAD",
                 "modulus"         : 1.0,

--- a/applications/StructuralMechanicsApplication/tests/patch_test/total_lagrangian/patch_test_2D_shear_qua_parameters.json
+++ b/applications/StructuralMechanicsApplication/tests/patch_test/total_lagrangian/patch_test_2D_shear_qua_parameters.json
@@ -63,7 +63,6 @@
         "check"         : "DirectorVectorNonZero direction",
         "process_name"  : "AssignVectorByDirectionToConditionProcess",
         "Parameters"    : {
-            "mesh_id"         : 0,
             "model_part_name" : "Structure.LineLoad2D_Load_on_lines_Auto2",
             "variable_name"   : "LINE_LOAD",
             "modulus"         : 1.0,
@@ -77,7 +76,6 @@
         "check"         : "DirectorVectorNonZero direction",
         "process_name"  : "AssignVectorByDirectionToConditionProcess",
         "Parameters"    : {
-            "mesh_id"         : 0,
             "model_part_name" : "Structure.LineLoad2D_Load_on_lines_Auto3",
             "variable_name"   : "LINE_LOAD",
             "modulus"         : 1.0,
@@ -91,7 +89,6 @@
         "check"         : "DirectorVectorNonZero direction",
         "process_name"  : "AssignVectorByDirectionToConditionProcess",
         "Parameters"    : {
-            "mesh_id"         : 0,
             "model_part_name" : "Structure.LineLoad2D_Load_on_lines_Auto4",
             "variable_name"   : "LINE_LOAD",
             "modulus"         : 1.0,
@@ -105,7 +102,6 @@
         "check"         : "DirectorVectorNonZero direction",
         "process_name"  : "AssignVectorByDirectionToConditionProcess",
         "Parameters"    : {
-            "mesh_id"         : 0,
             "model_part_name" : "Structure.LineLoad2D_Load_on_lines_Auto5",
             "variable_name"   : "LINE_LOAD",
             "modulus"         : 1.0,

--- a/applications/StructuralMechanicsApplication/tests/patch_test/total_lagrangian/patch_test_2D_shear_tri_parameters.json
+++ b/applications/StructuralMechanicsApplication/tests/patch_test/total_lagrangian/patch_test_2D_shear_tri_parameters.json
@@ -63,7 +63,6 @@
             "check"         : "DirectorVectorNonZero direction",
             "process_name"  : "AssignVectorByDirectionToConditionProcess",
             "Parameters"    : {
-                "mesh_id"         : 0,
                 "model_part_name" : "Structure.LineLoad2D_Load_on_lines_Auto2",
                 "variable_name"   : "LINE_LOAD",
                 "modulus"         : 1.0,
@@ -77,7 +76,6 @@
             "check"         : "DirectorVectorNonZero direction",
             "process_name"  : "AssignVectorByDirectionToConditionProcess",
             "Parameters"    : {
-                "mesh_id"         : 0,
                 "model_part_name" : "Structure.LineLoad2D_Load_on_lines_Auto3",
                 "variable_name"   : "LINE_LOAD",
                 "modulus"         : 1.0,
@@ -91,7 +89,6 @@
             "check"         : "DirectorVectorNonZero direction",
             "process_name"  : "AssignVectorByDirectionToConditionProcess",
             "Parameters"    : {
-                "mesh_id"         : 0,
                 "model_part_name" : "Structure.LineLoad2D_Load_on_lines_Auto4",
                 "variable_name"   : "LINE_LOAD",
                 "modulus"         : 1.0,
@@ -105,7 +102,6 @@
             "check"         : "DirectorVectorNonZero direction",
             "process_name"  : "AssignVectorByDirectionToConditionProcess",
             "Parameters"    : {
-                "mesh_id"         : 0,
                 "model_part_name" : "Structure.LineLoad2D_Load_on_lines_Auto5",
                 "variable_name"   : "LINE_LOAD",
                 "modulus"         : 1.0,

--- a/applications/StructuralMechanicsApplication/tests/patch_test/total_lagrangian/patch_test_2D_tension_qua_parameters.json
+++ b/applications/StructuralMechanicsApplication/tests/patch_test/total_lagrangian/patch_test_2D_tension_qua_parameters.json
@@ -63,7 +63,6 @@
         "check"         : "DirectorVectorNonZero direction",
         "process_name"  : "AssignVectorByDirectionToConditionProcess",
         "Parameters"    : {
-            "mesh_id"         : 0,
             "model_part_name" : "Structure.LineLoad2D_Load_on_lines_Auto1",
             "variable_name"   : "LINE_LOAD",
             "modulus"         : 1.0,

--- a/applications/StructuralMechanicsApplication/tests/patch_test/total_lagrangian/patch_test_2D_tension_tri_parameters.json
+++ b/applications/StructuralMechanicsApplication/tests/patch_test/total_lagrangian/patch_test_2D_tension_tri_parameters.json
@@ -63,7 +63,6 @@
         "check"         : "DirectorVectorNonZero direction",
         "process_name"  : "AssignVectorByDirectionToConditionProcess",
         "Parameters"    : {
-            "mesh_id"         : 0,
             "model_part_name" : "Structure.LineLoad2D_Load_on_lines_Auto1",
             "variable_name"   : "LINE_LOAD",
             "modulus"         : 1.0,

--- a/applications/StructuralMechanicsApplication/tests/patch_test/total_lagrangian/patch_test_3D_shear_hexa_parameters.json
+++ b/applications/StructuralMechanicsApplication/tests/patch_test/total_lagrangian/patch_test_3D_shear_hexa_parameters.json
@@ -75,7 +75,6 @@
         "check"         : "DirectorVectorNonZero direction",
         "process_name"  : "AssignVectorByDirectionToConditionProcess",
         "Parameters"    : {
-            "mesh_id"         : 0,
             "model_part_name" : "Structure.SurfaceLoad3D_Load_on_surfaces_Auto2",
             "variable_name"   : "SURFACE_LOAD",
             "modulus"         : 1.0,
@@ -89,7 +88,6 @@
         "check"         : "DirectorVectorNonZero direction",
         "process_name"  : "AssignVectorByDirectionToConditionProcess",
         "Parameters"    : {
-            "mesh_id"         : 0,
             "model_part_name" : "Structure.SurfaceLoad3D_Load_on_surfaces_Auto3",
             "variable_name"   : "SURFACE_LOAD",
             "modulus"         : 1.0,
@@ -103,7 +101,6 @@
         "check"         : "DirectorVectorNonZero direction",
         "process_name"  : "AssignVectorByDirectionToConditionProcess",
         "Parameters"    : {
-            "mesh_id"         : 0,
             "model_part_name" : "Structure.SurfaceLoad3D_Load_on_surfaces_Auto4",
             "variable_name"   : "SURFACE_LOAD",
             "modulus"         : 1.0,
@@ -117,7 +114,6 @@
         "check"         : "DirectorVectorNonZero direction",
         "process_name"  : "AssignVectorByDirectionToConditionProcess",
         "Parameters"    : {
-            "mesh_id"         : 0,
             "model_part_name" : "Structure.SurfaceLoad3D_Load_on_surfaces_Auto5",
             "variable_name"   : "SURFACE_LOAD",
             "modulus"         : 1.0,

--- a/applications/StructuralMechanicsApplication/tests/patch_test/total_lagrangian/patch_test_3D_shear_tetra_parameters.json
+++ b/applications/StructuralMechanicsApplication/tests/patch_test/total_lagrangian/patch_test_3D_shear_tetra_parameters.json
@@ -75,7 +75,6 @@
         "check"         : "DirectorVectorNonZero direction",
         "process_name"  : "AssignVectorByDirectionToConditionProcess",
         "Parameters"    : {
-            "mesh_id"         : 0,
             "model_part_name" : "Structure.SurfaceLoad3D_Load_on_surfaces_Auto2",
             "variable_name"   : "SURFACE_LOAD",
             "modulus"         : 1.0,
@@ -89,7 +88,6 @@
         "check"         : "DirectorVectorNonZero direction",
         "process_name"  : "AssignVectorByDirectionToConditionProcess",
         "Parameters"    : {
-            "mesh_id"         : 0,
             "model_part_name" : "Structure.SurfaceLoad3D_Load_on_surfaces_Auto3",
             "variable_name"   : "SURFACE_LOAD",
             "modulus"         : 1.0,
@@ -103,7 +101,6 @@
         "check"         : "DirectorVectorNonZero direction",
         "process_name"  : "AssignVectorByDirectionToConditionProcess",
         "Parameters"    : {
-            "mesh_id"         : 0,
             "model_part_name" : "Structure.SurfaceLoad3D_Load_on_surfaces_Auto4",
             "variable_name"   : "SURFACE_LOAD",
             "modulus"         : 1.0,
@@ -117,7 +114,6 @@
         "check"         : "DirectorVectorNonZero direction",
         "process_name"  : "AssignVectorByDirectionToConditionProcess",
         "Parameters"    : {
-            "mesh_id"         : 0,
             "model_part_name" : "Structure.SurfaceLoad3D_Load_on_surfaces_Auto5",
             "variable_name"   : "SURFACE_LOAD",
             "modulus"         : 1.0,

--- a/applications/StructuralMechanicsApplication/tests/patch_test/total_lagrangian/patch_test_3D_tension_hexa_parameters.json
+++ b/applications/StructuralMechanicsApplication/tests/patch_test/total_lagrangian/patch_test_3D_tension_hexa_parameters.json
@@ -75,7 +75,6 @@
         "check"         : "DirectorVectorNonZero direction",
         "process_name"  : "AssignVectorByDirectionToConditionProcess",
         "Parameters"    : {
-            "mesh_id"         : 0,
             "model_part_name" : "Structure.SurfaceLoad3D_Load_on_surfaces_Auto1",
             "variable_name"   : "SURFACE_LOAD",
             "modulus"         : 1.0,

--- a/applications/StructuralMechanicsApplication/tests/patch_test/total_lagrangian/patch_test_3D_tension_tetra_parameters.json
+++ b/applications/StructuralMechanicsApplication/tests/patch_test/total_lagrangian/patch_test_3D_tension_tetra_parameters.json
@@ -75,7 +75,6 @@
         "check"         : "DirectorVectorNonZero direction",
         "process_name"  : "AssignVectorByDirectionToConditionProcess",
         "Parameters"    : {
-            "mesh_id"         : 0,
             "model_part_name" : "Structure.SurfaceLoad3D_Load_on_surfaces_Auto1",
             "variable_name"   : "SURFACE_LOAD",
             "modulus"         : 1.0,

--- a/applications/StructuralMechanicsApplication/tests/patch_test/updated_lagrangian/patch_test_2D_shear_qua_parameters.json
+++ b/applications/StructuralMechanicsApplication/tests/patch_test/updated_lagrangian/patch_test_2D_shear_qua_parameters.json
@@ -63,7 +63,6 @@
         "check"         : "DirectorVectorNonZero direction",
         "process_name"  : "AssignVectorByDirectionToConditionProcess",
         "Parameters"    : {
-            "mesh_id"         : 0,
             "model_part_name" : "Structure.LineLoad2D_Load_on_lines_Auto2",
             "variable_name"   : "LINE_LOAD",
             "modulus"         : 1.0,
@@ -77,7 +76,6 @@
         "check"         : "DirectorVectorNonZero direction",
         "process_name"  : "AssignVectorByDirectionToConditionProcess",
         "Parameters"    : {
-            "mesh_id"         : 0,
             "model_part_name" : "Structure.LineLoad2D_Load_on_lines_Auto3",
             "variable_name"   : "LINE_LOAD",
             "modulus"         : 1.0,
@@ -91,7 +89,6 @@
         "check"         : "DirectorVectorNonZero direction",
         "process_name"  : "AssignVectorByDirectionToConditionProcess",
         "Parameters"    : {
-            "mesh_id"         : 0,
             "model_part_name" : "Structure.LineLoad2D_Load_on_lines_Auto4",
             "variable_name"   : "LINE_LOAD",
             "modulus"         : 1.0,
@@ -105,7 +102,6 @@
         "check"         : "DirectorVectorNonZero direction",
         "process_name"  : "AssignVectorByDirectionToConditionProcess",
         "Parameters"    : {
-            "mesh_id"         : 0,
             "model_part_name" : "Structure.LineLoad2D_Load_on_lines_Auto5",
             "variable_name"   : "LINE_LOAD",
             "modulus"         : 1.0,

--- a/applications/StructuralMechanicsApplication/tests/patch_test/updated_lagrangian/patch_test_2D_shear_tri_parameters.json
+++ b/applications/StructuralMechanicsApplication/tests/patch_test/updated_lagrangian/patch_test_2D_shear_tri_parameters.json
@@ -63,7 +63,6 @@
         "check"         : "DirectorVectorNonZero direction",
         "process_name"  : "AssignVectorByDirectionToConditionProcess",
         "Parameters"    : {
-            "mesh_id"         : 0,
             "model_part_name" : "Structure.LineLoad2D_Load_on_lines_Auto2",
             "variable_name"   : "LINE_LOAD",
             "modulus"         : 1.0,
@@ -77,7 +76,6 @@
         "check"         : "DirectorVectorNonZero direction",
         "process_name"  : "AssignVectorByDirectionToConditionProcess",
         "Parameters"    : {
-            "mesh_id"         : 0,
             "model_part_name" : "Structure.LineLoad2D_Load_on_lines_Auto3",
             "variable_name"   : "LINE_LOAD",
             "modulus"         : 1.0,
@@ -91,7 +89,6 @@
         "check"         : "DirectorVectorNonZero direction",
         "process_name"  : "AssignVectorByDirectionToConditionProcess",
         "Parameters"    : {
-            "mesh_id"         : 0,
             "model_part_name" : "Structure.LineLoad2D_Load_on_lines_Auto4",
             "variable_name"   : "LINE_LOAD",
             "modulus"         : 1.0,
@@ -105,7 +102,6 @@
         "check"         : "DirectorVectorNonZero direction",
         "process_name"  : "AssignVectorByDirectionToConditionProcess",
         "Parameters"    : {
-            "mesh_id"         : 0,
             "model_part_name" : "Structure.LineLoad2D_Load_on_lines_Auto5",
             "variable_name"   : "LINE_LOAD",
             "modulus"         : 1.0,

--- a/applications/StructuralMechanicsApplication/tests/patch_test/updated_lagrangian/patch_test_2D_tension_qua_parameters.json
+++ b/applications/StructuralMechanicsApplication/tests/patch_test/updated_lagrangian/patch_test_2D_tension_qua_parameters.json
@@ -63,7 +63,6 @@
         "check"         : "DirectorVectorNonZero direction",
         "process_name"  : "AssignVectorByDirectionToConditionProcess",
         "Parameters"    : {
-            "mesh_id"         : 0,
             "model_part_name" : "Structure.LineLoad2D_Load_on_lines_Auto1",
             "variable_name"   : "LINE_LOAD",
             "modulus"         : 1.0,

--- a/applications/StructuralMechanicsApplication/tests/patch_test/updated_lagrangian/patch_test_2D_tension_tri_parameters.json
+++ b/applications/StructuralMechanicsApplication/tests/patch_test/updated_lagrangian/patch_test_2D_tension_tri_parameters.json
@@ -63,7 +63,6 @@
         "check"         : "DirectorVectorNonZero direction",
         "process_name"  : "AssignVectorByDirectionToConditionProcess",
         "Parameters"    : {
-            "mesh_id"         : 0,
             "model_part_name" : "Structure.LineLoad2D_Load_on_lines_Auto1",
             "variable_name"   : "LINE_LOAD",
             "modulus"         : 1.0,

--- a/applications/StructuralMechanicsApplication/tests/patch_test/updated_lagrangian/patch_test_3D_shear_hexa_parameters.json
+++ b/applications/StructuralMechanicsApplication/tests/patch_test/updated_lagrangian/patch_test_3D_shear_hexa_parameters.json
@@ -75,7 +75,6 @@
         "check"         : "DirectorVectorNonZero direction",
         "process_name"  : "AssignVectorByDirectionToConditionProcess",
         "Parameters"    : {
-            "mesh_id"         : 0,
             "model_part_name" : "Structure.SurfaceLoad3D_Load_on_surfaces_Auto2",
             "variable_name"   : "SURFACE_LOAD",
             "modulus"         : 1.0,
@@ -89,7 +88,6 @@
         "check"         : "DirectorVectorNonZero direction",
         "process_name"  : "AssignVectorByDirectionToConditionProcess",
         "Parameters"    : {
-            "mesh_id"         : 0,
             "model_part_name" : "Structure.SurfaceLoad3D_Load_on_surfaces_Auto3",
             "variable_name"   : "SURFACE_LOAD",
             "modulus"         : 1.0,
@@ -103,7 +101,6 @@
         "check"         : "DirectorVectorNonZero direction",
         "process_name"  : "AssignVectorByDirectionToConditionProcess",
         "Parameters"    : {
-            "mesh_id"         : 0,
             "model_part_name" : "Structure.SurfaceLoad3D_Load_on_surfaces_Auto4",
             "variable_name"   : "SURFACE_LOAD",
             "modulus"         : 1.0,
@@ -117,7 +114,6 @@
         "check"         : "DirectorVectorNonZero direction",
         "process_name"  : "AssignVectorByDirectionToConditionProcess",
         "Parameters"    : {
-            "mesh_id"         : 0,
             "model_part_name" : "Structure.SurfaceLoad3D_Load_on_surfaces_Auto5",
             "variable_name"   : "SURFACE_LOAD",
             "modulus"         : 1.0,

--- a/applications/StructuralMechanicsApplication/tests/patch_test/updated_lagrangian/patch_test_3D_shear_tetra_parameters.json
+++ b/applications/StructuralMechanicsApplication/tests/patch_test/updated_lagrangian/patch_test_3D_shear_tetra_parameters.json
@@ -75,7 +75,6 @@
         "check"         : "DirectorVectorNonZero direction",
         "process_name"  : "AssignVectorByDirectionToConditionProcess",
         "Parameters"    : {
-            "mesh_id"         : 0,
             "model_part_name" : "Structure.SurfaceLoad3D_Load_on_surfaces_Auto2",
             "variable_name"   : "SURFACE_LOAD",
             "modulus"         : 1.0,
@@ -89,7 +88,6 @@
         "check"         : "DirectorVectorNonZero direction",
         "process_name"  : "AssignVectorByDirectionToConditionProcess",
         "Parameters"    : {
-            "mesh_id"         : 0,
             "model_part_name" : "Structure.SurfaceLoad3D_Load_on_surfaces_Auto3",
             "variable_name"   : "SURFACE_LOAD",
             "modulus"         : 1.0,
@@ -103,7 +101,6 @@
         "check"         : "DirectorVectorNonZero direction",
         "process_name"  : "AssignVectorByDirectionToConditionProcess",
         "Parameters"    : {
-            "mesh_id"         : 0,
             "model_part_name" : "Structure.SurfaceLoad3D_Load_on_surfaces_Auto4",
             "variable_name"   : "SURFACE_LOAD",
             "modulus"         : 1.0,
@@ -117,7 +114,6 @@
         "check"         : "DirectorVectorNonZero direction",
         "process_name"  : "AssignVectorByDirectionToConditionProcess",
         "Parameters"    : {
-            "mesh_id"         : 0,
             "model_part_name" : "Structure.SurfaceLoad3D_Load_on_surfaces_Auto5",
             "variable_name"   : "SURFACE_LOAD",
             "modulus"         : 1.0,

--- a/applications/StructuralMechanicsApplication/tests/patch_test/updated_lagrangian/patch_test_3D_tension_hexa_parameters.json
+++ b/applications/StructuralMechanicsApplication/tests/patch_test/updated_lagrangian/patch_test_3D_tension_hexa_parameters.json
@@ -75,7 +75,6 @@
         "check"         : "DirectorVectorNonZero direction",
         "process_name"  : "AssignVectorByDirectionToConditionProcess",
         "Parameters"    : {
-            "mesh_id"         : 0,
             "model_part_name" : "Structure.SurfaceLoad3D_Load_on_surfaces_Auto1",
             "variable_name"   : "SURFACE_LOAD",
             "modulus"         : 1.0,

--- a/applications/StructuralMechanicsApplication/tests/patch_test/updated_lagrangian/patch_test_3D_tension_tetra_parameters.json
+++ b/applications/StructuralMechanicsApplication/tests/patch_test/updated_lagrangian/patch_test_3D_tension_tetra_parameters.json
@@ -75,7 +75,6 @@
         "check"         : "DirectorVectorNonZero direction",
         "process_name"  : "AssignVectorByDirectionToConditionProcess",
         "Parameters"    : {
-            "mesh_id"         : 0,
             "model_part_name" : "Structure.SurfaceLoad3D_Load_on_surfaces_Auto1",
             "variable_name"   : "SURFACE_LOAD",
             "modulus"         : 1.0,

--- a/applications/StructuralMechanicsApplication/tests/response_function_tests/adjoint_max_stress_primal_parameters.json
+++ b/applications/StructuralMechanicsApplication/tests/response_function_tests/adjoint_max_stress_primal_parameters.json
@@ -47,7 +47,6 @@
             "check"         : "DirectorVectorNonZero direction",
             "process_name"  : "AssignVectorByDirectionToConditionProcess",
             "Parameters"    : {
-                "mesh_id"         : 0,
                 "model_part_name" : "cantilever_beam.PointLoad3D_load_point",
                 "variable_name"   : "POINT_LOAD",
                 "modulus"         : 10000.0,

--- a/applications/StructuralMechanicsApplication/tests/response_function_tests/rectangular_plate_parameters.json
+++ b/applications/StructuralMechanicsApplication/tests/response_function_tests/rectangular_plate_parameters.json
@@ -54,7 +54,6 @@
         "check"         : "DirectorVectorNonZero direction",
         "process_name"  : "AssignModulusAndDirectionToConditionsProcess",
         "Parameters"    : {
-            "mesh_id"         : 0,
             "model_part_name" : "rectangular_plate_structure.PointLoad3D_NODES",
             "variable_name"   : "POINT_LOAD",
             "modulus"         : 10.0,

--- a/applications/StructuralMechanicsApplication/tests/shell_test/Shell_Q4_Thin_linear_dynamic_test_parameters.json
+++ b/applications/StructuralMechanicsApplication/tests/shell_test/Shell_Q4_Thin_linear_dynamic_test_parameters.json
@@ -80,7 +80,6 @@
         "kratos_module" : "KratosMultiphysics",
         "process_name"  : "AssignVectorByDirectionToConditionsProcess",
         "Parameters"    : {
-            "mesh_id"         : 0,
             "model_part_name" : "Structure.SurfaceLoad3D_surface",
             "variable_name"   : "SURFACE_LOAD",
             "modulus"         : 0.25,

--- a/applications/StructuralMechanicsApplication/tests/shell_test/Shell_Q4_Thin_linear_static_test_parameters.json
+++ b/applications/StructuralMechanicsApplication/tests/shell_test/Shell_Q4_Thin_linear_static_test_parameters.json
@@ -111,7 +111,6 @@
         "kratos_module" : "KratosMultiphysics",
         "process_name"  : "AssignVectorByDirectionToConditionsProcess",
         "Parameters"    : {
-            "mesh_id"         : 0,
             "model_part_name" : "Structure.SurfaceLoad3D_Surface",
             "variable_name"   : "SURFACE_LOAD",
             "modulus"         : 90,

--- a/applications/StructuralMechanicsApplication/tests/shell_test/Shell_T3_Thick_linear_dynamic_test_parameters.json
+++ b/applications/StructuralMechanicsApplication/tests/shell_test/Shell_T3_Thick_linear_dynamic_test_parameters.json
@@ -80,7 +80,6 @@
         "check"         : "DirectorVectorNonZero direction",
         "process_name"  : "AssignModulusAndDirectionToConditionsProcess",
         "Parameters"    : {
-            "mesh_id"         : 0,
             "model_part_name" : "Structure.SurfaceLoad3D_surface",
             "variable_name"   : "SURFACE_LOAD",
             "modulus"         : 0.25,

--- a/applications/StructuralMechanicsApplication/tests/shell_test/Shell_T3_Thick_linear_static_test_parameters.json
+++ b/applications/StructuralMechanicsApplication/tests/shell_test/Shell_T3_Thick_linear_static_test_parameters.json
@@ -113,7 +113,6 @@
         "check"         : "DirectorVectorNonZero direction",
         "process_name"  : "AssignVectorByDirectionToConditionProcess",
         "Parameters"    : {
-            "mesh_id"         : 0,
             "model_part_name" : "Structure.SurfaceLoad3D_Surface",
             "variable_name"   : "SURFACE_LOAD",
             "modulus"         : 90,

--- a/applications/StructuralMechanicsApplication/tests/shell_test/Shell_T3_isotropic_linear_static_struct_scordelis_lo_roof_parameters.json
+++ b/applications/StructuralMechanicsApplication/tests/shell_test/Shell_T3_isotropic_linear_static_struct_scordelis_lo_roof_parameters.json
@@ -106,7 +106,6 @@
         "check"         : "DirectorVectorNonZero direction",
         "process_name"  : "AssignVectorByDirectionToConditionProcess",
         "Parameters"    : {
-            "mesh_id"         : 0,
             "model_part_name" : "Structure.SurfaceLoad3D_Surface",
             "variable_name"   : "SURFACE_LOAD",
             "modulus"         : 90.0,

--- a/applications/StructuralMechanicsApplication/tests/shell_test/Shell_T3andQ4_linear_static_struct_pinched_cylinder_parameters.json
+++ b/applications/StructuralMechanicsApplication/tests/shell_test/Shell_T3andQ4_linear_static_struct_pinched_cylinder_parameters.json
@@ -133,7 +133,6 @@
         "check"         : "DirectorVectorNonZero direction",
         "process_name"  : "AssignVectorByDirectionToConditionProcess",
         "Parameters"    : {
-            "mesh_id"         : 0,
             "model_part_name" : "Structure.PointLoad3D_Neumann",
             "variable_name"   : "POINT_LOAD",
             "modulus"         : 0.25,

--- a/applications/StructuralMechanicsApplication/tests/shell_test/Shell_T3andQ4_linear_static_struct_pinched_hemisphere_parameters.json
+++ b/applications/StructuralMechanicsApplication/tests/shell_test/Shell_T3andQ4_linear_static_struct_pinched_hemisphere_parameters.json
@@ -93,7 +93,6 @@
         "check"         : "DirectorVectorNonZero direction",
         "process_name"  : "AssignVectorByDirectionToConditionProcess",
         "Parameters"    : {
-            "mesh_id"         : 0,
             "model_part_name" : "Structure.PointLoad3D_neumann_x",
             "variable_name"   : "POINT_LOAD",
             "modulus"         : 1.0,
@@ -107,7 +106,6 @@
         "check"         : "DirectorVectorNonZero direction",
         "process_name"  : "AssignVectorByDirectionToConditionProcess",
         "Parameters"    : {
-            "mesh_id"         : 0,
             "model_part_name" : "Structure.PointLoad3D_neumann_y",
             "variable_name"   : "POINT_LOAD",
             "modulus"         : 1.0,

--- a/applications/StructuralMechanicsApplication/tests/shell_test/Shell_T3andQ4_linear_static_struct_scordelis_lo_roof_parameters.json
+++ b/applications/StructuralMechanicsApplication/tests/shell_test/Shell_T3andQ4_linear_static_struct_scordelis_lo_roof_parameters.json
@@ -106,7 +106,6 @@
         "check"         : "DirectorVectorNonZero direction",
         "process_name"  : "AssignVectorByDirectionToConditionProcess",
         "Parameters"    : {
-            "mesh_id"         : 0,
             "model_part_name" : "Structure.SurfaceLoad3D_Surface_Q4_thick",
             "variable_name"   : "SURFACE_LOAD",
             "modulus"         : 90.0,
@@ -120,7 +119,6 @@
         "check"         : "DirectorVectorNonZero direction",
         "process_name"  : "AssignVectorByDirectionToConditionProcess",
         "Parameters"    : {
-            "mesh_id"         : 0,
             "model_part_name" : "Structure.SurfaceLoad3D_Surface_Q4_thin",
             "variable_name"   : "SURFACE_LOAD",
             "modulus"         : 90.0,
@@ -134,7 +132,6 @@
         "check"         : "DirectorVectorNonZero direction",
         "process_name"  : "AssignVectorByDirectionToConditionProcess",
         "Parameters"    : {
-            "mesh_id"         : 0,
             "model_part_name" : "Structure.SurfaceLoad3D_Surface_T3_thick",
             "variable_name"   : "SURFACE_LOAD",
             "modulus"         : 90.0,
@@ -148,7 +145,6 @@
         "check"         : "DirectorVectorNonZero direction",
         "process_name"  : "AssignVectorByDirectionToConditionProcess",
         "Parameters"    : {
-            "mesh_id"         : 0,
             "model_part_name" : "Structure.SurfaceLoad3D_Surface_T3_thin",
             "variable_name"   : "SURFACE_LOAD",
             "modulus"         : 90.0,

--- a/applications/StructuralMechanicsApplication/tests/shell_test/Shell_T3andQ4_linear_static_unstruct_pinched_hemisphere_parameters.json
+++ b/applications/StructuralMechanicsApplication/tests/shell_test/Shell_T3andQ4_linear_static_unstruct_pinched_hemisphere_parameters.json
@@ -93,7 +93,6 @@
         "check"         : "DirectorVectorNonZero direction",
         "process_name"  : "AssignVectorByDirectionToConditionProcess",
         "Parameters"    : {
-            "mesh_id"         : 0,
             "model_part_name" : "Structure.PointLoad3D_neumann_x",
             "variable_name"   : "POINT_LOAD",
             "modulus"         : 1.0,
@@ -107,7 +106,6 @@
         "check"         : "DirectorVectorNonZero direction",
         "process_name"  : "AssignVectorByDirectionToConditionProcess",
         "Parameters"    : {
-            "mesh_id"         : 0,
             "model_part_name" : "Structure.PointLoad3D_neumann_y",
             "variable_name"   : "POINT_LOAD",
             "modulus"         : 1.0,

--- a/applications/StructuralMechanicsApplication/tests/shell_test/Shell_T3andQ4_linear_static_unstruct_scordelis_lo_roof_parameters.json
+++ b/applications/StructuralMechanicsApplication/tests/shell_test/Shell_T3andQ4_linear_static_unstruct_scordelis_lo_roof_parameters.json
@@ -106,7 +106,6 @@
         "check"         : "DirectorVectorNonZero direction",
         "process_name"  : "AssignVectorByDirectionToConditionProcess",
         "Parameters"    : {
-            "mesh_id"         : 0,
             "model_part_name" : "Structure.SurfaceLoad3D_Surface_Q4_thick",
             "variable_name"   : "SURFACE_LOAD",
             "modulus"         : 90.0,
@@ -120,7 +119,6 @@
         "check"         : "DirectorVectorNonZero direction",
         "process_name"  : "AssignVectorByDirectionToConditionProcess",
         "Parameters"    : {
-            "mesh_id"         : 0,
             "model_part_name" : "Structure.SurfaceLoad3D_Surface_Q4_thin",
             "variable_name"   : "SURFACE_LOAD",
             "modulus"         : 90.0,
@@ -134,7 +132,6 @@
         "check"         : "DirectorVectorNonZero direction",
         "process_name"  : "AssignVectorByDirectionToConditionProcess",
         "Parameters"    : {
-            "mesh_id"         : 0,
             "model_part_name" : "Structure.SurfaceLoad3D_Surface_T3_thick",
             "variable_name"   : "SURFACE_LOAD",
             "modulus"         : 90.0,
@@ -148,7 +145,6 @@
         "check"         : "DirectorVectorNonZero direction",
         "process_name"  : "AssignVectorByDirectionToConditionProcess",
         "Parameters"    : {
-            "mesh_id"         : 0,
             "model_part_name" : "Structure.SurfaceLoad3D_Surface_T3_thin",
             "variable_name"   : "SURFACE_LOAD",
             "modulus"         : 90.0,

--- a/applications/StructuralMechanicsApplication/tests/shell_test/Shell_T3andQ4_nonlinear_dynamic_struct_oscillating_plate_lumped_parameters.json
+++ b/applications/StructuralMechanicsApplication/tests/shell_test/Shell_T3andQ4_nonlinear_dynamic_struct_oscillating_plate_lumped_parameters.json
@@ -79,7 +79,6 @@
         "check"         : "DirectorVectorNonZero direction",
         "process_name"  : "AssignVectorByDirectionToConditionProcess",
         "Parameters"    : {
-            "mesh_id"         : 0,
             "model_part_name" : "Structure.SurfaceLoad3D_Surface_Q4_thick",
             "variable_name"   : "SURFACE_LOAD",
             "modulus"         : 0.25,
@@ -93,7 +92,6 @@
         "check"         : "DirectorVectorNonZero direction",
         "process_name"  : "AssignVectorByDirectionToConditionProcess",
         "Parameters"    : {
-            "mesh_id"         : 0,
             "model_part_name" : "Structure.SurfaceLoad3D_Surface_Q4_thin",
             "variable_name"   : "SURFACE_LOAD",
             "modulus"         : 0.25,
@@ -107,7 +105,6 @@
         "check"         : "DirectorVectorNonZero direction",
         "process_name"  : "AssignVectorByDirectionToConditionProcess",
         "Parameters"    : {
-            "mesh_id"         : 0,
             "model_part_name" : "Structure.SurfaceLoad3D_Surface_T3_thick",
             "variable_name"   : "SURFACE_LOAD",
             "modulus"         : 0.25,
@@ -121,7 +118,6 @@
         "check"         : "DirectorVectorNonZero direction",
         "process_name"  : "AssignVectorByDirectionToConditionProcess",
         "Parameters"    : {
-            "mesh_id"         : 0,
             "model_part_name" : "Structure.SurfaceLoad3D_Surface_T3_thin",
             "variable_name"   : "SURFACE_LOAD",
             "modulus"         : 0.25,

--- a/applications/StructuralMechanicsApplication/tests/shell_test/Shell_T3andQ4_nonlinear_dynamic_struct_oscillating_plate_parameters.json
+++ b/applications/StructuralMechanicsApplication/tests/shell_test/Shell_T3andQ4_nonlinear_dynamic_struct_oscillating_plate_parameters.json
@@ -79,7 +79,6 @@
         "check"         : "DirectorVectorNonZero direction",
         "process_name"  : "AssignVectorByDirectionToConditionProcess",
         "Parameters"    : {
-            "mesh_id"         : 0,
             "model_part_name" : "Structure.SurfaceLoad3D_Surface_Q4_thick",
             "variable_name"   : "SURFACE_LOAD",
             "modulus"         : 0.25,
@@ -93,7 +92,6 @@
         "check"         : "DirectorVectorNonZero direction",
         "process_name"  : "AssignVectorByDirectionToConditionProcess",
         "Parameters"    : {
-            "mesh_id"         : 0,
             "model_part_name" : "Structure.SurfaceLoad3D_Surface_Q4_thin",
             "variable_name"   : "SURFACE_LOAD",
             "modulus"         : 0.25,
@@ -107,7 +105,6 @@
         "check"         : "DirectorVectorNonZero direction",
         "process_name"  : "AssignVectorByDirectionToConditionProcess",
         "Parameters"    : {
-            "mesh_id"         : 0,
             "model_part_name" : "Structure.SurfaceLoad3D_Surface_T3_thick",
             "variable_name"   : "SURFACE_LOAD",
             "modulus"         : 0.25,
@@ -121,7 +118,6 @@
         "check"         : "DirectorVectorNonZero direction",
         "process_name"  : "AssignVectorByDirectionToConditionProcess",
         "Parameters"    : {
-            "mesh_id"         : 0,
             "model_part_name" : "Structure.SurfaceLoad3D_Surface_T3_thin",
             "variable_name"   : "SURFACE_LOAD",
             "modulus"         : 0.25,

--- a/applications/StructuralMechanicsApplication/tests/shell_test/Shell_T3andQ4_nonlinear_dynamic_unstruct_oscillating_plate_lumped_parameters.json
+++ b/applications/StructuralMechanicsApplication/tests/shell_test/Shell_T3andQ4_nonlinear_dynamic_unstruct_oscillating_plate_lumped_parameters.json
@@ -79,7 +79,6 @@
         "check"         : "DirectorVectorNonZero direction",
         "process_name"  : "AssignVectorByDirectionToConditionProcess",
         "Parameters"    : {
-            "mesh_id"         : 0,
             "model_part_name" : "Structure.SurfaceLoad3D_Surface_Q4_thick",
             "variable_name"   : "SURFACE_LOAD",
             "modulus"         : 0.25,
@@ -93,7 +92,6 @@
         "check"         : "DirectorVectorNonZero direction",
         "process_name"  : "AssignVectorByDirectionToConditionProcess",
         "Parameters"    : {
-            "mesh_id"         : 0,
             "model_part_name" : "Structure.SurfaceLoad3D_Surface_Q4_thin",
             "variable_name"   : "SURFACE_LOAD",
             "modulus"         : 0.25,
@@ -107,7 +105,6 @@
         "check"         : "DirectorVectorNonZero direction",
         "process_name"  : "AssignVectorByDirectionToConditionProcess",
         "Parameters"    : {
-            "mesh_id"         : 0,
             "model_part_name" : "Structure.SurfaceLoad3D_Surface_T3_thick",
             "variable_name"   : "SURFACE_LOAD",
             "modulus"         : 0.25,
@@ -121,7 +118,6 @@
         "check"         : "DirectorVectorNonZero direction",
         "process_name"  : "AssignVectorByDirectionToConditionProcess",
         "Parameters"    : {
-            "mesh_id"         : 0,
             "model_part_name" : "Structure.SurfaceLoad3D_Surface_T3_thin",
             "variable_name"   : "SURFACE_LOAD",
             "modulus"         : 0.25,

--- a/applications/StructuralMechanicsApplication/tests/shell_test/Shell_T3andQ4_nonlinear_dynamic_unstruct_oscillating_plate_parameters.json
+++ b/applications/StructuralMechanicsApplication/tests/shell_test/Shell_T3andQ4_nonlinear_dynamic_unstruct_oscillating_plate_parameters.json
@@ -79,7 +79,6 @@
         "check"         : "DirectorVectorNonZero direction",
         "process_name"  : "AssignVectorByDirectionToConditionProcess",
         "Parameters"    : {
-            "mesh_id"         : 0,
             "model_part_name" : "Structure.SurfaceLoad3D_Surface_Q4_thick",
             "variable_name"   : "SURFACE_LOAD",
             "modulus"         : 0.25,
@@ -93,7 +92,6 @@
         "check"         : "DirectorVectorNonZero direction",
         "process_name"  : "AssignVectorByDirectionToConditionProcess",
         "Parameters"    : {
-            "mesh_id"         : 0,
             "model_part_name" : "Structure.SurfaceLoad3D_Surface_Q4_thin",
             "variable_name"   : "SURFACE_LOAD",
             "modulus"         : 0.25,
@@ -107,7 +105,6 @@
         "check"         : "DirectorVectorNonZero direction",
         "process_name"  : "AssignVectorByDirectionToConditionProcess",
         "Parameters"    : {
-            "mesh_id"         : 0,
             "model_part_name" : "Structure.SurfaceLoad3D_Surface_T3_thick",
             "variable_name"   : "SURFACE_LOAD",
             "modulus"         : 0.25,
@@ -121,7 +118,6 @@
         "check"         : "DirectorVectorNonZero direction",
         "process_name"  : "AssignVectorByDirectionToConditionProcess",
         "Parameters"    : {
-            "mesh_id"         : 0,
             "model_part_name" : "Structure.SurfaceLoad3D_Surface_T3_thin",
             "variable_name"   : "SURFACE_LOAD",
             "modulus"         : 0.25,

--- a/applications/StructuralMechanicsApplication/tests/shell_test/Shell_T3andQ4_nonlinear_static_struct_hinged_cyl_roof_snapthrough_parameters.json
+++ b/applications/StructuralMechanicsApplication/tests/shell_test/Shell_T3andQ4_nonlinear_static_struct_hinged_cyl_roof_snapthrough_parameters.json
@@ -106,7 +106,6 @@
         "check"         : "DirectorVectorNonZero direction",
         "process_name"  : "AssignVectorByDirectionToConditionProcess",
         "Parameters"    : {
-            "mesh_id"         : 0,
             "model_part_name" : "Structure.PointLoad3D_point_load",
             "variable_name"   : "POINT_LOAD",
             "modulus"         : "750*t",

--- a/applications/StructuralMechanicsApplication/tests/shell_test/Shell_T3andQ4_nonlinear_static_unstruct_hinged_cyl_roof_snapthrough_parameters.json
+++ b/applications/StructuralMechanicsApplication/tests/shell_test/Shell_T3andQ4_nonlinear_static_unstruct_hinged_cyl_roof_snapthrough_parameters.json
@@ -106,7 +106,6 @@
         "check"         : "DirectorVectorNonZero direction",
         "process_name"  : "AssignVectorByDirectionToConditionProcess",
         "Parameters"    : {
-            "mesh_id"         : 0,
             "model_part_name" : "Structure.PointLoad3D_point_load",
             "variable_name"   : "POINT_LOAD",
             "modulus"         : "750*t",

--- a/applications/StructuralMechanicsApplication/tests/sprism_test/pan_test_parameters.json
+++ b/applications/StructuralMechanicsApplication/tests/sprism_test/pan_test_parameters.json
@@ -95,7 +95,6 @@
         "kratos_module" : "KratosMultiphysics",
         "process_name"  : "AssignVectorByDirectionToConditionProcess",
         "Parameters"    : {
-            "mesh_id"         : 0,
             "model_part_name" : "Structure.POINTLOAD_PointLoad_Auto4",
             "variable_name"   : "POINT_LOAD",
             "modulus"         : -1.0e3,

--- a/applications/StructuralMechanicsApplication/tests/truss_test/dynamic_3D2NTruss_test_parameters.json
+++ b/applications/StructuralMechanicsApplication/tests/truss_test/dynamic_3D2NTruss_test_parameters.json
@@ -64,7 +64,6 @@
         "kratos_module" : "KratosMultiphysics",
         "process_name"  : "AssignVectorByDirectionToConditionProcess",
         "Parameters"    : {
-            "mesh_id"         : 0,
             "model_part_name" : "Structure.PointLoad3D_neumann",
             "variable_name"   : "POINT_LOAD",
             "modulus"         : 10000000,

--- a/applications/StructuralMechanicsApplication/tests/truss_test/linear_3D2NTruss_test_parameters.json
+++ b/applications/StructuralMechanicsApplication/tests/truss_test/linear_3D2NTruss_test_parameters.json
@@ -61,7 +61,6 @@
         "kratos_module" : "KratosMultiphysics",
         "process_name"  : "ApplyVectorByDirectionToConditionProcess",
         "Parameters"    : {
-            "mesh_id"         : 0,
             "model_part_name" : "Structure.PointLoad3D_neumann",
             "variable_name"   : "POINT_LOAD",
             "modulus"         : 1000000,

--- a/applications/SystemIdentificationApplication/tests/auxiliary_files/damaged_problem/damaged_project_parameters.json
+++ b/applications/SystemIdentificationApplication/tests/auxiliary_files/damaged_problem/damaged_project_parameters.json
@@ -71,7 +71,6 @@
                 "check": "DirectorVectorNonZero direction",
                 "process_name": "AssignModulusAndDirectionToConditionsProcess",
                 "Parameters": {
-                    "mesh_id": 0,
                     "model_part_name": "Structure.load_boundary_P2",
                     "variable_name": "LINE_LOAD",
                     "modulus": 1000000.0,

--- a/applications/SystemIdentificationApplication/tests/auxiliary_files/system_identification/primal_project_parameters.json
+++ b/applications/SystemIdentificationApplication/tests/auxiliary_files/system_identification/primal_project_parameters.json
@@ -74,7 +74,6 @@
                 "check": "DirectorVectorNonZero direction",
                 "process_name": "AssignModulusAndDirectionToConditionsProcess",
                 "Parameters": {
-                    "mesh_id": 0,
                     "model_part_name": "Structure.load_boundary_P2",
                     "variable_name": "LINE_LOAD",
                     "modulus": 1000000.0,

--- a/applications/TopologyOptimizationApplication/tests/Small_Cantilever/ProjectParameters.json
+++ b/applications/TopologyOptimizationApplication/tests/Small_Cantilever/ProjectParameters.json
@@ -38,8 +38,8 @@
             "max_iteration"       : 500,
             "tolerance"           : 1e-8,
             "scaling"             : false
-        } 
-               
+        }
+
 
     },
     "processes"        : {
@@ -59,7 +59,6 @@
             "kratos_module" : "KratosMultiphysics",
             "check"         : "DirectorVectorNonZero direction",
             "Parameters"    : {
-           	    "mesh_id"         : 0,
            	    "model_part_name" : "Structure.PointLoad3D_load",
             	"variable_name"   : "POINT_LOAD",
             	"modulus"         : "1",

--- a/applications/TopologyOptimizationApplication/tests/Small_Cantilever_RAMP/ProjectParameters.json
+++ b/applications/TopologyOptimizationApplication/tests/Small_Cantilever_RAMP/ProjectParameters.json
@@ -38,8 +38,8 @@
             "max_iteration"       : 500,
             "tolerance"           : 1e-8,
             "scaling"             : false
-        } 
-               
+        }
+
 
     },
     "processes"        : {
@@ -59,7 +59,6 @@
             "kratos_module" : "KratosMultiphysics",
             "check"         : "DirectorVectorNonZero direction",
             "Parameters"    : {
-           	    "mesh_id"         : 0,
            	    "model_part_name" : "Structure.PointLoad3D_load",
             	"variable_name"   : "POINT_LOAD",
             	"modulus"         : "1",

--- a/kratos/python_scripts/assign_vector_by_direction_to_condition_process.py
+++ b/kratos/python_scripts/assign_vector_by_direction_to_condition_process.py
@@ -34,7 +34,6 @@ class AssignVectorByDirectionToConditionProcess(assign_vector_by_direction_to_en
         default_settings = KratosMultiphysics.Parameters("""
         {
             "help"                 : "This process sets a variable a certain scalar value in a given direction, for all the conditions belonging to a submodelpart. Uses assign_scalar_variable_to_conditions_process for each component",
-            "mesh_id"              : 0,
             "model_part_name"      : "please_specify_model_part_name",
             "variable_name"        : "SPECIFY_VARIABLE_NAME",
             "interval"             : [0.0, 1e30],
@@ -76,4 +75,4 @@ class AssignVectorByDirectionToConditionProcess(assign_vector_by_direction_to_en
                 settings["entities"] = default_settings["entities"]
 
         # Construct the base process.
-        super(AssignVectorByDirectionToConditionProcess, self).__init__(Model, settings)
+        super().__init__(Model, settings)

--- a/kratos/python_scripts/assign_vector_by_direction_to_element_process.py
+++ b/kratos/python_scripts/assign_vector_by_direction_to_element_process.py
@@ -31,7 +31,6 @@ class AssignVectorByDirectionToElementProcess(assign_vector_by_direction_to_enti
         default_settings = KratosMultiphysics.Parameters("""
         {
             "help"                 : "This process sets a variable a certain scalar value in a given direction, for all the elements belonging to a submodelpart. Uses assign_scalar_variable_to_elements_process for each component",
-            "mesh_id"              : 0,
             "model_part_name"      : "please_specify_model_part_name",
             "variable_name"        : "SPECIFY_VARIABLE_NAME",
             "interval"             : [0.0, 1e30],
@@ -73,4 +72,4 @@ class AssignVectorByDirectionToElementProcess(assign_vector_by_direction_to_enti
                 settings["entities"] = default_settings["entities"]
 
         # Construct the base process.
-        super(AssignVectorByDirectionToElementProcess, self).__init__(Model, settings)
+        super().__init__(Model, settings)

--- a/kratos/python_scripts/assign_vector_by_direction_to_entity_process.py
+++ b/kratos/python_scripts/assign_vector_by_direction_to_entity_process.py
@@ -44,12 +44,6 @@ class AssignVectorByDirectionToEntityProcess(KratosMultiphysics.Process):
         }
         """)
 
-        #TODO: Remove this after the deprecation period
-        # Check if the mesh_id is provided in the user defined settings and remove it
-        if settings.Has("mesh_id"):
-            settings.RemoveValue("mesh_id")
-            IssueDeprecationWarning("AssignVectorByDirectionProcess", "Found \'mesh_id\' in input settings. This is no longer required and can be removed.")
-
         # Trick: allow "modulus" and "direction" to be a double or a string value (otherwise the ValidateAndAssignDefaults might fail)
         if settings.Has("modulus"):
             if settings["modulus"].IsString():

--- a/kratos/python_scripts/assign_vector_by_direction_to_node_process.py
+++ b/kratos/python_scripts/assign_vector_by_direction_to_node_process.py
@@ -31,7 +31,6 @@ class AssignVectorByDirectionToNodeProcess(assign_vector_by_direction_to_entity_
         default_settings = KratosMultiphysics.Parameters("""
         {
             "help"                 : "This process sets a variable a certain scalar value in a given direction, for all the nodes belonging to a submodelpart. Uses assign_scalar_variable_to_nodes_process for each component",
-            "mesh_id"              : 0,
             "model_part_name"      : "please_specify_model_part_name",
             "variable_name"        : "SPECIFY_VARIABLE_NAME",
             "interval"             : [0.0, 1e30],
@@ -73,4 +72,4 @@ class AssignVectorByDirectionToNodeProcess(assign_vector_by_direction_to_entity_
                 settings["entities"] = default_settings["entities"]
 
         # Construct the base process.
-        super(AssignVectorByDirectionToNodeProcess, self).__init__(Model, settings)
+        super().__init__(Model, settings)


### PR DESCRIPTION
**📝 Description**
Remove the deprecated `mesh_id` from the defaults of these processes. Note that the backwards compatibility is handled in the parent class. Indeed, the defaults of these processes were always adding the `mesh_id` to be then removed in the parent class by the backwards compatibility handler (with the annoying warning message).
