### PR TITLE
Add the Calculate(NORMAL) for quadrature point curve on surface [IGA]

### DIFF
--- a/kratos/geometries/quadrature_point_curve_on_surface_geometry.h
+++ b/kratos/geometries/quadrature_point_curve_on_surface_geometry.h
@@ -154,6 +154,14 @@ public:
             rOutput[0] = mLocalTangentsU;
             rOutput[1] = mLocalTangentsV;
             rOutput[2] = 0.0;
+        } else if (rVariable == NORMAL) {
+            array_1d<double, 3> tangent_parameter_space;
+            Calculate(LOCAL_TANGENT, tangent_parameter_space);
+            double magnitude = std::sqrt(tangent_parameter_space[0] * tangent_parameter_space[0] + tangent_parameter_space[1] * tangent_parameter_space[1]);
+            
+            rOutput[0] = + tangent_parameter_space[1] / magnitude;
+            rOutput[1] = - tangent_parameter_space[0] / magnitude; 
+            rOutput[2] = 0;
         }
     }
 

--- a/kratos/geometries/quadrature_point_curve_on_surface_geometry.h
+++ b/kratos/geometries/quadrature_point_curve_on_surface_geometry.h
@@ -161,7 +161,7 @@ public:
             
             rOutput[0] = + tangent_parameter_space[1] / magnitude;
             rOutput[1] = - tangent_parameter_space[0] / magnitude; 
-            rOutput[2] = 0;
+            rOutput[2] = 0.0;
         }
     }
 


### PR DESCRIPTION
**📝 Description**

Add the Calculate(NORMAL) for _quadrature_point_curve_on_surface_geometry_

We need this additional feature in order to compute the normal for the laplacian conditions within the IGA application in 2D. 

**📝 Tags**

- IgaApplication
- geometries



@rickyaristio 
@andrewgorgi 
@rubenzorrilla 
