### PR TITLE
[GeoMechanicsApplication] Added rotation matrix and normalize utility

### DIFF
--- a/applications/GeoMechanicsApplication/custom_utilities/geometry_utilities.cpp
+++ b/applications/GeoMechanicsApplication/custom_utilities/geometry_utilities.cpp
@@ -1,0 +1,38 @@
+// KRATOS___
+//     //   ) )
+//    //         ___      ___
+//   //  ____  //___) ) //   ) )
+//  //    / / //       //   / /
+// ((____/ / ((____   ((___/ /  MECHANICS
+//
+//  License:         geo_mechanics_application/license.txt
+//
+//  Main authors:    Richard Faasse
+//
+#include "geometry_utilities.h"
+#include "math_utilities.h"
+
+#include <boost/numeric/ublas/assignment.hpp>
+
+namespace Kratos
+{
+
+Matrix GeometryUtilities::Calculate2DRotationMatrixForLineGeometry(const Geometry<Node>& rGeometry,
+                                                                   const array_1d<double, 3>& rLocalCoordinate)
+{
+    // Since the shape functions depend on one coordinate only
+    // for lines, the jacobian only has one column.
+    Matrix jacobian;
+    rGeometry.Jacobian(jacobian, rLocalCoordinate);
+    const auto tangential_vector = GeoMechanicsMathUtilities::Normalized(Vector{column(jacobian, 0)});
+
+    // clang-format off
+    Matrix result(2, 2);
+    result <<= tangential_vector[0], -tangential_vector[1],
+               tangential_vector[1],  tangential_vector[0];
+    // clang-format on
+
+    return result;
+}
+
+} // namespace Kratos

--- a/applications/GeoMechanicsApplication/custom_utilities/geometry_utilities.h
+++ b/applications/GeoMechanicsApplication/custom_utilities/geometry_utilities.h
@@ -14,6 +14,7 @@
 
 #include "containers/array_1d.h"
 #include "geometries/geometry.h"
+#include "includes/kratos_export_api.h"
 #include "includes/node.h"
 #include "includes/ublas_interface.h"
 

--- a/applications/GeoMechanicsApplication/custom_utilities/geometry_utilities.h
+++ b/applications/GeoMechanicsApplication/custom_utilities/geometry_utilities.h
@@ -1,0 +1,30 @@
+// KRATOS___
+//     //   ) )
+//    //         ___      ___
+//   //  ____  //___) ) //   ) )
+//  //    / / //       //   / /
+// ((____/ / ((____   ((___/ /  MECHANICS
+//
+//  License:         geo_mechanics_application/license.txt
+//
+//  Main authors:    Richard Faasse
+//
+
+#pragma once
+
+#include "containers/array_1d.h"
+#include "geometries/geometry.h"
+#include "includes/node.h"
+#include "includes/ublas_interface.h"
+
+namespace Kratos
+{
+
+class KRATOS_API(GEO_MECHANICS_APPLICATION) GeometryUtilities
+{
+public:
+    static Matrix Calculate2DRotationMatrixForLineGeometry(const Geometry<Node>& rGeometry,
+                                                           const array_1d<double, 3>& rLocalCoordinate);
+};
+
+} // namespace Kratos

--- a/applications/GeoMechanicsApplication/custom_utilities/math_utilities.h
+++ b/applications/GeoMechanicsApplication/custom_utilities/math_utilities.h
@@ -17,6 +17,8 @@
 #include "includes/kratos_export_api.h"
 #include "includes/ublas_interface.h"
 
