### PR TITLE
[GeoMechanicsApplication] default lhs upw condition is now a zero matrix

### DIFF
--- a/applications/GeoMechanicsApplication/custom_conditions/U_Pw_condition.cpp
+++ b/applications/GeoMechanicsApplication/custom_conditions/U_Pw_condition.cpp
@@ -60,19 +60,6 @@ void UPwCondition<TDim, TNumNodes>::CalculateLocalSystem(MatrixType&        rLef
 }
 
 //----------------------------------------------------------------------------------------
-
-template <unsigned int TDim, unsigned int TNumNodes>
-void UPwCondition<TDim, TNumNodes>::CalculateLeftHandSide(MatrixType&        rLeftHandSideMatrix,
-                                                          const ProcessInfo& rCurrentProcessInfo)
-{
-    KRATOS_TRY;
-
-    KRATOS_ERROR << "UPwCondition::CalculateLeftHandSide is not implemented" << std::endl;
-
-    KRATOS_CATCH("");
-}
-
-//----------------------------------------------------------------------------------------
 template <unsigned int TDim, unsigned int TNumNodes>
 void UPwCondition<TDim, TNumNodes>::CalculateRightHandSide(VectorType&        rRightHandSideVector,
                                                            const ProcessInfo& rCurrentProcessInfo)

--- a/applications/GeoMechanicsApplication/custom_conditions/U_Pw_condition.hpp
+++ b/applications/GeoMechanicsApplication/custom_conditions/U_Pw_condition.hpp
@@ -71,8 +71,6 @@ public:
                               VectorType&        rRightHandSideVector,
                               const ProcessInfo& rCurrentProcessInfo) override;
 
-    void CalculateLeftHandSide(MatrixType& rLeftHandSideMatrix, const ProcessInfo& rCurrentProcessInfo) override;
-
     void CalculateRightHandSide(VectorType& rRightHandSideVector, const ProcessInfo& rCurrentProcessInfo) override;
 
     void EquationIdVector(EquationIdVectorType& rResult, const ProcessInfo&) const override;

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/test_U_Pw_condition.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/test_U_Pw_condition.cpp
@@ -19,7 +19,7 @@ namespace Kratos::Testing {
 
 
         /// <summary>
-		/// Tests the calculation of the left hand side matrix of the default UPwCondition, which should be an empty matrix.
+        /// Tests the calculation of the left hand side matrix of the default UPwCondition, which should be an empty matrix.
         /// </summary>
         /// <param name=""></param>
         /// <param name=""></param>
@@ -28,19 +28,19 @@ namespace Kratos::Testing {
 
             Model current_model;
             auto& r_model_part = current_model.CreateModelPart("ModelPart", 1);
-			const auto& r_process_info = r_model_part.GetProcessInfo();
-  
-			auto p_cond = std::make_shared<UPwCondition<2, 2>>(1, nullptr);
-
-			// calculate left hand side matrix
-			Matrix left_hand_side_matrix = ZeroMatrix(6, 6);
-			p_cond->CalculateLeftHandSide(left_hand_side_matrix, r_process_info);
-
-			// set expected_results
-			Matrix expected_matrix = ZeroMatrix(0, 0);
-
-			// compare results
-			KRATOS_CHECK_MATRIX_NEAR(left_hand_side_matrix, expected_matrix, 1.0e-6);
+            const auto& r_process_info = r_model_part.GetProcessInfo();
+            
+            auto p_cond = std::make_shared<UPwCondition<2, 2>>(1, nullptr);
+            
+            // calculate left hand side matrix
+            Matrix left_hand_side_matrix = ZeroMatrix(6, 6);
+            p_cond->CalculateLeftHandSide(left_hand_side_matrix, r_process_info);
+            
+            // set expected_results
+            Matrix expected_matrix = ZeroMatrix(0, 0);
+            
+            // compare results
+            KRATOS_CHECK_MATRIX_NEAR(left_hand_side_matrix, expected_matrix, 1.0e-6);
         }
 
 }

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/test_U_Pw_condition.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/test_U_Pw_condition.cpp
@@ -11,7 +11,7 @@
 //
 
 // Project includes
-#include "custom_elements/U_Pw_condition.hpp"
+#include "custom_conditions/U_Pw_condition.hpp"
 
 #include "geo_mechanics_fast_suite.h"
 

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/test_U_Pw_condition.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/test_U_Pw_condition.cpp
@@ -10,8 +10,6 @@
 //  Main authors:    Aron Noordam
 //
 
-#include <string>
-
 // Project includes
 #include "custom_elements/U_Pw_condition.hpp"
 

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/test_U_Pw_condition.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/test_U_Pw_condition.cpp
@@ -15,6 +15,7 @@
 
 #include "geo_mechanics_fast_suite.h"
 
