### PR TITLE
[OptApp] Fix clearing of sub items in BufferedDict

### DIFF
--- a/applications/OptimizationApplication/python_scripts/utilities/buffered_dict.py
+++ b/applications/OptimizationApplication/python_scripts/utilities/buffered_dict.py
@@ -183,7 +183,7 @@ class BufferedDict:
             current_key = key[:pos]
             if not current_key in self.__sub_items.keys():
                 # no existing key found then create it.
-                self.__AddSubItem(current_key, BufferedDict(self.GetBufferSize()))
+                self.__AddSubItem(current_key, BufferedDict(self.GetBufferSize(), self.__clear_buffer_when_advancing))
 
             self.__sub_items[current_key].SetValue(key[pos+1:], value, step_index, overwrite)
 

--- a/applications/OptimizationApplication/tests/test_buffered_dict.py
+++ b/applications/OptimizationApplication/tests/test_buffered_dict.py
@@ -177,6 +177,17 @@ class TestBufferedDict(kratos_unittest.TestCase):
         self.assertEqual(buffered_data.GetValue("data/sub_1/sub_sub").GetBufferSize(), 4)
         self.assertEqual(buffered_data.GetValue("data/sub_2").GetBufferSize(), 5)
 
+    def test_Unbuffered(self):
+        unbuffered_data = BufferedDict(1, False)
+        unbuffered_data.SetValue("data/sub_1/sub_sub/value", 4.0)
+        unbuffered_data.SetValue("data/sub_2/value", 2.0)
+
+        unbuffered_data.AdvanceStep()
+        unbuffered_data.AdvanceStep()
+
+        self.assertEqual(unbuffered_data.GetValue("data/sub_1/sub_sub/value"), 4.0)
+        self.assertEqual(unbuffered_data.GetValue("data/sub_2/value"), 2.0)
+
     def test_GetParent(self):
         buffered_data = BufferedDict(3)
         buffered_data.SetValue("data/sub_1/sub_sub", BufferedDict(4))


### PR DESCRIPTION
**📝 Description**
This PR fixes a bug, when the parent `BufferedDict` is set to not to clear data when advancing step, so not to clear the sub items / sub `BufferedDict`.

**🆕 Changelog**
- Bug fix for sub item clearing
- Add a test
