### PR TITLE
[GeoMechanicsApplication] Fixed occasional crash when constructing `LineInterfaceGeometry` instances

### DIFF
--- a/applications/GeoMechanicsApplication/custom_geometries/line_interface_geometry.h
+++ b/applications/GeoMechanicsApplication/custom_geometries/line_interface_geometry.h
@@ -16,6 +16,8 @@
 #include "geometries/geometry.h"
 #include "includes/node.h"
 
+#include <algorithm>
+
 namespace Kratos
 {
 
@@ -239,6 +241,13 @@ private:
     {
         const auto points                  = this->Points();
         const auto number_of_midline_nodes = std::size_t{points.size() / 2};
+
+        auto is_null = [](const auto& rNodePtr) { return rNodePtr.get() == nullptr; };
+        if (std::any_of(points.ptr_begin(), points.ptr_end(), is_null)) {
+            // At least one point is not defined, so the points of the mid-line can't be computed.
+            // As a result, all the mid-line points will be undefined.
+            return PointerVector<Node>{number_of_midline_nodes};
+        }
 
         auto result = PointerVector<Node>{};
         for (std::size_t i = 0; i < number_of_midline_nodes; ++i) {

--- a/applications/GeoMechanicsApplication/custom_geometries/line_interface_geometry.h
+++ b/applications/GeoMechanicsApplication/custom_geometries/line_interface_geometry.h
@@ -242,7 +242,7 @@ private:
         const auto points                  = this->Points();
         const auto number_of_midline_nodes = std::size_t{points.size() / 2};
 
-        auto is_null = [](const auto& rNodePtr) { return rNodePtr.get() == nullptr; };
+        auto is_null = [](const auto& rNodePtr) { return rNodePtr == nullptr; };
         if (std::any_of(points.ptr_begin(), points.ptr_end(), is_null)) {
             // At least one point is not defined, so the points of the mid-line can't be computed.
             // As a result, all the mid-line points will be undefined.

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_geometries/test_interface_geometry.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_geometries/test_interface_geometry.cpp
@@ -70,6 +70,7 @@ KRATOS_TEST_CASE_IN_SUITE(InterfaceGeometryCanBeConstructedGivenASetOfNullPointe
     const auto geometry = LineInterfaceGeometry<Line2D3<Node>>{six_null_pointers_to_nodes};
 
     KRATOS_EXPECT_EQ(geometry.PointsNumber(), 6);
+    KRATOS_EXPECT_EQ(geometry.LocalSpaceDimension(), 1);
     KRATOS_EXPECT_EQ(geometry.WorkingSpaceDimension(), 2);
 }
 
@@ -88,6 +89,8 @@ KRATOS_TEST_CASE_IN_SUITE(InterfaceGeometry_Create_CreatesNewInstanceOfCorrectTy
     KRATOS_EXPECT_NE(dynamic_cast<const LineInterfaceGeometry<Line2D2<Node>>*>(new_geometry.get()), nullptr);
     KRATOS_EXPECT_EQ(new_geometry->PointsNumber(), 4);
     KRATOS_EXPECT_EQ(new_geometry->Id(), 0);
+    KRATOS_EXPECT_EQ(new_geometry->LocalSpaceDimension(), 1);
+    KRATOS_EXPECT_EQ(new_geometry->WorkingSpaceDimension(), 2);
 }
 
 KRATOS_TEST_CASE_IN_SUITE(InterfaceGeometry_CreateWithId_CreatesNewInstanceOfCorrectTypeAndId,
@@ -107,6 +110,8 @@ KRATOS_TEST_CASE_IN_SUITE(InterfaceGeometry_CreateWithId_CreatesNewInstanceOfCor
     KRATOS_EXPECT_NE(dynamic_cast<const LineInterfaceGeometry<Line2D2<Node>>*>(new_geometry.get()), nullptr);
     KRATOS_EXPECT_EQ(new_geometry->PointsNumber(), 4);
     KRATOS_EXPECT_EQ(new_geometry->Id(), new_geometry_id);
+    KRATOS_EXPECT_EQ(new_geometry->LocalSpaceDimension(), 1);
+    KRATOS_EXPECT_EQ(new_geometry->WorkingSpaceDimension(), 2);
 }
 
 KRATOS_TEST_CASE_IN_SUITE(CreatingInterfaceWithThreeNodesThrows, KratosGeoMechanicsFastSuiteWithoutKernel)

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_geometries/test_interface_geometry.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_geometries/test_interface_geometry.cpp
@@ -61,6 +61,18 @@ KRATOS_TEST_CASE_IN_SUITE(InterfaceGeometryIsAGeometry, KratosGeoMechanicsFastSu
     KRATOS_EXPECT_NE(base_geometry, nullptr);
 }
 
+KRATOS_TEST_CASE_IN_SUITE(InterfaceGeometryCanBeConstructedGivenASetOfNullPointersToNodes,
+                          KratosGeoMechanicsFastSuiteWithoutKernel)
+{
+    // The following constructor input data resembles what is done at element registration time
+    const auto six_null_pointers_to_nodes = Geometry<Node>::PointsArrayType{6};
+
+    const auto geometry = LineInterfaceGeometry<Line2D3<Node>>{six_null_pointers_to_nodes};
+
+    KRATOS_EXPECT_EQ(geometry.PointsNumber(), 6);
+    KRATOS_EXPECT_EQ(geometry.WorkingSpaceDimension(), 2);
+}
+
 KRATOS_TEST_CASE_IN_SUITE(InterfaceGeometry_Create_CreatesNewInstanceOfCorrectType, KratosGeoMechanicsFastSuiteWithoutKernel)
 {
     const auto          geometry = LineInterfaceGeometry<Line2D2<Node>>();


### PR DESCRIPTION
**📝 Description**

When a `LineInterfaceGeometry` instance was constructed with a list of node pointers where at least one of them is null, the application would crash. The underlying reason was that calculating the points of the mid-line geometry failed, due to dereferencing the null pointer. This fix checks whether there are any null pointers in the provided vector of node pointers, and if there are it will return a vector of null pointers for the mid-line points.

Note that being able to deal with such input is required, since at element registration time we always provide the "blueprint" element with a list of null pointers for the element's nodes.
