### PR TITLE
[GeoMechanicsApplication] Calculate the constitutive matrix of the incremental linear elastic law for interface elements

### DIFF
--- a/applications/GeoMechanicsApplication/custom_constitutive/incremental_linear_elastic_interface_law.cpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/incremental_linear_elastic_interface_law.cpp
@@ -55,6 +55,8 @@ Matrix& GeoIncrementalLinearElasticInterfaceLaw::CalculateValue(ConstitutiveLaw:
         const auto& r_properties = rParameterValues.GetMaterialProperties();
         rValue                   = MakeConstitutiveMatrix(r_properties[INTERFACE_NORMAL_STIFFNESS],
                                                           r_properties[INTERFACE_SHEAR_STIFFNESS]);
+    } else {
+        KRATOS_ERROR << "Can't calculate value of " << rThisVariable.Name() << ": unsupported variable\n";
     }
 
     return rValue;

--- a/applications/GeoMechanicsApplication/custom_constitutive/incremental_linear_elastic_interface_law.cpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/incremental_linear_elastic_interface_law.cpp
@@ -47,6 +47,19 @@ Vector& GeoIncrementalLinearElasticInterfaceLaw::GetValue(const Variable<Vector>
     return rValue;
 }
 
+Matrix& GeoIncrementalLinearElasticInterfaceLaw::CalculateValue(ConstitutiveLaw::Parameters& rParameterValues,
+                                                                const Variable<Matrix>& rThisVariable,
+                                                                Matrix& rValue)
+{
+    if (rThisVariable == CONSTITUTIVE_MATRIX) {
+        const auto& r_properties = rParameterValues.GetMaterialProperties();
+        rValue                   = MakeConstitutiveMatrix(r_properties[INTERFACE_NORMAL_STIFFNESS],
+                                                          r_properties[INTERFACE_SHEAR_STIFFNESS]);
+    }
+
+    return rValue;
+}
+
 ConstitutiveLaw::StressMeasure GeoIncrementalLinearElasticInterfaceLaw::GetStressMeasure()
 {
     return ConstitutiveLaw::StressMeasure_Cauchy;

--- a/applications/GeoMechanicsApplication/custom_constitutive/incremental_linear_elastic_interface_law.cpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/incremental_linear_elastic_interface_law.cpp
@@ -40,6 +40,8 @@ Vector& GeoIncrementalLinearElasticInterfaceLaw::GetValue(const Variable<Vector>
         rValue = mPreviousRelativeDisplacement;
     } else if (rThisVariable == CAUCHY_STRESS_VECTOR) {
         rValue = mPreviousTraction;
+    } else {
+        KRATOS_ERROR << "Can't get value of " << rThisVariable.Name() << ": unsupported variable\n";
     }
 
     return rValue;

--- a/applications/GeoMechanicsApplication/custom_constitutive/incremental_linear_elastic_interface_law.h
+++ b/applications/GeoMechanicsApplication/custom_constitutive/incremental_linear_elastic_interface_law.h
@@ -29,6 +29,8 @@ public:
     [[nodiscard]] SizeType GetStrainSize() const override;
     Vector&                GetValue(const Variable<Vector>& rThisVariable, Vector& rValue) override;
     using BaseType::GetValue;
+    Matrix& CalculateValue(Parameters& rParameterValues, const Variable<Matrix>& rThisVariable, Matrix& rValue) override;
+    using BaseType::CalculateValue;
     StressMeasure GetStressMeasure() override;
     bool          IsIncremental() override;
     void InitializeMaterial(const Properties&, const GeometryType&, const Vector&) override;

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_constitutive/test_incremental_linear_elastic_interface_law.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_constitutive/test_incremental_linear_elastic_interface_law.cpp
@@ -145,6 +145,19 @@ KRATOS_TEST_CASE_IN_SUITE(TheCalculatedConstitutiveMatrixIsADiagonalMatrixContai
     KRATOS_EXPECT_MATRIX_RELATIVE_NEAR(actual_constitutive_matrix, expected_constitutive_matrix, relative_tolerance)
 }
 
+KRATOS_TEST_CASE_IN_SUITE(TryingToCalculateTheValueOfAnUnsupportedMatrixVariableRaisesAnError,
+                          KratosGeoMechanicsFastSuiteWithoutKernel)
+{
+    auto        law                                = GeoIncrementalLinearElasticInterfaceLaw{};
+    const auto& r_some_unsupported_matrix_variable = ENGINEERING_STRAIN_TENSOR;
+    auto        dummy_parameters                   = ConstitutiveLaw::Parameters{};
+    auto        value                              = Matrix{};
+    
+    KRATOS_EXPECT_EXCEPTION_IS_THROWN(
+        law.CalculateValue(dummy_parameters, r_some_unsupported_matrix_variable, value),
+        "Can't calculate value of ENGINEERING_STRAIN_TENSOR: unsupported variable")
+}
+
 KRATOS_TEST_CASE_IN_SUITE(WhenNoInitialStateIsGivenStartWithZeroRelativeDisplacementAndZeroTraction,
                           KratosGeoMechanicsFastSuiteWithoutKernel)
 {

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_constitutive/test_incremental_linear_elastic_interface_law.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_constitutive/test_incremental_linear_elastic_interface_law.cpp
@@ -158,6 +158,18 @@ KRATOS_TEST_CASE_IN_SUITE(WhenAnInitialStateIsGivenStartFromThereAfterMaterialIn
     KRATOS_EXPECT_VECTOR_RELATIVE_NEAR(value, initial_traction, relative_tolerance)
 }
 
+KRATOS_TEST_CASE_IN_SUITE(TryingToGetTheValueOfAnUnsupportedVectorVariableRaisesAnError,
+                          KratosGeoMechanicsFastSuiteWithoutKernel)
+{
+    auto        law                                = GeoIncrementalLinearElasticInterfaceLaw{};
+    const auto& r_some_unsupported_vector_variable = GREEN_LAGRANGE_STRAIN_VECTOR;
+
+    auto value = Vector{};
+    KRATOS_EXPECT_EXCEPTION_IS_THROWN(
+        law.GetValue(r_some_unsupported_vector_variable, value),
+        "Can't get value of GREEN_LAGRANGE_STRAIN_VECTOR: unsupported variable")
+}
+
 KRATOS_TEST_CASE_IN_SUITE(ComputedIncrementalTractionIsProductOfIncrementalRelativeDisplacementAndStiffness,
                           KratosGeoMechanicsFastSuiteWithoutKernel)
 {

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_constitutive/test_incremental_linear_elastic_interface_law.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_constitutive/test_incremental_linear_elastic_interface_law.cpp
@@ -119,6 +119,32 @@ KRATOS_TEST_CASE_IN_SUITE(LinearElasticLawForInterfacesChecksForCorrectMaterialP
     KRATOS_EXPECT_EQ(law.Check(properties, geometry, process_info), 0);
 }
 
+KRATOS_TEST_CASE_IN_SUITE(TheCalculatedConstitutiveMatrixIsADiagonalMatrixContainingNormalAndShearStiffnessValues,
+                          KratosGeoMechanicsFastSuiteWithoutKernel)
+{
+    // Arrange
+    auto material_properties                        = Properties{};
+    material_properties[INTERFACE_NORMAL_STIFFNESS] = 20.0;
+    material_properties[INTERFACE_SHEAR_STIFFNESS]  = 10.0;
+
+    auto law_parameters = ConstitutiveLaw::Parameters{};
+    law_parameters.SetMaterialProperties(material_properties);
+
+    auto law = GeoIncrementalLinearElasticInterfaceLaw{};
+
+    // Act
+    auto actual_constitutive_matrix = Matrix{};
+    law.CalculateValue(law_parameters, CONSTITUTIVE_MATRIX, actual_constitutive_matrix);
+
+    // Assert
+    auto expected_constitutive_matrix = Matrix{2, 2};
+    // clang-format off
+    expected_constitutive_matrix <<= 20.0, 0.0,
+                                     0.0, 10.0;
+    // clang-format on
+    KRATOS_EXPECT_MATRIX_RELATIVE_NEAR(actual_constitutive_matrix, expected_constitutive_matrix, relative_tolerance)
+}
+
 KRATOS_TEST_CASE_IN_SUITE(WhenNoInitialStateIsGivenStartWithZeroRelativeDisplacementAndZeroTraction,
                           KratosGeoMechanicsFastSuiteWithoutKernel)
 {


### PR DESCRIPTION
**📝 Description**

Added support for calculating the constitutive matrix of the incremental linear elastic constitutive law for interface elements. In addition, attempting to calculate any unsupported matrix variable of this law raises an error. Similarly, attempting to _get_ any unsupported vector variable of this law raises an error.
