### PR TITLE
[GeoMechanicsApplication] Register two new elements and one new constitutive law

### DIFF
--- a/applications/GeoMechanicsApplication/geo_mechanics_application.cpp
+++ b/applications/GeoMechanicsApplication/geo_mechanics_application.cpp
@@ -370,7 +370,7 @@ void KratosGeoMechanicsApplication::Register()
     KRATOS_REGISTER_CONSTITUTIVE_LAW("LinearElastic2DBeamLaw", mLinearElastic2DBeamLaw)
     KRATOS_REGISTER_CONSTITUTIVE_LAW("TrussBackboneConstitutiveLaw", mTrussBackboneConstitutiveLaw)
 
-    KRATOS_REGISTER_CONSTITUTIVE_LAW("GeoIncrementalLinearElasticInterfaceLaw", mIncrementalLinearElasticInterfaceLaw)
+    KRATOS_REGISTER_CONSTITUTIVE_LAW("IncrementalLinearElasticInterfaceLaw", mIncrementalLinearElasticInterfaceLaw)
 
     // Register Variables
     KRATOS_REGISTER_VARIABLE(VELOCITY_COEFFICIENT)

--- a/applications/GeoMechanicsApplication/geo_mechanics_application.cpp
+++ b/applications/GeoMechanicsApplication/geo_mechanics_application.cpp
@@ -370,7 +370,7 @@ void KratosGeoMechanicsApplication::Register()
     KRATOS_REGISTER_CONSTITUTIVE_LAW("LinearElastic2DBeamLaw", mLinearElastic2DBeamLaw)
     KRATOS_REGISTER_CONSTITUTIVE_LAW("TrussBackboneConstitutiveLaw", mTrussBackboneConstitutiveLaw)
 
-    KRATOS_REGISTER_CONSTITUTIVE_LAW("IncrementalLinearElasticInterfaceLaw", mIncrementalLinearElasticInterfaceLaw)
+    KRATOS_REGISTER_CONSTITUTIVE_LAW("Geo_IncrementalLinearElasticInterfaceLaw", mIncrementalLinearElasticInterfaceLaw)
 
     // Register Variables
     KRATOS_REGISTER_VARIABLE(VELOCITY_COEFFICIENT)

--- a/applications/GeoMechanicsApplication/geo_mechanics_application.cpp
+++ b/applications/GeoMechanicsApplication/geo_mechanics_application.cpp
@@ -155,8 +155,8 @@ void KratosGeoMechanicsApplication::Register()
     KRATOS_REGISTER_ELEMENT("UPwSmallStrainLinkInterfaceElement3D6N", mUPwSmallStrainLinkInterfaceElement3D6N)
     KRATOS_REGISTER_ELEMENT("UPwSmallStrainLinkInterfaceElement3D8N", mUPwSmallStrainLinkInterfaceElement3D8N)
 
-    KRATOS_REGISTER_ELEMENT("UPw2DLineInterfaceElement2Plus2N", mUPw2DLineInterfaceElement2Plus2N)
-    KRATOS_REGISTER_ELEMENT("UPw2DLineInterfaceElement3Plus3N", mUPw2DLineInterfaceElement3Plus3N)
+    KRATOS_REGISTER_ELEMENT("Geo_UPwLineInterfacePlainStrainElement2Plus2N", mUPwLineInterfacePlaneStrainElement2Plus2N)
+    KRATOS_REGISTER_ELEMENT("Geo_UPwLineInterfacePlainStrainElement3Plus3N", mUPwLineInterfacePlaneStrainElement3Plus3N)
 
     // Updated-Lagranian elements
     KRATOS_REGISTER_ELEMENT("UPwUpdatedLagrangianElement2D3N", mUPwUpdatedLagrangianElement2D3N)

--- a/applications/GeoMechanicsApplication/geo_mechanics_application.cpp
+++ b/applications/GeoMechanicsApplication/geo_mechanics_application.cpp
@@ -370,6 +370,8 @@ void KratosGeoMechanicsApplication::Register()
     KRATOS_REGISTER_CONSTITUTIVE_LAW("LinearElastic2DBeamLaw", mLinearElastic2DBeamLaw)
     KRATOS_REGISTER_CONSTITUTIVE_LAW("TrussBackboneConstitutiveLaw", mTrussBackboneConstitutiveLaw)
 
