### PR TITLE
[LinearSolvers] Add external lib for parallel Gauss-Seidel

### DIFF
--- a/applications/LinearSolversApplication/CMakeLists.txt
+++ b/applications/LinearSolversApplication/CMakeLists.txt
@@ -75,6 +75,11 @@ set( KRATOS_LINEARSOLVERS_APPLICATION_CORE_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/custom_factories/dense_linear_solver_factory.cpp
 )
 
+# External libraries for the high order multigrid BuilderAndSolver
+add_subdirectory("${CMAKE_CURRENT_SOURCE_DIR}/external_libraries/mcgs"
+                 EXCLUDE_FROM_ALL)      # <== prevent MCGS from installing anything on its own
+install(TARGETS mcgs DESTINATION libs)  # <== install MCGS along other kratos binaries
+
 # Sources for the Python module
 file(
     GLOB_RECURSE
@@ -85,7 +90,7 @@ file(
 ###############################################################
 ## LinearSolversApplication core library (C++ parts)
 add_library( KratosLinearSolversCore SHARED ${KRATOS_LINEARSOLVERS_APPLICATION_CORE_SOURCES} )
-target_link_libraries( KratosLinearSolversCore PUBLIC KratosCore )
+target_link_libraries( KratosLinearSolversCore PUBLIC KratosCore mcgs )
 set_target_properties( KratosLinearSolversCore PROPERTIES COMPILE_DEFINITIONS "LINEARSOLVERS_APPLICATION=EXPORT,API")
 
 target_include_directories(KratosLinearSolversCore SYSTEM PUBLIC ${CMAKE_CURRENT_SOURCE_DIR} ${KRATOS_LINEAR_SOLVERS_APPLICATION_LIB_INC})

--- a/applications/LinearSolversApplication/external_libraries/mcgs/CMakeLists.txt
+++ b/applications/LinearSolversApplication/external_libraries/mcgs/CMakeLists.txt
@@ -1,0 +1,111 @@
+cmake_minimum_required(VERSION 3.15.0)
+project(mcgs LANGUAGES CXX VERSION 1.0.0)
+
+# Language requirements
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+# Options
+string(TOUPPER ${PROJECT_NAME} PROJECT_NAME_UPPER)
+
+set(${PROJECT_NAME_UPPER}_BUILD_TESTS
+    OFF
+    CACHE BOOL
+    "Compile tests.")
+
+set(${PROJECT_NAME_UPPER}_SHARED_MEMORY_PARALLELISM
+    "OpenMP"
+    CACHE STRING "Features/libraries to use for shared memory parallelism.")
+set_property(CACHE ${PROJECT_NAME_UPPER}_SHARED_MEMORY_PARALLELISM
+             PROPERTY STRINGS
+             "None"
+             "OpenMP")
+
+# Find dependencies
+if (${PROJECT_NAME_UPPER}_SHARED_MEMORY_PARALLELISM MATCHES "OpenMP")
+    find_package(OpenMP 2 REQUIRED)
+endif()
+
+# Define library
+add_library(${PROJECT_NAME} SHARED)
+target_sources(${PROJECT_NAME} PRIVATE
+               "${CMAKE_CURRENT_SOURCE_DIR}/src/color.cpp"
+               "${CMAKE_CURRENT_SOURCE_DIR}/src/partition.cpp"
+               "${CMAKE_CURRENT_SOURCE_DIR}/src/reorder.cpp"
+               "${CMAKE_CURRENT_SOURCE_DIR}/src/solve.cpp")
+target_include_directories(${PROJECT_NAME}
+                           PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+                           INTERFACE "$<INSTALL_INTERFACE:${PROJECT_NAME}/include>"
+                                     "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>")
+set_target_properties(${PROJECT_NAME} PROPERTIES
+                      LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
+                      ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
+                      RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
+                      INSTALL_RPATH "$ORIGIN"
+                      CXX_VISIBILITY_PRESET "hidden")
+
+if (${PROJECT_NAME_UPPER}_SHARED_MEMORY_PARALLELISM MATCHES "OpenMP")
+    target_link_libraries(${PROJECT_NAME} PRIVATE OpenMP::OpenMP_CXX)
+    target_compile_definitions(${PROJECT_NAME} PRIVATE ${PROJECT_NAME_UPPER}_OPENMP)
+endif()
+
+if (CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+    target_compile_options(${PROJECT_NAME} PRIVATE
+                           -Wall -Wpedantic -Wextra -Werror)
+endif()
+
+# Define testrunner
+if (${${PROJECT_NAME_UPPER}_BUILD_TESTS})
+    add_executable(${PROJECT_NAME}_testrunner
+                   "${CMAKE_CURRENT_SOURCE_DIR}/test/main.cpp"
+                   "${CMAKE_CURRENT_SOURCE_DIR}/test/parseMatrixMarket.cpp")
+    target_link_libraries(${PROJECT_NAME}_testrunner PRIVATE ${PROJECT_NAME})
+    set_target_properties(${PROJECT_NAME}_testrunner PROPERTIES
+                          RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin")
+endif()
+
+# Package
+include(InstallRequiredSystemLibraries)
+set(CPACK_PACKAGE_VENDOR "Máté Kelemen")
+set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "A simple implementation of multicolor Gauss-Seidel relaxation.")
+set(CPACK_PACKAGE_VERSION_MAJOR ${PROJECT_VERSION_MAJOR})
+set(CPACK_PACKAGE_VERSION_MINOR ${PROJECT_VERSION_MINOR})
+set(CPACK_PACKAGE_VERSION_PATCH ${PROJECT_VERSION_PATCH})
+set(CPACK_RESOURCE_FILE_LICENSE "${CMAKE_CURRENT_SOURCE_DIR}/license.txt")
+set(CPACK_RESOURCE_FILE_README "${CMAKE_CURRENT_SOURCE_DIR}/readme.md")
+
+set(CPACK_GENERATOR "ZIP")
+set(CPACK_SOURCE_GENERATOR "ZIP")
+set(CPACK_SOURCE_IGNORE_FILES
+    "/\.git"
+    "/build"
+    "/install"
+    "/\.gitignore"
+    "/\.cache"
+    ".*\.mm"
+    ".*\.mtx"
+    ".*\.png")
+include(CPack)
+
+# Generate CMake config
+include(CMakePackageConfigHelpers)
+configure_package_config_file("${CMAKE_CURRENT_SOURCE_DIR}/Config.cmake.in"
+                              "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake"
+                              INSTALL_DESTINATION "lib/cmake/${PROJECT_NAME}"
+                              NO_SET_AND_CHECK_MACRO
+                              NO_CHECK_REQUIRED_COMPONENTS_MACRO)
+write_basic_package_version_file("${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake"
+                                 VERSION "${${PROJECT_NAME}_VERSION_MAJOR}.${${PROJECT_NAME}_VERSION_MINOR}"
+                                 COMPATIBILITY AnyNewerVersion)
+
+# Install
+install(TARGETS ${PROJECT_NAME}
+        EXPORT ${PROJECT_NAME}Targets
+        LIBRARY DESTINATION "lib"
+        ARCHIVE DESTINATION "lib"
+        RUNTIME DESTINATION "bin"
+        INCLUDES DESTINATION "include")
+install(EXPORT ${PROJECT_NAME}Targets
+        FILE ${PROJECT_NAME}Targets.cmake
+        NAMESPACE ${PROJECT_NAME}::
+        DESTINATION "lib/cmake/${PROJECT_NAME}")

--- a/applications/LinearSolversApplication/external_libraries/mcgs/Config.cmake.in
+++ b/applications/LinearSolversApplication/external_libraries/mcgs/Config.cmake.in
@@ -1,0 +1,2 @@
+@PACKAGE_INIT@
+include("${CMAKE_CURRENT_LIST_DIR}/mcgsTargets.cmake")

--- a/applications/LinearSolversApplication/external_libraries/mcgs/build.bat
+++ b/applications/LinearSolversApplication/external_libraries/mcgs/build.bat
@@ -1,0 +1,8 @@
+if [%1]==[] (
+    set buildType=Release
+) else (
+    set buildType=%1
+)
+
+cmake -H. -Bbuild -DCMAKE_BUILD_TYPE:STRING=%buildType% -DCMAKE_EXPORT_COMPILE_COMMANDS:BOOL=ON -DMCGS_BUILD_TESTS:BOOL=ON
+cmake --build build --config %buildType%

--- a/applications/LinearSolversApplication/external_libraries/mcgs/build.sh
+++ b/applications/LinearSolversApplication/external_libraries/mcgs/build.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+
+scriptName="$(basename ${BASH_SOURCE[0]})"
+scriptDir="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+projectName="$(basename $scriptDir)"
+
+print_help() {
+    echo "$scriptName - Configure, build, and install $projectName."
+    echo "Usage: $scriptName [OPTION [ARGUMENT]]"
+    echo "-h                : print this help and exit."
+    echo "-p                : package after building."
+    echo "-t build-type     : build type [Debug, Release, RelWithDebInfo] (default: Release)."
+    echo "-j job-count      : number of build jobs to launch in parallel (Default: use as many threads as the machine supports)."
+    echo "-b build-dir      : build directory."
+    echo "-i install-dir    : install directory (local directory by default)."
+    echo "-o [opts]         : options/arguments to pass on to CMake. Semicolon (;) delimited, or defined repeatedly."
+}
+
+# Default arguments
+package=0
+buildType="Release"
+buildDir="$scriptDir/build"
+installDir="$scriptDir/install"
+cmakeArguments=""
+jobCount=""
+
+while getopts ":h p t: j: b: i: o:" arg; do
+    case "$arg" in
+        h)  # Print help and exit without doing anything
+            print_help
+            exit 0
+            ;;
+        p)  # Package after building
+            package=1
+            ;;
+        t)  # Set build type
+            buildType="$OPTARG"
+            if ! [[ "${buildType}" = "Debug"            \
+                 || "${buildType}" = "RelWithDebInfo"   \
+                 || "${buildType}" = "Release" ]]; then
+                 print_help
+                 echo "Invalid build type: $buildType"
+                 exit 1
+            fi
+            ;;
+        j)  # Set the number of build jobs
+            if [[ "$OPTARG" =~ ^[1-9][0-9]*$ ]]; then
+                jobCount="$OPTARG"
+            else
+                echo "Error: invalid number of jobs requested: '$OPTARG'"
+                exit 1
+            fi
+            ;;
+        b)  # Set build directory
+            buildDir="$OPTARG"
+            ;;
+        i)  # Set install directory
+            installDir="$OPTARG"
+            ;;
+        o)  # Append CMake arguments
+            cmakeArguments="$cmakeArguments;$OPTARG"
+            ;;
+        \?) # Unrecognized argument
+            print_help
+            echo "Error: unrecognized argument -$OPTARG"
+            exit 1
+            ;;
+    esac
+done
+
+case "$(uname -s)" in
+    Linux*)
+        export cxx=g++
+        ;;
+    Darwin*)
+        if [ -z "$jobCount" ]; then
+            jobCount=$(sysctl -n machdep.cpu.thread_count)
+        fi
+
+        if [ -z "$cxx" ]; then
+            # Set clang from homebrew
+            if ! command -v brew &> /dev/null; then
+                echo "Error: $scriptName requires Homebrew"
+                exit 1
+            fi
+
+            if ! brew list llvm >/dev/null 2>&1; then
+                echo "Error: missing dependency: llvm"
+                echo "Consider running 'brew install llvm'"
+                exit 1
+            fi
+
+            toolchainRoot="$(brew --prefix llvm)"
+            toolchainBin="${toolchainRoot}/bin"
+            toolchainLib="${toolchainRoot}/lib"
+            toolchainInclude="${toolchainRoot}/include"
+            export cc="$toolchainBin/clang"
+            export cxx="$toolchainBin/clang++"
+        fi
+        ;;
+    \?)
+        echo "Error: unsupported OS $(uname -s)"
+        exit 1
+esac
+
+# Create or clear the build directory
+if ! [ -d "$buildDir" ]; then
+    mkdir -p "$buildDir"
+else
+    rm -f "$buildDir/cmake_install.cmake"
+    rm -f "$buildDir/CMakeCache.txt"
+fi
+
+# Generate with CMake
+if ! cmake                                                  \
+    "-H$scriptDir"                                          \
+    "-B$buildDir"                                           \
+    "-DCMAKE_INSTALL_PREFIX:STRING=$installDir"             \
+    "-DCMAKE_BUILD_TYPE:STRING=$buildType"                  \
+    "-DCMAKE_CXX_COMPILER:STRING=$cxx"                      \
+    "-DCMAKE_COLOR_DIAGNOSTICS:BOOL=ON"                     \
+    "-DCMAKE_EXPORT_COMPILE_COMMANDS:BOOL=ON"               \
+    "-DMCGS_BUILD_TESTS:BOOL=ON"                            \
+    $(echo $cmakeArguments | tr '\;' '\n')                  \
+    ; then
+    exit 1
+fi
+
+# Build and install
+if ! cmake --build "$buildDir" --config "$buildType" --target install -j$jobCount; then
+    exit 1
+fi
+
+# Package
+if [ $package -eq 1 ]; then
+    cd "$buildDir"
+    echo make package
+    make package
+    make package_source
+fi
+
+# Success
+exit 0

--- a/applications/LinearSolversApplication/external_libraries/mcgs/include/mcgs/mcgs.hpp
+++ b/applications/LinearSolversApplication/external_libraries/mcgs/include/mcgs/mcgs.hpp
@@ -213,9 +213,9 @@ class Partition;
 ///
 /// @see destroyPartition
 template <class TIndex, class TColor>
