### PR TITLE
[CORE] Move initial residual assignment

### DIFF
--- a/kratos/solving_strategies/convergencecriterias/residual_criteria.h
+++ b/kratos/solving_strategies/convergencecriterias/residual_criteria.h
@@ -191,6 +191,11 @@ public:
         const TSystemVectorType& rb
         ) override
     {
+        if (rModelPart.GetProcessInfo()[NL_ITERATION_NUMBER] <= 1) {
+            [[maybe_unused]] SizeType size_residual;
+            CalculateResidualNorm(rModelPart, mInitialResidualNorm, size_residual, rDofSet, rb);
+        }
+
         if (TSparseSpace::Size(rb) != 0) { //if we are solving for something
             // Some values
             const int rank = rModelPart.GetCommunicator().GetDataCommunicator().Rank();
@@ -245,9 +250,6 @@ public:
         if (rModelPart.NumberOfMasterSlaveConstraints() > 0) {
             ComputeActiveDofs(rModelPart, rDofSet);
         }
-
-        SizeType size_residual;
-        CalculateResidualNorm(rModelPart, mInitialResidualNorm, size_residual, rDofSet, rb);
     }
 
     /**


### PR DESCRIPTION
This PR addresses #12394 [Incorrect initial residuals for convergence criteria in CoSim]

## Changes
We moved the initial residual assignment from `InitializeSolutionStep` to `PostCriteria`with the condition that the `NL_ITERATION_NUMBER` must be 1. This ensures that the initial residual is updated between coupling iterations. 

## Drawback
The initial residual is computed after the first non-linear iteration, since we do not have access to the residual before the first one.

## Outlook
Properly solving this problem would mean adding new virtual functions for the initialization and finalization of the non linear solvers and related objects. This would be an extensive change what we are planning to implement in the future,. However, for now, this solution is less inaccurate than the current state. 

FYI @philbucher @matekelemen @sunethwarna @Igarizza  