### PR TITLE
DRAFT [CoSim] Registering 3D4N Quad element for CoSim

### DIFF
--- a/applications/CoSimulationApplication/custom_utilities/co_sim_io_conversion_utilities.cpp
+++ b/applications/CoSimulationApplication/custom_utilities/co_sim_io_conversion_utilities.cpp
@@ -92,7 +92,7 @@ const std::map<CoSimIO::ElementType, std::string> elem_name_map {
     {CoSimIO::ElementType::Pyramid3D13, "Element3D13N"},
     {CoSimIO::ElementType::Pyramid3D5, "Element3D5N"},
     {CoSimIO::ElementType::Quadrilateral2D4, "Element2D4N"},
-    {CoSimIO::ElementType::Quadrilateral3D4, "Element3D4N_Q"},
+    {CoSimIO::ElementType::Quadrilateral3D4, "QuadElement3D4N"},
     {CoSimIO::ElementType::Quadrilateral2D8, "Element2D8N"},
     {CoSimIO::ElementType::Quadrilateral2D9, "Element2D9N"},
     {CoSimIO::ElementType::Quadrilateral3D8, "Element3D8N"},

--- a/applications/CoSimulationApplication/custom_utilities/co_sim_io_conversion_utilities.cpp
+++ b/applications/CoSimulationApplication/custom_utilities/co_sim_io_conversion_utilities.cpp
@@ -92,6 +92,7 @@ const std::map<CoSimIO::ElementType, std::string> elem_name_map {
     {CoSimIO::ElementType::Pyramid3D13, "Element3D13N"},
     {CoSimIO::ElementType::Pyramid3D5, "Element3D5N"},
     {CoSimIO::ElementType::Quadrilateral2D4, "Element2D4N"},
+    {CoSimIO::ElementType::Quadrilateral3D4, "Element3D4N_Q"},
     {CoSimIO::ElementType::Quadrilateral2D8, "Element2D8N"},
     {CoSimIO::ElementType::Quadrilateral2D9, "Element2D9N"},
     {CoSimIO::ElementType::Quadrilateral3D8, "Element3D8N"},

--- a/kratos/includes/kratos_application.h
+++ b/kratos/includes/kratos_application.h
@@ -496,7 +496,7 @@ class KRATOS_API(KRATOS_CORE) KratosApplication {
     const MeshElement mElement2D3N;
     const MeshElement mElement2D6N;
     const MeshElement mElement2D4N;
-    const MeshElement mElement3D4N_Q;
+    const MeshElement mQuadElement3D4N;
     const MeshElement mElement2D8N;
     const MeshElement mElement2D9N;
 

--- a/kratos/includes/kratos_application.h
+++ b/kratos/includes/kratos_application.h
@@ -496,6 +496,7 @@ class KRATOS_API(KRATOS_CORE) KratosApplication {
     const MeshElement mElement2D3N;
     const MeshElement mElement2D6N;
     const MeshElement mElement2D4N;
+    const MeshElement mElement3D4N_Q;
     const MeshElement mElement2D8N;
     const MeshElement mElement2D9N;
 

--- a/kratos/sources/kratos_application.cpp
+++ b/kratos/sources/kratos_application.cpp
@@ -77,6 +77,7 @@ KratosApplication::KratosApplication(const std::string& ApplicationName)
       mElement2D3N( 0, GeometryType::Pointer(new Triangle2D3<NodeType >(GeometryType::PointsArrayType(3)))),
       mElement2D6N( 0, GeometryType::Pointer(new Triangle2D6<NodeType >(GeometryType::PointsArrayType(6)))),
       mElement2D4N( 0, GeometryType::Pointer(new Quadrilateral2D4<NodeType >(GeometryType::PointsArrayType(4)))),
+      mElement3D4N_Q( 0, GeometryType::Pointer(new Quadrilateral3D4<NodeType >(GeometryType::PointsArrayType(4)))),
       mElement2D8N( 0, GeometryType::Pointer(new Quadrilateral2D8<NodeType >(GeometryType::PointsArrayType(8)))),
       mElement2D9N( 0, GeometryType::Pointer(new Quadrilateral2D9<NodeType >(GeometryType::PointsArrayType(9)))),
 
@@ -195,6 +196,7 @@ void KratosApplication::RegisterKratosCore() {
     KRATOS_REGISTER_ELEMENT("Element2D3N", mElement2D3N)
     KRATOS_REGISTER_ELEMENT("Element2D6N", mElement2D6N)
     KRATOS_REGISTER_ELEMENT("Element2D4N", mElement2D4N)
+    KRATOS_REGISTER_ELEMENT("Element3D3N_Q", mElement3D4N_Q)
     KRATOS_REGISTER_ELEMENT("Element2D8N", mElement2D8N)
     KRATOS_REGISTER_ELEMENT("Element2D9N", mElement2D9N)
 

--- a/kratos/sources/kratos_application.cpp
+++ b/kratos/sources/kratos_application.cpp
@@ -77,7 +77,7 @@ KratosApplication::KratosApplication(const std::string& ApplicationName)
       mElement2D3N( 0, GeometryType::Pointer(new Triangle2D3<NodeType >(GeometryType::PointsArrayType(3)))),
       mElement2D6N( 0, GeometryType::Pointer(new Triangle2D6<NodeType >(GeometryType::PointsArrayType(6)))),
       mElement2D4N( 0, GeometryType::Pointer(new Quadrilateral2D4<NodeType >(GeometryType::PointsArrayType(4)))),
-      mElement3D4N_Q( 0, GeometryType::Pointer(new Quadrilateral3D4<NodeType >(GeometryType::PointsArrayType(4)))),
+      mQuadElement3D4N( 0, GeometryType::Pointer(new Quadrilateral3D4<NodeType >(GeometryType::PointsArrayType(4)))),
       mElement2D8N( 0, GeometryType::Pointer(new Quadrilateral2D8<NodeType >(GeometryType::PointsArrayType(8)))),
       mElement2D9N( 0, GeometryType::Pointer(new Quadrilateral2D9<NodeType >(GeometryType::PointsArrayType(9)))),
 
@@ -196,7 +196,7 @@ void KratosApplication::RegisterKratosCore() {
     KRATOS_REGISTER_ELEMENT("Element2D3N", mElement2D3N)
     KRATOS_REGISTER_ELEMENT("Element2D6N", mElement2D6N)
     KRATOS_REGISTER_ELEMENT("Element2D4N", mElement2D4N)
-    KRATOS_REGISTER_ELEMENT("Element3D4N_Q", mElement3D4N_Q)
+    KRATOS_REGISTER_ELEMENT("QuadElement3D4N", mQuadElement3D4N)
     KRATOS_REGISTER_ELEMENT("Element2D8N", mElement2D8N)
     KRATOS_REGISTER_ELEMENT("Element2D9N", mElement2D9N)
 

--- a/kratos/sources/kratos_application.cpp
+++ b/kratos/sources/kratos_application.cpp
@@ -196,7 +196,7 @@ void KratosApplication::RegisterKratosCore() {
     KRATOS_REGISTER_ELEMENT("Element2D3N", mElement2D3N)
     KRATOS_REGISTER_ELEMENT("Element2D6N", mElement2D6N)
     KRATOS_REGISTER_ELEMENT("Element2D4N", mElement2D4N)
-    KRATOS_REGISTER_ELEMENT("Element3D3N_Q", mElement3D4N_Q)
+    KRATOS_REGISTER_ELEMENT("Element3D4N_Q", mElement3D4N_Q)
     KRATOS_REGISTER_ELEMENT("Element2D8N", mElement2D8N)
     KRATOS_REGISTER_ELEMENT("Element2D9N", mElement2D9N)
 


### PR DESCRIPTION
**📝 Description**
Exrternal solvers like OpenFoam uses structured meshes. Hence, the interface may consist with Quad elements. Currently, only Quads2D4N is registered. This PR registers Quad3D4N element to allow creating it from python and from co sim convertor. It is required to work with external solvers coupled in cpp and python.