-MCGS_EXPORT_SYMBOL
-[[nodiscard]] Partition<TIndex>* makePartition(const TColor* pColors,
-                                               const TIndex rowCount);
+[[nodiscard]] MCGS_EXPORT_SYMBOL
+Partition<TIndex>* makePartition(const TColor* pColors,
+                                 const TIndex rowCount);
 
 
 /// @brief Destroy a partition that was successfully constructed by @ref makePartition.
@@ -272,11 +272,11 @@ void destroyPartition(Partition<TIndex>* pPartition);
 /// @see revertReorder(TValue*,const TIndex,const Partition*)
 /// @see revertReorder(const TIndex,const TIndex,const TIndex,TIndex*,TIndex*,TValue*,TValue*,TValue*,const Partition*)
 template <class TIndex, class TValue>
-MCGS_EXPORT_SYMBOL
-[[nodiscard]] Partition<TIndex>* reorder(const unsigned long rowCount, const unsigned long columnCount, const unsigned long entryCount,
-                                         TIndex* pRowExtents, TIndex* pColumnIndices, TValue* pEntries,
-                                         TValue* pSolution, TValue* pRHS,
-                                         const Partition<TIndex>* pPartition);
+[[nodiscard]] MCGS_EXPORT_SYMBOL
+Partition<TIndex>* reorder(const unsigned long rowCount, const unsigned long columnCount, const unsigned long entryCount,
+                           TIndex* pRowExtents, TIndex* pColumnIndices, TValue* pEntries,
+                           TValue* pSolution, TValue* pRHS,
+                           const Partition<TIndex>* pPartition);
 
 
 /// @brief Restore the original order of a @ref reorder "reordered" vector.

