### PR TITLE
[Core][MeshingApplication] Refactor `Timer` class to fix typos and deprecate old methods

### DIFF
--- a/applications/MeshingApplication/custom_io/mmg/mmg_io.cpp
+++ b/applications/MeshingApplication/custom_io/mmg/mmg_io.cpp
@@ -66,7 +66,7 @@ MmgIO<TMMGLibrary>::MmgIO(
         KRATOS_ERROR << "APPEND not compatible with MmgIO" << std::endl;
     }
 
-    if (mOptions.IsNot(IO::SKIP_TIMER)) Timer::SetOuputFile(rFilename + ".time");
+    if (mOptions.IsNot(IO::SKIP_TIMER)) Timer::SetOutputFile(rFilename + ".time");
 
     /* We restart the MMG mesh and solution */
     mMmgUtilities.SetEchoLevel(mThisParameters["echo_level"].GetInt());

--- a/kratos/python/add_other_utilities_to_python.cpp
+++ b/kratos/python/add_other_utilities_to_python.cpp
@@ -249,8 +249,10 @@ void AddOtherUtilitiesToPython(pybind11::module &m)
         .def_static("Start", &Timer::Start)
         .def_static("Stop", &Timer::Stop)
         .def_static("GetTime", &Timer::GetTime)
-        .def_static("SetOuputFile", &Timer::SetOuputFile)
-        .def_static("CloseOuputFile", &Timer::CloseOuputFile)
+        .def_static("SetOutputFile", &Timer::SetOutputFile)
+        .def_static("CloseOutputFile", &Timer::CloseOutputFile)
+        .def_static("SetOuputFile", &Timer::SetOuputFile) // TODO: Remove this line eventually, it is a typo
+        .def_static("CloseOuputFile", &Timer::CloseOuputFile) // TODO: Remove this line eventually, it is a typo
         .def_static("GetPrintOnScreen", &Timer::GetPrintOnScreen)
         .def_static("SetPrintOnScreen", &Timer::SetPrintOnScreen)
         .def_static("GetPrintIntervalInformation", &Timer::GetPrintIntervalInformation)

--- a/kratos/python_scripts/timer_process.py
+++ b/kratos/python_scripts/timer_process.py
@@ -55,7 +55,7 @@ class TimerProcess(KratosMultiphysics.Process):
 
         # Output file
         if self.output_filename != "":
-            self.timer.SetOuputFile(self.output_filename)
+            self.timer.SetOutputFile(self.output_filename)
         else:
             self.timer.SetPrintOnScreen(True)
 
@@ -71,4 +71,4 @@ class TimerProcess(KratosMultiphysics.Process):
         self.timer.Stop(self.interval_name)
         self.timer.PrintTimingInformation()
         if self.output_filename != "":
-            self.timer.CloseOuputFile()
+            self.timer.CloseOutputFile()

--- a/kratos/sources/model_part_io.cpp
+++ b/kratos/sources/model_part_io.cpp
@@ -62,7 +62,7 @@ ModelPartIO::ModelPartIO(std::filesystem::path const& Filename, const Flags Opti
     // Store the pointer as a regular std::iostream
     mpStream = pFile;
 
-    if (mOptions.IsNot(IO::SKIP_TIMER)) Timer::SetOuputFile(time_file_name.string());
+    if (mOptions.IsNot(IO::SKIP_TIMER)) Timer::SetOutputFile(time_file_name.string());
 }
 
 /// Constructor with stream
