### PR TITLE
[Core][Geometry] Refactor `HasIntersection` method for performance

### DIFF
--- a/kratos/geometries/tetrahedra_3d_4.h
+++ b/kratos/geometries/tetrahedra_3d_4.h
@@ -1395,25 +1395,48 @@ public:
         return bool (intersections.size() > 0);
     }
 
-
+    /**
+     * @brief Test intersection of the geometry with a box
+     * @details Tests the intersection of the geometry with a 3D box defined by rLowPoint and rHighPoint
+     * @param rLowPoint  Lower point of the box to test the intersection
+     * @param rHighPoint Higher point of the box to test the intersection
+     * @return True if the geometry intersects the box, False in any other case.
+     */
     bool HasIntersection(const Point& rLowPoint, const Point& rHighPoint) const override
     {
-        using Triangle3D3Type = Triangle3D3<TPointType>;
         // Check if faces have intersection
-        if(Triangle3D3Type(this->pGetPoint(0),this->pGetPoint(2), this->pGetPoint(1)).HasIntersection(rLowPoint, rHighPoint))
+        Point box_center;
+        Point box_half_size;
+
+        // Compute the center and half size of the box
+        box_center[0] = 0.5 * (rLowPoint[0] + rHighPoint[0]);
+        box_center[1] = 0.5 * (rLowPoint[1] + rHighPoint[1]);
+        box_center[2] = 0.5 * (rLowPoint[2] + rHighPoint[2]);
+
+        box_half_size[0] = 0.5 * std::abs(rHighPoint[0] - rLowPoint[0]);
+        box_half_size[1] = 0.5 * std::abs(rHighPoint[1] - rLowPoint[1]);
+        box_half_size[2] = 0.5 * std::abs(rHighPoint[2] - rLowPoint[2]);
+
+        // Check if any face intersects the box
+        const auto& r_point_0 = this->GetPoint(0);
+        const auto& r_point_1 = this->GetPoint(1);
+        const auto& r_point_2 = this->GetPoint(2);
+        const auto& r_point_3 = this->GetPoint(3);
+
+        // Check if any face intersects the box
+        if (GeometryUtils::TriangleBoxOverlap(box_center, box_half_size, r_point_0, r_point_2, r_point_1))
             return true;
-        if(Triangle3D3Type(this->pGetPoint(0),this->pGetPoint(3), this->pGetPoint(2)).HasIntersection(rLowPoint, rHighPoint))
+        if (GeometryUtils::TriangleBoxOverlap(box_center, box_half_size, r_point_0, r_point_3, r_point_2))
             return true;
-        if(Triangle3D3Type(this->pGetPoint(0),this->pGetPoint(1), this->pGetPoint(3)).HasIntersection(rLowPoint, rHighPoint))
+        if (GeometryUtils::TriangleBoxOverlap(box_center, box_half_size, r_point_0, r_point_1, r_point_3))
             return true;
-        if(Triangle3D3Type(this->pGetPoint(2),this->pGetPoint(3), this->pGetPoint(1)).HasIntersection(rLowPoint, rHighPoint))
+        if (GeometryUtils::TriangleBoxOverlap(box_center, box_half_size, r_point_2, r_point_3, r_point_1))
             return true;
 
-        // if there are no faces intersecting the box then or the box is inside the tetrahedron or it does not have intersection
+        // If there are no faces intersecting the box then or the box is inside the tetrahedron or it does not have intersection
         CoordinatesArrayType local_coordinates;
         return IsInside(rLowPoint,local_coordinates);
     }
-
 
     void SplitAndDecompose(
         const BaseType& tetra, Plane& plane,

--- a/kratos/geometries/triangle_3d_3.h
+++ b/kratos/geometries/triangle_3d_3.h
@@ -690,7 +690,7 @@ public:
         box_half_size[1] = 0.5 * std::abs(rHighPoint[1] - rLowPoint[1]);
         box_half_size[2] = 0.5 * std::abs(rHighPoint[2] - rLowPoint[2]);
 
-        return TriBoxOverlap(box_center, box_half_size);
+        return GeometryUtils::TriangleBoxOverlap(box_center, box_half_size, this->GetPoint(0), this->GetPoint(1), this->GetPoint(2));
     }
 
     /// Quality functions
@@ -2298,205 +2298,13 @@ private:
         return false;
     }
 