--- a/applications/LinearSolversApplication/external_libraries/mcgs/include/mcgs/mcgs.hpp
+++ b/applications/LinearSolversApplication/external_libraries/mcgs/include/mcgs/mcgs.hpp
@@ -1,0 +1,497 @@
+#pragma once
+
+/// @def MCGS_EXPORT_SYMBOL
+/// @brief Exposes the symbol in the shared object.
+#if _WIN32
+    #ifdef MCGS_INTERNAL
+        #define MCGS_EXPORT_SYMBOL __declspec(dllexport)
+    #else
+        #define MCGS_EXPORT_SYMBOL __declspec(dllimport)
+    #endif
+#else
+    #define MCGS_EXPORT_SYMBOL __attribute__((visibility ("default")))
+#endif
+
+
+namespace mcgs {
+
+
+/// @def MCGS_SUCCESS
+/// @brief Return value indicating success.
+#define MCGS_SUCCESS 0
+
+
+/// @def MCGS_FAILURE
+/// @brief Return value indicating failure.
+#define MCGS_FAILURE 1
+
+
+/// @brief Adaptor for matrices stored in the compressed sparse row format.
+///
+/// @tparam TIndex Integer type of stored indices (@p int, @p long, @p unsigned or <c>unsigned long</c>).
+/// @tparam TValue Number type of stored entries (for now, only @p double is supported).
+///
+/// @details This class is a hollow adaptor that does not own any of the arrays associated
+///          with the matrix, and does not have mutable access to them. Its purpose is restricted
+///          to providing read access to the matrix.
+///
+/// @see <a href="https://en.wikipedia.org/wiki/Sparse_matrix#Compressed_sparse_row_(CSR,_CRS_or_Yale_format)">CSR format</a>.
+template <class TIndex, class TValue>
+struct CSRAdaptor
+{
+    unsigned long rowCount;         ///< @brief Number of rows in the matrix.
+    unsigned long columnCount;      ///< @brief Number of columns in the matrix.
+    unsigned long entryCount;       ///< @brief Number of stored entries in the matrix.
+    const TIndex* pRowExtents;      ///< @brief Index array defining entries related to each row within the @ref CSRAdaptor::pEntries "array of entries". Size at least @ref rowCount + 1.
+    const TIndex* pColumnIndices;   ///< @brief Index array assigning column indices to each entry in the @ref CSRAdaptor::pEntries "array of entries". Size at least @ref entryCount.
+    const TValue* pEntries;         ///< @brief Array of stored entries. Size at least @ref entryCount.
+
+    /// @brief Default constructor creating an invalid object that must be initialized by the user.
+    CSRAdaptor() noexcept
+        : rowCount(0ul),
+          columnCount(0ul),
+          entryCount(0ul),
+          pRowExtents(nullptr),
+          pColumnIndices(nullptr),
+          pEntries(nullptr)
+    {}
+};
+
+
+/// @brief Settings for the coloring algorithm.
+/// @tparam TValue Number type of stored entries in the related matrix (for now, only @p double is supported).
+template <class TValue>
+struct ColorSettings
+{
+    /// @brief Parameter controlling the initial palette size.
+    /// @details This is the only algorithmic parameter, but it has a significant
+    ///          influence on the quality of the resulting coloring as well as
+    ///          the runtime of the algorithm. In general, a shrinking factor that
+    ///          leads to a good coloring also has shorter runtimes.
+    ///
+    ///          The initial palette size @f$p@f$ depends on the maximum vertex degree
+    ///          @f$v_{max}@f$ and shrinking factor @f$s@f$:
+    ///          @f[ p = \frac{v_{max}}{s} @f]
+    ///
+    /// @note
+    /// - If a nonpositive value is passed, the minimum vertex degree is used instead.
+    /// - Defaults to @p -1.
+    int shrinkingFactor;
+
+    /// @brief Controls how many consequent failed coloring iterations to allow before terminating.
+    /// @details Since the algorithm randomly picks colors for each vertex from their remaining
+    ///          palettes, it is possible to end up with iterations that fail to assign valid colors
+    ///          to any of the remaining vertices. This is characteristic of the final stages of the
+    ///          coloring process for runs with too tight initial palettes. Allowing a longer chain
+    ///          of failed iterations makes the algorithm more robust in these cases.
+    ///
+    /// @note
+    /// - Negative values for @p maxStallCount allow infinite stalling.
+    /// - Defaults to @p 1e3.
+    int maxStallCount;
+
+    /// @brief Minimum absolute value for matrix entries to treat as nonzero.
+    /// @details Some software store actual zeros in their sparse matrices. For example, this can
+    ///          happen during the naive enforcement of Dirichlet conditions or linear constraints
+    ///          in FEM software. Topology complexity can be reduced in these cases by defining
+    ///          a small tolerance, under which entries in the sparse matrix are ignored.
+    /// @note
+    /// - Nonpositive values for @p tolerance will respect the matrix topology as is.
+    /// - Defaults to @p 0.
+    TValue tolerance;
+
+    /// @brief Verbosity level controlling the volume of output to @p std::cerr and @p std::cout.
+    /// @details Each level is a strict superset of lower levels.
+    ///          - @p 0: no output is written to @p std::cerr or @p std::cout.
+    ///          - @p 1: error messages are written to @p std::cerr.
+    ///          - @p 2: information outside iterations is written to @p std::cout.
+    ///          - @p 3: information from iterations is written to @p std::cout.
+    ///
+    /// @note Defaults to @p 1.
+    unsigned short verbosity;
+
+    /// @brief Constructor initializing settings to their default values.
+    ColorSettings() noexcept
+        : shrinkingFactor(-1),
+          maxStallCount(1e3),
+          tolerance(0),
+          verbosity(1)
+    {}
+};
+
+
+/// @brief Compute an approximate coloring of a graph.
+///
+/// @tparam TIndex Integer type of stored indices in the matrix (@p int, @p long, @p unsigned or <c>unsigned long</c>).
+/// @tparam TValue Number type of stored entries in the matrix (for now, only @p double is supported).
+/// @tparam TColor Integer type of vertex colors (@p unsigned or <c>unsigned long</c>).
+///
+/// @details @par Output
+///          The output is written to @p pColors, which stores the color of each row at the matching index.
+///
+/// @details @par Algorithm
+///          The algorithm randomly assigns colors to each uncolored vertex from their palette of remaining
+///          colors. After each round of assignment, vertices with valid colors are frozen and a basic
+///          conflict resolution step is carried out. The color of newly frozen vertices is removed from their
+///          neighbors' palettes.
+///
+///          The quality of the resulting coloring, as well as the number of iterations to find it strongly
+///          depend on the size of the initial palettes. This can be adjusted via the
+///          @ref ColorSettings::shrinkingFactor "shrinking factor", which is the only algorithmic parameter.
+///
+/// @details @par Parallelism
+///          Coloring is performed in parallel on the CPU in a shared memory model using @a OpenMP, if
+///          @a MCGS was compiled with @a OpenMP support. The maximum number of used threads is controlled
+///          by @a OpenMP.
+///
+/// @details @par Stalling
+///          Due to the random nature of assignments, iterations that fail to freeze the color of any remaining
+///          vertex can occur. Such an iteration is labelled a stalled iteration, and the function is set to
+///          fail after a given number of consequent stalls. The length of tolerated consequent stalls is
+///          controlled by @ref ColorSettings::maxStallCount.
+///
+/// @details @par Errors
+///          The algorithm can fail if
+///          - the number of consequent stalls reaches @ref ColorSettings::maxStallCount
+///          - the number of rows, columns, or nonzeros in the input matrix is negative
+///          - the input matrix is not square
+///          - @ref CSRAdaptor::pRowExtents, @ref CSRAdaptor::pColumnIndices, or @ref CSRAdaptor::pEntries is @p nullptr.
+///          - @p pColors is @p nullptr
+///          If any of the above is detected, the function returns @ref MCGS_FAILURE.
+///
+///          No exceptions are thrown by the function directly, but exceptions from the C++ standard library
+///          can propagate to the user (provided that exceptions are enabled by the compiler).
+///
+///          Segmentation faults can occur if the user manages the memory of the input matrix
+///          or output colors incorrectly. Requirements on matrix storage are specified by @ref CSRAdaptor.
+///          @p pColors must be at least of length @ref CSRAdaptor::rowCount.
+///
+/// @param pColors output array of vertex colors. The memory must be managed by the user, and the array
+///                must have a length at least as the number of columns in the input matrix @p rMatrix.
+/// @param rMatrix @ref CSRAdaptor "CSR matrix adaptor" representing the graph to be colored.
+/// @param settings @ref ColorSettings "algorithmic parameters and other settings" to apply during coloring.
+///
+/// @return @ref MCGS_SUCCESS if successful, otherwise @ref MCGS_FAILURE.
+///
+/// @note This function is a loose implementation of the algorithm described in
+///       <i>Fast Distributed Algorithms for Brooks-Vizing Colorings</i>, doi:<c>10.1006/jagm.2000.1097</c>.
+template <class TIndex, class TValue, class TColor>
+MCGS_EXPORT_SYMBOL
+int color(TColor* pColors,
+          const CSRAdaptor<TIndex,TValue>& rMatrix,
+          const ColorSettings<TValue> settings);
+
+
+/// @brief Partition of a graph with respect to a coloring.
+/// @details This class is meant for internal use. It stores
+///          an ordering of the representing matrix' rows, as
+///          well as the extents of each group within the partition.
+///
+///          Users can create partitions with @ref makePartition and
+///          @b must destroy them with @ref destroyPartition.
+///
+/// @see makePartition
+/// @see destroyPartition
+template <class TIndex>
+class Partition;
+
+
+/// @brief Construct the @ref Partition of a graph with respect to a coloring.
+///
+/// @tparam TIndex Integer type of stored indices in the matrix (@p int, @p long, @p unsigned or <c>unsigned long</c>).
+/// @tparam TColor Integer type of vertex colors (@p unsigned or <c>unsigned long</c>).
+///
+/// @param pColors Array of vertex colors.
+/// @param rowCount Number of vertices (must match the number of rows of the matrix representation of the graph).
+///
+/// @return a valid pointer to a partition if successful, otherwise @p nullptr.
+///
+/// @note
+/// - successful partitionings @b must be destroyed explicitly by the user with @ref destroyPartition.
+/// - if partitioning fails, a @p nullptr is returned. In such cases, the user must not invoke
+///   @ref destroyPartition with the returned pointer.
+///
+/// @see destroyPartition
+template <class TIndex, class TColor>
+MCGS_EXPORT_SYMBOL
+[[nodiscard]] Partition<TIndex>* makePartition(const TColor* pColors,
+                                               const TIndex rowCount);
+
+
+/// @brief Destroy a partition that was successfully constructed by @ref makePartition.
+///
+/// @tparam TIndex Integer type of stored indices in the matrix (@p int, @p long, @p unsigned or <c>unsigned long</c>).
+///
+/// @param pPartition Pointer to the @ref Partition to destroy.
+///
+/// @note successful calls to @ref makePartition must be followed by a matching call to @p destroyPartition,
+///       once the constructed @ref Partition is no longer used. Memory allocated by the partition will otherwise
+///       not be released.
+///
+/// @see makePartition
+template <class TIndex>
+MCGS_EXPORT_SYMBOL
+void destroyPartition(Partition<TIndex>* pPartition);
+
+
+/// @brief Reorder rows and columns of a CSR matrix as well as a matching dense vector, with respect to a coloring.
+///
+/// @tparam TIndex Integer type of stored indices in the matrix (@p int, @p long, @p unsigned or <c>unsigned long</c>).
+/// @tparam TValue Number type of stored entries in the matrix (for now, only @p double is supported).
+///
+/// @details This function reorders the rows of a matrix stored in the compressed sparse row format such that
+///          rows with identical colors become contiguous. Columns of the matrix, as well as the associated
+///          right hand side vector @p pRHS are reordered accordingly.
+///
+///          A new partition is returned in which rows of the same color are contiguous. Such a partition is
+///          a prerequisite for running @ref solve(TValue*,const CSRAdaptor&,const TValue*,const Partition*,const SolveSettings)
+///          "parallel versions of Gauss-Seidel smoothing".
+///
+/// @param rowCount Number of rows in the matrix.
+/// @param columnCount Number of columns in the matrix.
+/// @param entryCount Number of entries stored in the compressed matrix.
+/// @param pRowExtents Index array defining entries in the matrix related to each row in @p pEntries.
+///                    Size must be at least <c>rowCount + 1</c>.
+/// @param pColumnIndices Index array assigning column indices to each entry in @p pEntries.
+///                       Size must be at least @p entryCount.
+/// @param pEntries Array of stored entries in the matrix. Size must be at least @p entryCount.
+/// @param pSolution Initial solution vector stored in a dense contiguous array. Size must be at least @p columnCount.
+///                  Pass @p nullptr if you don't want to reorder the initial solution vector.
+/// @param pRHS Right hand side vector stored in a dense contiguous array. Size must be at least @p rowCount.
+///             Pass @p nullptr if you don't want to reorder the right hand side vector.
+/// @param pPartition Pointer to the partition that encodes the coloring of the input matrix.
+///
+/// @return a pointer to a contiguous partition of the reordered system if the reordering is successful,
+///         otherwise @p nullptr.
+///
+/// @note
+/// - The function allocates a duplicate of the input matrix, vector and partition during execution.
+/// - The returned partition must be destroyed explicitly by the user with @ref destroyPartition
+///   (provided the reordering was successful).
+///
+/// @see revertReorder(TValue*,const TIndex,const Partition*)
+/// @see revertReorder(const TIndex,const TIndex,const TIndex,TIndex*,TIndex*,TValue*,TValue*,TValue*,const Partition*)
+template <class TIndex, class TValue>
+MCGS_EXPORT_SYMBOL
+[[nodiscard]] Partition<TIndex>* reorder(const unsigned long rowCount, const unsigned long columnCount, const unsigned long entryCount,
+                                         TIndex* pRowExtents, TIndex* pColumnIndices, TValue* pEntries,
+                                         TValue* pSolution, TValue* pRHS,
+                                         const Partition<TIndex>* pPartition);
+
+
+/// @brief Restore the original order of a @ref reorder "reordered" vector.
+///
+/// @tparam TIndex Integer type of the partition (@p int, @p long, @p unsigned or <c>unsigned long</c>).
+/// @tparam TValue Number type of stored entries in the vector (for now, only @p double is supported).
+///
+/// @param pRHS Dense vector to be reordered.
+/// @param rowCount Size of the dense vector (should be equal to the number of columns in the associated matrix).
+/// @param pPartition Pointer to the original @ref Partition the vector was reordered by.
+///
+/// @return @ref MCGS_SUCCESS if successful, otherwise @ref MCGS_FAILURE.
+///
+/// @fn revertReorder(TValue*,const unsigned long,const Partition*)
+template <class TIndex, class TValue>
+MCGS_EXPORT_SYMBOL
+int revertReorder(TValue* pRHS,
+                  const unsigned long rowCount,
+                  const Partition<TIndex>* pPartition);
+
+
+/// @brief Restore the original order of a @ref reorder "reordered" CSR matrix and associated right hand side vector.
+///
+/// @tparam TIndex Integer type of stored indices in the matrix (@p int, @p long, @p unsigned or <c>unsigned long</c>).
+/// @tparam TValue Number type of stored entries in the matrix (for now, only @p double is supported).
+///
+/// @param rowCount Number of rows in the matrix.
+/// @param columnCount Number of columns in the matrix.
+/// @param entryCount Number of entries stored in the compressed matrix.
+/// @param pRowExtents Index array defining entries in the matrix related to each row in @p pEntries.
+///                    Size must be at least <c>rowCount + 1</c>.
+/// @param pColumnIndices Index array assigning column indices to each entry in @p pEntries.
+///                       Size must be at least @p entryCount.
+/// @param pEntries Array of stored entries in the matrix. Size must be at least @p entryCount.
+/// @param pSolution Initial solution vector stored in a dense contiguous array. Size must be at least @p columnCount.
+///                  Pass @p nullptr if you don't want to reorder the initial solution vector.
+/// @param pRHS Right hand side vector stored in a dense contiguous array. Size must be at least @p rowCount.
+///             Pass @p nullptr if you don't want to reorder the right hand side vector.
+/// @param pPartition Pointer to the original @ref Partition the matrix and vector were reordered by.
+///
+/// @return @ref MCGS_SUCCESS if successful, otherwise @ref MCGS_FAILURE.
+///
+/// @fn revertReorder(const unsigned long,const unsigned long,const unsigned long,TIndex*,TIndex*,TValue*,TValue*,TValue*,const Partition*)
+template <class TIndex, class TValue>
+MCGS_EXPORT_SYMBOL
+int revertReorder(const unsigned long rowCount, const unsigned long columnCount, const unsigned long entryCount,
+                  TIndex* pRowExtents, TIndex* pColumnIndices, TValue* pEntries,
+                  TValue* pSolution, TValue* pRHS,
+                  const Partition<TIndex>* pPartition);
+
+
+/// @brief Compute the 2-norm of the residual of a linear system's approximate solution.
+///
+/// @tparam TIndex Integer type of stored indices in the matrix (@p int, @p long, @p unsigned or <c>unsigned long</c>).
+/// @tparam TValue Number type of stored entries in the matrix (for now, only @p double is supported).
+///
+/// @details @f[ r = \sqrt{\sum_i{(b_i - a_{ij}x_j)^2}} @f]
+///
+/// @param rMatrix Left hand side square matrix in compressed sparse row format (@f$a_{ij}@f$).
+/// @param pSolution Approximate solution vector (@f$x_j@f$).
+///                  Size must be at least equal to the number of @ref CSRAdaptor::columnCount "columns" in the matrix.
+/// @param pRHS Right hand side vector (@f$b_i@f$).
+///             Size must be at least equal to the number of @ref CSRAdaptor::rowCount "rows" in the matrix.
+///
+/// @return The residual's 2-norm.
+template <class TIndex, class TValue>
+MCGS_EXPORT_SYMBOL
+TValue residual(const CSRAdaptor<TIndex,TValue>& rMatrix,
+                const TValue* pSolution,
+                const TValue* pRHS) noexcept;
+
+
+/// @brief Enum for all supported Gauss-Seidel parallelization strategies.
+enum struct Parallelization
+{
+    None        = 1,    ///< @brief Perform Gauss-Seidel iterations in serial.
+    RowWise     = 2,    ///< @brief Distribute work assuming each row has the same number of entries.
+    EntryWise   = 4     ///< @brief Distribute work along equal chunks of entries.
+};
+
+
+/// @brief Settings for Gauss-Seidel relaxation.
+///
+/// @tparam TIndex Integer type of stored indices in the matrix (@p int, @p long, @p unsigned or <c>unsigned long</c>).
+/// @tparam TValue Number type of stored entries in the matrix (for now, only @p double is supported).
+template <class TIndex, class TValue>
+struct SolveSettings
+{
+    /// @brief Absolute tolerance used for convergence checks.
+    /// @note
+    /// - If @ref residualRelativeTolerance "both" tolerances are non-positive,
+    ///   residuals are not computed and relaxation ends when the number of iterations
+    ///   reaches @ref maxIterations.
+    /// - Defaults to @p -1.
+    TValue residualAbsoluteTolerance;
+
+    /// @brief Relative tolerance used for convergence checks.
+    /// @note
+    /// - If @ref residualAbsoluteTolerance "both" tolerances are non-positive,
+    ///   residuals are not computed and relaxation ends when the number of iterations
+    ///   reaches @ref maxIterations.
+    /// - Defaults to @p -1.
+    TValue residualRelativeTolerance;
+
+    /// @brief Maximum number of Gauss-Seidel iterations to allow.
+    /// @note
+    /// - Defaults to @p 1.
+    TIndex maxIterations;
+
+    /// @brief Overrelaxation parameter.
+    /// @note Defaults to @p 1.0.
+    /// @see <a href="https://en.wikipedia.org/wiki/Successive_over-relaxation">Successive Over-relaxation</a>
+    TValue relaxation;
+
+    /// @brief Parallelization strategy.
+    /// @note Defaults to @ref Parallelization::RowWise "row-wise" parallelization.
+    /// @see Parallelization
+    Parallelization parallelization;
+
+    /// @brief Verbosity level controlling the volume of output to @p std::cerr and @p std::cout.
+    /// @details Each level is a strict superset of lower levels.
+    ///          - @p 0: no output is written to @p std::cerr or @p std::cout.
+    ///          - @p 1: error messages are written to @p std::cerr.
+    ///          - @p 2: information outside iterations is written to @p std::cout.
+    ///          - @p 3: information from iterations is written to @p std::cout.
+    ///
+    /// @note Defaults to @p 1.
+    unsigned short verbosity;
+
+    /// @brief Constructor initializing settings to their default values.
+    SolveSettings() noexcept
+        : residualAbsoluteTolerance(-1),
+          residualRelativeTolerance(-1),
+          maxIterations(1),
+          relaxation(1),
+          parallelization(Parallelization::RowWise),
+          verbosity(1)
+    {}
+};
+
+
+/// @brief Perform Gauss-Seidel relaxation in serial.
+///
+/// @tparam TIndex Integer type of stored indices (@p int, @p long, @p unsigned or <c>unsigned long</c>).
+/// @tparam TValue Number type of stored entries (for now, only @p double is supported).
+///
+/// @details @par Algorithm
+///          Given the linear system @f$ a_{ij} x_j^0 = b_i @f$ and the decomposition of
+///          @f$a_{ij}@f$ into the sum of a strictly lower triangular matrix @f$l_{ij}@f$,
+///          a diagonal matrix @f$d_{ij}@f$ and strictly upper triangular matrix @f$u_{ij}@f$
+///          (@f$ a_{ij} = l_{ij} + d_{ij} + u_{ij} @f$), this function computes
+///          @f[
+///             x_j^{k+1} = (1 - \omega)x_j^k + \frac{\omega}{a_{jj}} (b_j - \sum_{i<j}{a_{ji} x_i^{k+1}} - \sum_{i>j}{a_{ji} x_i^k})
+///          @f]
+///          where @f$\omega@f$ is a user-selected relaxation parameter.
+///
+/// @param pSolution Solution array @f$x_j@f$. Size must be at least equal to the number of @ref CSRAdaptor::columnCount "columns" in @p rMatrix.
+/// @param rMatrix Left hand side square matrix in compressed sparse row format @f$a_{ij}@f$.
+/// @param pRHS Right hand side vector @f$b_i@f$. Size must be at least equal to the number of @ref CSRAdaptor::rowCount "rows" in @p rMatrix.
+/// @param settings @ref SolveSettings "algorithmic parameters and other settings" to apply during relaxation.
+///
+/// @return @ref MCGS_SUCCESS if successful, otherwise @ref MCGS_FAILURE.
+///
+/// @see solve(TValue*,const CSRAdaptor&,const TValue*,const Partition*,const SolveSettings)
+/// @fn solve(TValue*,const CSRAdaptor&,const TValue*,const SolveSettings)
+template <class TIndex, class TValue>
+MCGS_EXPORT_SYMBOL
+int solve(TValue* pSolution,
+          const CSRAdaptor<TIndex,TValue>& rMatrix,
+          const TValue* pRHS,
+          const SolveSettings<TIndex,TValue> settings);
+
+
+/// @brief Perform Gauss-Seidel relaxation on a reordered system in parallel.
+///
+/// @tparam TIndex Integer type of stored indices (@p int, @p long, @p unsigned or <c>unsigned long</c>).
+/// @tparam TValue Number type of stored entries (for now, only @p double is supported).
+///
+/// @details @par Algorithm
+///          Given the linear system @f$ a_{ij} x_j^0 = b_i @f$ and the decomposition of
+///          @f$a_{ij}@f$ into the sum of a strictly lower triangular matrix @f$l_{ij}@f$,
+///          a diagonal matrix @f$d_{ij}@f$ and strictly upper triangular matrix @f$u_{ij}@f$
+///          (@f$ a_{ij} = l_{ij} + d_{ij} + u_{ij} @f$), this function computes
+///          @f[
+///             x_j^{k+1} = (1 - \omega)x_j^k + \frac{\omega}{a_{jj}} (b_j - \sum_{i<j}{a_{ji} x_i^{k+1}} - \sum_{i<j}{a_{ji} x_i^k})
+///          @f]
+///          where @f$\omega@f$ is a user-selected relaxation parameter.
+///
+/// @details @par Prerequisites
+///          The input system must be reordered with respect to a coloring of the system matrix' graph.
+///          This ensures that the algorithm doesn't run into race conditions and performs Gauss-Seidel
+///          iterations instead of some aliased product.
+///
+/// @param pSolution Solution array @f$x_j@f$. Size must be at least equal to the number of @ref CSRAdaptor::columnCount "columns" in @p rMatrix.
+/// @param rMatrix Left hand side square matrix in compressed sparse row format @f$a_{ij}@f$.
+/// @param pRHS Right hand side vector @f$b_i@f$. Size must be at least equal to the number of @ref CSRAdaptor::rowCount "rows" in @p rMatrix.
+/// @param pPartition Contiguous partition of the input matrix.
+/// @param settings @ref SolveSettings "algorithmic parameters and other settings" to apply during relaxation.
+///
+/// @return @ref MCGS_SUCCESS if successful, otherwise @ref MCGS_FAILURE.
+///
+/// @see solve(TValue*,const CSRAdaptor&,const TValue*,const SolveSettings)
+/// @see color
+/// @see reorder
+/// @fn solve(TValue*,const CSRAdaptor&,const TValue*,const Partition*,const SolveSettings)
+template <class TIndex, class TValue>
+MCGS_EXPORT_SYMBOL
+int solve(TValue* pSolution,
+          const CSRAdaptor<TIndex,TValue>& rMatrix,
+          const TValue* pRHS,
+          const Partition<TIndex>* pPartition,
+          const SolveSettings<TIndex,TValue> settings);
+
+
+} // namespace mcgs
+
+
+#undef MCGS_EXPORT_SYMBOL

