### PR TITLE
[Core] Optimize distance calculation in `GeometricalObjectBins`

### DIFF
--- a/kratos/spatial_containers/geometrical_objects_bins.cpp
+++ b/kratos/spatial_containers/geometrical_objects_bins.cpp
@@ -108,8 +108,9 @@ void GeometricalObjectsBins::SearchInRadius(
         }
     }
 
-    // Shrink the results
-    rResults.shrink_to_fit();
+    // NOTE: We avoid shrink_to_fit for performance potential issues
+    // // Shrink the results
+    // rResults.shrink_to_fit();
 }
 
 /***********************************************************************************/

--- a/kratos/spatial_containers/geometrical_objects_bins.cpp
+++ b/kratos/spatial_containers/geometrical_objects_bins.cpp
@@ -98,14 +98,14 @@ void GeometricalObjectsBins::SearchInRadius(
 
     // Loop over the candidates and filter by distance
     double distance = 0.0;
-    std::vector<GeometricalObject*> to_erase;
+    std::unordered_set<GeometricalObject*> to_erase;
     for(auto& r_pair : results) {
         auto p_geometrical_object = r_pair.first;
         double& r_distance = r_pair.second;
         auto& r_geometry = p_geometrical_object->GetGeometry();
         r_distance = r_geometry.CalculateDistance(rPoint, mTolerance);
         if((Radius + mTolerance) <= r_distance) {
-            to_erase.push_back(p_geometrical_object);
+            to_erase.insert(p_geometrical_object);
         }
     }
     // Erase the objects that are not within the radius

--- a/kratos/spatial_containers/geometrical_objects_bins.cpp
+++ b/kratos/spatial_containers/geometrical_objects_bins.cpp
@@ -97,7 +97,6 @@ void GeometricalObjectsBins::SearchInRadius(
     }
 
     // Loop over the candidates and filter by distance
-    double distance = 0.0;
     std::unordered_set<GeometricalObject*> to_erase;
     for(auto& r_pair : results) {
         auto p_geometrical_object = r_pair.first;

--- a/kratos/spatial_containers/geometrical_objects_bins.cpp
+++ b/kratos/spatial_containers/geometrical_objects_bins.cpp
@@ -71,24 +71,43 @@ void GeometricalObjectsBins::SearchInRadius(
     std::vector<ResultType>& rResults
     )
 {
+    // Initialize the results
     std::unordered_map<GeometricalObject*, double> results;
+    std::unordered_set<GeometricalObject*> candidates;
 
+    // Initialize the position bounds
     array_1d<std::size_t, Dimension> min_position;
     array_1d<std::size_t, Dimension> max_position;
 
+    // Calculate the position bounds
     for(unsigned int i = 0; i < Dimension; i++ ) {
         min_position[i] = CalculatePosition(rPoint[i] - Radius, i);
         max_position[i] = CalculatePosition(rPoint[i] + Radius, i) + 1;
     }
-    for(std::size_t k = min_position[2] ; k < max_position[2] ; k++){
-        for(std::size_t j = min_position[1] ; j < max_position[1] ; j++){
-            for(std::size_t i = min_position[0] ; i < max_position[0] ; i++){
-                auto& r_cell = GetCell(i,j,k);
-                SearchInRadiusInCell(r_cell, rPoint, Radius, results);
+
+    // Loop over the cells and gather candidates
+    for(std::size_t k = min_position[2]; k < max_position[2]; k++) {
+        for(std::size_t j = min_position[1]; j < max_position[1]; j++) {
+            for(std::size_t i = min_position[0]; i < max_position[0]; i++) {
+                auto& r_cell = GetCell(i, j, k);
+                for(auto p_geometrical_object : r_cell) {
+                    candidates.insert(p_geometrical_object);
+                }
             }
         }
     }
 
+    // Loop over the candidates and filter by distance
+    double distance = 0.0;
+    for(auto p_geometrical_object : candidates) {
+        auto& r_geometry = p_geometrical_object->GetGeometry();
+        distance = r_geometry.CalculateDistance(rPoint, mTolerance);
+        if((Radius + mTolerance) > distance) {
+            results.insert({p_geometrical_object, distance});
+        }
+    }
+
+    // Fill the results
     rResults.clear();
     rResults.reserve(results.size());
     for(auto& object : results){
@@ -269,26 +288,6 @@ std::size_t GeometricalObjectsBins::CalculatePosition(
                             ? mNumberOfCells[ ThisDimension ] - 1
                             : position;
     return result;
-}
-
-/***********************************************************************************/
-/***********************************************************************************/
-
-void GeometricalObjectsBins::SearchInRadiusInCell(
-    const CellType& rCell,
-    const PointType& rPoint,
-    const double Radius,
-    std::unordered_map<GeometricalObject*, double>& rResults
-    )
-{
-    double distance = 0.0;
-    for(auto p_geometrical_object : rCell){
-        auto& r_geometry = p_geometrical_object->GetGeometry();
-        distance = r_geometry.CalculateDistance(rPoint, mTolerance);
-        if((Radius + mTolerance) > distance){
-            rResults.insert({p_geometrical_object, distance});
-        }
-    }
 }
 
 /***********************************************************************************/

--- a/kratos/spatial_containers/geometrical_objects_bins.h
+++ b/kratos/spatial_containers/geometrical_objects_bins.h
@@ -516,21 +516,6 @@ private:
     }
 
     /**
-     * @brief Searchs in objects in the given cell for the ones with distance less than given radius + tolerance.
-     * @details This method takes a cell and a point and searchs in objects in the given cell for the ones with distance less than given radius + tolerance.
-     * @param rCell The cell to be checked
-     * @param rPoint The point to be checked
-     * @param Radius The radius to be considered
-     * @param rResults The results of the search
-     */
-    void SearchInRadiusInCell(
-        const CellType& rCell,
-        const PointType& rPoint,
-        const double Radius,
-        std::unordered_map<GeometricalObject*, double>& rResults
-        );
-
-    /**
      * @brief Searchs in objects in the given cell for the nearest one.
      * @details This method takes a cell and a point and searchs in objects in the given cell for the nearest one.
      * @param rCell The cell to be checked


### PR DESCRIPTION
**📝 Description**

Reopens https://github.com/KratosMultiphysics/Kratos/pull/12588 after merge conflict

This pull request introduces an optimization to the distance calculation algorithm in the `GeometricalObjectBins` class. The new approach reduces redundant distance checks for geometrical objects that span multiple cells by first gathering candidates into an unordered set and then filtering them by distance.

1. **Gather Candidates First**:
   - Modified the nested loops to gather candidates instead of directly calculating distances.

2. **Filter Candidates by Distance**:
   - After gathering candidates, a separate loop calculates distances and filters the geometrical objects based on the specified radius and tolerance.

3. **Optimization Details**:
   - Reduced redundant distance calculations by ensuring each geometrical object is processed only once.
   - Improved the efficiency of the algorithm, particularly in scenarios where geometrical objects span multiple cells.

**🆕 Changelog**

- [Refactor GeometricalObjectsBins::SearchInRadius method](https://github.com/KratosMultiphysics/Kratos/commit/64ca24898f3d9654b4caaf237cabf90a03f3e83b)
- [More refactor GeometricalObjectsBins::SearchInRadius method](https://github.com/KratosMultiphysics/Kratos/commit/cd5b11dcd8ee2f138ab52abef41514a694c3993e)
