### PR TITLE
[Core][TrilinosApplication] Remove `IsDistributedSpace` as duplicated with `IsDistributed`

### DIFF
--- a/applications/TrilinosApplication/trilinos_space.h
+++ b/applications/TrilinosApplication/trilinos_space.h
@@ -1332,16 +1332,6 @@ public:
         KRATOS_CATCH("");
     }
 
-   /**
-    * @brief Check if the TrilinosSpace is distributed.
-    * @details This static member function checks whether the TrilinosSpace is distributed or not.
-    * @return True if the space is distributed, false otherwise.
-    */
-    static constexpr bool IsDistributedSpace()
-    {
-        return true;
-    }
-
     ///@}
     ///@name Access
     ///@{

--- a/kratos/solving_strategies/convergencecriterias/displacement_criteria.h
+++ b/kratos/solving_strategies/convergencecriterias/displacement_criteria.h
@@ -412,7 +412,7 @@ private:
         const int Rank
         )
     {
-        if constexpr (!TSparseSpace::IsDistributedSpace()) {
+        if constexpr (!TSparseSpace::IsDistributed()) {
             return rDof.IsFree();
         } else {
             return (rDof.IsFree() && (rDof.GetSolutionStepValue(PARTITION_INDEX) == Rank));

--- a/kratos/solving_strategies/convergencecriterias/residual_criteria.h
+++ b/kratos/solving_strategies/convergencecriterias/residual_criteria.h
@@ -390,7 +390,7 @@ protected:
         )
     {
         const IndexType dof_id = rDof.EquationId();
-        if constexpr (!TSparseSpace::IsDistributedSpace()) {
+        if constexpr (!TSparseSpace::IsDistributed()) {
             return mActiveDofs[dof_id] == 1;
         } else {
             KRATOS_DEBUG_ERROR_IF((dof_id - mInitialDoFId) >= mActiveDofs.size() && (rDof.GetSolutionStepValue(PARTITION_INDEX) == Rank)) << "DofId is greater than the size of the active Dofs vector. DofId: " << dof_id << "\tInitialDoFId: " << mInitialDoFId << "\tActiveDofs size: " << mActiveDofs.size() << std::endl;
@@ -411,7 +411,7 @@ protected:
         const int Rank
         )
     {
-        if constexpr (!TSparseSpace::IsDistributedSpace()) {
+        if constexpr (!TSparseSpace::IsDistributed()) {
             return rDof.IsFree();
         } else {
             return (rDof.IsFree() && (rDof.GetSolutionStepValue(PARTITION_INDEX) == Rank));

--- a/kratos/spaces/ublas_space.h
+++ b/kratos/spaces/ublas_space.h
@@ -945,16 +945,6 @@ public:
         return tmp.Create();
     }
 
-   /**
-    * @brief Check if the UblasSpace is distributed.
-    * @details This static member function checks whether the UblasSpace is distributed or not.
-    * @return True if the space is distributed, false otherwise.
-    */
-    static constexpr bool IsDistributedSpace()
-    {
-        return false;
-    }
-
     ///@}
     ///@name Friends
     ///@{


### PR DESCRIPTION
**📝 Description**

Remove `IsDistributedSpace` as duplicated with `IsDistributed`. The method was originally introduced by me as I didn't realised that `IsDistributed` existed. It only used in the convergence criteria as it is the reason I implemented this originally.

**🆕 Changelog**

- [Remove `IsDistributedSpace` as duplicated with `IsDistributed`](https://github.com/KratosMultiphysics/Kratos/commit/a65dee396a0dae096ed7bc3338f42cb43c9ec07b)