-    /**
-     * @see HasIntersection
-     * use separating axis theorem to test overlap between triangle and box
-     * need to test for overlap in these directions:
-     * 1) the {x,y,(z)}-directions
-     * 2) normal of the triangle
-     * 3) crossproduct (edge from tri, {x,y,z}-direction) gives 3x3=9 more tests
-     */
-    inline bool TriBoxOverlap(Point& rBoxCenter, Point& rBoxHalfSize) const
-    {
-        double abs_ex, abs_ey, abs_ez, distance;
-        array_1d<double,3 > vert0, vert1, vert2;
-        array_1d<double,3 > edge0, edge1, edge2, normal;
-        std::pair<double, double> min_max;
-
-        // move everything so that the boxcenter is in (0,0,0)
-        noalias(vert0) = this->GetPoint(0) - rBoxCenter;
-        noalias(vert1) = this->GetPoint(1) - rBoxCenter;
-        noalias(vert2) = this->GetPoint(2) - rBoxCenter;
-
-        // compute triangle edges
-        noalias(edge0) = vert1 - vert0;
-        noalias(edge1) = vert2 - vert1;
-        noalias(edge2) = vert0 - vert2;
-
-        // Bullet 3:
-        // test the 9 tests first (this was faster)
-        abs_ex = std::abs(edge0[0]);
-        abs_ey = std::abs(edge0[1]);
-        abs_ez = std::abs(edge0[2]);
-        if (AxisTestX(edge0[1],edge0[2],abs_ey,abs_ez,vert0,vert2,rBoxHalfSize)) return false;
-        if (AxisTestY(edge0[0],edge0[2],abs_ex,abs_ez,vert0,vert2,rBoxHalfSize)) return false;
-        if (AxisTestZ(edge0[0],edge0[1],abs_ex,abs_ey,vert0,vert2,rBoxHalfSize)) return false;
-
-        abs_ex = std::abs(edge1[0]);
-        abs_ey = std::abs(edge1[1]);
-        abs_ez = std::abs(edge1[2]);
-        if (AxisTestX(edge1[1],edge1[2],abs_ey,abs_ez,vert1,vert0,rBoxHalfSize)) return false;
-        if (AxisTestY(edge1[0],edge1[2],abs_ex,abs_ez,vert1,vert0,rBoxHalfSize)) return false;
-        if (AxisTestZ(edge1[0],edge1[1],abs_ex,abs_ey,vert1,vert0,rBoxHalfSize)) return false;
-
-        abs_ex = std::abs(edge2[0]);
-        abs_ey = std::abs(edge2[1]);
-        abs_ez = std::abs(edge2[2]);
-        if (AxisTestX(edge2[1],edge2[2],abs_ey,abs_ez,vert2,vert1,rBoxHalfSize)) return false;
-        if (AxisTestY(edge2[0],edge2[2],abs_ex,abs_ez,vert2,vert1,rBoxHalfSize)) return false;
-        if (AxisTestZ(edge2[0],edge2[1],abs_ex,abs_ey,vert2,vert1,rBoxHalfSize)) return false;
-
-        // Bullet 1:
-        //  first test overlap in the {x,y,z}-directions
-        //  find min, max of the triangle for each direction, and test for
-        //  overlap in that direction -- this is equivalent to testing a minimal
-        //  AABB around the triangle against the AABB
-
-        // test in X-direction
-        min_max = std::minmax({vert0[0], vert1[0], vert2[0]});
-        if(min_max.first>rBoxHalfSize[0] || min_max.second<-rBoxHalfSize[0]) return false;
-
-        // test in Y-direction
-        min_max = std::minmax({vert0[1], vert1[1], vert2[1]});
-        if(min_max.first>rBoxHalfSize[1] || min_max.second<-rBoxHalfSize[1]) return false;
-
-        // test in Z-direction
-        min_max = std::minmax({vert0[2], vert1[2], vert2[2]});
-        if(min_max.first>rBoxHalfSize[2] || min_max.second<-rBoxHalfSize[2]) return false;
-
-        // Bullet 2:
-        //  test if the box intersects the plane of the triangle
-        //  compute plane equation of triangle: normal*x+distance=0
-        MathUtils<double>::CrossProduct(normal, edge0, edge1);
-        distance = -inner_prod(normal, vert0);
-        if(!PlaneBoxOverlap(normal, distance, rBoxHalfSize)) return false;
-
-        return true;  // box and triangle overlaps
-    }
-
-    /**
-     * Check if a plane intersects a box
-     * @see TriBoxOverlap
-     *
-     * @return bool intersection flagg
-     * @param rNormal the plane normal
-     * @param rDist   distance to origin
-     * @param rMaxBox box corner from the origin
-     *
-     * plane equation: rNormal*x+rDist=0
-     */
-    bool PlaneBoxOverlap(const array_1d<double,3>& rNormal, const double& rDist, const array_1d<double,3>& rMaxBox) const
-    {
-        array_1d<double,3> vmin, vmax;
-        for(int q = 0; q < 3; q++)
-        {
-            if(rNormal[q] > 0.00)
-            {
-                vmin[q] = -rMaxBox[q];
-                vmax[q] =  rMaxBox[q];
-            }
-            else
-            {
-                vmin[q] =  rMaxBox[q];
-                vmax[q] = -rMaxBox[q];
-            }
-        }
-        if(inner_prod(rNormal, vmin) + rDist >  0.00) return false;
-        if(inner_prod(rNormal, vmax) + rDist >= 0.00) return true;
-
-        return false;
-    }
-
-    /** AxisTestX
-     * This method returns true if there is a separating axis
-     *
-     * @param rEdgeY, rEdgeZ: i-edge corrdinates
-     * @param rAbsEdgeY, rAbsEdgeZ: i-edge abs coordinates
-     * @param rVertA: i   vertex
-     * @param rVertB: i+1 vertex (omitted, proj_a = proj_b)
-     * @param rVertC: i+2 vertex
-     * @param rBoxHalfSize
-     */
-    bool AxisTestX(double& rEdgeY, double& rEdgeZ,
-                   double& rAbsEdgeY, double& rAbsEdgeZ,
-                   array_1d<double,3>& rVertA,
-                   array_1d<double,3>& rVertC,
-                   Point& rBoxHalfSize) const
-    {
-        double proj_a, proj_c, rad;
-        proj_a = rEdgeY*rVertA[2] - rEdgeZ*rVertA[1];
-        proj_c = rEdgeY*rVertC[2] - rEdgeZ*rVertC[1];
-        std::pair<double, double> min_max = std::minmax(proj_a, proj_c);
-
-        rad = rAbsEdgeZ*rBoxHalfSize[1] + rAbsEdgeY*rBoxHalfSize[2];
-
-        if(min_max.first>rad || min_max.second<-rad) return true;
-        else return false;
-    }
-
-    /** AxisTestY
-     * This method returns true if there is a separating axis
-     *
-     * @param rEdgeX, rEdgeZ: i-edge corrdinates
-     * @param rAbsEdgeX, rAbsEdgeZ: i-edge fabs coordinates
-     * @param rVertA: i   vertex
-     * @param rVertB: i+1 vertex (omitted, proj_a = proj_b)
-     * @param rVertC: i+2 vertex
-     * @param rBoxHalfSize
-     */
-    bool AxisTestY(double& rEdgeX, double& rEdgeZ,
-                   double& rAbsEdgeX, double& rAbsEdgeZ,
-                   array_1d<double,3>& rVertA,
-                   array_1d<double,3>& rVertC,
-                   Point& rBoxHalfSize) const
-    {
-        double proj_a, proj_c, rad;
-        proj_a = rEdgeZ*rVertA[0] - rEdgeX*rVertA[2];
-        proj_c = rEdgeZ*rVertC[0] - rEdgeX*rVertC[2];
-        std::pair<double, double> min_max = std::minmax(proj_a, proj_c);
-
-        rad = rAbsEdgeZ*rBoxHalfSize[0] + rAbsEdgeX*rBoxHalfSize[2];
-
-        if(min_max.first>rad || min_max.second<-rad) return true;
-        else return false;
-    }
-
-    /** AxisTestZ
-     * This method returns true if there is a separating axis
-     *
-     * @param rEdgeX, rEdgeY: i-edge corrdinates
-     * @param rAbsEdgeX, rAbsEdgeY: i-edge fabs coordinates
-     * @param rVertA: i   vertex
-     * @param rVertB: i+1 vertex (omitted, proj_a = proj_b)
-     * @param rVertC: i+2 vertex
-     * @param rBoxHalfSize
-     */
-    bool AxisTestZ(double& rEdgeX, double& rEdgeY,
-                   double& rAbsEdgeX, double& rAbsEdgeY,
-                   array_1d<double,3>& rVertA,
-                   array_1d<double,3>& rVertC,
-                   Point& rBoxHalfSize) const
-    {
-        double proj_a, proj_c, rad;
-        proj_a = rEdgeX*rVertA[1] - rEdgeY*rVertA[0];
-        proj_c = rEdgeX*rVertC[1] - rEdgeY*rVertC[0];
-        std::pair<double, double> min_max = std::minmax(proj_a, proj_c);
-
-        rad = rAbsEdgeY*rBoxHalfSize[0] + rAbsEdgeX*rBoxHalfSize[1];
-
-        if(min_max.first>rad || min_max.second<-rad) return true;
-        else return false;
-    }
-
     ///@}
     ///@name Private  Access
     ///@{
 
