### PR TITLE
[PotentialFlow] Set elemental wake distances signs according to wake normal

### DIFF
--- a/applications/CompressiblePotentialFlowApplication/custom_processes/define_embedded_wake_process.cpp
+++ b/applications/CompressiblePotentialFlowApplication/custom_processes/define_embedded_wake_process.cpp
@@ -85,9 +85,11 @@ void DefineEmbeddedWakeProcess::ComputeDistanceToWake(){
     KRATOS_CATCH("");
 }
 
-void DefineEmbeddedWakeProcess::SetWakeDistancesSignAccordingToNormal(Element& rElement, BoundedVector<double, 3>& rElementalDistances) {
+void DefineEmbeddedWakeProcess::SetWakeDistancesSignAccordingToNormal(
+    Element& rElement,
+    BoundedVector<double, 3>& rElementalDistances) {
     const bool is_wake_element = PotentialFlowUtilities::CheckIfElementIsCutByDistance<2,3>(rElementalDistances);
-    auto& r_geometry = rElement.GetGeometry();
+    const auto& r_geometry = rElement.GetGeometry();
     if (is_wake_element) {
         for(unsigned int i_node = 0; i_node< r_geometry.size(); ++i_node){
             array_1d<double, 3> pos_vector;

--- a/applications/CompressiblePotentialFlowApplication/custom_processes/define_embedded_wake_process.h
+++ b/applications/CompressiblePotentialFlowApplication/custom_processes/define_embedded_wake_process.h
@@ -79,12 +79,16 @@ private:
 
     ModelPart& mrModelPart;
     ModelPart& mrWakeModelPart;
+    array_1d<double, 3> mWakeNormal;
+    array_1d<double, 3> mWakeOrigin;
 
     void ComputeDistanceToWake();
 
     void MarkWakeElements();
 
     void ComputeTrailingEdgeNode();
+
+    void SetWakeDistancesSignAccordingToNormal(Element& rElement, BoundedVector<double, 3>& rElementalDistances);
 
     ModelPart::NodeType::Pointer pGetTrailingEdgeNode();
 

--- a/applications/CompressiblePotentialFlowApplication/custom_processes/define_embedded_wake_process.h
+++ b/applications/CompressiblePotentialFlowApplication/custom_processes/define_embedded_wake_process.h
@@ -88,7 +88,9 @@ private:
 
     void ComputeTrailingEdgeNode();
 
-    void SetWakeDistancesSignAccordingToNormal(Element& rElement, BoundedVector<double, 3>& rElementalDistances);
+    void SetWakeDistancesSignAccordingToNormal(
+        Element& rElement,
+        BoundedVector<double, 3>& rElementalDistances);
 
     ModelPart::NodeType::Pointer pGetTrailingEdgeNode();
 


### PR DESCRIPTION
**📝 Description**
Currently for the embedded formulations, the wake distance values were computed with the Discontinuous Distance process, and its sign followed the convention from the process. The sign is eventually used to determine the upper and lower sides of the wake. In order to avoid depending on the convetion of the distance calculation, the sign of the distance values is computed using the origin of the wake and its normal to determine the nodes laying above and below the wake.  This assumes the wake is a straight line. 


**🆕 Changelog**
Please summarize the changes in one list to generate the changelog:

- Compute wake distance sign using the wake normal vector. 