+    KRATOS_REGISTER_CONSTITUTIVE_LAW("GeoIncrementalLinearElasticInterfaceLaw", mIncrementalLinearElasticInterfaceLaw)
+
     // Register Variables
     KRATOS_REGISTER_VARIABLE(VELOCITY_COEFFICIENT)
     KRATOS_REGISTER_VARIABLE(DT_PRESSURE_COEFFICIENT)

--- a/applications/GeoMechanicsApplication/geo_mechanics_application.cpp
+++ b/applications/GeoMechanicsApplication/geo_mechanics_application.cpp
@@ -155,6 +155,9 @@ void KratosGeoMechanicsApplication::Register()
     KRATOS_REGISTER_ELEMENT("UPwSmallStrainLinkInterfaceElement3D6N", mUPwSmallStrainLinkInterfaceElement3D6N)
     KRATOS_REGISTER_ELEMENT("UPwSmallStrainLinkInterfaceElement3D8N", mUPwSmallStrainLinkInterfaceElement3D8N)
 
+    KRATOS_REGISTER_ELEMENT("UPw2DLineInterfaceElement2Plus2N", mUPw2DLineInterfaceElement2Plus2N)
+    KRATOS_REGISTER_ELEMENT("UPw2DLineInterfaceElement3Plus3N", mUPw2DLineInterfaceElement3Plus3N)
+
     // Updated-Lagranian elements
     KRATOS_REGISTER_ELEMENT("UPwUpdatedLagrangianElement2D3N", mUPwUpdatedLagrangianElement2D3N)
     KRATOS_REGISTER_ELEMENT("UPwUpdatedLagrangianElement2D4N", mUPwUpdatedLagrangianElement2D4N)

--- a/applications/GeoMechanicsApplication/geo_mechanics_application.h
+++ b/applications/GeoMechanicsApplication/geo_mechanics_application.h
@@ -52,6 +52,7 @@
 #include "custom_conditions/thermal_point_flux_condition.h"
 
 // Geometries
+#include "custom_geometries/line_interface_geometry.h"
 #include "geometries/hexahedra_3d_20.h"
 #include "geometries/hexahedra_3d_27.h"
 #include "geometries/hexahedra_3d_8.h"