-
     ///@}
     ///@name Private Inquiry
     ///@{
-
 
     ///@}
     ///@name Private Friends
@@ -2508,15 +2316,12 @@ private:
     ///@name Un accessible methods
     ///@{
 
-
-
     ///@}
 }; // Class Geometry
 
 ///@}
 ///@name Type Definitions
 ///@{
-
 
 ///@}
 ///@name Input and output

--- a/kratos/utilities/geometry_utilities.cpp
+++ b/kratos/utilities/geometry_utilities.cpp
@@ -16,6 +16,7 @@
 // External includes
 
 // Project includes
+#include "utilities/math_utils.h"
 #include "utilities/geometry_utilities.h"
 #include "utilities/geometrical_projection_utilities.h"
 
@@ -523,146 +524,146 @@ void GeometryUtils::ShapeFunctionsSecondDerivativesTransformOnIntegrationPoint(
       const GeometryType::CoordinatesArrayType& rLocalIntegrationPointCoordinates,
       DenseVector<Matrix>& rResult)
 {
-        KRATOS_ERROR_IF_NOT(rGeometry.WorkingSpaceDimension() == rGeometry.LocalSpaceDimension())
-            << "\'ShapeFunctionsIntegrationPointsSecondDerivatives\' is not defined for current geometry type as second derivatives are only defined in the local space." << std::endl;
+    KRATOS_ERROR_IF_NOT(rGeometry.WorkingSpaceDimension() == rGeometry.LocalSpaceDimension())
+        << "\'ShapeFunctionsIntegrationPointsSecondDerivatives\' is not defined for current geometry type as second derivatives are only defined in the local space." << std::endl;
 
-        GeometryType::ShapeFunctionsSecondDerivativesType DDN_DDe;
-        rGeometry.ShapeFunctionsSecondDerivatives(DDN_DDe, rLocalIntegrationPointCoordinates);
+    GeometryType::ShapeFunctionsSecondDerivativesType DDN_DDe;
+    rGeometry.ShapeFunctionsSecondDerivatives(DDN_DDe, rLocalIntegrationPointCoordinates);
 
-        Matrix A, Ainv;
-        double DetA;
-        Matrix J(rGeometry.WorkingSpaceDimension(),rGeometry.LocalSpaceDimension());
-        rGeometry.Jacobian(J,rLocalIntegrationPointCoordinates);
+    Matrix A, Ainv;
+    double DetA;
+    Matrix J(rGeometry.WorkingSpaceDimension(),rGeometry.LocalSpaceDimension());
+    rGeometry.Jacobian(J,rLocalIntegrationPointCoordinates);
 
-        DenseVector<Matrix> aux(rGeometry.PointsNumber());
-        Vector rhs, result;
-        if (rGeometry.WorkingSpaceDimension() == 2){
-            rhs.resize(3, false);
-            result.resize(3, false);
+    DenseVector<Matrix> aux(rGeometry.PointsNumber());
+    Vector rhs, result;
+    if (rGeometry.WorkingSpaceDimension() == 2){
+        rhs.resize(3, false);
+        result.resize(3, false);
+    }
+    else if (rGeometry.WorkingSpaceDimension() == 3){
+        rhs.resize(6, false);
+        result.resize(6, false);
+    }
+
+    for (IndexType i = 0; i < rGeometry.PointsNumber(); i++) {
+        aux[i].resize(rGeometry.WorkingSpaceDimension(), rGeometry.WorkingSpaceDimension(), false);
+    }
+
+    if (rGeometry.WorkingSpaceDimension() == 2){
+            A.resize(3,3,false);
+            Ainv.resize(3,3,false);
+
+            A(0,0) = J(0,0) * J(0,0);
+            A(0,1) = J(1,0) * J(1,0);
+            A(0,2) = 2.0 * J(0,0) * J(1,0);
+
+            A(1,0) = J(0,1) * J(0,1);
+            A(1,1) = J(1,1) * J(1,1);
+            A(1,2) = 2.0 * J(0,1) * J(1,1);
+
+            A(2,0) = J(0,0) * J(0,1);
+            A(2,1) = J(1,0) * J(1,1);
+            A(2,2) = J(0,0) * J(1,1) + J(0,1) * J(1,0);
         }
         else if (rGeometry.WorkingSpaceDimension() == 3){
-            rhs.resize(6, false);
-            result.resize(6, false);
+            A.resize(6,6,false);
+            Ainv.resize(6,6,false);
+
+            A(0,0) = J(0,0) * J(0,0);
+            A(0,1) = J(1,0) * J(1,0);
+            A(0,2) = J(2,0) * J(2,0);
+            A(0,3) = 2.0 * J(0,0) * J(1,0);
+            A(0,4) = 2.0 * J(1,0) * J(2,0);
+            A(0,5) = 2.0 * J(0,0) * J(2,0);
+
+            A(1,0) = J(0,1) * J(0,1);
+            A(1,1) = J(1,1) * J(1,1);
+            A(1,2) = J(2,1) * J(2,1);
+            A(1,3) = 2.0 * J(0,1) * J(1,1);
+            A(1,4) = 2.0 * J(1,1) * J(2,1);
+            A(1,5) = 2.0 * J(0,1) * J(2,1);
+
+            A(2,0) = J(0,2) * J(0,2);
+            A(2,1) = J(1,2) * J(1,2);
+            A(2,2) = J(2,2) * J(2,2);
+            A(2,3) = 2.0 * J(0,2) * J(1,2);
+            A(2,4) = 2.0 * J(1,2) * J(2,2);
+            A(2,5) = 2.0 * J(0,2) * J(2,2);
+
+            A(3,0) = J(0,0) * J(0,1);
+            A(3,1) = J(1,0) * J(1,1);
+            A(3,2) = J(2,0) * J(2,1);
+            A(3,3) = J(0,0) * J(1,1) + J(0,1) * J(1,0);
+            A(3,4) = J(1,0) * J(2,1) + J(1,1) * J(2,0);
+            A(3,5) = J(0,0) * J(2,1) + J(0,1) * J(2,0);
+
+            A(4,0) = J(0,1) * J(0,2);
+            A(4,1) = J(1,1) * J(1,2);
+            A(4,2) = J(2,1) * J(2,2);
+            A(4,3) = J(0,1) * J(1,2) + J(0,2) * J(1,1);
+            A(4,4) = J(1,1) * J(2,2) + J(1,2) * J(2,1);
+            A(4,5) = J(0,1) * J(2,2) + J(0,2) * J(2,1);
+
+            A(5,0) = J(0,0) * J(0,2);
+            A(5,1) = J(1,0) * J(1,2);
+            A(5,2) = J(2,0) * J(2,2);
+            A(5,3) = J(0,0) * J(1,2) + J(0,2) * J(1,0);
+            A(5,4) = J(1,0) * J(2,2) + J(1,2) * J(2,0);
+            A(5,5) = J(0,0) * J(2,2) + J(0,2) * J(2,0);
+
         }
+        MathUtils<double>::InvertMatrix( A, Ainv, DetA );
+        DenseVector<Matrix> H(rGeometry.WorkingSpaceDimension());
+        for (unsigned int d = 0; d < rGeometry.WorkingSpaceDimension(); ++d)
+            H[d] = ZeroMatrix(rGeometry.LocalSpaceDimension(),rGeometry.LocalSpaceDimension());
 
-        for (IndexType i = 0; i < rGeometry.PointsNumber(); i++) {
-            aux[i].resize(rGeometry.WorkingSpaceDimension(), rGeometry.WorkingSpaceDimension(), false);
-        }
-
-        if (rGeometry.WorkingSpaceDimension() == 2){
-                A.resize(3,3,false);
-                Ainv.resize(3,3,false);
-
-                A(0,0) = J(0,0) * J(0,0);
-                A(0,1) = J(1,0) * J(1,0);
-                A(0,2) = 2.0 * J(0,0) * J(1,0);
-
-                A(1,0) = J(0,1) * J(0,1);
-                A(1,1) = J(1,1) * J(1,1);
-                A(1,2) = 2.0 * J(0,1) * J(1,1);
-
-                A(2,0) = J(0,0) * J(0,1);
-                A(2,1) = J(1,0) * J(1,1);
-                A(2,2) = J(0,0) * J(1,1) + J(0,1) * J(1,0);
-            }
-            else if (rGeometry.WorkingSpaceDimension() == 3){
-                A.resize(6,6,false);
-                Ainv.resize(6,6,false);
-
-                A(0,0) = J(0,0) * J(0,0);
-                A(0,1) = J(1,0) * J(1,0);
-                A(0,2) = J(2,0) * J(2,0);
-                A(0,3) = 2.0 * J(0,0) * J(1,0);
-                A(0,4) = 2.0 * J(1,0) * J(2,0);
-                A(0,5) = 2.0 * J(0,0) * J(2,0);
-
-                A(1,0) = J(0,1) * J(0,1);
-                A(1,1) = J(1,1) * J(1,1);
-                A(1,2) = J(2,1) * J(2,1);
-                A(1,3) = 2.0 * J(0,1) * J(1,1);
-                A(1,4) = 2.0 * J(1,1) * J(2,1);
-                A(1,5) = 2.0 * J(0,1) * J(2,1);
-
-                A(2,0) = J(0,2) * J(0,2);
-                A(2,1) = J(1,2) * J(1,2);
-                A(2,2) = J(2,2) * J(2,2);
-                A(2,3) = 2.0 * J(0,2) * J(1,2);
-                A(2,4) = 2.0 * J(1,2) * J(2,2);
-                A(2,5) = 2.0 * J(0,2) * J(2,2);
-
-                A(3,0) = J(0,0) * J(0,1);
-                A(3,1) = J(1,0) * J(1,1);
-                A(3,2) = J(2,0) * J(2,1);
-                A(3,3) = J(0,0) * J(1,1) + J(0,1) * J(1,0);
-                A(3,4) = J(1,0) * J(2,1) + J(1,1) * J(2,0);
-                A(3,5) = J(0,0) * J(2,1) + J(0,1) * J(2,0);
-
-                A(4,0) = J(0,1) * J(0,2);
-                A(4,1) = J(1,1) * J(1,2);
-                A(4,2) = J(2,1) * J(2,2);
-                A(4,3) = J(0,1) * J(1,2) + J(0,2) * J(1,1);
-                A(4,4) = J(1,1) * J(2,2) + J(1,2) * J(2,1);
-                A(4,5) = J(0,1) * J(2,2) + J(0,2) * J(2,1);
-
-                A(5,0) = J(0,0) * J(0,2);
-                A(5,1) = J(1,0) * J(1,2);
-                A(5,2) = J(2,0) * J(2,2);
-                A(5,3) = J(0,0) * J(1,2) + J(0,2) * J(1,0);
-                A(5,4) = J(1,0) * J(2,2) + J(1,2) * J(2,0);
-                A(5,5) = J(0,0) * J(2,2) + J(0,2) * J(2,0);
-
-            }
-            MathUtils<double>::InvertMatrix( A, Ainv, DetA );
-            DenseVector<Matrix> H(rGeometry.WorkingSpaceDimension());
-            for (unsigned int d = 0; d < rGeometry.WorkingSpaceDimension(); ++d)
-                H[d] = ZeroMatrix(rGeometry.LocalSpaceDimension(),rGeometry.LocalSpaceDimension());
-
-            for (IndexType p = 0; p < rGeometry.PointsNumber(); ++p) {
-                const array_1d<double, 3>& r_coordinates = rGeometry[p].Coordinates();
-                for (unsigned int d=0 ; d < rGeometry.WorkingSpaceDimension(); ++d){
-                    for (unsigned int e=0 ; e < rGeometry.WorkingSpaceDimension(); ++e){
-                        for (unsigned int f=0 ; f < rGeometry.WorkingSpaceDimension(); ++f){
-                            H[d](e,f) += r_coordinates[d] * DDN_DDe[p](e,f);
-                        }
+        for (IndexType p = 0; p < rGeometry.PointsNumber(); ++p) {
+            const array_1d<double, 3>& r_coordinates = rGeometry[p].Coordinates();
+            for (unsigned int d=0 ; d < rGeometry.WorkingSpaceDimension(); ++d){
+                for (unsigned int e=0 ; e < rGeometry.WorkingSpaceDimension(); ++e){
+                    for (unsigned int f=0 ; f < rGeometry.WorkingSpaceDimension(); ++f){
+                        H[d](e,f) += r_coordinates[d] * DDN_DDe[p](e,f);
                     }
                 }
             }
-            for (IndexType p = 0; p < rGeometry.PointsNumber(); ++p) {
-                if (rGeometry.WorkingSpaceDimension() == 2){
-                    rhs[0] = DDN_DDe[p](0,0) - DN_DX(p,0) * H[0](0,0) - DN_DX(p,1) * H[1](0,0);
-                    rhs[1] = DDN_DDe[p](1,1) - DN_DX(p,0) * H[0](1,1) - DN_DX(p,1) * H[1](1,1);
-                    rhs[2] = DDN_DDe[p](0,1) - DN_DX(p,0) * H[0](0,1) - DN_DX(p,1) * H[1](0,1);
-                }
-                else if (rGeometry.WorkingSpaceDimension() == 3){
-                    rhs[0] = DDN_DDe[p](0,0) - DN_DX(p,0) * H[0](0,0) - DN_DX(p,1) * H[1](0,0) - DN_DX(p,2) * H[2](0,0);
-                    rhs[1] = DDN_DDe[p](1,1) - DN_DX(p,0) * H[0](1,1) - DN_DX(p,1) * H[1](1,1) - DN_DX(p,2) * H[2](0,0);
-                    rhs[2] = DDN_DDe[p](2,2) - DN_DX(p,0) * H[0](2,2) - DN_DX(p,1) * H[1](2,2) - DN_DX(p,2) * H[2](2,2);
-                    rhs[3] = DDN_DDe[p](0,1) - DN_DX(p,0) * H[0](0,1) - DN_DX(p,1) * H[1](0,1) - DN_DX(p,2) * H[2](0,1);
-                    rhs[4] = DDN_DDe[p](1,2) - DN_DX(p,0) * H[0](1,2) - DN_DX(p,1) * H[1](1,2) - DN_DX(p,2) * H[2](1,2);
-                    rhs[5] = DDN_DDe[p](0,2) - DN_DX(p,0) * H[0](0,2) - DN_DX(p,1) * H[1](0,2) - DN_DX(p,2) * H[2](0,2);
-                }
-
-                aux[p].resize(rGeometry.WorkingSpaceDimension(), rGeometry.WorkingSpaceDimension(), false );
-
-                noalias(result) = prod(Ainv, rhs);
-
-                aux[p](0,0) = result[0];
-                aux[p](1,1) = result[1];
-                if (rGeometry.WorkingSpaceDimension() == 2){
-                    aux[p](0,1) = result[2];
-                    aux[p](1,0) = result[2];
-                }
-                else if (rGeometry.WorkingSpaceDimension() == 3){
-                    aux[p](2,2) = result[2];
-                    aux[p](0,1) = result[3];
-                    aux[p](1,0) = result[3];
-                    aux[p](0,2) = result[5];
-                    aux[p](2,0) = result[5];
-                    aux[p](2,1) = result[4];
-                    aux[p](1,2) = result[4];
-                }
+        }
+        for (IndexType p = 0; p < rGeometry.PointsNumber(); ++p) {
+            if (rGeometry.WorkingSpaceDimension() == 2){
+                rhs[0] = DDN_DDe[p](0,0) - DN_DX(p,0) * H[0](0,0) - DN_DX(p,1) * H[1](0,0);
+                rhs[1] = DDN_DDe[p](1,1) - DN_DX(p,0) * H[0](1,1) - DN_DX(p,1) * H[1](1,1);
+                rhs[2] = DDN_DDe[p](0,1) - DN_DX(p,0) * H[0](0,1) - DN_DX(p,1) * H[1](0,1);
             }
-            noalias(rResult) = aux;
+            else if (rGeometry.WorkingSpaceDimension() == 3){
+                rhs[0] = DDN_DDe[p](0,0) - DN_DX(p,0) * H[0](0,0) - DN_DX(p,1) * H[1](0,0) - DN_DX(p,2) * H[2](0,0);
+                rhs[1] = DDN_DDe[p](1,1) - DN_DX(p,0) * H[0](1,1) - DN_DX(p,1) * H[1](1,1) - DN_DX(p,2) * H[2](0,0);
+                rhs[2] = DDN_DDe[p](2,2) - DN_DX(p,0) * H[0](2,2) - DN_DX(p,1) * H[1](2,2) - DN_DX(p,2) * H[2](2,2);
+                rhs[3] = DDN_DDe[p](0,1) - DN_DX(p,0) * H[0](0,1) - DN_DX(p,1) * H[1](0,1) - DN_DX(p,2) * H[2](0,1);
+                rhs[4] = DDN_DDe[p](1,2) - DN_DX(p,0) * H[0](1,2) - DN_DX(p,1) * H[1](1,2) - DN_DX(p,2) * H[2](1,2);
+                rhs[5] = DDN_DDe[p](0,2) - DN_DX(p,0) * H[0](0,2) - DN_DX(p,1) * H[1](0,2) - DN_DX(p,2) * H[2](0,2);
+            }
+
+            aux[p].resize(rGeometry.WorkingSpaceDimension(), rGeometry.WorkingSpaceDimension(), false );
+
+            noalias(result) = prod(Ainv, rhs);
+
+            aux[p](0,0) = result[0];
+            aux[p](1,1) = result[1];
+            if (rGeometry.WorkingSpaceDimension() == 2){
+                aux[p](0,1) = result[2];
+                aux[p](1,0) = result[2];
+            }
+            else if (rGeometry.WorkingSpaceDimension() == 3){
+                aux[p](2,2) = result[2];
+                aux[p](0,1) = result[3];
+                aux[p](1,0) = result[3];
+                aux[p](0,2) = result[5];
+                aux[p](2,0) = result[5];
+                aux[p](2,1) = result[4];
+                aux[p](1,2) = result[4];
+            }
+        }
+        noalias(rResult) = aux;
 }
 
 /***********************************************************************************/
@@ -706,5 +707,179 @@ template void KRATOS_API(KRATOS_CORE) GeometryUtils::EvaluateHistoricalVariableV
     const Variable<array_1d<double, 3>>&,
     const Vector&,
     const int);
+
+/***********************************************************************************/
+/***********************************************************************************/
+
+bool GeometryUtils::TriangleBoxOverlap(
+    const Point& rBoxCenter,
+    const Point& rBoxHalfSize,
+    const Point& rVertex0,
+    const Point& rVertex1,
+    const Point& rVertex2
+    )
+{
+    double abs_ex, abs_ey, abs_ez, distance;
+    array_1d<double,3 > vert0, vert1, vert2;
+    array_1d<double,3 > edge0, edge1, edge2, normal;
+    std::pair<double, double> min_max;
+
+    // move everything so that the boxcenter is in (0,0,0)
+    noalias(vert0) = rVertex0 - rBoxCenter;
+    noalias(vert1) = rVertex1 - rBoxCenter;
+    noalias(vert2) = rVertex2 - rBoxCenter;
+
+    // compute triangle edges
+    noalias(edge0) = vert1 - vert0;
+    noalias(edge1) = vert2 - vert1;
+    noalias(edge2) = vert0 - vert2;
+
+    // Bullet 3:
+    // test the 9 tests first (this was faster)
+    abs_ex = std::abs(edge0[0]);
+    abs_ey = std::abs(edge0[1]);
+    abs_ez = std::abs(edge0[2]);
+    if (AxisTestX(edge0[1],edge0[2],abs_ey,abs_ez,vert0,vert2,rBoxHalfSize)) return false;
+    if (AxisTestY(edge0[0],edge0[2],abs_ex,abs_ez,vert0,vert2,rBoxHalfSize)) return false;
+    if (AxisTestZ(edge0[0],edge0[1],abs_ex,abs_ey,vert0,vert2,rBoxHalfSize)) return false;
+
+    abs_ex = std::abs(edge1[0]);
+    abs_ey = std::abs(edge1[1]);
+    abs_ez = std::abs(edge1[2]);
+    if (AxisTestX(edge1[1],edge1[2],abs_ey,abs_ez,vert1,vert0,rBoxHalfSize)) return false;
+    if (AxisTestY(edge1[0],edge1[2],abs_ex,abs_ez,vert1,vert0,rBoxHalfSize)) return false;
+    if (AxisTestZ(edge1[0],edge1[1],abs_ex,abs_ey,vert1,vert0,rBoxHalfSize)) return false;
+
+    abs_ex = std::abs(edge2[0]);
+    abs_ey = std::abs(edge2[1]);
+    abs_ez = std::abs(edge2[2]);
+    if (AxisTestX(edge2[1],edge2[2],abs_ey,abs_ez,vert2,vert1,rBoxHalfSize)) return false;
+    if (AxisTestY(edge2[0],edge2[2],abs_ex,abs_ez,vert2,vert1,rBoxHalfSize)) return false;
+    if (AxisTestZ(edge2[0],edge2[1],abs_ex,abs_ey,vert2,vert1,rBoxHalfSize)) return false;
+
+    // Bullet 1:
+    //  first test overlap in the {x,y,z}-directions
+    //  find min, max of the triangle for each direction, and test for
+    //  overlap in that direction -- this is equivalent to testing a minimal
+    //  AABB around the triangle against the AABB
+
+    // test in X-direction
+    min_max = std::minmax({vert0[0], vert1[0], vert2[0]});
+    if(min_max.first>rBoxHalfSize[0] || min_max.second<-rBoxHalfSize[0]) return false;
+
+    // test in Y-direction
+    min_max = std::minmax({vert0[1], vert1[1], vert2[1]});
+    if(min_max.first>rBoxHalfSize[1] || min_max.second<-rBoxHalfSize[1]) return false;
+
+    // test in Z-direction
+    min_max = std::minmax({vert0[2], vert1[2], vert2[2]});
+    if(min_max.first>rBoxHalfSize[2] || min_max.second<-rBoxHalfSize[2]) return false;
+
+    // Bullet 2:
+    //  test if the box intersects the plane of the triangle
+    //  compute plane equation of triangle: normal*x+distance=0
+    MathUtils<double>::CrossProduct(normal, edge0, edge1);
+    distance = -inner_prod(normal, vert0);
+    if(!PlaneBoxOverlap(normal, distance, rBoxHalfSize)) return false;
+
+    return true;  // box and triangle overlaps
+}
+
+/***********************************************************************************/
+/***********************************************************************************/
+
+bool GeometryUtils::AxisTestX(
+    const double EdgeY,
+    const double EdgeZ,
+    const double AbsEdgeY,
+    const double AbsEdgeZ,
+    const array_1d<double,3>& rVertA,
+    const array_1d<double,3>& rVertC,
+    const Point& rBoxHalfSize
+    )
+{
+    double proj_a, proj_c, rad;
+    proj_a = EdgeY*rVertA[2] - EdgeZ*rVertA[1];
+    proj_c = EdgeY*rVertC[2] - EdgeZ*rVertC[1];
+    std::pair<double, double> min_max = std::minmax(proj_a, proj_c);
+
+    rad = AbsEdgeZ*rBoxHalfSize[1] + AbsEdgeY*rBoxHalfSize[2];
+
+    if(min_max.first>rad || min_max.second<-rad) return true;
+    else return false;
+}
+
+/***********************************************************************************/
+/***********************************************************************************/
+
+bool GeometryUtils::AxisTestY(
+    const double EdgeX,
+    const double EdgeY,
+    const double AbsEdgeX,
+    const double AbsEdgeZ,
+    const array_1d<double,3>& rVertA,
+    const array_1d<double,3>& rVertC,
+    const Point& rBoxHalfSize
+    )
+{
+    double proj_a, proj_c, rad;
+    proj_a = EdgeY*rVertA[0] - EdgeX*rVertA[2];
+    proj_c = EdgeY*rVertC[0] - EdgeX*rVertC[2];
+    std::pair<double, double> min_max = std::minmax(proj_a, proj_c);
+
+    rad = AbsEdgeZ*rBoxHalfSize[0] + AbsEdgeX*rBoxHalfSize[2];
+
+    if(min_max.first>rad || min_max.second<-rad) return true;
+    else return false;
+}
+
+/***********************************************************************************/
+/***********************************************************************************/
+
+bool GeometryUtils::AxisTestZ(
+    const double EdgeX,
+    const double EdgeY,
+    const double AbsEdgeX,
+    const double AbsEdgeY,
+    const array_1d<double,3>& rVertA,
+    const array_1d<double,3>& rVertC,
+    const Point& rBoxHalfSize
+    )
+{
+    double proj_a, proj_c, rad;
+    proj_a = EdgeX*rVertA[1] - EdgeY*rVertA[0];
+    proj_c = EdgeX*rVertC[1] - EdgeY*rVertC[0];
+    std::pair<double, double> min_max = std::minmax(proj_a, proj_c);
+
+    rad = AbsEdgeY*rBoxHalfSize[0] + AbsEdgeX*rBoxHalfSize[1];
+
+    if(min_max.first>rad || min_max.second<-rad) return true;
+    else return false;
+}
+
+/***********************************************************************************/
+/***********************************************************************************/
+
+bool GeometryUtils::PlaneBoxOverlap(
+    const array_1d<double,3>& rNormal,
+    const double Distance,
+    const array_1d<double,3>& rMaxBox
+    )
+{
+    array_1d<double,3> vmin, vmax;
+    for(int q = 0; q < 3; q++) {
+        if(rNormal[q] > 0.00) {
+            vmin[q] = -rMaxBox[q];
+            vmax[q] =  rMaxBox[q];
+        } else {
+            vmin[q] =  rMaxBox[q];
+            vmax[q] = -rMaxBox[q];
+        }
+    }
+    if(inner_prod(rNormal, vmin) + Distance >  0.0) return false;
+    if(inner_prod(rNormal, vmax) + Distance >= 0.0) return true;
+
+    return false;
+}
 
 } // namespace Kratos.

--- a/kratos/utilities/geometry_utilities.h
+++ b/kratos/utilities/geometry_utilities.h
@@ -853,6 +853,103 @@ public:
         const auto min = std::min_element(distances.begin(), distances.end());
         return *min;
     }
+
+    /**
+     * @brief use separating axis theorem to test overlap between triangle and box
+     * @details Need to test for overlap in these directions:
+     * 1) the {x,y,(z)}-directions
+     * 2) normal of the triangle
+     * 3) crossproduct (edge from tri, {x,y,z}-direction) gives 3x3=9 more tests
+     * @param rBoxCenter The center of the box
+     * @param rBoxHalfSize The half size of the box
+     * @param rVertex0 The first vertex of the triangle
+     * @param rVertex1 The second vertex of the triangle
+     * @param rVertex2 The third vertex of the triangle
+     */
+    static bool TriangleBoxOverlap(
+        const Point& rBoxCenter,
+        const Point& rBoxHalfSize,
+        const Point& rVertex0,
+        const Point& rVertex1,
+        const Point& rVertex2
+        );
+
+    /**
+     * @brief Check if a plane intersects a box
+     * @see TriBoxOverlap
+     * @details Plane equation: rNormal*x+rDist=0
+     * @return bool intersection flag
+     * @param rNormal the plane normal
+     * @param rDist   distance to origin
+     * @param rMaxBox box corner from the origin
+     */
+    static bool PlaneBoxOverlap(
+        const array_1d<double,3>& rNormal,
+        const double Distance,
+        const array_1d<double,3>& rMaxBox
+        );
+
+private:
+
+    /**
+     * @brief AxisTestX
+     * @details This method returns true if there is a separating axis
+     * @param EdgeY, EdgeZ: i-edge coordinates
+     * @param AbsEdgeY, AbsEdgeZ: i-edge abs coordinates
+     * @param rVertA: i   vertex
+     * @param rVertB: i+1 vertex (omitted, proj_a = proj_b)
+     * @param rVertC: i+2 vertex
+     * @param rBoxHalfSize Box half size
+     */
+    static bool AxisTestX(
+        const double EdgeY,
+        const double EdgeZ,
+        const double AbsEdgeY,
+        const double AbsEdgeZ,
+        const array_1d<double,3>& rVertA,
+        const array_1d<double,3>& rVertC,
+        const Point& rBoxHalfSize
+        );
+
+    /**
+     * @brief AxisTestY
+     * @details This method returns true if there is a separating axis
+     * @param EdgeX, EdgeY: i-edge coordinates
+     * @param AbsEdgeX, AbsEdgeZ: i-edge fabs coordinates
+     * @param rVertA: i   vertex
+     * @param rVertB: i+1 vertex (omitted, proj_a = proj_b)
+     * @param rVertC: i+2 vertex
+     * @param rBoxHalfSize Box half size
+     */
+    static bool AxisTestY(
+        const double EdgeX,
+        const double EdgeY,
+        const double AbsEdgeX,
+        const double AbsEdgeZ,
+        const array_1d<double,3>& rVertA,
+        const array_1d<double,3>& rVertC,
+        const Point& rBoxHalfSize
+        );
+
+    /**
+     * @brief AxisTestZ
+     * @details This method returns true if there is a separating axis
+     * @param EdgeX, EdgeY: i-edge coordinates
+     * @param AbsEdgeX, AbsEdgeY: i-edge fabs coordinates
+     * @param rVertA: i   vertex
+     * @param rVertB: i+1 vertex (omitted, proj_a = proj_b)
+     * @param rVertC: i+2 vertex
+     * @param rBoxHalfSize Box half size
+     */
+    static bool AxisTestZ(
+        const double EdgeX,
+        const double EdgeY,
+        const double AbsEdgeX,
+        const double AbsEdgeY,
+        const array_1d<double,3>& rVertA,
+        const array_1d<double,3>& rVertC,
+        const Point& rBoxHalfSize
+        );
 };
 
 }  // namespace Kratos.


### PR DESCRIPTION
**📝 Description**

Current `Tetrahedra3D4` `HasIntersection` method implementation creates 4 triangles and calls `HasIntersection`  from every one of them. This is very expensive and inefficient. In order to avoid that we refactor the method and move it into the geometric utilities and call it from both the triangle and the tetrahedra.

**🆕 Changelog**

- [Refactor `HasIntersection`method for performance](https://github.com/KratosMultiphysics/Kratos/commit/6221062897c86cac5049e5193c56f63c7ffe73a1)