@@ -81,7 +81,7 @@ ModelPartIO::ModelPartIO(Kratos::shared_ptr<std::iostream> Stream, const Flags O
 
 /// Destructor.
 ModelPartIO::~ModelPartIO() {
-    if (mOptions.IsNot(IO::SKIP_TIMER)) Timer::CloseOuputFile();
+    if (mOptions.IsNot(IO::SKIP_TIMER)) Timer::CloseOutputFile();
 }
 
 bool ModelPartIO::ReadNode(NodeType& rThisNode)

--- a/kratos/tests/cpp_tests/external_libraries/test_delaunator.cpp
+++ b/kratos/tests/cpp_tests/external_libraries/test_delaunator.cpp
@@ -54,7 +54,7 @@ inline void validatewithtolerance(
     }
 
     if (Debug != "")
-        Timer::SetOuputFile("times/" + Debug + ".time");
+        Timer::SetOutputFile("times/" + Debug + ".time");
 
     // Comparing with the results obtained with triangle
     std::vector<double> triangles_areas;
@@ -65,7 +65,7 @@ inline void validatewithtolerance(
     Timer::Stop("Triangle");
 
     if (Debug != "")
-        Timer::CloseOuputFile();
+        Timer::CloseOutputFile();
 
     for (std::size_t i = 0; i < r_triangles_list.size(); i += 3) {
         const double ax = rCoordinates[2 * r_triangles_list[i]];

--- a/kratos/utilities/timer.cpp
+++ b/kratos/utilities/timer.cpp
@@ -162,6 +162,18 @@ int Timer::CloseOutputFile()
     return msOutputFile.is_open();
 }
 
+int Timer::SetOuputFile(std::string const& rOutputFileName)
+{
+    KRATOS_WARNING("Timer") << "Please use SetOutputFile instead. Will be removed eventually" << std::endl;
+    return SetOutputFile(rOutputFileName);
+}
+
+int Timer::CloseOuputFile()
+{
+    KRATOS_WARNING("Timer") << "Please use CloseOutputFile instead. Will be removed eventually" << std::endl;
+    return CloseOutputFile();
+}
+
 bool Timer::GetPrintOnScreen()
 {
     return msPrintOnScreen;

--- a/kratos/utilities/timer.cpp
+++ b/kratos/utilities/timer.cpp
@@ -4,8 +4,8 @@
 //   _|\_\_|  \__,_|\__|\___/ ____/
 //                   Multi-Physics
 //
-//  License:		 BSD License
-//					 Kratos default license: kratos/license.txt
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
 //
 //  Main authors:    Pooyan Dadvand
 //                   Vicente Mataix Ferrandiz
@@ -140,7 +140,7 @@ void Timer::Stop(std::string const& rIntervalName)
     }
 }
 
-int Timer::SetOuputFile(std::string const& rOutputFileName)
+int Timer::SetOutputFile(std::string const& rOutputFileName)
 {
     if(msOutputFile.is_open())
         msOutputFile.close();
@@ -154,7 +154,7 @@ int Timer::SetOuputFile(std::string const& rOutputFileName)
     return msOutputFile.is_open();
 }
 
-int Timer::CloseOuputFile()
+int Timer::CloseOutputFile()
 {
     if(msOutputFile.is_open())
         msOutputFile.close();

--- a/kratos/utilities/timer.h
+++ b/kratos/utilities/timer.h
@@ -204,6 +204,7 @@ public:
     KRATOS_DEPRECATED_MESSAGE("Please use SetOutputFile instead. Will be removed eventually")
     static int SetOuputFile(std::string const& rOutputFileName)
     {
+        KRATOS_WARNING("Timer") << "Please use SetOutputFile instead. Will be removed eventually" << std::endl;
         return SetOutputFile(rOutputFileName);
     }
 
@@ -214,6 +215,7 @@ public:
     KRATOS_DEPRECATED_MESSAGE("Please use CloseOutputFile instead. Will be removed eventually")
     static int CloseOuputFile()
     {
+        KRATOS_WARNING("Timer") << "Please use CloseOutputFile instead. Will be removed eventually" << std::endl;
         return CloseOutputFile();
     }
 

--- a/kratos/utilities/timer.h
+++ b/kratos/utilities/timer.h
@@ -202,22 +202,14 @@ public:
      * @note This is a deprecated method please use SetOutputFile instead. Will be removed eventually
      */
     KRATOS_DEPRECATED_MESSAGE("Please use SetOutputFile instead. Will be removed eventually")
-    static int SetOuputFile(std::string const& rOutputFileName)
-    {
-        KRATOS_WARNING("Timer") << "Please use SetOutputFile instead. Will be removed eventually" << std::endl;
-        return SetOutputFile(rOutputFileName);
-    }
+    static int SetOuputFile(std::string const& rOutputFileName);
 
     /**
      * @brief This method closes the output file
      * @note This is a deprecated method please use CloseOutputFile instead. Will be removed eventually
      */
     KRATOS_DEPRECATED_MESSAGE("Please use CloseOutputFile instead. Will be removed eventually")
-    static int CloseOuputFile()
-    {
-        KRATOS_WARNING("Timer") << "Please use CloseOutputFile instead. Will be removed eventually" << std::endl;
-        return CloseOutputFile();
-    }
+    static int CloseOuputFile();
 
     /**
      * @brief This method gets the variable which stores if the information is printed on screen

--- a/kratos/utilities/timer.h
+++ b/kratos/utilities/timer.h
@@ -4,8 +4,8 @@
 //   _|\_\_|  \__,_|\__|\___/ ____/
 //                   Multi-Physics
 //
-//  License:		 BSD License
-//					 Kratos default license: kratos/license.txt
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
 //
 //  Main authors:    Pooyan Dadvand
 //                   Riccardo Rossi
@@ -13,8 +13,7 @@
 //
 //
 
-#if !defined(KRATOS_TIMER_H_INCLUDED )
-#define  KRATOS_TIMER_H_INCLUDED
+#pragma once
 
 // System includes
 #include <string>
@@ -190,12 +189,33 @@ public:
      * @brief This method sets the output file *.time that will store the timing
      * @param rOutputFileName The name of the output file
      */
-    static int SetOuputFile(std::string const& rOutputFileName);
+    static int SetOutputFile(std::string const& rOutputFileName);
 
     /**
      * @brief This method closes the output file
      */
-    static int CloseOuputFile();
+    static int CloseOutputFile();
+
+    /**
+     * @brief This method sets the output file *.time that will store the timing
+     * @param rOutputFileName The name of the output file
+     * @note This is a deprecated method please use SetOutputFile instead. Will be removed eventually
+     */
+    KRATOS_DEPRECATED_MESSAGE("Please use SetOutputFile instead. Will be removed eventually")
+    static int SetOuputFile(std::string const& rOutputFileName)
+    {
+        return SetOutputFile(rOutputFileName);
+    }
+
+    /**
+     * @brief This method closes the output file
+     * @note This is a deprecated method please use CloseOutputFile instead. Will be removed eventually
+     */
+    KRATOS_DEPRECATED_MESSAGE("Please use CloseOutputFile instead. Will be removed eventually")
+    static int CloseOuputFile()
+    {
+        return CloseOutputFile();
+    }
 
     /**
      * @brief This method gets the variable which stores if the information is printed on screen
@@ -423,7 +443,5 @@ inline std::ostream& operator << (std::ostream& rOStream,
 ///@}
 
 }  // namespace Kratos.
-
-#endif // KRATOS_TIMER_H_INCLUDED  defined
 
 


### PR DESCRIPTION
**📝 Description**

Depreacted only typo methods and replace them with new, non typo methods.

- **SetOutputFile Method:**
  - Renamed deprecated `SetOuputFile` method to `SetOutputFile` for consistency and clarity.
  - Introduced warning messages to encourage migration to the updated method.

- **CloseOutputFile Method:**
  - Deprecated `CloseOuputFile` method renamed to `CloseOutputFile` to align with naming conventions.
  - Added warning messages prompting users to transition to the new method.
  
Refactor current calls.

**🆕 Changelog**

- [Refactor Timer class to fix typos and deprecate old methods](https://github.com/KratosMultiphysics/Kratos/commit/2a09e4e3b8ab58fcdd610cac3ab2118dc02e371f)
- [Rename to new methods in code](https://github.com/KratosMultiphysics/Kratos/commit/a4bada15e76a8b1df1cdf878196b079c0b12e262)
- [Fix typo in Timer class output file name in meshing application](https://github.com/KratosMultiphysics/Kratos/commit/e1d6a79a62f25521abf088065ad5a366c38cebc7)
- [Adding warning on execution time](https://github.com/KratosMultiphysics/Kratos/commit/a9cd441400455dd84d4f229201eca3fe294826fa)