@@ -136,6 +137,15 @@
 
 namespace Kratos
 {
+
+// Adding a dummy class here to get the unit test up and running. When the minimal line interface
+// element is available from `master`, we can remove it and include the corresponding header file.
+class LineInterfaceElement : public Element
+{
+public:
+    LineInterfaceElement() = default;
+    LineInterfaceElement(Element::IndexType, const Element::GeometryType::Pointer&) {}
+};
 
 ///@name Kratos Globals
 ///@{
@@ -555,6 +565,13 @@ private:
     const UPwSmallStrainLinkInterfaceElement<3, 8> mUPwSmallStrainLinkInterfaceElement3D8N{
         0, Kratos::make_shared<HexahedraInterface3D8<NodeType>>(Element::GeometryType::PointsArrayType(8)),
         std::make_unique<ThreeDimensionalStressState>()};
+
+    const LineInterfaceElement mUPw2DLineInterfaceElement2Plus2N{
+        0, Kratos::make_shared<LineInterfaceGeometry<Line2D2<NodeType>>>(
+               Element::GeometryType::PointsArrayType(4))};
+    const LineInterfaceElement mUPw2DLineInterfaceElement3Plus3N{
+        0, Kratos::make_shared<LineInterfaceGeometry<Line2D3<NodeType>>>(
+               Element::GeometryType::PointsArrayType(6))};
 
     // Updated-Lagrangian elements:
     const UPwUpdatedLagrangianElement<2, 3> mUPwUpdatedLagrangianElement2D3N{

--- a/applications/GeoMechanicsApplication/geo_mechanics_application.h
+++ b/applications/GeoMechanicsApplication/geo_mechanics_application.h
@@ -120,6 +120,7 @@
 #include "custom_constitutive/bilinear_cohesive_2D_law.hpp"
 #include "custom_constitutive/bilinear_cohesive_3D_law.hpp"
 #include "custom_constitutive/elastic_isotropic_K0_3d_law.h"
+#include "custom_constitutive/incremental_linear_elastic_interface_law.h"
 #include "custom_constitutive/linear_elastic_2D_beam_law.h"
 #include "custom_constitutive/linear_elastic_2D_interface_law.h"
 #include "custom_constitutive/linear_elastic_3D_interface_law.h"
@@ -962,6 +963,8 @@ private:
 
     const LinearElastic2DBeamLaw       mLinearElastic2DBeamLaw;
     const TrussBackboneConstitutiveLaw mTrussBackboneConstitutiveLaw;
+
+    const GeoIncrementalLinearElasticInterfaceLaw mIncrementalLinearElasticInterfaceLaw;
 
     ///@}
 

--- a/applications/GeoMechanicsApplication/geo_mechanics_application.h
+++ b/applications/GeoMechanicsApplication/geo_mechanics_application.h
@@ -559,10 +559,10 @@ private:
         0, Kratos::make_shared<HexahedraInterface3D8<NodeType>>(Element::GeometryType::PointsArrayType(8)),
         std::make_unique<ThreeDimensionalStressState>()};
 
-    const LineInterfaceElement mUPw2DLineInterfaceElement2Plus2N{
+    const LineInterfaceElement mUPwLineInterfacePlaneStrainElement2Plus2N{
         0, Kratos::make_shared<LineInterfaceGeometry<Line2D2<NodeType>>>(
                Element::GeometryType::PointsArrayType(4))};
-    const LineInterfaceElement mUPw2DLineInterfaceElement3Plus3N{
+    const LineInterfaceElement mUPwLineInterfacePlaneStrainElement3Plus3N{
         0, Kratos::make_shared<LineInterfaceGeometry<Line2D3<NodeType>>>(
                Element::GeometryType::PointsArrayType(6))};
 

--- a/applications/GeoMechanicsApplication/geo_mechanics_application.h
+++ b/applications/GeoMechanicsApplication/geo_mechanics_application.h
@@ -89,6 +89,7 @@
 #include "custom_elements/U_Pw_updated_lagrangian_FIC_element.hpp"
 #include "custom_elements/U_Pw_updated_lagrangian_element.hpp"
 #include "custom_elements/drained_U_Pw_small_strain_element.hpp"
+#include "custom_elements/line_interface_element.h"
 #include "custom_elements/small_strain_U_Pw_diff_order_element.hpp"
 #include "custom_elements/steady_state_Pw_element.hpp"
 #include "custom_elements/steady_state_Pw_interface_element.hpp"
@@ -137,15 +138,6 @@
 
 namespace Kratos
 {
-
-// Adding a dummy class here to get the unit test up and running. When the minimal line interface
-// element is available from `master`, we can remove it and include the corresponding header file.
-class LineInterfaceElement : public Element
-{
-public:
-    LineInterfaceElement() = default;
-    LineInterfaceElement(Element::IndexType, const Element::GeometryType::Pointer&) {}
-};
 
 ///@name Kratos Globals
 ///@{

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/test_geo_mechanics_application.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/test_geo_mechanics_application.cpp
@@ -13,6 +13,10 @@
 #include "geo_mechanics_application.h"
 #include "geo_mechanics_fast_suite.h"
 
+#include <string>
+
+using namespace std::string_literals;
+
 namespace Kratos::Testing
 {
 
@@ -53,6 +57,18 @@ KRATOS_TEST_CASE_IN_SUITE(ThermalAnalysisVariablesExistAfterRegistration, Kratos
     for (const auto& name : variable_names) {
         KRATOS_EXPECT_TRUE(KratosComponents<VariableData>::Has(name))
     }
+}
+
+KRATOS_TEST_CASE_IN_SUITE(IncrementalLinearElasticConstitutiveLawIsAvailableAfterGeoAppRegistration, KratosGeoMechanicsFastSuiteWithoutKernel)
+{
+    KratosGeoMechanicsApplication geo_app;
+    const auto constitutive_law_name = "GeoIncrementalLinearElasticInterfaceLaw"s;
+
+    KRATOS_EXPECT_FALSE(KratosComponents<ConstitutiveLaw>::Has(constitutive_law_name))
+
+    geo_app.Register();
+
+    KRATOS_EXPECT_TRUE(KratosComponents<ConstitutiveLaw>::Has(constitutive_law_name))
 }
 
 KRATOS_TEST_CASE_IN_SUITE(LineInterfaceElementsAreAvailableAfterGeoAppRegistration, KratosGeoMechanicsFastSuiteWithoutKernel)

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/test_geo_mechanics_application.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/test_geo_mechanics_application.cpp
@@ -55,4 +55,21 @@ KRATOS_TEST_CASE_IN_SUITE(ThermalAnalysisVariablesExistAfterRegistration, Kratos
     }
 }
 
+KRATOS_TEST_CASE_IN_SUITE(LineInterfaceElementsAreAvailableAfterGeoAppRegistration, KratosGeoMechanicsFastSuiteWithoutKernel)
+{
+    KratosGeoMechanicsApplication geo_app;
+    const auto element_type_names = std::vector<std::string>{"UPw2DLineInterfaceElement2Plus2N",
+                                                             "UPw2DLineInterfaceElement3Plus3N"};
+
+    for (const auto& r_name : element_type_names) {
+        KRATOS_EXPECT_FALSE(KratosComponents<Element>::Has(r_name))
+    }
+
+    geo_app.Register();
+
+    for (const auto& r_name : element_type_names) {
+        KRATOS_EXPECT_TRUE(KratosComponents<Element>::Has(r_name))
+    }
 }
+
+} // namespace Kratos::Testing

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/test_geo_mechanics_application.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/test_geo_mechanics_application.cpp
@@ -62,7 +62,7 @@ KRATOS_TEST_CASE_IN_SUITE(ThermalAnalysisVariablesExistAfterRegistration, Kratos
 KRATOS_TEST_CASE_IN_SUITE(IncrementalLinearElasticConstitutiveLawIsAvailableAfterGeoAppRegistration, KratosGeoMechanicsFastSuiteWithoutKernel)
 {
     KratosGeoMechanicsApplication geo_app;
-    const auto constitutive_law_name = "GeoIncrementalLinearElasticInterfaceLaw"s;
+    const auto constitutive_law_name = "IncrementalLinearElasticInterfaceLaw"s;
 
     KRATOS_EXPECT_FALSE(KratosComponents<ConstitutiveLaw>::Has(constitutive_law_name))
 

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/test_geo_mechanics_application.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/test_geo_mechanics_application.cpp
@@ -62,7 +62,7 @@ KRATOS_TEST_CASE_IN_SUITE(ThermalAnalysisVariablesExistAfterRegistration, Kratos
 KRATOS_TEST_CASE_IN_SUITE(IncrementalLinearElasticConstitutiveLawIsAvailableAfterGeoAppRegistration, KratosGeoMechanicsFastSuiteWithoutKernel)
 {
     KratosGeoMechanicsApplication geo_app;
-    const auto constitutive_law_name = "IncrementalLinearElasticInterfaceLaw"s;
+    const auto constitutive_law_name = "Geo_IncrementalLinearElasticInterfaceLaw"s;
 
     KRATOS_EXPECT_FALSE(KratosComponents<ConstitutiveLaw>::Has(constitutive_law_name))
 

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/test_geo_mechanics_application.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/test_geo_mechanics_application.cpp
@@ -74,8 +74,8 @@ KRATOS_TEST_CASE_IN_SUITE(IncrementalLinearElasticConstitutiveLawIsAvailableAfte
 KRATOS_TEST_CASE_IN_SUITE(LineInterfaceElementsAreAvailableAfterGeoAppRegistration, KratosGeoMechanicsFastSuiteWithoutKernel)
 {
     KratosGeoMechanicsApplication geo_app;
-    const auto element_type_names = std::vector<std::string>{"UPw2DLineInterfaceElement2Plus2N",
-                                                             "UPw2DLineInterfaceElement3Plus3N"};
+    const auto element_type_names = std::vector<std::string>{"Geo_UPwLineInterfacePlainStrainElement2Plus2N",
+                                                             "Geo_UPwLineInterfacePlainStrainElement3Plus3N"};
 
     for (const auto& r_name : element_type_names) {
         KRATOS_EXPECT_FALSE(KratosComponents<Element>::Has(r_name))


### PR DESCRIPTION
**📝 Description**

This PR registers two new U-Pw 2D line interface elements: one having 2+2 nodes, the other one having 3+3 nodes. It also registers a new incremental linear elastic interface law. Unit tests have been added to cover the effect of the element and constitutive law registrations.