+#include <algorithm>
+
 namespace Kratos
 {
 
@@ -24,6 +26,16 @@ class KRATOS_API(GEO_MECHANICS_APPLICATION) GeoMechanicsMathUtilities
 {
 public:
     [[nodiscard]] static std::vector<double> CalculateDeterminants(const std::vector<Matrix>& rMatrices);
+
+    template <typename VectorType>
+    [[nodiscard]] static VectorType Normalized(const VectorType& rVector)
+    {
+        KRATOS_ERROR_IF(std::none_of(rVector.begin(), rVector.end(), [](auto Component) {
+            return std::abs(Component) > 0.0;
+        })) << "A zero vector cannot be normalized\n";
+
+        return rVector / norm_2(rVector);
+    }
 
 }; // class GeoMechanicsMathUtilities
 

--- a/applications/GeoMechanicsApplication/custom_utilities/math_utilities.h
+++ b/applications/GeoMechanicsApplication/custom_utilities/math_utilities.h
@@ -12,12 +12,12 @@
 
 #pragma once
 
-#include <vector>
-
 #include "includes/kratos_export_api.h"
 #include "includes/ublas_interface.h"
 
 #include <algorithm>
+#include <vector>
+#include <cstdlib>
 
 namespace Kratos
 {
@@ -30,11 +30,10 @@ public:
     template <typename VectorType>
     [[nodiscard]] static VectorType Normalized(const VectorType& rVector)
     {
-        KRATOS_ERROR_IF(std::none_of(rVector.begin(), rVector.end(), [](auto Component) {
-            return std::abs(Component) > 0.0;
-        })) << "A zero vector cannot be normalized\n";
+        const auto length = norm_2(rVector);
+        KRATOS_ERROR_IF_NOT(length > 0.0) << "A zero vector cannot be normalized\n";
 
-        return rVector / norm_2(rVector);
+        return rVector / length;
     }
 
 }; // class GeoMechanicsMathUtilities

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_utilities/test_geometry_utilities.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_utilities/test_geometry_utilities.cpp
@@ -1,0 +1,259 @@
+// KRATOS___
+//     //   ) )
+//    //         ___      ___
+//   //  ____  //___) ) //   ) )
+//  //    / / //       //   / /
+// ((____/ / ((____   ((___/ /  MECHANICS
+//
+//  License:         geo_mechanics_application/license.txt
+//
+//  Main authors:    Richard Faasse
+//
+
+#include "custom_geometries/line_interface_geometry.h"
+#include "custom_utilities/geometry_utilities.h"
+#include "tests/cpp_tests/geo_mechanics_fast_suite.h"
+
+#include <boost/numeric/ublas/assignment.hpp>
+
+namespace Kratos::Testing
+{
+
+KRATOS_TEST_CASE_IN_SUITE(GeometryUtilities_RotationMatrixForHorizontalInterfaceIsIdentityMatrix,
+                          KratosGeoMechanicsFastSuiteWithoutKernel)
+{
+    PointerVector<Node> nodes;
+    nodes.push_back(Kratos::make_intrusive<Node>(1, 0.0, 0.0, 0.0));
+    nodes.push_back(Kratos::make_intrusive<Node>(2, 5.0, 0.0, 0.0));
+    nodes.push_back(Kratos::make_intrusive<Node>(3, 0.0, 0.0, 0.0));
+    nodes.push_back(Kratos::make_intrusive<Node>(4, 5.0, 0.0, 0.0));
+    const LineInterfaceGeometry<Line2D2<Node>> geometry(1, nodes);
+
+    // Note that only the first component of the local coordinate is used
+    const auto local_coordinate = array_1d<double, 3>{0.0, 0.0, 0.0};
+    Matrix     rotation_matrix =
+        GeometryUtilities::Calculate2DRotationMatrixForLineGeometry(geometry, local_coordinate);
+
+    KRATOS_EXPECT_MATRIX_NEAR(Matrix{IdentityMatrix{2}}, rotation_matrix, 1e-6)
+}
+
+KRATOS_TEST_CASE_IN_SUITE(GeometryUtilities_ReturnsCorrectRotationMatrixForInclinedInterface,
+                          KratosGeoMechanicsFastSuiteWithoutKernel)
+{
+    PointerVector<Node> nodes;
+    nodes.push_back(Kratos::make_intrusive<Node>(1, 0.0, 0.0, 0.0));
+    nodes.push_back(Kratos::make_intrusive<Node>(2, 0.5 * std::sqrt(3), -0.5, 0.0));
+    nodes.push_back(Kratos::make_intrusive<Node>(3, 0.0, 0.0, 0.0));
+    nodes.push_back(Kratos::make_intrusive<Node>(4, 0.5 * std::sqrt(3), -0.5, 0.0));
+    const LineInterfaceGeometry<Line2D2<Node>> geometry(1, nodes);
+
+    const auto local_coordinate = array_1d<double, 3>{0.0, 0.0, 0.0};
+    Matrix     rotation_matrix =
+        GeometryUtilities::Calculate2DRotationMatrixForLineGeometry(geometry, local_coordinate);
+
+    // clang-format off
+    Matrix expected_rotation_matrix(2, 2);
+    expected_rotation_matrix <<= 0.5 * sqrt(3), 0.5,
+                                -0.5,           0.5 * sqrt(3); // Rotation of 30 degrees clockwise
+    // clang-format on
+    KRATOS_EXPECT_MATRIX_NEAR(expected_rotation_matrix, rotation_matrix, 1e-6)
+}
+
+KRATOS_TEST_CASE_IN_SUITE(GeometryUtilities_ReturnsCorrectRotationMatrixForInclinedInterface2,
+                          KratosGeoMechanicsFastSuiteWithoutKernel)
+{
+    PointerVector<Node> nodes;
+    nodes.push_back(Kratos::make_intrusive<Node>(1, -0.5, 0.5 * std::sqrt(3), 0.0));
+    nodes.push_back(Kratos::make_intrusive<Node>(2, 0.0, 0.0, 0.0));
+    nodes.push_back(Kratos::make_intrusive<Node>(3, -0.5, 0.5 * std::sqrt(3), 0.0));
+    nodes.push_back(Kratos::make_intrusive<Node>(4, 0.0, 0.0, 0.0));
+    const LineInterfaceGeometry<Line2D2<Node>> geometry(1, nodes);
+
+    // Since the gradient of the shape functions is constant, the rotation matrix is the same at
+    // each point, meaning the local_coordinate should not have an effect
+    const auto local_coordinate = array_1d<double, 3>{0.5, 0.0, 0.0};
+    Matrix     rotation_matrix =
+        GeometryUtilities::Calculate2DRotationMatrixForLineGeometry(geometry, local_coordinate);
+
+    // clang-format off
+    Matrix expected_rotation_matrix(2, 2);
+    expected_rotation_matrix <<= 0.5,           0.5 * sqrt(3),
+                                -0.5 * sqrt(3), 0.5; // rotation of 60 degrees clockwise
+    // clang-format on
+    KRATOS_EXPECT_MATRIX_NEAR(expected_rotation_matrix, rotation_matrix, 1e-6)
+}
+
+KRATOS_TEST_CASE_IN_SUITE(GeometryUtilities_ReturnsCorrectRotationMatrixForInclinedInterface_WithNonUnitLength,
+                          KratosGeoMechanicsFastSuiteWithoutKernel)
+{
+    PointerVector<Node> nodes;
+    nodes.push_back(Kratos::make_intrusive<Node>(1, -0.5 * std::sqrt(3), 0.5, 0.0));
+    nodes.push_back(Kratos::make_intrusive<Node>(2, 0.5 * std::sqrt(3), -0.5, 0.0));
+    nodes.push_back(Kratos::make_intrusive<Node>(3, -0.5 * std::sqrt(3), 0.5, 0.0));
+    nodes.push_back(Kratos::make_intrusive<Node>(4, 0.5 * std::sqrt(3), -0.5, 0.0));
+    const LineInterfaceGeometry<Line2D2<Node>> geometry(1, nodes);
+
+    const auto local_coordinate = array_1d<double, 3>{0.0, 0.0, 0.0};
+    Matrix     rotation_matrix =
+        GeometryUtilities::Calculate2DRotationMatrixForLineGeometry(geometry, local_coordinate);
+
+    // clang-format off
+    Matrix expected_rotation_matrix(2, 2);
+    expected_rotation_matrix <<= 0.5 * sqrt(3), 0.5,
+                                -0.5,           0.5 * sqrt(3); // Rotation of 30 degrees clockwise
+    // clang-format on
+    KRATOS_EXPECT_MATRIX_NEAR(expected_rotation_matrix, rotation_matrix, 1e-6)
+}
+
+KRATOS_TEST_CASE_IN_SUITE(GeometryUtilities_ReturnsCorrectRotationMatrixForVerticalElement_WithNonUnitLength,
+                          KratosGeoMechanicsFastSuiteWithoutKernel)
+{
+    PointerVector<Node> nodes;
+    nodes.push_back(Kratos::make_intrusive<Node>(1, 0.0, -7.0, 0.0));
+    nodes.push_back(Kratos::make_intrusive<Node>(2, 0.0, 10.0, 0.0));
+    nodes.push_back(Kratos::make_intrusive<Node>(3, 0.0, -7.0, 0.0));
+    nodes.push_back(Kratos::make_intrusive<Node>(4, 0.0, 10.0, 0.0));
+    const LineInterfaceGeometry<Line2D2<Node>> geometry(1, nodes);
+
+    const auto local_coordinate = array_1d<double, 3>{0.0, 0.0, 0.0};
+    Matrix     rotation_matrix =
+        GeometryUtilities::Calculate2DRotationMatrixForLineGeometry(geometry, local_coordinate);
+
+    // clang-format off
+    Matrix expected_rotation_matrix(2, 2);
+    expected_rotation_matrix <<= 0.0, -1.0,
+                                 1.0,  0.0; // Rotation of 90 degrees counterclockwise
+    // clang-format on
+    KRATOS_EXPECT_MATRIX_NEAR(expected_rotation_matrix, rotation_matrix, 1e-6)
+}
+
+KRATOS_TEST_CASE_IN_SUITE(GeometryUtilities_UnityRotationFor3Plus3NodedInterface_WithNonUnitLength,
+                          KratosGeoMechanicsFastSuiteWithoutKernel)
+{
+    PointerVector<Node> nodes;
+    nodes.push_back(Kratos::make_intrusive<Node>(1, 0.0, 0.0, 0.0));
+    nodes.push_back(Kratos::make_intrusive<Node>(2, 1.0, 0.0, 0.0));
+    nodes.push_back(Kratos::make_intrusive<Node>(3, 2.0, 0.0, 0.0));
+    nodes.push_back(Kratos::make_intrusive<Node>(4, 0.0, 0.0, 0.0));
+    nodes.push_back(Kratos::make_intrusive<Node>(5, 1.0, 0.0, 0.0));
+    nodes.push_back(Kratos::make_intrusive<Node>(6, 2.0, 0.0, 0.0));
+    const LineInterfaceGeometry<Line2D3<Node>> geometry(1, nodes);
+
+    const auto local_coordinate = array_1d<double, 3>{0.0, 0.0, 0.0};
+    Matrix     rotation_matrix =
+        GeometryUtilities::Calculate2DRotationMatrixForLineGeometry(geometry, local_coordinate);
+
+    KRATOS_EXPECT_MATRIX_NEAR(Matrix{IdentityMatrix{2}}, rotation_matrix, 1e-6)
+}
+
+KRATOS_TEST_CASE_IN_SUITE(GeometryUtilities_UnityRotationForCurved3Plus3NodedInterface_WithNonUnitLength,
+                          KratosGeoMechanicsFastSuiteWithoutKernel)
+{
+    PointerVector<Node> nodes;
+    nodes.push_back(Kratos::make_intrusive<Node>(1, 0.0, 0.0, 0.0));
+    nodes.push_back(Kratos::make_intrusive<Node>(2, 2.0, 0.0, 0.0));
+    nodes.push_back(Kratos::make_intrusive<Node>(3, 1.0, -1.0, 0.0));
+    nodes.push_back(Kratos::make_intrusive<Node>(4, 0.0, 0.0, 0.0));
+    nodes.push_back(Kratos::make_intrusive<Node>(5, 2.0, 0.0, 0.0));
+    nodes.push_back(Kratos::make_intrusive<Node>(6, 1.0, -1.0, 0.0));
+    const LineInterfaceGeometry<Line2D3<Node>> geometry(1, nodes);
+
+    const auto local_coordinate = array_1d<double, 3>{0.0, 0.0, 0.0};
+    Matrix     rotation_matrix =
+        GeometryUtilities::Calculate2DRotationMatrixForLineGeometry(geometry, local_coordinate);
+
+    KRATOS_EXPECT_MATRIX_NEAR(Matrix{IdentityMatrix{2}}, rotation_matrix, 1e-6)
+}
+
+KRATOS_TEST_CASE_IN_SUITE(GeometryUtilities_ReturnsCorrectRotationForInclinedCurved3Plus3NodedInterface_WithNonUnitLength,
+                          KratosGeoMechanicsFastSuiteWithoutKernel)
+{
+    PointerVector<Node> nodes;
+    nodes.push_back(Kratos::make_intrusive<Node>(1, 0.0, 2.0, 0.0));
+    nodes.push_back(Kratos::make_intrusive<Node>(2, 2.0, 0.0, 0.0));
+    nodes.push_back(Kratos::make_intrusive<Node>(3, 0.8, 0.8, 0.0));
+    nodes.push_back(Kratos::make_intrusive<Node>(4, 0.0, 2.0, 0.0));
+    nodes.push_back(Kratos::make_intrusive<Node>(5, 2.0, 0.0, 0.0));
+    nodes.push_back(Kratos::make_intrusive<Node>(6, 0.8, 0.8, 0.0));
+    const LineInterfaceGeometry<Line2D3<Node>> geometry(1, nodes);
+
+    const auto local_coordinate = array_1d<double, 3>{0.0, 0.0, 0.0};
+    Matrix     rotation_matrix =
+        GeometryUtilities::Calculate2DRotationMatrixForLineGeometry(geometry, local_coordinate);
+
+    // clang-format off
+    Matrix expected_rotation_matrix(2, 2);
+    expected_rotation_matrix <<= 0.5 * sqrt(2), 0.5 * sqrt(2),
+                                -0.5 * sqrt(2), 0.5 * sqrt(2); // Rotation of 45 degrees clockwise
+    // clang-format on
+    KRATOS_EXPECT_MATRIX_NEAR(expected_rotation_matrix, rotation_matrix, 1e-6)
+}
+
+KRATOS_TEST_CASE_IN_SUITE(GeometryUtilities_ReturnsCorrectRotationAtEdgeOfQuadraticElement_WithNonUnitLength,
+                          KratosGeoMechanicsFastSuiteWithoutKernel)
+{
+    PointerVector<Node> nodes;
+    nodes.push_back(Kratos::make_intrusive<Node>(1, -1.0, 1.0, 0.0));
+    nodes.push_back(Kratos::make_intrusive<Node>(2, 1.0, 1.0, 0.0));
+    nodes.push_back(Kratos::make_intrusive<Node>(3, 0.0, 0.0, 0.0));
+    nodes.push_back(Kratos::make_intrusive<Node>(4, -1.0, 1.0, 0.0));
+    nodes.push_back(Kratos::make_intrusive<Node>(5, 1.0, 1.0, 0.0));
+    nodes.push_back(Kratos::make_intrusive<Node>(6, 0.0, 0.0, 0.0));
+    const LineInterfaceGeometry<Line2D3<Node>> geometry(1, nodes);
+
+    const auto local_coordinate = array_1d<double, 3>{1.0, 0.0, 0.0};
+    Matrix     rotation_matrix =
+        GeometryUtilities::Calculate2DRotationMatrixForLineGeometry(geometry, local_coordinate);
+
+    // clang-format off
+    Matrix expected_rotation_matrix(2, 2);
+    // Rotation of 63.43 (atan(2)) degrees counterclockwise
+    expected_rotation_matrix <<= std::cos(1.1071), -std::sin(1.1071),
+                                 std::sin(1.1071), std::cos(1.1071);
+    // clang-format on
+    KRATOS_EXPECT_MATRIX_NEAR(expected_rotation_matrix, rotation_matrix, 1e-3)
+}
+
+KRATOS_TEST_CASE_IN_SUITE(GeometryUtilities_ReturnsCorrectRotationAtArbitraryXiForQuadraticElement_WithNonUnitLength,
+                          KratosGeoMechanicsFastSuiteWithoutKernel)
+{
+    PointerVector<Node> nodes;
+    nodes.push_back(Kratos::make_intrusive<Node>(1, -1.0, 1.0, 0.0));
+    nodes.push_back(Kratos::make_intrusive<Node>(2, 1.0, 1.0, 0.0));
+    nodes.push_back(Kratos::make_intrusive<Node>(3, 0.0, 0.0, 0.0));
+    nodes.push_back(Kratos::make_intrusive<Node>(4, -1.0, 1.0, 0.0));
+    nodes.push_back(Kratos::make_intrusive<Node>(5, 1.0, 1.0, 0.0));
+    nodes.push_back(Kratos::make_intrusive<Node>(6, 0.0, 0.0, 0.0));
+    const LineInterfaceGeometry<Line2D3<Node>> geometry(1, nodes);
+
+    const auto local_coordinate = array_1d<double, 3>{-0.5, 0.0, 0.0};
+    Matrix     rotation_matrix =
+        GeometryUtilities::Calculate2DRotationMatrixForLineGeometry(geometry, local_coordinate);
+
+    // clang-format off
+    Matrix expected_rotation_matrix(2, 2);
+    expected_rotation_matrix <<= 0.5 * sqrt(2), 0.5 * sqrt(2),
+                                -0.5 * sqrt(2), 0.5 * sqrt(2); // Rotation of 45 degrees clockwise
+    // clang-format on
+    KRATOS_EXPECT_MATRIX_NEAR(expected_rotation_matrix, rotation_matrix, 1e-3)
+}
+
+KRATOS_TEST_CASE_IN_SUITE(GeometryUtilities_RotationMatrixForOpenHorizontalInterfaceIsIdentityMatrix,
+                          KratosGeoMechanicsFastSuiteWithoutKernel)
+{
+    PointerVector<Node> nodes;
+    // Make sure the two sides of the interface are separated by a distance of 2
+    nodes.push_back(Kratos::make_intrusive<Node>(1, 0.0, 1.0, 0.0));
+    nodes.push_back(Kratos::make_intrusive<Node>(2, 5.0, 1.0, 0.0));
+    nodes.push_back(Kratos::make_intrusive<Node>(3, 0.0, -1.0, 0.0));
+    nodes.push_back(Kratos::make_intrusive<Node>(4, 5.0, -1.0, 0.0));
+    const LineInterfaceGeometry<Line2D2<Node>> geometry(1, nodes);
+
+    const auto local_coordinate = array_1d<double, 3>{0.0, 0.0, 0.0};
+    Matrix     rotation_matrix =
+        GeometryUtilities::Calculate2DRotationMatrixForLineGeometry(geometry, local_coordinate);
+
+    KRATOS_EXPECT_MATRIX_NEAR(Matrix{IdentityMatrix{2}}, rotation_matrix, 1e-6)
+}
+
+} // namespace Kratos::Testing

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_utilities/test_geometry_utilities.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_utilities/test_geometry_utilities.cpp
@@ -19,7 +19,7 @@
 namespace Kratos::Testing
 {
 
-KRATOS_TEST_CASE_IN_SUITE(GeometryUtilities_RotationMatrixForHorizontalInterfaceIsIdentityMatrix,
+KRATOS_TEST_CASE_IN_SUITE(GeometryUtilities_RotationMatrixForHorizontal2Plus2LineInterfaceIsIdentityMatrix,
                           KratosGeoMechanicsFastSuiteWithoutKernel)
 {
     PointerVector<Node> nodes;
@@ -31,7 +31,7 @@ KRATOS_TEST_CASE_IN_SUITE(GeometryUtilities_RotationMatrixForHorizontalInterface
 
     // Note that only the first component of the local coordinate is used
     const auto local_coordinate = array_1d<double, 3>{0.0, 0.0, 0.0};
-    Matrix     rotation_matrix =
+    const auto rotation_matrix =
         GeometryUtilities::Calculate2DRotationMatrixForLineGeometry(geometry, local_coordinate);
 
     KRATOS_EXPECT_MATRIX_NEAR(Matrix{IdentityMatrix{2}}, rotation_matrix, 1e-6)
@@ -48,7 +48,7 @@ KRATOS_TEST_CASE_IN_SUITE(GeometryUtilities_ReturnsCorrectRotationMatrixForIncli
     const LineInterfaceGeometry<Line2D2<Node>> geometry(1, nodes);
 
     const auto local_coordinate = array_1d<double, 3>{0.0, 0.0, 0.0};
-    Matrix     rotation_matrix =
+    const auto rotation_matrix =
         GeometryUtilities::Calculate2DRotationMatrixForLineGeometry(geometry, local_coordinate);
 
     // clang-format off
@@ -72,7 +72,7 @@ KRATOS_TEST_CASE_IN_SUITE(GeometryUtilities_ReturnsCorrectRotationMatrixForIncli
     // Since the gradient of the shape functions is constant, the rotation matrix is the same at
     // each point, meaning the local_coordinate should not have an effect
     const auto local_coordinate = array_1d<double, 3>{0.5, 0.0, 0.0};
-    Matrix     rotation_matrix =
+    const auto rotation_matrix =
         GeometryUtilities::Calculate2DRotationMatrixForLineGeometry(geometry, local_coordinate);
 
     // clang-format off
@@ -94,7 +94,7 @@ KRATOS_TEST_CASE_IN_SUITE(GeometryUtilities_ReturnsCorrectRotationMatrixForIncli
     const LineInterfaceGeometry<Line2D2<Node>> geometry(1, nodes);
 
     const auto local_coordinate = array_1d<double, 3>{0.0, 0.0, 0.0};
-    Matrix     rotation_matrix =
+    const auto rotation_matrix =
         GeometryUtilities::Calculate2DRotationMatrixForLineGeometry(geometry, local_coordinate);
 
     // clang-format off
@@ -116,7 +116,7 @@ KRATOS_TEST_CASE_IN_SUITE(GeometryUtilities_ReturnsCorrectRotationMatrixForVerti
     const LineInterfaceGeometry<Line2D2<Node>> geometry(1, nodes);
 
     const auto local_coordinate = array_1d<double, 3>{0.0, 0.0, 0.0};
-    Matrix     rotation_matrix =
+    const auto rotation_matrix =
         GeometryUtilities::Calculate2DRotationMatrixForLineGeometry(geometry, local_coordinate);
 
     // clang-format off
@@ -127,7 +127,7 @@ KRATOS_TEST_CASE_IN_SUITE(GeometryUtilities_ReturnsCorrectRotationMatrixForVerti
     KRATOS_EXPECT_MATRIX_NEAR(expected_rotation_matrix, rotation_matrix, 1e-6)
 }
 
-KRATOS_TEST_CASE_IN_SUITE(GeometryUtilities_UnityRotationFor3Plus3NodedInterface_WithNonUnitLength,
+KRATOS_TEST_CASE_IN_SUITE(GeometryUtilities_RotationMatrixForHorizontal3Plus3LineInterfaceIsIdentityMatrix,
                           KratosGeoMechanicsFastSuiteWithoutKernel)
 {
     PointerVector<Node> nodes;
@@ -140,13 +140,13 @@ KRATOS_TEST_CASE_IN_SUITE(GeometryUtilities_UnityRotationFor3Plus3NodedInterface
     const LineInterfaceGeometry<Line2D3<Node>> geometry(1, nodes);
 
     const auto local_coordinate = array_1d<double, 3>{0.0, 0.0, 0.0};
-    Matrix     rotation_matrix =
+    const auto rotation_matrix =
         GeometryUtilities::Calculate2DRotationMatrixForLineGeometry(geometry, local_coordinate);
 
     KRATOS_EXPECT_MATRIX_NEAR(Matrix{IdentityMatrix{2}}, rotation_matrix, 1e-6)
 }
 
-KRATOS_TEST_CASE_IN_SUITE(GeometryUtilities_UnityRotationForCurved3Plus3NodedInterface_WithNonUnitLength,
+KRATOS_TEST_CASE_IN_SUITE(GeometryUtilities_UnityRotationForCenterOfCurved3Plus3NodedInterface_WithNonUnitLength,
                           KratosGeoMechanicsFastSuiteWithoutKernel)
 {
     PointerVector<Node> nodes;
@@ -159,7 +159,7 @@ KRATOS_TEST_CASE_IN_SUITE(GeometryUtilities_UnityRotationForCurved3Plus3NodedInt
     const LineInterfaceGeometry<Line2D3<Node>> geometry(1, nodes);
 
     const auto local_coordinate = array_1d<double, 3>{0.0, 0.0, 0.0};
-    Matrix     rotation_matrix =
+    const auto rotation_matrix =
         GeometryUtilities::Calculate2DRotationMatrixForLineGeometry(geometry, local_coordinate);
 
     KRATOS_EXPECT_MATRIX_NEAR(Matrix{IdentityMatrix{2}}, rotation_matrix, 1e-6)
@@ -178,7 +178,7 @@ KRATOS_TEST_CASE_IN_SUITE(GeometryUtilities_ReturnsCorrectRotationForInclinedCur
     const LineInterfaceGeometry<Line2D3<Node>> geometry(1, nodes);
 
     const auto local_coordinate = array_1d<double, 3>{0.0, 0.0, 0.0};
-    Matrix     rotation_matrix =
+    const auto rotation_matrix =
         GeometryUtilities::Calculate2DRotationMatrixForLineGeometry(geometry, local_coordinate);
 
     // clang-format off
@@ -202,7 +202,7 @@ KRATOS_TEST_CASE_IN_SUITE(GeometryUtilities_ReturnsCorrectRotationAtEdgeOfQuadra
     const LineInterfaceGeometry<Line2D3<Node>> geometry(1, nodes);
 
     const auto local_coordinate = array_1d<double, 3>{1.0, 0.0, 0.0};
-    Matrix     rotation_matrix =
+    const auto rotation_matrix =
         GeometryUtilities::Calculate2DRotationMatrixForLineGeometry(geometry, local_coordinate);
 
     // clang-format off
@@ -227,7 +227,7 @@ KRATOS_TEST_CASE_IN_SUITE(GeometryUtilities_ReturnsCorrectRotationAtArbitraryXiF
     const LineInterfaceGeometry<Line2D3<Node>> geometry(1, nodes);
 
     const auto local_coordinate = array_1d<double, 3>{-0.5, 0.0, 0.0};
-    Matrix     rotation_matrix =
+    const auto rotation_matrix =
         GeometryUtilities::Calculate2DRotationMatrixForLineGeometry(geometry, local_coordinate);
 
     // clang-format off
@@ -250,7 +250,7 @@ KRATOS_TEST_CASE_IN_SUITE(GeometryUtilities_RotationMatrixForOpenHorizontalInter
     const LineInterfaceGeometry<Line2D2<Node>> geometry(1, nodes);
 
     const auto local_coordinate = array_1d<double, 3>{0.0, 0.0, 0.0};
-    Matrix     rotation_matrix =
+    const auto rotation_matrix =
         GeometryUtilities::Calculate2DRotationMatrixForLineGeometry(geometry, local_coordinate);
 
     KRATOS_EXPECT_MATRIX_NEAR(Matrix{IdentityMatrix{2}}, rotation_matrix, 1e-6)

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_utilities/test_math_utilities.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_utilities/test_math_utilities.cpp
@@ -12,7 +12,7 @@
 
 #include "custom_utilities/math_utilities.h"
 #include "includes/checks.h"
-#include "geo_mechanics_fast_suite.h"
+#include "tests/cpp_tests/geo_mechanics_fast_suite.h"
 
 namespace Kratos::Testing
 {
@@ -34,6 +34,28 @@ KRATOS_TEST_CASE_IN_SUITE(CalculateDeterminants_ReturnsEmptyVectorForEmptyInput,
     const std::vector<double> results = GeoMechanicsMathUtilities::CalculateDeterminants(matrices);
 
     KRATOS_EXPECT_TRUE(results.empty())
+}
+
+KRATOS_TEST_CASE_IN_SUITE(Normalized_ReturnsNormalizedVector, KratosGeoMechanicsFastSuiteWithoutKernel)
+{
+    const Vector vector = ScalarVector(3, 2.0);
+    KRATOS_EXPECT_VECTOR_NEAR(GeoMechanicsMathUtilities::Normalized(vector),
+                              Vector{ScalarVector(3, 1 / std::sqrt(3))}, 1.0e-6);
+}
+
+KRATOS_TEST_CASE_IN_SUITE(Normalized_ReturnsNormalizedVector_ForAllNegativeVector, KratosGeoMechanicsFastSuiteWithoutKernel)
+{
+    const Vector vector = ScalarVector(3, -2.0);
+    KRATOS_EXPECT_VECTOR_NEAR(GeoMechanicsMathUtilities::Normalized(vector),
+                              Vector{ScalarVector(3, -1 / std::sqrt(3))}, 1.0e-6);
+}
+
+KRATOS_TEST_CASE_IN_SUITE(Normalized_Throws_WhenInputtingZeroVector, KratosGeoMechanicsFastSuiteWithoutKernel)
+{
+    const Vector vector = ZeroVector(3);
+    KRATOS_EXPECT_EXCEPTION_IS_THROWN(
+        [[maybe_unused]] const auto normalized = GeoMechanicsMathUtilities::Normalized(vector),
+        "A zero vector cannot be normalized")
 }
 
 } // namespace Kratos::Testing


### PR DESCRIPTION
**📝 Description**
This PR adds a utility that calculates the rotation matrix given a certain local coordinate ξ, given a line interface geometry. It also includes splitting the interface element utilities in a .h and .cpp. A lot of the other functions in this class can be removed in time, because we now also have an automated way to create the same 'Nu matrix'.

I had to create a new PR, because the location of this function in https://github.com/KratosMultiphysics/Kratos/pull/12662 was not correct and I didn't want to clutter this PR with the (then) unrelated change to interface element utilities