### PR TITLE
[GeoMechanicsApplication] Towards application-wide tolerance values for C++ unit tests

### DIFF
--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_constitutive/test_incremental_linear_elastic_interface_law.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_constitutive/test_incremental_linear_elastic_interface_law.cpp
@@ -19,6 +19,7 @@
 #include "includes/checks.h"
 #include "includes/serializer.h"
 #include "tests/cpp_tests/geo_mechanics_fast_suite.h"
+#include "tests/cpp_tests/test_utilities.h"
 
 #include <boost/numeric/ublas/assignment.hpp>
 #include <sstream>
@@ -26,14 +27,6 @@
 
 using namespace Kratos;
 using namespace std::string_literals;
-
-namespace
-{
-
-constexpr auto absolute_tolerance = 1.0e-6;
-constexpr auto relative_tolerance = 1.0e-6;
-
-} // namespace
 
 namespace Kratos::Testing
 {
@@ -142,7 +135,8 @@ KRATOS_TEST_CASE_IN_SUITE(TheCalculatedConstitutiveMatrixIsADiagonalMatrixContai
     expected_constitutive_matrix <<= 20.0, 0.0,
                                      0.0, 10.0;
     // clang-format on
-    KRATOS_EXPECT_MATRIX_RELATIVE_NEAR(actual_constitutive_matrix, expected_constitutive_matrix, relative_tolerance)
+    KRATOS_EXPECT_MATRIX_RELATIVE_NEAR(actual_constitutive_matrix, expected_constitutive_matrix,
+                                       Defaults::relative_tolerance)
 }
 
 KRATOS_TEST_CASE_IN_SUITE(TryingToCalculateTheValueOfAnUnsupportedMatrixVariableRaisesAnError,
@@ -152,7 +146,7 @@ KRATOS_TEST_CASE_IN_SUITE(TryingToCalculateTheValueOfAnUnsupportedMatrixVariable
     const auto& r_some_unsupported_matrix_variable = ENGINEERING_STRAIN_TENSOR;
     auto        dummy_parameters                   = ConstitutiveLaw::Parameters{};
     auto        value                              = Matrix{};
-    
+
     KRATOS_EXPECT_EXCEPTION_IS_THROWN(
         law.CalculateValue(dummy_parameters, r_some_unsupported_matrix_variable, value),
         "Can't calculate value of ENGINEERING_STRAIN_TENSOR: unsupported variable")
@@ -171,9 +165,9 @@ KRATOS_TEST_CASE_IN_SUITE(WhenNoInitialStateIsGivenStartWithZeroRelativeDisplace
     auto value = Vector{};
     law.GetValue(STRAIN, value);
     const auto zero_vector = Vector{ZeroVector{2}};
-    KRATOS_EXPECT_VECTOR_NEAR(value, zero_vector, absolute_tolerance)
+    KRATOS_EXPECT_VECTOR_NEAR(value, zero_vector, Defaults::absolute_tolerance)
     law.GetValue(CAUCHY_STRESS_VECTOR, value);
-    KRATOS_EXPECT_VECTOR_NEAR(value, zero_vector, absolute_tolerance)
+    KRATOS_EXPECT_VECTOR_NEAR(value, zero_vector, Defaults::absolute_tolerance)
 }
 
 KRATOS_TEST_CASE_IN_SUITE(WhenAnInitialStateIsGivenStartFromThereAfterMaterialInitialization,
@@ -192,9 +186,9 @@ KRATOS_TEST_CASE_IN_SUITE(WhenAnInitialStateIsGivenStartFromThereAfterMaterialIn
 
     auto value = Vector{};
     law.GetValue(STRAIN, value);
-    KRATOS_EXPECT_VECTOR_RELATIVE_NEAR(value, initial_relative_displacement, relative_tolerance)
+    KRATOS_EXPECT_VECTOR_RELATIVE_NEAR(value, initial_relative_displacement, Defaults::relative_tolerance)
     law.GetValue(CAUCHY_STRESS_VECTOR, value);
-    KRATOS_EXPECT_VECTOR_RELATIVE_NEAR(value, initial_traction, relative_tolerance)
+    KRATOS_EXPECT_VECTOR_RELATIVE_NEAR(value, initial_traction, Defaults::relative_tolerance)
 }
 
 KRATOS_TEST_CASE_IN_SUITE(TryingToGetTheValueOfAnUnsupportedVectorVariableRaisesAnError,
@@ -231,7 +225,7 @@ KRATOS_TEST_CASE_IN_SUITE(ComputedIncrementalTractionIsProductOfIncrementalRelat
 
     auto expected_traction = Vector{2};
     expected_traction <<= 2.0, 3.0;
-    KRATOS_EXPECT_VECTOR_RELATIVE_NEAR(law_parameters.GetStressVector(), expected_traction, relative_tolerance)
+    KRATOS_EXPECT_VECTOR_RELATIVE_NEAR(law_parameters.GetStressVector(), expected_traction, Defaults::relative_tolerance)
 }
 
 KRATOS_TEST_CASE_IN_SUITE(ComputedTractionIsSumOfPreviousTractionAndTractionIncrement, KratosGeoMechanicsFastSuiteWithoutKernel)
@@ -267,10 +261,11 @@ KRATOS_TEST_CASE_IN_SUITE(ComputedTractionIsSumOfPreviousTractionAndTractionIncr
     auto expected_traction = Vector{2};
     expected_traction <<= 30.0 + (5.1 - 5.0) * 20.0 + (5.2 - 5.1) * 20.0,
         30.0 + (5.3 - 5.0) * 10.0 + (5.6 - 5.3) * 10.0;
-    KRATOS_EXPECT_VECTOR_RELATIVE_NEAR(law_parameters.GetStressVector(), expected_traction, relative_tolerance)
+    KRATOS_EXPECT_VECTOR_RELATIVE_NEAR(law_parameters.GetStressVector(), expected_traction, Defaults::relative_tolerance)
     auto expected_relative_displacement = Vector{2};
     expected_relative_displacement <<= 5.0 + (5.1 - 5.0) + (5.2 - 5.1), 5.0 + (5.3 - 5.0) + (5.6 - 5.3);
-    KRATOS_EXPECT_VECTOR_RELATIVE_NEAR(law_parameters.GetStrainVector(), expected_relative_displacement, relative_tolerance)
+    KRATOS_EXPECT_VECTOR_RELATIVE_NEAR(law_parameters.GetStrainVector(),
+                                       expected_relative_displacement, Defaults::relative_tolerance)
 }
 
 KRATOS_TEST_CASE_IN_SUITE(LinearElasticLawForInterfacesCanBeSavedToAndLoadedFromASerializer,
@@ -305,14 +300,14 @@ KRATOS_TEST_CASE_IN_SUITE(LinearElasticLawForInterfacesCanBeSavedToAndLoadedFrom
 
     auto value = Vector{};
     restored_law.GetValue(STRAIN, value);
-    KRATOS_EXPECT_VECTOR_RELATIVE_NEAR(value, relative_displacement, relative_tolerance)
+    KRATOS_EXPECT_VECTOR_RELATIVE_NEAR(value, relative_displacement, Defaults::relative_tolerance)
     restored_law.GetValue(CAUCHY_STRESS_VECTOR, value);
-    KRATOS_EXPECT_VECTOR_RELATIVE_NEAR(value, traction, relative_tolerance)
+    KRATOS_EXPECT_VECTOR_RELATIVE_NEAR(value, traction, Defaults::relative_tolerance)
     KRATOS_EXPECT_TRUE(restored_law.HasInitialState())
     KRATOS_EXPECT_VECTOR_RELATIVE_NEAR(restored_law.GetInitialState().GetInitialStrainVector(),
-                                       initial_relative_displacement, relative_tolerance)
+                                       initial_relative_displacement, Defaults::relative_tolerance)
     KRATOS_EXPECT_VECTOR_RELATIVE_NEAR(restored_law.GetInitialState().GetInitialStressVector(),
-                                       initial_traction, relative_tolerance)
+                                       initial_traction, Defaults::relative_tolerance)
 }
 
 } // namespace Kratos::Testing

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/test_equation_of_motion.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/test_equation_of_motion.cpp
@@ -13,6 +13,7 @@
 #include "custom_utilities/equation_of_motion_utilities.h"
 #include "geo_mechanics_application_variables.h"
 #include "geo_mechanics_fast_suite.h"
+#include "tests/cpp_tests/test_utilities.h"
 #include "tests/cpp_tests/test_utilities/model_setup_utilities.h"
 
 #include <boost/numeric/ublas/assignment.hpp>
@@ -192,11 +193,10 @@ KRATOS_TEST_CASE_IN_SUITE(TheInternalForceVectorIsTheIntegralOfBTransposedTimesS
     const auto stress_vectors           = std::vector<Vector>{stress_vector, stress_vector};
     const auto integration_coefficients = std::vector<double>{0.25, 0.4};
 
-    const auto     expected_internal_force_vector = Vector{ScalarVector{8, 1.3}};
-    constexpr auto relative_tolerance             = 1.0e-6;
+    const auto expected_internal_force_vector = Vector{ScalarVector{8, 1.3}};
     KRATOS_EXPECT_VECTOR_RELATIVE_NEAR(GeoEquationOfMotionUtilities::CalculateInternalForceVector(
                                            b_matrices, stress_vectors, integration_coefficients),
-                                       expected_internal_force_vector, relative_tolerance)
+                                       expected_internal_force_vector, Defaults::relative_tolerance)
 }
 
 // The following tests only raise errors when using debug builds

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/test_utilities.h
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/test_utilities.h
@@ -12,17 +12,23 @@
 
 #pragma once
 
-#include <string>
 #include <filesystem>
 
 namespace Kratos::Testing
 {
 
+namespace Defaults
+{
+
+constexpr auto absolute_tolerance = 1.0e-12;
+constexpr auto relative_tolerance = 1.0e-6;
+
+} // namespace Defaults
+
 class TestUtilities
 {
 public:
-    static bool CompareFiles(const std::filesystem::path& rPath1,
-                             const std::filesystem::path& rPath2);
+    static bool CompareFiles(const std::filesystem::path& rPath1, const std::filesystem::path& rPath2);
 };
 
-}
+} // namespace Kratos::Testing


### PR DESCRIPTION
**📝 Description**

Defined default values for the absolute and relative tolerance values, which are intended to be adopted by C++ unit tests of the GeoMechanicsApplication. Note that these values are adopted by just a few unit test cases. Other existing test cases still need to be modified to use these default values.

**🆕 Changelog**

Other changes include:
- Removed an unused `#include`.
- Adopt the style that is prescribed by clang-format.