### PR TITLE
[GeoMechanicsApplication] Make sure all 'integration scheme related' functions throw an exception

### DIFF
--- a/applications/GeoMechanicsApplication/custom_geometries/line_interface_geometry.h
+++ b/applications/GeoMechanicsApplication/custom_geometries/line_interface_geometry.h
@@ -117,6 +117,128 @@ public:
 
     void PrintData(std::ostream& rOStream) const override { mMidLineGeometry->PrintData(rOStream); }
 
+    std::string IntegrationCalculationNotImplementedMessage() const
+    {
+        return "This Geometry type does not support calculations on integration points.\n";
+    }
+
+    array_1d<double, 3> Normal(IndexType IntegrationPointIndex) const override
+    {
+        KRATOS_ERROR << IntegrationCalculationNotImplementedMessage();
+    }
+
+    array_1d<double, 3> Normal(IndexType IntegrationPointIndex, IntegrationMethod ThisMethod) const override
+    {
+        KRATOS_ERROR << IntegrationCalculationNotImplementedMessage();
+    }
+
+    array_1d<double, 3> UnitNormal(IndexType IntegrationPointIndex) const override
+    {
+        KRATOS_ERROR << IntegrationCalculationNotImplementedMessage();
+    }
+
+    array_1d<double, 3> UnitNormal(IndexType IntegrationPointIndex, IntegrationMethod ThisMethod) const override
+    {
+        KRATOS_ERROR << IntegrationCalculationNotImplementedMessage();
+    }
+
+    JacobiansType& Jacobian(JacobiansType& rResult, IntegrationMethod ThisMethod) const override
+    {
+        KRATOS_ERROR << IntegrationCalculationNotImplementedMessage();
+    }
+
+    JacobiansType& Jacobian(JacobiansType& rResult, IntegrationMethod ThisMethod, Matrix& DeltaPosition) const override
+    {
+        KRATOS_ERROR << IntegrationCalculationNotImplementedMessage();
+    }
+
+    Matrix& Jacobian(Matrix& rResult, IndexType IntegrationPointIndex, IntegrationMethod ThisMethod) const override
+    {
+        KRATOS_ERROR << IntegrationCalculationNotImplementedMessage();
+    }
+
+    Matrix& Jacobian(Matrix&           rResult,
+                     IndexType         IntegrationPointIndex,
+                     IntegrationMethod ThisMethod,
+                     const Matrix&     rDeltaPosition) const override
+    {
+        KRATOS_ERROR << IntegrationCalculationNotImplementedMessage();
+    }
+
+    Vector& DeterminantOfJacobian(Vector& rResult, IntegrationMethod ThisMethod) const override
+    {
+        KRATOS_ERROR << IntegrationCalculationNotImplementedMessage();
+    }
+
+    double DeterminantOfJacobian(IndexType IntegrationPointIndex, IntegrationMethod ThisMethod) const override
+    {
+        KRATOS_ERROR << IntegrationCalculationNotImplementedMessage();
+    }
+
+    JacobiansType& InverseOfJacobian(JacobiansType& rResult, IntegrationMethod ThisMethod) const override
+    {
+        KRATOS_ERROR << IntegrationCalculationNotImplementedMessage();
+    }
+
+    Matrix& InverseOfJacobian(Matrix& rResult, IndexType IntegrationPointIndex, IntegrationMethod ThisMethod) const override
+    {
+        KRATOS_ERROR << IntegrationCalculationNotImplementedMessage();
+    }
+
+    void ShapeFunctionsIntegrationPointsGradients(ShapeFunctionsGradientsType& rResult,
+                                                  IntegrationMethod ThisMethod) const override
+    {
+        KRATOS_ERROR << IntegrationCalculationNotImplementedMessage();
+    }
+
+    void ShapeFunctionsIntegrationPointsGradients(ShapeFunctionsGradientsType& rResult,
+                                                  Vector&           rDeterminantsOfJacobian,
+                                                  IntegrationMethod ThisMethod) const override
+    {
+        KRATOS_ERROR << IntegrationCalculationNotImplementedMessage();
+    }
+
+    void ShapeFunctionsIntegrationPointsGradients(ShapeFunctionsGradientsType& rResult,
+                                                  Vector&           rDeterminantsOfJacobian,
+                                                  IntegrationMethod ThisMethod,
+                                                  Matrix& ShapeFunctionsIntegrationPointsValues) const override
+    {
+        KRATOS_ERROR << IntegrationCalculationNotImplementedMessage();
+    }
+
+    IntegrationInfo GetDefaultIntegrationInfo() const override
+    {
+        KRATOS_ERROR << IntegrationCalculationNotImplementedMessage();
+    }
+
+    void CreateIntegrationPoints(IntegrationPointsArrayType& rIntegrationPoints,
+                                 IntegrationInfo&            rIntegrationInfo) const override
+    {
+        KRATOS_ERROR << IntegrationCalculationNotImplementedMessage();
+    }
+
+    void CreateQuadraturePointGeometries(GeometriesArrayType& rResultGeometries,
+                                     IndexType            NumberOfShapeFunctionDerivatives,
+                                     const IntegrationPointsArrayType& rIntegrationPoints,
+                                     IntegrationInfo& rIntegrationInfo) override
+    {
+        KRATOS_ERROR << IntegrationCalculationNotImplementedMessage();
+    }
+
+    void CreateQuadraturePointGeometries(GeometriesArrayType& rResultGeometries,
+                                         IndexType            NumberOfShapeFunctionDerivatives,
+                                         IntegrationInfo&     rIntegrationInfo) override
+    {
+        KRATOS_ERROR << IntegrationCalculationNotImplementedMessage();
+    }
+
+    void GlobalSpaceDerivatives(std::vector<CoordinatesArrayType>& rGlobalSpaceDerivatives,
+                                IndexType                          IntegrationPointIndex,
+                                const SizeType                     DerivativeOrder) const override
+    {
+        KRATOS_ERROR << IntegrationCalculationNotImplementedMessage();
+    }
+
 private:
     [[nodiscard]] PointerVector<Node> CreatePointsOfMidLine() const
     {

--- a/applications/GeoMechanicsApplication/custom_geometries/line_interface_geometry.h
+++ b/applications/GeoMechanicsApplication/custom_geometries/line_interface_geometry.h
@@ -117,7 +117,7 @@ public:
 
     void PrintData(std::ostream& rOStream) const override { mMidLineGeometry->PrintData(rOStream); }
 
-    std::string IntegrationCalculationNotImplementedMessage() const
+    [[nodiscard]] static std::string IntegrationCalculationNotImplementedMessage()
     {
         return "This Geometry type does not support calculations on integration points.\n";
     }

--- a/applications/GeoMechanicsApplication/custom_geometries/line_interface_geometry.h
+++ b/applications/GeoMechanicsApplication/custom_geometries/line_interface_geometry.h
@@ -117,44 +117,44 @@ public:
 
     void PrintData(std::ostream& rOStream) const override { mMidLineGeometry->PrintData(rOStream); }
 
-    [[nodiscard]] static std::string IntegrationCalculationNotImplementedMessage()
+    [[nodiscard]] static std::string IntegrationSchemeFunctionalityNotImplementedMessage()
     {
-        return "This Geometry type does not support calculations on integration points.\n";
+        return "This Geometry type does not support functionality related to integration schemes.\n";
     }
 
     array_1d<double, 3> Normal(IndexType IntegrationPointIndex) const override
     {
-        KRATOS_ERROR << IntegrationCalculationNotImplementedMessage();
+        KRATOS_ERROR << IntegrationSchemeFunctionalityNotImplementedMessage();
     }
 
     array_1d<double, 3> Normal(IndexType IntegrationPointIndex, IntegrationMethod ThisMethod) const override
     {
-        KRATOS_ERROR << IntegrationCalculationNotImplementedMessage();
+        KRATOS_ERROR << IntegrationSchemeFunctionalityNotImplementedMessage();
     }
 
     array_1d<double, 3> UnitNormal(IndexType IntegrationPointIndex) const override
     {
-        KRATOS_ERROR << IntegrationCalculationNotImplementedMessage();
+        KRATOS_ERROR << IntegrationSchemeFunctionalityNotImplementedMessage();
     }
 
     array_1d<double, 3> UnitNormal(IndexType IntegrationPointIndex, IntegrationMethod ThisMethod) const override
     {
-        KRATOS_ERROR << IntegrationCalculationNotImplementedMessage();
+        KRATOS_ERROR << IntegrationSchemeFunctionalityNotImplementedMessage();
     }
 
     JacobiansType& Jacobian(JacobiansType& rResult, IntegrationMethod ThisMethod) const override
     {
-        KRATOS_ERROR << IntegrationCalculationNotImplementedMessage();
+        KRATOS_ERROR << IntegrationSchemeFunctionalityNotImplementedMessage();
     }
 
     JacobiansType& Jacobian(JacobiansType& rResult, IntegrationMethod ThisMethod, Matrix& DeltaPosition) const override
     {
-        KRATOS_ERROR << IntegrationCalculationNotImplementedMessage();
+        KRATOS_ERROR << IntegrationSchemeFunctionalityNotImplementedMessage();
     }
 
     Matrix& Jacobian(Matrix& rResult, IndexType IntegrationPointIndex, IntegrationMethod ThisMethod) const override
     {
-        KRATOS_ERROR << IntegrationCalculationNotImplementedMessage();
+        KRATOS_ERROR << IntegrationSchemeFunctionalityNotImplementedMessage();
     }
 
     Matrix& Jacobian(Matrix&           rResult,
@@ -162,40 +162,40 @@ public:
                      IntegrationMethod ThisMethod,
                      const Matrix&     rDeltaPosition) const override
     {
-        KRATOS_ERROR << IntegrationCalculationNotImplementedMessage();
+        KRATOS_ERROR << IntegrationSchemeFunctionalityNotImplementedMessage();
     }
 
     Vector& DeterminantOfJacobian(Vector& rResult, IntegrationMethod ThisMethod) const override
     {
-        KRATOS_ERROR << IntegrationCalculationNotImplementedMessage();
+        KRATOS_ERROR << IntegrationSchemeFunctionalityNotImplementedMessage();
     }
 
     double DeterminantOfJacobian(IndexType IntegrationPointIndex, IntegrationMethod ThisMethod) const override
     {
-        KRATOS_ERROR << IntegrationCalculationNotImplementedMessage();
+        KRATOS_ERROR << IntegrationSchemeFunctionalityNotImplementedMessage();
     }
 
     JacobiansType& InverseOfJacobian(JacobiansType& rResult, IntegrationMethod ThisMethod) const override
     {
-        KRATOS_ERROR << IntegrationCalculationNotImplementedMessage();
+        KRATOS_ERROR << IntegrationSchemeFunctionalityNotImplementedMessage();
     }
 
     Matrix& InverseOfJacobian(Matrix& rResult, IndexType IntegrationPointIndex, IntegrationMethod ThisMethod) const override
     {
-        KRATOS_ERROR << IntegrationCalculationNotImplementedMessage();
+        KRATOS_ERROR << IntegrationSchemeFunctionalityNotImplementedMessage();
     }
 
     void ShapeFunctionsIntegrationPointsGradients(ShapeFunctionsGradientsType& rResult,
                                                   IntegrationMethod ThisMethod) const override
     {
-        KRATOS_ERROR << IntegrationCalculationNotImplementedMessage();
+        KRATOS_ERROR << IntegrationSchemeFunctionalityNotImplementedMessage();
     }
 
     void ShapeFunctionsIntegrationPointsGradients(ShapeFunctionsGradientsType& rResult,
                                                   Vector&           rDeterminantsOfJacobian,
                                                   IntegrationMethod ThisMethod) const override
     {
-        KRATOS_ERROR << IntegrationCalculationNotImplementedMessage();
+        KRATOS_ERROR << IntegrationSchemeFunctionalityNotImplementedMessage();
     }
 
     void ShapeFunctionsIntegrationPointsGradients(ShapeFunctionsGradientsType& rResult,
@@ -203,18 +203,18 @@ public:
                                                   IntegrationMethod ThisMethod,
                                                   Matrix& ShapeFunctionsIntegrationPointsValues) const override
     {
-        KRATOS_ERROR << IntegrationCalculationNotImplementedMessage();
+        KRATOS_ERROR << IntegrationSchemeFunctionalityNotImplementedMessage();
     }
 
     IntegrationInfo GetDefaultIntegrationInfo() const override
     {
-        KRATOS_ERROR << IntegrationCalculationNotImplementedMessage();
+        KRATOS_ERROR << IntegrationSchemeFunctionalityNotImplementedMessage();
     }
 
     void CreateIntegrationPoints(IntegrationPointsArrayType& rIntegrationPoints,
                                  IntegrationInfo&            rIntegrationInfo) const override
     {
-        KRATOS_ERROR << IntegrationCalculationNotImplementedMessage();
+        KRATOS_ERROR << IntegrationSchemeFunctionalityNotImplementedMessage();
     }
 
     void CreateQuadraturePointGeometries(GeometriesArrayType& rResultGeometries,
@@ -222,21 +222,21 @@ public:
                                      const IntegrationPointsArrayType& rIntegrationPoints,
                                      IntegrationInfo& rIntegrationInfo) override
     {
-        KRATOS_ERROR << IntegrationCalculationNotImplementedMessage();
+        KRATOS_ERROR << IntegrationSchemeFunctionalityNotImplementedMessage();
     }
 
     void CreateQuadraturePointGeometries(GeometriesArrayType& rResultGeometries,
                                          IndexType            NumberOfShapeFunctionDerivatives,
                                          IntegrationInfo&     rIntegrationInfo) override
     {
-        KRATOS_ERROR << IntegrationCalculationNotImplementedMessage();
+        KRATOS_ERROR << IntegrationSchemeFunctionalityNotImplementedMessage();
     }
 
     void GlobalSpaceDerivatives(std::vector<CoordinatesArrayType>& rGlobalSpaceDerivatives,
                                 IndexType                          IntegrationPointIndex,
                                 const SizeType                     DerivativeOrder) const override
     {
-        KRATOS_ERROR << IntegrationCalculationNotImplementedMessage();
+        KRATOS_ERROR << IntegrationSchemeFunctionalityNotImplementedMessage();
     }
 
 private:

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_geometries/test_interface_geometry.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_geometries/test_interface_geometry.cpp
@@ -15,6 +15,7 @@
 #include "tests/cpp_tests/geo_mechanics_fast_suite.h"
 
 #include <boost/numeric/ublas/assignment.hpp>
+#include <utilities/exact_mortar_segmentation_utility.h>
 
 namespace
 {
@@ -353,4 +354,60 @@ KRATOS_TEST_CASE_IN_SUITE(InterfaceGeometry_Throws_WhenCallingVolume, KratosGeoM
                                       "one. Please check the definition of derived class. ")
 }
 
+KRATOS_TEST_CASE_IN_SUITE(InterfaceGeometry_Throws_WhenCallingFunctionsRelatedToIntegrationPoints,
+                          KratosGeoMechanicsFastSuiteWithoutKernel)
+{
+    auto                          geometry = CreateThreePlusThreeNodedLineInterfaceGeometry();
+    Geometry<Node>::JacobiansType dummy_jacobian;
+    Geometry<Node>::ShapeFunctionsGradientsType dummy_shape_functions_gradients;
+    Vector                                      dummy_vector;
+    Matrix                                      dummy_matrix;
+    IndexType                                   dummy_index = 0;
+    IntegrationMethod dummy_integration_method              = IntegrationMethod::GI_GAUSS_1;
+    Geometry<Node>::IntegrationPointsArrayType dummy_integration_points;
+    IntegrationInfo dummy_integration_info(dummy_index, dummy_integration_method);
+    Geometry<Node>::GeometriesArrayType     dummy_geometries;
+    std::vector<Node::CoordinatesArrayType> dummy_coordinates;
+    const std::string                       message =
+        "This Geometry type does not support calculations on integration points.\n";
+
+    KRATOS_EXPECT_EXCEPTION_IS_THROWN(geometry.Normal(dummy_index), message)
+    KRATOS_EXPECT_EXCEPTION_IS_THROWN(geometry.Normal(dummy_index, dummy_integration_method), message)
+    KRATOS_EXPECT_EXCEPTION_IS_THROWN(geometry.UnitNormal(dummy_index), message)
+    KRATOS_EXPECT_EXCEPTION_IS_THROWN(geometry.UnitNormal(dummy_index, dummy_integration_method), message)
+    KRATOS_EXPECT_EXCEPTION_IS_THROWN(geometry.Jacobian(dummy_jacobian, dummy_integration_method), message)
+    KRATOS_EXPECT_EXCEPTION_IS_THROWN(
+        geometry.Jacobian(dummy_jacobian, dummy_integration_method, dummy_matrix), message)
+    KRATOS_EXPECT_EXCEPTION_IS_THROWN(
+        geometry.Jacobian(dummy_matrix, dummy_index, dummy_integration_method), message)
+    KRATOS_EXPECT_EXCEPTION_IS_THROWN(
+        geometry.Jacobian(dummy_matrix, dummy_index, dummy_integration_method, dummy_matrix), message)
+    KRATOS_EXPECT_EXCEPTION_IS_THROWN(
+        geometry.DeterminantOfJacobian(dummy_vector, dummy_integration_method), message)
+    KRATOS_EXPECT_EXCEPTION_IS_THROWN(geometry.DeterminantOfJacobian(dummy_index, dummy_integration_method), message)
+    KRATOS_EXPECT_EXCEPTION_IS_THROWN(geometry.InverseOfJacobian(dummy_jacobian, dummy_integration_method), message)
+    KRATOS_EXPECT_EXCEPTION_IS_THROWN(
+        geometry.InverseOfJacobian(dummy_matrix, dummy_index, dummy_integration_method), message)
+    KRATOS_EXPECT_EXCEPTION_IS_THROWN(geometry.ShapeFunctionsIntegrationPointsGradients(
+                                          dummy_shape_functions_gradients, dummy_integration_method),
+                                      message)
+    KRATOS_EXPECT_EXCEPTION_IS_THROWN(geometry.ShapeFunctionsIntegrationPointsGradients(
+                                          dummy_shape_functions_gradients, dummy_vector, dummy_integration_method),
+                                      message)
+    KRATOS_EXPECT_EXCEPTION_IS_THROWN(
+        geometry.ShapeFunctionsIntegrationPointsGradients(
+            dummy_shape_functions_gradients, dummy_vector, dummy_integration_method, dummy_matrix),
+        message)
+    KRATOS_EXPECT_EXCEPTION_IS_THROWN(
+        geometry.CreateIntegrationPoints(dummy_integration_points, dummy_integration_info), message)
+    KRATOS_EXPECT_EXCEPTION_IS_THROWN(geometry.GetDefaultIntegrationInfo(), message)
+    KRATOS_EXPECT_EXCEPTION_IS_THROWN(
+        geometry.CreateQuadraturePointGeometries(dummy_geometries, dummy_index,
+                                                 dummy_integration_points, dummy_integration_info),
+        message)
+    KRATOS_EXPECT_EXCEPTION_IS_THROWN(
+        geometry.CreateQuadraturePointGeometries(dummy_geometries, dummy_index, dummy_integration_info), message)
+    KRATOS_EXPECT_EXCEPTION_IS_THROWN(
+        geometry.GlobalSpaceDerivatives(dummy_coordinates, dummy_index, dummy_index), message)
+}
 } // namespace Kratos::Testing

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_geometries/test_interface_geometry.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_geometries/test_interface_geometry.cpp
@@ -369,7 +369,7 @@ KRATOS_TEST_CASE_IN_SUITE(InterfaceGeometry_Throws_WhenCallingFunctionsRelatedTo
     Geometry<Node>::GeometriesArrayType     dummy_geometries;
     std::vector<Node::CoordinatesArrayType> dummy_coordinates;
     const std::string                       message =
-        "This Geometry type does not support calculations on integration points.\n";
+        "This Geometry type does not support functionality related to integration schemes.\n";
 
     KRATOS_EXPECT_EXCEPTION_IS_THROWN(geometry.Normal(dummy_index), message)
     KRATOS_EXPECT_EXCEPTION_IS_THROWN(geometry.Normal(dummy_index, dummy_integration_method), message)

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_geometries/test_interface_geometry.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_geometries/test_interface_geometry.cpp
@@ -12,10 +12,10 @@
 //
 
 #include "custom_geometries/line_interface_geometry.h"
+#include "geometries/geometry_data.h"
 #include "tests/cpp_tests/geo_mechanics_fast_suite.h"
 
 #include <boost/numeric/ublas/assignment.hpp>
-#include <utilities/exact_mortar_segmentation_utility.h>
 
 namespace
 {
@@ -363,7 +363,7 @@ KRATOS_TEST_CASE_IN_SUITE(InterfaceGeometry_Throws_WhenCallingFunctionsRelatedTo
     Vector                                      dummy_vector;
     Matrix                                      dummy_matrix;
     IndexType                                   dummy_index = 0;
-    IntegrationMethod dummy_integration_method              = IntegrationMethod::GI_GAUSS_1;
+    GeometryData::IntegrationMethod dummy_integration_method = GeometryData::IntegrationMethod::GI_GAUSS_1;
     Geometry<Node>::IntegrationPointsArrayType dummy_integration_points;
     IntegrationInfo dummy_integration_info(dummy_index, dummy_integration_method);
     Geometry<Node>::GeometriesArrayType     dummy_geometries;


### PR DESCRIPTION
**📝 Description**
Make sure the integration scheme related functions throw, such that when they are called it is clear that this geometry won't have that functionality.