--- a/applications/LinearSolversApplication/external_libraries/mcgs/license.txt
+++ b/applications/LinearSolversApplication/external_libraries/mcgs/license.txt
@@ -1,0 +1,7 @@
+Copyright 2023 Máté Kelemen
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/applications/LinearSolversApplication/external_libraries/mcgs/readme.md
+++ b/applications/LinearSolversApplication/external_libraries/mcgs/readme.md
@@ -1,0 +1,113 @@
+# MCGS - Multicolor Gauss-Seidel Smoother
+
+MCGS is a lightweight library for performing parallelized Gauss-Sidel smoothing, focusing on sparse systems with imbalanced topologies. Implementations for related tasks such as graph coloring and reordering are included as well.
+
+<p style="display: flex; justify-content: center; align-items: center;">
+<img src=".github/assets/matrix.png" width=300/>
+<img src=".github/assets/right_arrow.png" width=100 style="object-fit: scale-down;">
+<img src=".github/assets/matrix_reordered.png" width=300/>
+</p>
+
+## Features
+
+- Gauss-Seidel iterations in parallel (OpenMP) or serial
+- SOR (successive over-relaxation) in parallel (OpenMP) or serial
+- Graph coloring in parallel (loose implementation of `doi:10.1006/jagm.2000.1097`)
+- Matrix/vector reordering and reverse reordering
+
+## Usage
+
+Typical workflow
+
+- construct your linear system $A x = b$
+- construct and adaptor for $A$ (see [mcgs::CSRAdaptor](structmcgs_1_1CSRAdaptor.html))
+- compute a coloring of $A$ (see [mcgs::color](namespacemcgs.html#ad660f970843b8c8edea18c6e9291f6e5))
+- construct a partition of $A$ with respect to the coloring (see [mcgs::makePartition](namespacemcgs.html#adbeb4189f3eadcb713e803cf94aa38cf))
+- reorder the system with respect to the coloring (see [mcgs::reorder](namespacemcgs.html#a5291808c16a69190ac0bb31a1f3ee81d))
+- perform Gauss-Seidel iterations **using the reordered partition** (see [mcgs::solve](namespacemcgs.html#ae862fac411e001950f012872f6ac7e0c))
+- *optional: restore the original order of your system* (see [mcgs::revertReorder](namespacemcgs.html#aa5b1a78cfa8d230b2100320dde50f3c7))
+- deallocate partitions (see [mcgs::destroyPartition](namespacemcgs.html#ad619ded9f67d8a9f379ad7e4b759d854))
+
+
+### C++ Example Snippet
+
+```cpp
+#include "mcgs/mcgs.hpp"
+
+...
+
+// Any CSR matrix will do but for the sake of familiarity, let's assume you're using Eigen.
+Eigen::SparseMatrix<double,Eigen::RowMajor> A;  // <== left hand side matrix
+Eigen::Matrix<double,Eigen::Dynamic,1> b;       // <== right hand side vector
+
+// Construct an adaptor for your matrix.
+mcgs::CSRAdaptor</*index type=*/ int, /*value type=*/double> adaptor;
+adaptor.rowCount        = A.rows();
+adaptor.columnCount     = A.cols();
+adaptor.entryCount      = A.nonZeros();
+adaptor.pRowExtents     = A.outerIndexPtr();
+adaptor.pColumnIndices  = A.innerIndexPtr();
+adaptor.pEntries        = A.innerNonZeroPtr();
+
+// Color the rows of your matrix.
+std::vector<unsigned> colors(adaptor.rowCount);
+mcgs::color(colors.data(),
+            adaptor,
+            mcgs::ColorSettings {});
+
+// Construct a partition for your matrix with respect to the coloring,
+// and reorder the system accordingly. Note that this mutates your original matrix!
+auto pPartition = mcgs::makePartition(colors.data(), adaptor.rowCount);
+auto pReorderedPartition = mcgs::reorder(A.rows(), A.cols(), A.nonZeros(),
+                                         A.outerIndexPtr(), A.innerIndexPtr(), A.innerNonZeroPtr(),
+                                         b.data());
+
+// Do 10 Gauss-Seidel iterations.
+std::vector<double> x(adaptor.columnCount);
+mcgs::SolveSettings</*index type=*/int, /*value type=*/double> settings;
+settings.maxIterations = 10;
+settings.parallelization = mcgs::Parallelization::RowWise; // <== default parallelization strategy, check out the other ones as well.
+mcgs::solve(x.data(), adaptor, b.data(), pReorderedPartition, settings);
+
+// Optional: if you need to recover your original system,
+//           you need to undo the reordering.
+// See mcgs::revertReorder
+
+// Cleanup
+mcgs::destroyPartition(pPartition);
+mcgs::destroyPartition(pReorderedPartition);
+```
+
+## Requirements
+
+- C++ compiler with full C++17 support (GCC or Clang are tested)
+- CMake version 3.15 or later
+- [optional] OpenMP 2.0 or later for shared memory parallelization
+
+## Installation
+
+MCGS is written in C++ and uses CMake as a build system. Building produces a single shared library and matching header.
+
+### Build and Install
+  ```bash
+  cmake <path-to-mcgs-source>                       \
+        -B<path-to-build-dir>                       \
+        -DCMAKE_INSTALL_PREFIX=<your-install-dir>   \
+        -DCMAKE_BUILD_TYPE=Release                  \
+        -DMCGS_SHARED_MEMORY_PARALLELISM=OpenMP
+
+  cmake <path-to-build-dir> --build --target install
+  ```
+
+### Build options
+
+- CMake options for `MCGS_SHARED_MEMORY_PARALLELISM`
+  - `None`: no parallelization
+  - `OpenMP`: use OpenMP for shared memory parallelization
+
+### Include MCGS in a CMake project
+
+```cmake
+find_package(MCGS REQUIRED)
+target_link_libraries(<your_target> PRIVATE mcgs)
+```

--- a/applications/LinearSolversApplication/external_libraries/mcgs/src/color.cpp
+++ b/applications/LinearSolversApplication/external_libraries/mcgs/src/color.cpp
@@ -80,7 +80,7 @@ std::vector<NeighborSet<TIndex>> collectNeighbors(const CSRAdaptor<TIndex,TValue
                     MCGS_ACQUIRE_MUTEX(rMutexes[iColumn]);
                     const auto [itBegin, itEnd] = std::equal_range(neighbors[iColumn].begin(),
                                                                    neighbors[iColumn].end(),
-                                                                   iRow);
+                                                                   static_cast<TIndex>(iRow));
                     if (itBegin == itEnd) neighbors[iColumn].insert(itBegin, iRow);
                     MCGS_RELEASE_MUTEX(rMutexes[iColumn]);
                 }

--- a/applications/LinearSolversApplication/external_libraries/mcgs/src/color.cpp
+++ b/applications/LinearSolversApplication/external_libraries/mcgs/src/color.cpp
@@ -425,7 +425,7 @@ int color(TColor* pColors,
 #define MCGS_INSTANTIATE_COLOR(TIndex, TValue, TColor)                                 \
     template MCGS_EXPORT_SYMBOL int color(TColor* pColors,                             \
                                           const CSRAdaptor<TIndex,TValue>& rMatrix,    \
-                                          const ColorSettings<TValue> settings);
+                                          const ColorSettings<TValue> settings)
 
 MCGS_INSTANTIATE_COLOR(int, double, unsigned);
 MCGS_INSTANTIATE_COLOR(long, double, unsigned);

--- a/applications/LinearSolversApplication/external_libraries/mcgs/src/color.cpp
+++ b/applications/LinearSolversApplication/external_libraries/mcgs/src/color.cpp
@@ -1,0 +1,440 @@
+#define MCGS_INTERNAL
+
+// --- Internal Includes ---
+#include "mcgs/mcgs.hpp" // mcgs::color
+#include "multithreading.hpp" // MCGS_MUTEX_ARRAY
+#include "defineMacros.hpp" // MCGS_EXPORT_SYMBOL
+
+// --- STL Includes ---
+#include <vector> // std::vector
+#include <cstddef> // std::size_t
+#include <algorithm> // std::min, std::max, std::equal_range
+#include <numeric> // std::iota
+#include <random> // std::mt19937, std::uniform_int_distribution
+#include <iostream> // std::cout, std::cerr
+
+
+namespace mcgs {
+
+
+namespace detail {
+
+
+template <class TIndex>
+struct IndexPairTraits
+{
+    using value_type = std::pair<TIndex,TIndex>;
+
+    struct Less
+    {
+        bool operator()(value_type left, value_type right) const noexcept
+        {
+            if (left.first < right.first) {
+                return true;
+            } else if (left.first == right.first) {
+                return left.second < right.second;
+            } else {
+                return false;
+            }
+        }
+    }; // struct Less
+}; // struct IndexPairTraits
+
+
+} // namespace detail
+
+
+template <class TIndex>
+using NeighborSet = std::vector<TIndex>;
+
+
+/// @brief Collect all edges of an undirected graph.
+template <class TIndex, class TValue>
+std::vector<NeighborSet<TIndex>> collectNeighbors(const CSRAdaptor<TIndex,TValue>& rMatrix,
+                                                  const ColorSettings<TValue> settings,
+                                                  [[maybe_unused]] MCGS_MUTEX_ARRAY& rMutexes)
+{
+    std::vector<NeighborSet<TIndex>> neighbors(rMatrix.columnCount);
+
+    #ifdef MCGS_OPENMP
+    #pragma omp parallel for
+    #endif
+    for (int iRow=0; iRow<static_cast<int>(rMatrix.rowCount); ++iRow) {
+        const TIndex iRowBegin = rMatrix.pRowExtents[iRow];
+        const TIndex iRowEnd = rMatrix.pRowExtents[iRow + 1];
+
+        for (TIndex iEntry=iRowBegin; iEntry<iRowEnd; ++iEntry) {
+            const TIndex iColumn = rMatrix.pColumnIndices[iEntry];
+            const TValue value = rMatrix.pEntries[iEntry];
+            if (settings.tolerance <= std::abs(value) && static_cast<TIndex>(iRow) != iColumn) {
+                {
+                    MCGS_ACQUIRE_MUTEX(rMutexes[iRow]);
+                    const auto [itBegin, itEnd] = std::equal_range(neighbors[iRow].begin(),
+                                                                   neighbors[iRow].end(),
+                                                                   iColumn);
+                    if (itBegin == itEnd) neighbors[iRow].insert(itBegin, iColumn);
+                    MCGS_RELEASE_MUTEX(rMutexes[iRow]);
+                }
+
+                {
+                    MCGS_ACQUIRE_MUTEX(rMutexes[iColumn]);
+                    const auto [itBegin, itEnd] = std::equal_range(neighbors[iColumn].begin(),
+                                                                   neighbors[iColumn].end(),
+                                                                   iRow);
+                    if (itBegin == itEnd) neighbors[iColumn].insert(itBegin, iRow);
+                    MCGS_RELEASE_MUTEX(rMutexes[iColumn]);
+                }
+            }
+        } // for iEntry in range(iRowBegin, iRowEnd)
+    } // for iRow in range(rowCount)
+
+    return neighbors;
+}
+
+
+using Mask = std::vector<char>;
+
+
+template <class TIndex, class TColor>
+bool isColored(const TIndex iVertex,
+               const NeighborSet<TIndex>* pNeighborMap,
+               const TColor* pColors,
+               const Mask& rColoredMask)
+{
+    const TColor currentColor = pColors[iVertex];
+
+    // If there's a conflict, keep the coloring of the vertex with the higher index.
+    bool colored = true;
+
+    for (const TIndex iNeighbor : pNeighborMap[iVertex]) {
+        const TColor neighborColor = pColors[iNeighbor];
+        if (neighborColor == currentColor) {
+            if (iVertex < iNeighbor) {
+                // The current vertex has a lower index than the neighbor
+                // it's in conflict with => give up on this vertex.
+                colored = false;
+                break;
+            } else if (rColoredMask[iNeighbor]) {
+                // Although the current vertex would win a tiebreaker against
+                // its neighbor it's in conflict with, the neighbor's color is
+                // already set and cannot be changed => give up on this vertex.
+                colored = false;
+                break;
+            }
+
+            // Otherwise, the current vertex has a higher index
+            // than its conflicting neighbor, who is still waiting
+            // to be colored, winning the tiebreaker
+            // => hang on to this vertex.
+        }
+    } // for iNeighbor in neighbors[iVertex]
+
+    return colored;
+}
+
+
+template <class TColor>
+struct Palette
+{
+    TColor maxColor;
+
+    std::vector<TColor> palette;
+}; // struct Palette
+
+
+template <class TColor>
+void extendPalette(Palette<TColor>& rPalette, const TColor color)
+{
+    rPalette.palette.push_back(color);
+    rPalette.maxColor = std::max(color, rPalette.maxColor);
+}
+
+
+template <class TColor>
+void extendPalette(Palette<TColor>& rPalette)
+{
+    extendPalette(rPalette, rPalette.maxColor + 1);
+}
+
+
+template <class TColor>
+void removeFromPalette(const TColor color,
+                       Palette<TColor>& rPalette)
+{
+    if (rPalette.maxColor < color) return;
+
+    // The palette's colors are assumed to be sorted
+    const auto [itBegin, itEnd] = std::equal_range(rPalette.palette.begin(),
+                                                   rPalette.palette.end(),
+                                                   color);
+    rPalette.palette.erase(itBegin, itEnd);
+}
+
+
+template <class TIndex, class TValue, class TColor>
+MCGS_EXPORT_SYMBOL
+int color(TColor* pColors,
+          const CSRAdaptor<TIndex,TValue>& rMatrix,
+          const ColorSettings<TValue> settings)
+{
+    // Cheap sanity checks
+    if (rMatrix.rowCount < 0) {
+        if (1 < settings.verbosity) std::cerr << "mcgs: error: invalid number of rows " << rMatrix.rowCount << "\n";
+        return MCGS_FAILURE;
+    }
+
+    if (rMatrix.columnCount < 0) {
+        if (1 < settings.verbosity) std::cerr << "mcgs: error: invalid number of columns " << rMatrix.columnCount << "\n";
+        return MCGS_FAILURE;
+    }
+
+    if (rMatrix.entryCount < 0) {
+        if (1 < settings.verbosity) std::cerr << "mcgs: error: invalid number of nonzeros " << rMatrix.entryCount << "\n";
+        return MCGS_FAILURE;
+    }
+
+    if (!rMatrix.pRowExtents) {
+        if (1 < settings.verbosity) std::cerr << "mcgs: error: missing row data\n";
+        return MCGS_FAILURE;
+    }
+
+    if (!rMatrix.pColumnIndices) {
+        if (1 < settings.verbosity) std::cerr << "mcgs: error: missing column data\n";
+        return MCGS_FAILURE;
+    }
+
+    if (!rMatrix.pEntries) {
+        if (1 < settings.verbosity) std::cerr << "mcgs: error: missing nonzeros\n";
+        return MCGS_FAILURE;
+    }
+
+    if (!pColors) {
+        if (1 < settings.verbosity) std::cerr << "mcgs: error: missing output array\n";
+        return MCGS_FAILURE;
+    }
+
+    if (rMatrix.rowCount != rMatrix.columnCount) {
+        if (1 < settings.verbosity) std::cerr << "mcgs: error: expecting a square matrix, but got "
+                                              << rMatrix.rowCount << "x" << rMatrix.columnCount << "\n";
+        return MCGS_FAILURE;
+    }
+
+    MCGS_MUTEX_ARRAY mutexes(rMatrix.rowCount);
+    for ([[maybe_unused]] MCGS_MUTEX& rMutex : mutexes) MCGS_INITIALIZE_MUTEX(rMutex);
+
+    // Collect all edges of the graph
+    // (symmetric version of the input matrix)
+    const auto neighbors = collectNeighbors(rMatrix, settings, mutexes);
+
+    // Find the minimum and maximum vertex degrees.
+    TIndex minDegree = std::numeric_limits<TIndex>::max();
+    TIndex maxDegree = 0;
+
+    #if defined(MCGS_OPENMP) && 201107 <= _OPENMP
+    #pragma omp parallel for reduction(min: minDegree) reduction(max: maxDegree)
+    #endif
+    for (int iRow=0; iRow<static_cast<int>(rMatrix.rowCount); ++iRow) {
+        const TIndex degree = static_cast<TIndex>(neighbors[iRow].size());
+        minDegree = std::min(minDegree, degree);
+        maxDegree = std::max(maxDegree, degree);
+    } // for iRow in range(rowCount)
+
+    if (2 <= settings.verbosity) {
+        std::cout << "mcgs: max vertex degree is " << maxDegree << '\n'
+                  << "mcgs: min vertex degree is " << minDegree << '\n'
+                  ;
+    }
+
+    // Allocate the palette of every vertex to the max possible (maximum vertex degree).
+    // An extra entry at the end of each palette indicates the palette's actual size.
+    const TIndex shrinkingFactor = 0 < settings.shrinkingFactor ?
+                                   static_cast<TIndex>(settings.shrinkingFactor) :
+                                   std::max(TIndex(1), minDegree);
+
+    const TIndex initialPaletteSize = std::max(
+        TIndex(1),
+        TIndex(double(maxDegree) / double(shrinkingFactor)));
+
+    if (3 <= settings.verbosity) {
+        std::cout << "mcgs: initial palette size is " << initialPaletteSize << std::endl;
+    }
+
+    // Initialize the palette of all vertices to a shrunk set
+    std::vector<Palette<TColor>> palettes(rMatrix.columnCount);
+
+    #ifdef MCGS_OPENMP
+    #pragma omp parallel for
+    #endif
+    for (int iVertex=0; iVertex<static_cast<int>(rMatrix.columnCount); ++iVertex) {
+        palettes[iVertex].palette.resize(initialPaletteSize);
+        std::iota(palettes[iVertex].palette.begin(), palettes[iVertex].palette.end(), TColor(0));
+        palettes[iVertex].maxColor = palettes[iVertex].palette.back();
+    } // for iVertex in range(columnCount)
+
+    // Track vertices that need to be colored.
+    Mask coloredMask(rMatrix.columnCount, false);
+    std::vector<TIndex> uncolored(rMatrix.rowCount);
+    std::iota(uncolored.begin(), uncolored.end(), TIndex(0));
+
+    #ifdef MCGS_OPENMP
+    [[maybe_unused]] const int threadCount = omp_get_max_threads();
+    #else
+    [[maybe_unused]] const int threadCount = 1;
+    #endif
+
+    // Keep coloring until all vertices are colored.
+    std::size_t iterationCount = 0ul;
+    int stallCounter = 0;
+
+    while (!uncolored.empty()) {
+        const TIndex uncoloredCount = uncolored.size();
+        if (3 <= settings.verbosity) {
+            std::cout << "mcgs: coloring iteration " << iterationCount++
+                      << " (" << uncoloredCount << "/" << rMatrix.columnCount
+                      << " left to color)\n";
+        }
+
+        // Assign random colors to each remaining vertex from their palette.
+        #ifdef MCGS_OPENMP
+        #pragma omp parallel
+        #endif
+        {
+
+            {
+                #ifdef MCGS_OPENMP
+                    const int iThread = omp_get_thread_num();
+                #else
+                    const int iThread = 0;
+                #endif
+                constexpr int seed = 0;
+                std::mt19937 randomGenerator(seed);
+
+                // To produce reproducible results, the random number
+                // generator must be consistent for all possible number
+                // of threads. To emulate what we'd get from a single-threaded
+                // run, we need to partition the work manually and discard
+                // the sequence of random numbers generated by other threads
+                // before the current one.
+                const TIndex uiThread = static_cast<TIndex>(iThread);
+                const TIndex minChunkSize = uncoloredCount / static_cast<TIndex>(threadCount);
+                const TIndex chunkLeftovers = uncoloredCount % static_cast<TIndex>(threadCount);
+                const TIndex iChunkBegin = uiThread * minChunkSize + std::min(chunkLeftovers, uiThread);
+                const TIndex iChunkEnd = iChunkBegin + minChunkSize + (chunkLeftovers <= uiThread ? 0 : 1);
+
+                if (iChunkBegin != iChunkEnd) {
+                    randomGenerator.discard(iChunkBegin);
+                }
+
+                for (TIndex iVisit=iChunkBegin; iVisit<iChunkEnd; ++iVisit) {
+                    const TIndex iVertex = uncolored[iVisit];
+                    const TColor paletteSize = palettes[iVertex].palette.size();
+                    //const TColor iColorMax = paletteSize ? paletteSize - 1 : static_cast<TColor>(0);
+                    //const TColor iColor = std::uniform_int_distribution<TColor>(TColor(0), iColorMax)(randomGenerator);
+                    const TColor iColor = randomGenerator() % paletteSize;
+                    pColors[iVertex] = palettes[iVertex].palette[iColor];
+                } // for iVisit in range(iChunkBegin, iChunkEnd)
+
+                #ifdef MCGS_OPENMP
+                #pragma omp barrier
+                #endif
+            }
+
+            #ifdef MCGS_OPENMP
+            #pragma omp for
+            #endif
+            for (int iVisit=0; iVisit<static_cast<int>(uncoloredCount); ++iVisit) {
+                const TIndex iVertex = uncolored[iVisit];
+                const bool colored = isColored(iVertex, neighbors.data(), pColors, coloredMask);
+
+                // If the current vertex has a valid color, remove
+                // its color from the palettes of its neighbors.
+                if (colored) {
+                    MCGS_ACQUIRE_MUTEX(mutexes[iVertex]);
+                    coloredMask[iVertex] = true;
+                    palettes[iVertex].palette = std::vector<TColor> {};
+                    MCGS_RELEASE_MUTEX(mutexes[iVertex]);
+
+
+                    for (TIndex iNeighbor : neighbors[iVertex]) {
+                        if (!coloredMask[iNeighbor]) {
+                            MCGS_ACQUIRE_MUTEX(mutexes[iNeighbor]);
+                            removeFromPalette(pColors[iVertex], palettes[iNeighbor]);
+                            MCGS_RELEASE_MUTEX(mutexes[iNeighbor]);
+                        } // if !coloredMask[iNeighbor]
+                    } // for iNeighbor in neighbors[iVertex]
+                } // if colored
+            } // for iVertex in uncolored
+
+            #ifdef MCGS_OPENMP
+            #pragma omp for
+            #endif
+            for (int iVisit=0; iVisit<static_cast<int>(uncoloredCount); ++iVisit) {
+                const TIndex iVertex = uncolored[iVisit];
+                const bool needsExtension = !coloredMask[iVertex] && palettes[iVertex].palette.empty();
+                if (needsExtension) {
+                    TColor extension = palettes[iVertex].maxColor + 1;
+                    extendPalette(palettes[iVertex], extension);
+                } // if needsExtension
+            } // for iVisit in range(uncoloredCount)
+        } // omp parallel
+
+        // Update remaining vertices
+        {
+            std::vector<TIndex> swap;
+            swap.reserve(uncolored.size());
+
+            for (TIndex iVisit=0; iVisit<static_cast<TIndex>(uncolored.size()); ++iVisit) {
+                const TIndex iVertex = uncolored[iVisit];
+                if (!coloredMask[iVertex]) swap.push_back(iVertex);
+            }
+
+            uncolored.swap(swap);
+        }
+
+        if (static_cast<TIndex>(uncolored.size()) == uncoloredCount) {
+            // Failed to color any vertices => extend the palette of some random vertices
+            const TIndex maxExtensions = std::max(TIndex(1), TIndex(25 * uncolored.size() / 100));
+            TIndex extensionCounter = 0;
+
+            // @todo parallelize
+            for (TIndex iUncolored=0; iUncolored<static_cast<TIndex>(uncolored.size()) && extensionCounter < maxExtensions; ++iUncolored) {
+                extendPalette(palettes[uncolored[iUncolored]]);
+                ++extensionCounter;
+            }
+
+            if (!extensionCounter) {
+                ++stallCounter;
+                if (0 <= settings.maxStallCount && settings.maxStallCount <= stallCounter) {
+                    if (1 <= settings.verbosity) std::cerr << "mcgs: error: reached stall limit (" << settings.maxStallCount << ")\n";
+                    return MCGS_FAILURE;
+                }
+            } else {
+                stallCounter = 0;
+            }
+        } else {
+            stallCounter = 0;
+        }
+    };
+
+    for ([[maybe_unused]] MCGS_MUTEX& rMutex : mutexes) MCGS_DEINITIALIZE_MUTEX(rMutex);
+
+    return MCGS_SUCCESS;
+}
+
+
+#define MCGS_INSTANTIATE_COLOR(TIndex, TValue, TColor)                                 \
+    template MCGS_EXPORT_SYMBOL int color(TColor* pColors,                             \
+                                          const CSRAdaptor<TIndex,TValue>& rMatrix,    \
+                                          const ColorSettings<TValue> settings);
+
+MCGS_INSTANTIATE_COLOR(int, double, unsigned);
+MCGS_INSTANTIATE_COLOR(long, double, unsigned);
+MCGS_INSTANTIATE_COLOR(unsigned, double, unsigned);
+MCGS_INSTANTIATE_COLOR(unsigned long, double, unsigned);
+
+#undef MCGS_INSTANTIATE_COLOR
+#undef MCGS_INTERNAL
+#include "undefineMacros.hpp"
+
+
+} // namespace mcgs

--- a/applications/LinearSolversApplication/external_libraries/mcgs/src/defineMacros.hpp
+++ b/applications/LinearSolversApplication/external_libraries/mcgs/src/defineMacros.hpp
@@ -1,0 +1,9 @@
+#include "undefineMacros.hpp"
+
+#define MCGS_INTERNAL
+
+#if _WIN32
+    #define MCGS_EXPORT_SYMBOL __declspec(dllexport)
+#else
+    #define MCGS_EXPORT_SYMBOL __attribute__((visibility ("default")))
+#endif

--- a/applications/LinearSolversApplication/external_libraries/mcgs/src/multithreading.hpp
+++ b/applications/LinearSolversApplication/external_libraries/mcgs/src/multithreading.hpp
@@ -1,0 +1,55 @@
+#pragma once
+
+// --- External Includes ---
+#ifdef MCGS_OPENMP
+    #include <omp.h> // omp_lock_t
+#endif
+
+// --- STL Includes ---
+#ifdef MCGS_OPENMP
+    #include <vector> // std::vector
+#else
+    #include <cstddef> // std::size_t, std::ptrdiff_t
+    #include <iterator> // std::random_access_iterator_tag
+
+    namespace mcgs::detail {
+        struct Dummy {};
+
+        template <class T>
+        struct DummyVector
+        {
+            using value_type = T;
+            using pointer = value_type*;
+            using reference = value_type&;
+            using const_reference = const value_type&;
+            using iterator = value_type*;
+            using const_iterator = const value_type*;
+            using size_type = std::size_t;
+            using difference_type = std::ptrdiff_t;
+            DummyVector() noexcept = default;
+            DummyVector(std::size_t) noexcept {}
+            DummyVector(std::size_t, const T&) noexcept {}
+            void resize(std::size_t) noexcept {}
+            void operator[](std::size_t) noexcept {}
+            iterator begin() noexcept {return nullptr;}
+            iterator end() noexcept {return nullptr;}
+            size_type size() const noexcept {return 0;}
+        }; // struct DummyVector
+    } // namespace mcgs::detail
+#endif
+
+#ifdef MCGS_OPENMP
+    #define MCGS_MUTEX omp_lock_t
+    #define MCGS_MUTEX_ARRAY std::vector<MCGS_MUTEX>
+    #define MCGS_INITIALIZE_MUTEX(rMutex) omp_init_lock(&rMutex)
+    #define MCGS_ACQUIRE_MUTEX(rMutex) omp_set_lock(&rMutex)
+    #define MCGS_RELEASE_MUTEX(rMutex) omp_unset_lock(&rMutex)
+    #define MCGS_DEINITIALIZE_MUTEX(rMutex) omp_destroy_lock(&rMutex)
+#else
+    #define MCGS_MUTEX mcgs::detail::Dummy
+    #define MCGS_MUTEX_ARRAY mcgs::detail::DummyVector<MCGS_MUTEX>
+    #define MCGS_INITIALIZE_MUTEX(rMutex)
+    #define MCGS_ACQUIRE_MUTEX(rMutex)
+    #define MCGS_RELEASE_MUTEX(rMutex)
+    #define MCGS_DEINITIALIZE_MUTEX(rMutex)
+#endif

--- a/applications/LinearSolversApplication/external_libraries/mcgs/src/partition.cpp
+++ b/applications/LinearSolversApplication/external_libraries/mcgs/src/partition.cpp
@@ -67,9 +67,9 @@ Partition<TIndex>::Partition(std::vector<TIndex>&& rPartitionExtents,
 
 
 template <class TIndex, class TColor>
-MCGS_EXPORT_SYMBOL
-[[nodiscard]] Partition<TIndex>* makePartition(const TColor* pColors,
-                                               const TIndex rowCount)
+[[nodiscard]] MCGS_EXPORT_SYMBOL
+Partition<TIndex>* makePartition(const TColor* pColors,
+                                 const TIndex rowCount)
 {
     return new Partition<TIndex>(pColors, rowCount);
 }

--- a/applications/LinearSolversApplication/external_libraries/mcgs/src/partition.cpp
+++ b/applications/LinearSolversApplication/external_libraries/mcgs/src/partition.cpp
@@ -90,7 +90,7 @@ void destroyPartition(Partition<TIndex>* pPartition)
     template class Partition<TIndex>;                                               \
     MCGS_INSTANTIATE_PARTITION_FACTORY(TIndex, unsigned)                            \
     MCGS_INSTANTIATE_PARTITION_FACTORY(TIndex, unsigned long)                       \
-    template MCGS_EXPORT_SYMBOL void destroyPartition<TIndex>(Partition<TIndex>*)   \
+    template MCGS_EXPORT_SYMBOL void destroyPartition<TIndex>(Partition<TIndex>*)
 
 MCGS_INSTANTIATE_PARTITION(int);
 MCGS_INSTANTIATE_PARTITION(long);

--- a/applications/LinearSolversApplication/external_libraries/mcgs/src/partition.cpp
+++ b/applications/LinearSolversApplication/external_libraries/mcgs/src/partition.cpp
@@ -1,0 +1,106 @@
+#define MCGS_INTERNAL
+
+// --- Internal Includes ---
+#include "mcgs/mcgs.hpp" // mcgs::partition
+#include "partition.hpp" // mcgs::Partition
+#include "defineMacros.hpp" // MCGS_EXPORT_SYMBOL
+
+// --- STL Includes ---
+#include <cstddef> // std::size_t
+#include <vector> // std::vector
+#include <unordered_map> // std::unordered_map
+#include <algorithm> // std::copy, std::is_sorted
+
+
+namespace mcgs {
+
+
+template <class TIndex>
+template <class TColor>
+Partition<TIndex>::Partition(const TColor* pColors, const TIndex rowCount)
+    : _isContiguous(false),
+      _partitionExtents(),
+      _rowIndices()
+{
+    std::unordered_map<
+        TColor,
+        std::vector<TIndex>
+    > partitionMap;
+
+    for (TIndex iColumn=0; iColumn<rowCount; ++iColumn) {
+        const TColor color = pColors[iColumn];
+        partitionMap.emplace(color, std::vector<TIndex> {}) // <== make sure an entry is mapped to color
+            .first                                          // <== iterator pointing to the entry
+            ->second                                        // <== reference to the mapped vector
+            .push_back(iColumn);                            // <== insert the column index into the mapped vector
+    } // for iColumn in range(rowCount)
+
+    _rowIndices.resize(rowCount + 1);
+    _partitionExtents.resize(partitionMap.size() + 1);
+
+    TIndex iColor = 0;
+    TIndex rowCounter = 0;
+
+    for ([[maybe_unused]] const auto& [color, rColumns] : partitionMap) {
+        _partitionExtents[iColor] = rowCounter;
+        std::copy(rColumns.begin(), rColumns.end(), _rowIndices.begin() + rowCounter);
+
+        ++iColor;
+        rowCounter += rColumns.size();
+    }
+
+    _partitionExtents.back() = rowCounter;
+    _rowIndices.back() = rowCount;
+    _isContiguous = std::is_sorted(_rowIndices.begin(), _rowIndices.end());
+}
+
+
+template <class TIndex>
+Partition<TIndex>::Partition(std::vector<TIndex>&& rPartitionExtents,
+                             std::vector<TIndex>&& rRowIndices) noexcept
+    : _isContiguous(false),
+      _partitionExtents(std::move(rPartitionExtents)),
+      _rowIndices(std::move(rRowIndices))
+{
+    _isContiguous = std::is_sorted(_rowIndices.begin(), _rowIndices.end());
+}
+
+
+template <class TIndex, class TColor>
+MCGS_EXPORT_SYMBOL
+[[nodiscard]] Partition<TIndex>* makePartition(const TColor* pColors,
+                                               const TIndex rowCount)
+{
+    return new Partition<TIndex>(pColors, rowCount);
+}
+
+
+template <class TIndex>
+MCGS_EXPORT_SYMBOL
+void destroyPartition(Partition<TIndex>* pPartition)
+{
+    delete pPartition;
+}
+
+
+#define MCGS_INSTANTIATE_PARTITION_FACTORY(TIndex, TColor)                                  \
+    template MCGS_EXPORT_SYMBOL Partition<TIndex>* makePartition<TIndex,TColor>(const TColor*, const TIndex);
+
+#define MCGS_INSTANTIATE_PARTITION(TIndex)                                          \
+    template class Partition<TIndex>;                                               \
+    MCGS_INSTANTIATE_PARTITION_FACTORY(TIndex, unsigned)                            \
+    MCGS_INSTANTIATE_PARTITION_FACTORY(TIndex, unsigned long)                       \
+    template MCGS_EXPORT_SYMBOL void destroyPartition<TIndex>(Partition<TIndex>*)   \
+
+MCGS_INSTANTIATE_PARTITION(int);
+MCGS_INSTANTIATE_PARTITION(long);
+MCGS_INSTANTIATE_PARTITION(unsigned);
+MCGS_INSTANTIATE_PARTITION(unsigned long);
+
+#undef MCGS_INSTANTIATE_PARTITION_FACTORY
+#undef MCGS_INSTANTIATE_PARTITION
+#undef MCGS_INTERNAL
+#include "undefineMacros.hpp"
+
+
+} // namespace mcgs

--- a/applications/LinearSolversApplication/external_libraries/mcgs/src/partition.hpp
+++ b/applications/LinearSolversApplication/external_libraries/mcgs/src/partition.hpp
@@ -1,0 +1,63 @@
+#pragma once
+
+// --- Internal Includes ---
+#include "defineMacros.hpp"
+
+// --- STL Includes ---
+#include <vector> // std::vector
+#include <cstddef> // std::size_t, std::ptrdiff_t
+#include <iterator> // std::distance
+
+
+namespace mcgs {
+
+
+template <class TIndex>
+class MCGS_EXPORT_SYMBOL Partition
+{
+private:
+    bool _isContiguous;
+
+    std::vector<TIndex> _partitionExtents;
+
+    std::vector<TIndex> _rowIndices;
+
+    Partition() = delete;
+    Partition(Partition&&) = delete;
+    Partition(const Partition&) = delete;
+    Partition& operator=(Partition&&) = delete;
+    Partition& operator=(const Partition&) = delete;
+
+public:
+    using value_type = TIndex;
+    using reference = TIndex&;
+    using const_reference = const TIndex&;
+    using iterator = TIndex*;
+    using const_iterator = const TIndex*;
+    using difference_type = std::ptrdiff_t;
+    using size_type = std::size_t;
+
+    template <class TColor>
+    Partition(const TColor* pColors, const TIndex rowCount);
+
+    Partition(std::vector<TIndex>&& rPartitionExtents,
+              std::vector<TIndex>&& rRowIndices) noexcept;
+
+    size_type size() const noexcept
+    {return _partitionExtents.size() - 1;}
+
+    size_type size(const size_type iPartition) const noexcept
+    {return std::distance(this->begin(iPartition), this->end(iPartition));}
+
+    const_iterator begin(const size_type iPartition) const noexcept
+    {return &_rowIndices[_partitionExtents[iPartition]];}
+
+    const_iterator end(const size_type iPartition) const noexcept
+    {return &_rowIndices[_partitionExtents[iPartition + 1]];}
+
+    bool isContiguous() const noexcept
+    {return _isContiguous;}
+};
+
+
+} // namespace mcgs

--- a/applications/LinearSolversApplication/external_libraries/mcgs/src/reorder.cpp
+++ b/applications/LinearSolversApplication/external_libraries/mcgs/src/reorder.cpp
@@ -1,0 +1,200 @@
+#define MCGS_INTERNAL
+
+// --- Internal Includes ---
+#include "mcgs/mcgs.hpp" // mcgs::reorder, mcgs::CSRAdaptor
+#include "partition.hpp" // mcgs::Partition
+#include "defineMacros.hpp" // MCGS_EXPORT_SYMBOL
+
+// --- STL Includes ---
+#include <vector> // std::vector
+#include <algorithm> // std::copy, std::swap, std::transform
+#include <numeric> // std::iota
+
+
+namespace mcgs {
+
+
+template <class TIndex, class TValue>
+MCGS_EXPORT_SYMBOL
+Partition<TIndex>* reorder(const unsigned long rowCount, const unsigned long columnCount, const unsigned long nonzeroCount,
+                           TIndex* pRowExtents, TIndex* pColumnIndices, TValue* pNonzeros,
+                           TValue* pSolution, TValue* pRHS,
+                           const Partition<TIndex>* pPartition)
+{
+    // Allocate arrays for the new partition
+    std::vector<TIndex> newPartitionExtents(pPartition->size() + 1);
+    newPartitionExtents[0] = static_cast<TIndex>(0);
+
+    // Reorder matrix and vectors
+    {
+        // Allocate temporary matrix
+        const auto partitionCount = pPartition->size();
+        std::vector<TIndex> newRowExtents(rowCount + 1);
+        std::vector<TIndex> newColumnIndices(nonzeroCount);
+        std::vector<TValue> newNonzeros(nonzeroCount);
+
+        // Allocate temporary vectors
+        std::vector<TValue> solution, rhs;
+        if (pSolution != nullptr) solution.resize(columnCount);
+        if (pRHS != nullptr) rhs.resize(rowCount);
+        const bool reorderSolution = !solution.empty();
+        const bool reorderRHS = !rhs.empty();
+
+        newRowExtents.front() = 0;
+
+        // Compute new extents
+        {
+            TIndex iNewRow = 0;
+
+            for (std::size_t iPartition=0; iPartition<partitionCount; ++iPartition) {
+                const auto itPartitionBegin = pPartition->begin(iPartition);
+                const auto partitionSize = pPartition->size(iPartition);
+
+                for (std::remove_const_t<decltype(partitionSize)> iLocal=0; iLocal<partitionSize; ++iLocal) {
+                    const TIndex iOldRow = itPartitionBegin[iLocal];
+                    const auto rowSize = pRowExtents[iOldRow + 1] - pRowExtents[iOldRow];
+                    newRowExtents[iNewRow + 1] = newRowExtents[iNewRow] + rowSize;
+                    ++iNewRow;
+                } // for iLocal in range(parititionSize)
+
+                newPartitionExtents[iPartition + 1] = newPartitionExtents[iPartition] + partitionSize;
+            } // for iPartition in range(partitionCount)
+        }
+
+        std::vector<TIndex> columnMap(columnCount);
+
+        #ifdef MCGS_OPENMP
+        #pragma omp parallel
+        #endif
+        {
+            for (std::size_t iPartition=0; iPartition<partitionCount; ++iPartition) {
+                auto itPartitionBegin = pPartition->begin(iPartition);
+                const auto partitionSize = pPartition->size(iPartition);
+
+                #ifdef MCGS_OPENMP
+                #pragma omp for
+                #endif
+                for (int iLocal=0; iLocal<static_cast<int>(partitionSize); ++iLocal) {
+                    const TIndex iOldRow = itPartitionBegin[iLocal];
+                    const TIndex iNewRow = newPartitionExtents[iPartition] + iLocal;
+                    columnMap[iOldRow] = iNewRow;
+
+                    std::copy(pColumnIndices + pRowExtents[iOldRow],
+                            pColumnIndices + pRowExtents[iOldRow + 1],
+                            newColumnIndices.data() + newRowExtents[iNewRow]);
+
+                    std::copy(pNonzeros + pRowExtents[iOldRow],
+                            pNonzeros + pRowExtents[iOldRow + 1],
+                            newNonzeros.data() + newRowExtents[iNewRow]);
+
+                    if (reorderSolution) solution[iNewRow] = pSolution[iOldRow];
+                    if (reorderRHS) rhs[iNewRow] = pRHS[iOldRow];
+                } // for iLocal in range(parititionSize)
+            } // for iPartition in range(partitionCount)
+        } // omp parallel
+
+        std::copy(newRowExtents.begin(), newRowExtents.end(), pRowExtents);
+        std::copy(newNonzeros.begin(), newNonzeros.end(), pNonzeros);
+        std::copy(solution.begin(), solution.end(), pSolution);
+        std::copy(rhs.begin(), rhs.end(), pRHS);
+        std::transform(newColumnIndices.begin(),
+                       newColumnIndices.end(),
+                       pColumnIndices,
+                       [&columnMap](const TIndex iOldColumn) -> TIndex {
+                               return columnMap[iOldColumn];
+                       });
+    }
+
+    // Allocate arrays for the new partition
+    // and assign the new row indices
+    std::vector<TIndex> newRowIndices(rowCount + 1);
+    std::iota(newRowIndices.begin(), newRowIndices.end(), TIndex(0));
+
+    return new Partition<TIndex>(std::move(newPartitionExtents), std::move(newRowIndices));
+}
+
+
+template <class TIndex, class TValue>
+MCGS_EXPORT_SYMBOL
+int revertReorder(TValue* pRHS,
+                  const unsigned long columnCount,
+                  const Partition<TIndex>* pPartition)
+{
+    std::vector<TValue> swap(columnCount);
+
+    TIndex iNewRow = 0;
+    for (typename Partition<TIndex>::size_type iPartition=0; iPartition<pPartition->size(); ++iPartition) {
+        for (auto itPartition=pPartition->begin(iPartition); itPartition!=pPartition->end(iPartition); ++itPartition) {
+            swap[*itPartition] = pRHS[iNewRow++];
+        }
+    }
+
+    if (iNewRow != static_cast<TIndex>(columnCount)) {
+        return MCGS_FAILURE;
+    }
+
+    std::copy(swap.begin(), swap.end(), pRHS);
+    return MCGS_SUCCESS;
+}
+
+
+template <class TIndex, class TValue>
+MCGS_EXPORT_SYMBOL
+int revertReorder(const unsigned long rowCount, const unsigned long columnCount, const unsigned long nonzeroCount,
+                  TIndex* pRowExtents, TIndex* pColumnIndices, TValue* pNonzeros,
+                  TValue* pSolution, TValue* pRHS,
+                  const Partition<TIndex>* pPartition)
+{
+    // Construct inverse partition
+    std::vector<TIndex> partitionExtents {static_cast<TIndex>(0), static_cast<TIndex>(rowCount)}, rowIndices(rowCount);
+    const TIndex* itPartitionBegin = pPartition->begin(0);
+
+    #ifdef MCGS_OPENMP
+    #pragma omp parallel for
+    #endif
+    for (int iRow=0; iRow<static_cast<int>(rowCount); ++iRow) {
+        rowIndices[itPartitionBegin[iRow]] = iRow;
+    } // for iRow in range(rowCount)
+
+    Partition<TIndex> inversePartition(std::move(partitionExtents), std::move(rowIndices));
+
+    // Reorder
+    Partition<TIndex>* pDummy = reorder(rowCount, columnCount, nonzeroCount,
+                                        pRowExtents, pColumnIndices, pNonzeros,
+                                        pSolution, pRHS,
+                                        &inversePartition);
+
+    if (pDummy == nullptr) {
+        return MCGS_FAILURE;
+    } else {
+        delete pDummy;
+    }
+
+    return MCGS_SUCCESS;
+}
+
+
+#define MCGS_INSTANTIATE_REORDER(TIndex, TValue)                                                                                            \
+    template MCGS_EXPORT_SYMBOL Partition<TIndex>* reorder<TIndex,TValue>(const unsigned long, const unsigned long, const unsigned long,    \
+                                                       TIndex*, TIndex*, TValue*,                                                           \
+                                                       TValue*, TValue*,                                                                    \
+                                                       const Partition<TIndex>*);                                                           \
+    template MCGS_EXPORT_SYMBOL int revertReorder<TIndex,TValue>(TValue*,                                                                   \
+                                                                 const unsigned long,                                                       \
+                                                                 const Partition<TIndex>*);                                                 \
+    template MCGS_EXPORT_SYMBOL int revertReorder<TIndex,TValue>(const unsigned long, const unsigned long, const unsigned long,             \
+                                                                 TIndex*, TIndex*, TValue*,                                                 \
+                                                                 TValue*, TValue*,                                                          \
+                                                                 const Partition<TIndex>*)
+
+MCGS_INSTANTIATE_REORDER(int, double);
+MCGS_INSTANTIATE_REORDER(long, double);
+MCGS_INSTANTIATE_REORDER(unsigned, double);
+MCGS_INSTANTIATE_REORDER(unsigned long, double);
+
+#undef MCGS_INSTANTIATE_REORDER
+#undef MCGS_INTERNAL
+#include "undefineMacros.hpp"
+
+
+} // namespace mcgs

--- a/applications/LinearSolversApplication/external_libraries/mcgs/src/solve.cpp
+++ b/applications/LinearSolversApplication/external_libraries/mcgs/src/solve.cpp
@@ -1,0 +1,434 @@
+#define MCGS_INTERNAL
+
+// --- External Includes ---
+#ifdef MCGS_OPENMP
+#include <omp.h> // omp_get_num_threads
+#endif
+
+// --- Internal Includes ---
+#include "mcgs/mcgs.hpp" // mcgs::solve, mcgs::CSRAdaptor
+#include "partition.hpp" // mcgs::Partition
+#include "defineMacros.hpp" // MCGS_EXPORT_SYMBOL
+
+// --- STL Includes ---
+#include <cstddef> // std::size_t
+#include <vector> // std::vector
+#include <algorithm> // std::copy, std::clamp
+#include <cmath> // std::sqrt
+#include <iostream> // std::cout, std::cerr
+
+
+namespace mcgs {
+
+
+template <class TIndex, class TValue>
+MCGS_EXPORT_SYMBOL
+TValue residual(const CSRAdaptor<TIndex,TValue>& rMatrix,
+                const TValue* pSolution,
+                const TValue* pRHS) noexcept
+{
+    TValue residual = 0;
+
+    #ifdef MCGS_OPENMP
+    #pragma omp parallel for reduction(+: residual)
+    #endif
+    for (int iRow=0; iRow<static_cast<int>(rMatrix.rowCount); ++iRow) {
+        TValue residualComponent = pRHS[iRow];
+        const TIndex iRowBegin = rMatrix.pRowExtents[iRow];
+        const TIndex iRowEnd = rMatrix.pRowExtents[iRow + 1];
+
+        for (TIndex iEntry=iRowBegin; iEntry<iRowEnd; ++iEntry) {
+            const TIndex iColumn = rMatrix.pColumnIndices[iEntry];
+            residualComponent -= rMatrix.pEntries[iEntry] * pSolution[iColumn];
+        } // for iEntry in range(iRowBegin, iRowEnd)
+
+        residual += residualComponent * residualComponent;
+    } // for iRow in range(0, rowCount)
+
+    return std::sqrt(residual);
+}
+
+
+/// @brief Do one Gauss-Seidel iteration in serial.
+template <class TIndex, class TValue>
+int sweep(TValue* pSolution,
+          const CSRAdaptor<TIndex,TValue>& rMatrix,
+          const TValue* pRHS,
+          const unsigned long iRowBegin,
+          const unsigned long iRowEnd,
+          const SolveSettings<TIndex,TValue> settings)
+{
+    for (TIndex iRow=iRowBegin; iRow<static_cast<TIndex>(iRowEnd); ++iRow) {
+        TValue value = pRHS[iRow];
+        TValue diagonal = 1;
+
+        const TIndex iEntryBegin = rMatrix.pRowExtents[iRow];
+        const TIndex iEntryEnd = rMatrix.pRowExtents[iRow + 1];
+
+        for (TIndex iEntry=iEntryBegin; iEntry<iEntryEnd; ++iEntry) {
+            const TIndex iColumn = rMatrix.pColumnIndices[iEntry];
+            const TValue nonzero = rMatrix.pEntries[iEntry];
+
+            if (iRow == iColumn) diagonal = nonzero;
+            else value -= nonzero * pSolution[iColumn];
+        } /*for iEntry in range(iEntryBegin, iEntryEnd)*/
+
+        pSolution[iRow] += settings.relaxation * (value / diagonal - pSolution[iRow]);
+    }
+
+    return MCGS_SUCCESS;
+}
+
+
+/// @brief Do one Gauss-Seidel iteration, distributing jobs row-wise.
+template <class TIndex, class TValue>
+int rowWiseSweep(TValue* pSolution,
+                 const TValue* pSolutionBuffer,
+                 const CSRAdaptor<TIndex,TValue>& rMatrix,
+                 const TValue* pRHS,
+                 const SolveSettings<TIndex,TValue> settings,
+                 const TIndex iRowBegin,
+                 const TIndex iRowEnd,
+                 [[maybe_unused]] const int threadCount)
+{
+    #ifdef MCGS_OPENMP
+    #pragma omp parallel for num_threads(threadCount)
+    #endif
+    for (int iRow=iRowBegin; iRow<static_cast<int>(iRowEnd); ++iRow) {
+        TValue value = pRHS[iRow];
+        TValue diagonal = 1;
+
+        const TIndex iEntryBegin = rMatrix.pRowExtents[iRow];
+        const TIndex iEntryEnd = rMatrix.pRowExtents[iRow + 1];
+
+        for (TIndex iEntry=iEntryBegin; iEntry<iEntryEnd; ++iEntry) {
+            const TIndex iColumn = rMatrix.pColumnIndices[iEntry];
+            const TValue nonzero = rMatrix.pEntries[iEntry];
+
+            if (iColumn < static_cast<TIndex>(iRow)) value -= nonzero * pSolution[iColumn];
+            else if (static_cast<TIndex>(iRow) < iColumn) value -= nonzero * pSolutionBuffer[iColumn];
+            else diagonal = nonzero;
+        } /*for iEntry in range(iEntryBegin, iEntryEnd)*/
+
+        pSolution[iRow] += settings.relaxation * (value / diagonal - pSolution[iRow]);
+    } // omp parallel for
+
+    return MCGS_SUCCESS;
+}
+
+
+/// @brief Do one Gauss-Seidel iteration, distributing jobs by chunks of nonzeros in the matrix.
+template <class TIndex, class TValue>
+int entrywiseSweep(TValue* pSolution,
+                   const TValue* pSolutionBuffer,
+                   const CSRAdaptor<TIndex,TValue>& rMatrix,
+                   const TValue* pRHS,
+                   const SolveSettings<TIndex,TValue> settings,
+                   const TIndex iRowBegin,
+                   const TIndex iRowEnd,
+                   const int threadCount)
+{
+    const TIndex partitionRowCount = iRowEnd - iRowBegin;
+    const auto itEntryBegin = rMatrix.pRowExtents + iRowBegin;
+    const auto itEntryEnd = rMatrix.pRowExtents + iRowEnd;
+    const TIndex iEntryBegin = *itEntryBegin;
+    const TIndex iEntryEnd = *itEntryEnd;
+    const TIndex entryCount = iEntryEnd - iEntryBegin;
+
+    std::vector<TValue> diagonals(partitionRowCount);
+    std::vector<TValue> updates(partitionRowCount);
+    std::copy(pRHS + iRowBegin, pRHS + iRowEnd, updates.data());
+
+    std::vector<TIndex> threadEntryExtents(threadCount + 1);
+    threadEntryExtents.front() = iEntryBegin;
+    {
+        const TIndex chunkSize = entryCount / threadCount + (entryCount % threadCount ? 1 : 0);
+        for (TIndex iEnd=1; iEnd<static_cast<TIndex>(threadCount) + 1; ++iEnd) {
+            threadEntryExtents[iEnd] = std::min(
+                iEntryEnd,
+                threadEntryExtents[iEnd - 1] + chunkSize
+            );
+        }
+    }
+
+    #ifdef MCGS_OPENMP
+    #pragma omp parallel num_threads(threadCount)
+    #endif
+    {
+        std::vector<TValue> localUpdates(partitionRowCount, static_cast<TValue>(0));
+
+        #ifdef MCGS_OPENMP
+        const TIndex iThread = omp_get_thread_num();
+        #else
+        const TIndex iThread = 0;
+        #endif
+
+        const TIndex iLocalEntryBegin = threadEntryExtents[iThread];
+        const TIndex iLocalEntryEnd = threadEntryExtents[iThread + 1];
+
+        const auto itLocalEntryBegin = std::max(std::upper_bound(itEntryBegin, itEntryEnd, iLocalEntryBegin) - 1,
+                                                itEntryBegin);
+        TIndex iRow = std::distance(rMatrix.pRowExtents, itLocalEntryBegin);
+        TIndex iLocalRow = iRow - iRowBegin;
+        const TIndex* itRowEnd = rMatrix.pRowExtents + iRow + 1;
+
+        for (TIndex iEntry=iLocalEntryBegin; iEntry<iLocalEntryEnd; ++iEntry) {
+            while (*itRowEnd <= iEntry) {
+                ++iRow;
+                ++iLocalRow;
+                ++itRowEnd;
+            }
+
+            const TIndex iColumn = rMatrix.pColumnIndices[iEntry];
+            const TValue nonzero = rMatrix.pEntries[iEntry];
+
+            if (iColumn < iRow) {
+                localUpdates[iLocalRow] -= nonzero * pSolution[iColumn];
+            } else if (iRow < iColumn) {
+                localUpdates[iLocalRow] -= nonzero * pSolutionBuffer[iColumn];
+            } else {
+                diagonals[iLocalRow] = nonzero;
+            }
+        } // for iEntry in range(iLocalEntryBegin, iLocalEntryEnd)
+
+        #ifdef MCGS_OPENMP
+        #pragma omp critical
+        #endif
+        {
+            for (TIndex iLocal=0; iLocal<static_cast<TIndex>(updates.size()); ++iLocal) {
+                updates[iLocal] += localUpdates[iLocal];
+            }
+        } // omp critical
+    } // omp parallel
+
+    #ifdef MCGS_OPENMP
+    #pragma omp parallel for num_threads(threadCount)
+    #endif
+    for (int iRow=iRowBegin; iRow<static_cast<int>(iRowEnd); ++iRow) {
+        const TIndex iLocalRow = iRow - iRowBegin;
+        pSolution[iRow] += settings.relaxation * (updates[iLocalRow] / diagonals[iLocalRow] - pSolution[iRow]);
+    }
+
+    return MCGS_SUCCESS;
+}
+
+
+/// @brief Decide which parallelization strategy to use and perform a single Gauss-Seidel iteration.
+template <class TIndex, class TValue>
+int dispatchSweep(TValue* pSolution,
+                  const TValue* pSolutionBuffer,
+                  const CSRAdaptor<TIndex,TValue>& rMatrix,
+                  const TValue* pRHS,
+                  const SolveSettings<TIndex,TValue> settings,
+                  const TIndex iRowBegin,
+                  const TIndex iRowEnd,
+                  const int threadCount)
+{
+    if (iRowEnd < iRowBegin) {
+        if (1 <= settings.verbosity) {
+            std::cerr << "mcgs: error: invalid range [" << iRowBegin << ", " << iRowEnd << "[\n";
+        }
+        return MCGS_FAILURE;
+    }
+
+    if (settings.parallelization == Parallelization::RowWise) {
+        return rowWiseSweep(pSolution,
+                            pSolutionBuffer,
+                            rMatrix,
+                            pRHS,
+                            settings,
+                            iRowBegin,
+                            iRowEnd,
+                            threadCount);
+    } /*if settings.parallelization == RowWise*/ else if (settings.parallelization == Parallelization::EntryWise) {
+        return entrywiseSweep(pSolution,
+                                pSolutionBuffer,
+                                rMatrix,
+                                pRHS,
+                                settings,
+                                iRowBegin,
+                                iRowEnd,
+                                threadCount);
+    } /*if settings.parallelization == Parallelization::EntryWise*/ else if (settings.parallelization == Parallelization::None) {
+        return sweep(pSolution,
+                     rMatrix,
+                     pRHS,
+                     iRowBegin,
+                     iRowEnd,
+                     settings);
+    } // /*if settings.parallelization == Parallelization::None*/
+
+    return MCGS_SUCCESS;
+}
+
+
+/// @brief Perform Gauss-Seidel iterations in serial.
+template <class TIndex, class TValue>
+MCGS_EXPORT_SYMBOL
+int solve(TValue* pSolution,
+          const CSRAdaptor<TIndex,TValue>& rMatrix,
+          const TValue* pRHS,
+          const SolveSettings<TIndex,TValue> settings)
+{
+    std::vector<TValue> buffer(rMatrix.columnCount);
+    const TValue initialResidual = 3 <= settings.verbosity ?
+                                   residual(rMatrix, pSolution, pRHS) :
+                                   static_cast<TValue>(1);
+
+    for (TIndex iIteration=0; iIteration<settings.maxIterations; ++iIteration) {
+        if (sweep(pSolution,
+                  rMatrix,
+                  pRHS,
+                  TIndex(0),
+                  rMatrix.rowCount,
+                  settings) != MCGS_SUCCESS) {
+            if (1 <= settings.verbosity) {
+                std::cerr << "mcgs: error: serial Gauss-Seidel failed at iteration "
+                          << iIteration
+                          << '\n';
+            }
+            return MCGS_FAILURE;
+        }
+
+        if (3 <= settings.verbosity) {
+            std::cout << "iteration " << iIteration
+                      << " residual: "
+                      << residual(rMatrix, pSolution, pRHS) / initialResidual
+                      << "\n";
+        }
+    }
+
+    return MCGS_SUCCESS;
+}
+
+
+/// @brief Perform Gauss-Seidel iterations in parallel.
+template <class TIndex, class TValue>
+MCGS_EXPORT_SYMBOL
+int solve(TValue* pSolution,
+          const CSRAdaptor<TIndex,TValue>& rMatrix,
+          const TValue* pRHS,
+          const Partition<TIndex>* pPartition,
+          const SolveSettings<TIndex,TValue> settings)
+{
+    // Query the maximum number of threads MCGS is allowed to use.
+    #ifdef MCGS_OPENMP
+    const int maxThreadCount = omp_get_max_threads();
+    #else
+    const int maxThreadCount = 1;
+    #endif
+
+    if (maxThreadCount < 1) {
+        if (1 <= settings.verbosity) {
+            std::cerr << "mcgs: error: maximum number of allowed threads must be at least 1\n";
+        }
+        return MCGS_FAILURE;
+    }
+
+    // Run serial smoothing if no parallelization is allowed
+    // or only a single thread is available.
+    if (settings.parallelization == Parallelization::None || maxThreadCount == 1) {
+        return solve(pSolution,
+                     rMatrix,
+                     pRHS,
+                     settings);
+    }
+
+    // Run parallel smoothing otherwise.
+    else {
+        // Collect how many threads should execute each partition.
+        std::vector<int> threadCounts(pPartition->size());
+
+        #ifdef MCGS_OPENMP
+        #pragma omp parallel for
+        #endif
+        for (int iPartition=0; iPartition<static_cast<int>(pPartition->size()); ++iPartition) {
+            // @todo Find a dynamic way of approximating the optimal load of a single thread.
+            //std::size_t nonzeroCount = 0ul;
+            //for (auto itPartition=pPartition->begin(iPartition); itPartition!=pPartition->end(iPartition); ++itPartition) {
+            //    const TIndex iRow = *itPartition;
+            //    nonzeroCount += rMatrix.pRowExtents[iRow + 1] - rMatrix.pRowExtents[iRow];
+            //} // for itPartition in pPartition[iPartition]
+            //
+            //threadCounts[iPartition] = std::clamp(nonzeroCount / 1024,
+            //                                      static_cast<std::size_t>(1),
+            //                                      std::min(pPartition->size(iPartition),
+            //                                               static_cast<std::size_t>(maxThreadCount)));
+            threadCounts[iPartition] = maxThreadCount;
+        }
+
+        std::vector<TValue> buffer(rMatrix.columnCount);
+        const TValue initialResidual = 3 <= settings.verbosity ?
+                                    residual(rMatrix, pSolution, pRHS) :
+                                    static_cast<TValue>(1);
+
+        for (TIndex iIteration=0; iIteration<settings.maxIterations; ++iIteration) {
+            std::copy(pSolution, pSolution + rMatrix.rowCount, buffer.data());
+
+            for (typename Partition<TIndex>::size_type iPartition=0; iPartition<pPartition->size(); ++iPartition) {
+                const auto threadCount = threadCounts[iPartition];
+                if (pPartition->isContiguous()) {
+                    if (dispatchSweep(pSolution,
+                                      buffer.data(),
+                                      rMatrix,
+                                      pRHS,
+                                      settings,
+                                      *pPartition->begin(iPartition),
+                                      *pPartition->end(iPartition),
+                                      threadCount) != MCGS_SUCCESS) {
+                        if (1 <= settings.verbosity) {
+                            std::cerr << "mcgs: error: parallel Gauss-Seidel failed at iteration "
+                                      << iIteration
+                                      << " on partition "
+                                      << iPartition
+                                      << '\n';
+                        }
+                        return MCGS_FAILURE;
+                    }
+                } /*if pPartition->isContiguous()*/ else {
+                    if (1 <= settings.verbosity) {
+                        std::cerr << "mcgs: error: parallel Gauss-Seidel requires a reordered system\n";
+                    }
+                    return MCGS_FAILURE;
+                }
+            } // for iPartition in range(partitionCount)
+
+            if (3 <= settings.verbosity) {
+                std::cout << "mcgs: iteration " << iIteration
+                        << ", residual "
+                        << residual(rMatrix, pSolution, pRHS) / initialResidual
+                        << '\n';
+            } // if 3 <= settings.verbosity
+        } // for iIteration in range(settings.maxIterations)
+    }
+
+    return MCGS_SUCCESS;
+}
+
+
+
+#define MCGS_INSTANTIATE_SOLVE(TIndex, TValue)                                                 \
+    template MCGS_EXPORT_SYMBOL TValue residual(const CSRAdaptor<TIndex,TValue>&,              \
+                                                const TValue*,                                 \
+                                                const TValue*) noexcept;                       \
+    template MCGS_EXPORT_SYMBOL int solve<TIndex,TValue>(TValue*,                              \
+                                                         const CSRAdaptor<TIndex,TValue>&,     \
+                                                         const TValue*,                        \
+                                                         const SolveSettings<TIndex,TValue>);  \
+    template MCGS_EXPORT_SYMBOL int solve<TIndex,TValue>(TValue*,                              \
+                                                         const CSRAdaptor<TIndex,TValue>&,     \
+                                                         const TValue*,                        \
+                                                         const Partition<TIndex>*,             \
+                                                         const SolveSettings<TIndex,TValue>);
+
+MCGS_INSTANTIATE_SOLVE(int, double);
+MCGS_INSTANTIATE_SOLVE(long, double);
+MCGS_INSTANTIATE_SOLVE(unsigned, double);
+MCGS_INSTANTIATE_SOLVE(unsigned long, double);
+
+#undef MCGS_INSTANTIATE_SOLVE
+#undef MCGS_INTERNAL
+#include "undefineMacros.hpp"
+
+
+} // namespace mcgs

--- a/applications/LinearSolversApplication/external_libraries/mcgs/src/solve.cpp
+++ b/applications/LinearSolversApplication/external_libraries/mcgs/src/solve.cpp
@@ -419,7 +419,7 @@ int solve(TValue* pSolution,
                                                          const CSRAdaptor<TIndex,TValue>&,     \
                                                          const TValue*,                        \
                                                          const Partition<TIndex>*,             \
-                                                         const SolveSettings<TIndex,TValue>);
+                                                         const SolveSettings<TIndex,TValue>)
 
 MCGS_INSTANTIATE_SOLVE(int, double);
 MCGS_INSTANTIATE_SOLVE(long, double);

--- a/applications/LinearSolversApplication/external_libraries/mcgs/src/undefineMacros.hpp
+++ b/applications/LinearSolversApplication/external_libraries/mcgs/src/undefineMacros.hpp
@@ -1,0 +1,7 @@
+#ifdef MCGS_INTERNAL
+    #undef MCGS_INTERNAL
+#endif
+
+#ifdef MCGS_EXPORT_SYMBOL
+    #undef MCGS_EXPORT_SYMBOL
+#endif


### PR DESCRIPTION
I'm adding an external library I wrote for Gauss-Seidel smoothing in parallel for systems with imbalanced topologies. For better or worse, it includes related functionalities such as graph coloring and reordering as decided in #12343.

The library will be used as a smoother of a multigrid preconditioner/solver for higher order elements. 

## Changes

- add [MCGS](https://github.com/matekelemen/mcgs) as an external library for `LinearSolversApplication`
- adapt the `LinearSolversApplication`'s `CMakeLists` to include the new library