+using namespace Kratos;
 namespace Kratos::Testing {
 
 
@@ -27,14 +28,19 @@ namespace Kratos::Testing {
         {
 
             Model current_model;
-            auto& r_model_part = current_model.CreateModelPart("ModelPart", 1);
-            const auto& r_process_info = r_model_part.GetProcessInfo();
-            
-            auto p_cond = std::make_shared<UPwCondition<2, 2>>(1, nullptr);
+            auto& r_model_part = current_model.CreateModelPart("ModelPart", 1);	
+
+			// create geometry as UPwCondition needs a geometry to be initialized
+            auto node = r_model_part.CreateNewNode(1, 0.0, 0.0, 0.0);
+			std::vector< ModelPart::IndexType> element_nodes{ 1};
+			auto p_geometry = r_model_part.CreateNewGeometry("Point2D", element_nodes);
+
+			// create UPwCondition
+			auto cond = UPwCondition<2, 2>(1, p_geometry, nullptr);
             
             // calculate left hand side matrix
             Matrix left_hand_side_matrix = ZeroMatrix(6, 6);
-            p_cond->CalculateLeftHandSide(left_hand_side_matrix, r_process_info);
+            cond.CalculateLeftHandSide(left_hand_side_matrix, ProcessInfo{});
             
             // set expected_results
             Matrix expected_matrix = ZeroMatrix(0, 0);

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/test_U_Pw_condition.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/test_U_Pw_condition.cpp
@@ -30,13 +30,13 @@ namespace Kratos::Testing {
             Model current_model;
             auto& r_model_part = current_model.CreateModelPart("ModelPart", 1);	
 
-			// create geometry as UPwCondition needs a geometry to be initialized
+            // create geometry as UPwCondition needs a geometry to be initialized
             auto node = r_model_part.CreateNewNode(1, 0.0, 0.0, 0.0);
-			std::vector< ModelPart::IndexType> element_nodes{ 1};
-			auto p_geometry = r_model_part.CreateNewGeometry("Point2D", element_nodes);
-
-			// create UPwCondition
-			auto cond = UPwCondition<2, 2>(1, p_geometry, nullptr);
+            std::vector< ModelPart::IndexType> element_nodes{ 1};
+            auto p_geometry = r_model_part.CreateNewGeometry("Point2D", element_nodes);
+            
+            // create UPwCondition
+            auto cond = UPwCondition<2, 2>(1, p_geometry, nullptr);
             
             // calculate left hand side matrix
             Matrix left_hand_side_matrix = ZeroMatrix(6, 6);

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/test_U_Pw_condition.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/test_U_Pw_condition.cpp
@@ -16,37 +16,37 @@
 #include "geo_mechanics_fast_suite.h"
 
 using namespace Kratos;
-namespace Kratos::Testing {
 
+namespace Kratos::Testing
+{
 
-        /// <summary>
-        /// Tests the calculation of the left hand side matrix of the default UPwCondition, which should be an empty matrix.
-        /// </summary>
-        /// <param name=""></param>
-        /// <param name=""></param>
-        KRATOS_TEST_CASE_IN_SUITE(CalculateLeftHandSideUPwCondition, KratosGeoMechanicsFastSuite)
-        {
+/// <summary>
+/// Tests the calculation of the left hand side matrix of the default UPwCondition, which should be an empty matrix.
+/// </summary>
+/// <param name=""></param>
+/// <param name=""></param>
+KRATOS_TEST_CASE_IN_SUITE(CalculateLeftHandSideUPwCondition, KratosGeoMechanicsFastSuite)
+{
+    Model current_model;
+    auto& r_model_part = current_model.CreateModelPart("ModelPart", 1);
 
-            Model current_model;
-            auto& r_model_part = current_model.CreateModelPart("ModelPart", 1);	
+    // create geometry as UPwCondition needs a geometry to be initialized
+    auto                              node = r_model_part.CreateNewNode(1, 0.0, 0.0, 0.0);
+    std::vector<ModelPart::IndexType> element_nodes{1};
+    auto p_geometry = r_model_part.CreateNewGeometry("Point2D", element_nodes);
 
-            // create geometry as UPwCondition needs a geometry to be initialized
-            auto node = r_model_part.CreateNewNode(1, 0.0, 0.0, 0.0);
-            std::vector< ModelPart::IndexType> element_nodes{ 1};
-            auto p_geometry = r_model_part.CreateNewGeometry("Point2D", element_nodes);
-            
-            // create UPwCondition
-            auto cond = UPwCondition<2, 2>(1, p_geometry, nullptr);
-            
-            // calculate left hand side matrix
-            Matrix left_hand_side_matrix = ZeroMatrix(6, 6);
-            cond.CalculateLeftHandSide(left_hand_side_matrix, ProcessInfo{});
-            
-            // set expected_results
-            Matrix expected_matrix = ZeroMatrix(0, 0);
-            
-            // compare results
-            KRATOS_CHECK_MATRIX_NEAR(left_hand_side_matrix, expected_matrix, 1.0e-6);
-        }
+    // create UPwCondition
+    auto cond = UPwCondition<2, 2>(1, p_geometry, nullptr);
 
+    // calculate left hand side matrix
+    Matrix left_hand_side_matrix = ZeroMatrix(6, 6);
+    cond.CalculateLeftHandSide(left_hand_side_matrix, ProcessInfo{});
+
+    // set expected_results
+    Matrix expected_matrix = ZeroMatrix(0, 0);
+
+    // compare results
+    KRATOS_CHECK_MATRIX_NEAR(left_hand_side_matrix, expected_matrix, 1.0e-6);
 }
+
+} // namespace Kratos::Testing

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/test_U_Pw_condition.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/test_U_Pw_condition.cpp
@@ -19,12 +19,7 @@ using namespace Kratos;
 namespace Kratos::Testing {
 
 
-        /// <summary>
-        /// Tests the calculation of the left hand side matrix of the default UPwCondition, which should be an empty matrix.
-        /// </summary>
-        /// <param name=""></param>
-        /// <param name=""></param>
-        KRATOS_TEST_CASE_IN_SUITE(CalculateLeftHandSideUPwCondition, KratosGeoMechanicsFastSuite)
+        KRATOS_TEST_CASE_IN_SUITE(CalculateLeftHandSideUPwCondition_ReturnsEmptyMatrix, KratosGeoMechanicsFastSuite)
         {
 
             Model current_model;

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/test_U_Pw_condition.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/test_U_Pw_condition.cpp
@@ -1,0 +1,48 @@
+// KRATOS___
+//     //   ) )
+//    //         ___      ___
+//   //  ____  //___) ) //   ) )
+//  //    / / //       //   / /
+// ((____/ / ((____   ((___/ /  MECHANICS
+//
+//  License:         geo_mechanics_application/license.txt
+//
+//  Main authors:    Aron Noordam
+//
+
+#include <string>
+
+// Project includes
+#include "custom_elements/U_Pw_condition.hpp"
+
+#include "geo_mechanics_fast_suite.h"
+
+namespace Kratos::Testing {
+
+
+        /// <summary>
+		/// Tests the calculation of the left hand side matrix of the default UPwCondition, which should be an empty matrix.
+        /// </summary>
+        /// <param name=""></param>
+        /// <param name=""></param>
+        KRATOS_TEST_CASE_IN_SUITE(CalculateLeftHandSideUPwCondition, KratosGeoMechanicsFastSuite)
+        {
+
+            Model current_model;
+            auto& r_model_part = current_model.CreateModelPart("ModelPart", 1);
+			const auto& r_process_info = r_model_part.GetProcessInfo();
+  
+			auto p_cond = std::make_shared<UPwCondition<2, 2>>(1, nullptr);
+
+			// calculate left hand side matrix
+			Matrix left_hand_side_matrix = ZeroMatrix(6, 6);
+			p_cond->CalculateLeftHandSide(left_hand_side_matrix, r_process_info);
+
+			// set expected_results
+			Matrix expected_matrix = ZeroMatrix(0, 0);
+
+			// compare results
+			KRATOS_CHECK_MATRIX_NEAR(left_hand_side_matrix, expected_matrix, 1.0e-6);
+        }
+
+}

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/test_U_Pw_condition.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/test_U_Pw_condition.cpp
@@ -30,17 +30,12 @@ namespace Kratos::Testing {
             std::vector< ModelPart::IndexType> element_nodes{ 1};
             auto p_geometry = r_model_part.CreateNewGeometry("Point2D", element_nodes);
             
-            // create UPwCondition
             auto cond = UPwCondition<2, 2>(1, p_geometry, nullptr);
             
-            // calculate left hand side matrix
             Matrix left_hand_side_matrix = ZeroMatrix(6, 6);
             cond.CalculateLeftHandSide(left_hand_side_matrix, ProcessInfo{});
             
-            // set expected_results
             Matrix expected_matrix = ZeroMatrix(0, 0);
-            
-            // compare results
             KRATOS_CHECK_MATRIX_NEAR(left_hand_side_matrix, expected_matrix, 1.0e-6);
         }
 


### PR DESCRIPTION
lhs of upw condition is now set to a zero matrix

Else solvers depending on the calculateLeftHandSide function fail on conditions which dont contribute to the lhs