### PR TITLE
[GeoMechanicsApplication] Remove the "solution_type" = "K0-procedure"

### DIFF
--- a/applications/GeoMechanicsApplication/python_scripts/geomechanics_U_Pw_solver.py
+++ b/applications/GeoMechanicsApplication/python_scripts/geomechanics_U_Pw_solver.py
@@ -187,13 +187,6 @@ class UPwSolver(GeoSolver):
             elif (solution_type.lower() == "dynamic"):
                 KratosMultiphysics.Logger.PrintInfo("GeoMechanics_U_Pw_Solver, scheme", "Dynamic.")
                 scheme = KratosGeo.NewmarkDynamicUPwScheme(beta,gamma,theta)
-            elif (solution_type.lower() == "k0-procedure" or solution_type.lower() == "k0_procedure"):
-                if (rayleigh_m < 1.0e-20 and rayleigh_k < 1.0e-20):
-                    KratosMultiphysics.Logger.PrintInfo("GeoMechanics_U_Pw_Solver, scheme", "Quasi-UnDamped.")
-                    scheme = KratosGeo.NewmarkQuasistaticUPwScheme(beta,gamma,theta)
-                else:
-                    KratosMultiphysics.Logger.PrintInfo("GeoMechanics_U_Pw_Solver, scheme", "Quasi-Damped.")
-                    scheme = KratosGeo.NewmarkQuasistaticDampedUPwScheme(beta,gamma,theta)
             else:
               raise RuntimeError(f"Undefined solution type '{solution_type}'")
         elif (scheme_type.lower() == "backward_euler"or scheme_type.lower() == "backward-euler"):

--- a/applications/GeoMechanicsApplication/python_scripts/geomechanics_U_Pw_solver.py
+++ b/applications/GeoMechanicsApplication/python_scripts/geomechanics_U_Pw_solver.py
@@ -193,9 +193,6 @@ class UPwSolver(GeoSolver):
             if (solution_type.lower() == "quasi-static" or solution_type.lower() == "quasi_static"):
                 KratosMultiphysics.Logger.PrintInfo("GeoMechanics_U_Pw_Solver, scheme", "Backward Euler.")
                 scheme = KratosGeo.BackwardEulerQuasistaticUPwScheme()
-            elif (solution_type.lower() == "k0-procedure" or solution_type.lower() == "k0_procedure"):
-                KratosMultiphysics.Logger.PrintInfo("GeoMechanics_U_Pw_Solver, scheme", "Backward Euler.")
-                scheme = KratosGeo.BackwardEulerQuasistaticUPwScheme()
             else:
                 raise RuntimeError(f"Undefined/incompatible solution type with Backward Euler: '{solution_type}'")
         else:

--- a/applications/GeoMechanicsApplication/tests/C-Phi_reduction_process/ProjectParameters_stage1.json
+++ b/applications/GeoMechanicsApplication/tests/C-Phi_reduction_process/ProjectParameters_stage1.json
@@ -69,7 +69,7 @@
         "rotation_dofs": true,
         "scheme_type": "Newmark",
         "second_alpha_value": 1.0,
-        "solution_type": "K0-Procedure",
+        "solution_type": "quasi_static",
         "solver_type": "U_Pw",
         "strategy_type": "linear",
         "time_stepping": {

--- a/applications/GeoMechanicsApplication/tests/test_Abc_1_1_0_True_Deformations/ProjectParameters_stage1.json
+++ b/applications/GeoMechanicsApplication/tests/test_Abc_1_1_0_True_Deformations/ProjectParameters_stage1.json
@@ -30,7 +30,7 @@
     "reform_dofs_at_each_step": false,
     "nodal_smoothing": false,
     "block_builder": true,
-    "solution_type": "K0-Procedure",
+    "solution_type": "quasi_static",
     "scheme_type": "Newmark",
     "reset_displacements": true,
     "strategy_type": "line_search",

--- a/applications/GeoMechanicsApplication/tests/test_k0_procedure_process/test_k0_procedure_k0_nc/ProjectParameters.json
+++ b/applications/GeoMechanicsApplication/tests/test_k0_procedure_process/test_k0_procedure_k0_nc/ProjectParameters.json
@@ -30,7 +30,7 @@
     "reform_dofs_at_each_step": false,
     "nodal_smoothing": false,
     "block_builder": true,
-    "solution_type": "K0-Procedure",
+    "solution_type": "quasi_static",
     "scheme_type": "Newmark",
     "reset_displacements": true,
     "strategy_type": "linear",

--- a/applications/GeoMechanicsApplication/tests/test_k0_procedure_process/test_k0_procedure_k0_nc_layers/ProjectParameters.json
+++ b/applications/GeoMechanicsApplication/tests/test_k0_procedure_process/test_k0_procedure_k0_nc_layers/ProjectParameters.json
@@ -30,7 +30,7 @@
     "reform_dofs_at_each_step": false,
     "nodal_smoothing": false,
     "block_builder": true,
-    "solution_type": "K0-Procedure",
+    "solution_type": "quasi_static",
     "scheme_type": "Newmark",
     "reset_displacements": true,
     "strategy_type": "linear",

--- a/applications/GeoMechanicsApplication/tests/test_k0_procedure_process/test_k0_procedure_k0_nc_ocr/ProjectParameters.json
+++ b/applications/GeoMechanicsApplication/tests/test_k0_procedure_process/test_k0_procedure_k0_nc_ocr/ProjectParameters.json
@@ -30,7 +30,7 @@
     "reform_dofs_at_each_step": false,
     "nodal_smoothing": false,
     "block_builder": true,
-    "solution_type": "K0-Procedure",
+    "solution_type": "quasi_static",
     "scheme_type": "Newmark",
     "reset_displacements": true,
     "strategy_type": "linear",

--- a/applications/GeoMechanicsApplication/tests/test_k0_procedure_process/test_k0_procedure_k0_nc_skew_layers/ProjectParameters.json
+++ b/applications/GeoMechanicsApplication/tests/test_k0_procedure_process/test_k0_procedure_k0_nc_skew_layers/ProjectParameters.json
@@ -30,7 +30,7 @@
         "reform_dofs_at_each_step":           false,
         "nodal_smoothing":                    false,
         "block_builder":                      true,
-        "solution_type":                      "K0-Procedure",
+        "solution_type":                      "quasi_static",
         "scheme_type":                        "Backward_Euler",
         "reset_displacements":                true,
         "newmark_beta":                       0.25,

--- a/applications/GeoMechanicsApplication/tests/test_k0_procedure_process/test_k0_procedure_k0_nc_skew_layers_dam/ProjectParameters.json
+++ b/applications/GeoMechanicsApplication/tests/test_k0_procedure_process/test_k0_procedure_k0_nc_skew_layers_dam/ProjectParameters.json
@@ -30,7 +30,7 @@
         "reform_dofs_at_each_step":           false,
         "nodal_smoothing":                    false,
         "block_builder":                      true,
-        "solution_type":                      "K0-Procedure",
+        "solution_type":                      "quasi_static",
         "scheme_type":                        "Backward_Euler",
         "reset_displacements":                true,
         "newmark_beta":                       0.25,

--- a/applications/GeoMechanicsApplication/tests/test_k0_procedure_process/test_k0_procedure_k0_umat/ProjectParameters.json
+++ b/applications/GeoMechanicsApplication/tests/test_k0_procedure_process/test_k0_procedure_k0_umat/ProjectParameters.json
@@ -30,7 +30,7 @@
     "reform_dofs_at_each_step": false,
     "nodal_smoothing": false,
     "block_builder": true,
-    "solution_type": "K0-Procedure",
+    "solution_type": "quasi_static",
     "scheme_type": "Newmark",
     "reset_displacements": true,
     "strategy_type": "linear",

--- a/applications/GeoMechanicsApplication/tests/test_k0_procedure_process/test_k0_procedure_with_horizontal_layers/ProjectParameters.json
+++ b/applications/GeoMechanicsApplication/tests/test_k0_procedure_process/test_k0_procedure_with_horizontal_layers/ProjectParameters.json
@@ -233,7 +233,7 @@
         "rotation_dofs": true,
         "scheme_type": "Newmark",
         "second_alpha_value": 1.0,
-        "solution_type": "K0-Procedure",
+        "solution_type": "quasi_static",
         "solver_type": "U_Pw",
         "strategy_type": "linear",
         "time_stepping": {

--- a/applications/GeoMechanicsApplication/tests/test_k0_procedure_process/test_k0_procedure_with_tilted_layers/ProjectParameters.json
+++ b/applications/GeoMechanicsApplication/tests/test_k0_procedure_process/test_k0_procedure_with_tilted_layers/ProjectParameters.json
@@ -233,7 +233,7 @@
         "rotation_dofs": true,
         "scheme_type": "Newmark",
         "second_alpha_value": 1.0,
-        "solution_type": "K0-Procedure",
+        "solution_type": "quasi_static",
         "solver_type": "U_Pw",
         "strategy_type": "linear",
         "time_stepping": {

--- a/applications/GeoMechanicsApplication/tests/test_soil_weight_saturated_below_and_above_phreatic_quad_4n.gid/ProjectParameters.json
+++ b/applications/GeoMechanicsApplication/tests/test_soil_weight_saturated_below_and_above_phreatic_quad_4n.gid/ProjectParameters.json
@@ -30,7 +30,7 @@
         "reform_dofs_at_each_step":           true,
         "nodal_smoothing":                    false,
         "block_builder":                      true,
-        "solution_type":                      "K0-Procedure",
+        "solution_type":                      "quasi_static",
         "scheme_type":                        "Backward_Euler",
         "reset_displacements":                true,
         "newmark_beta":                       0.25,

--- a/applications/GeoMechanicsApplication/tests/test_soil_weight_saturated_below_and_above_phreatic_quad_8n.gid/ProjectParameters.json
+++ b/applications/GeoMechanicsApplication/tests/test_soil_weight_saturated_below_and_above_phreatic_quad_8n.gid/ProjectParameters.json
@@ -30,7 +30,7 @@
         "reform_dofs_at_each_step":           true,
         "nodal_smoothing":                    false,
         "block_builder":                      true,
-        "solution_type":                      "K0-Procedure",
+        "solution_type":                      "quasi_static",
         "scheme_type":                        "Backward_Euler",
         "reset_displacements":                true,
         "newmark_beta":                       0.25,

--- a/applications/GeoMechanicsApplication/tests/test_soil_weight_saturated_below_phreatic_quad_4n.gid/ProjectParameters.json
+++ b/applications/GeoMechanicsApplication/tests/test_soil_weight_saturated_below_phreatic_quad_4n.gid/ProjectParameters.json
@@ -30,7 +30,7 @@
         "reform_dofs_at_each_step":           true,
         "nodal_smoothing":                    false,
         "block_builder":                      true,
-        "solution_type":                      "K0-Procedure",
+        "solution_type":                      "quasi_static",
         "scheme_type":                        "Backward_Euler",
         "reset_displacements":                true,
         "newmark_beta":                       0.25,

--- a/applications/GeoMechanicsApplication/tests/test_soil_weight_saturated_below_phreatic_quad_8n.gid/ProjectParameters.json
+++ b/applications/GeoMechanicsApplication/tests/test_soil_weight_saturated_below_phreatic_quad_8n.gid/ProjectParameters.json
@@ -30,7 +30,7 @@
         "reform_dofs_at_each_step":           true,
         "nodal_smoothing":                    false,
         "block_builder":                      true,
-        "solution_type":                      "K0-Procedure",
+        "solution_type":                      "quasi_static",
         "scheme_type":                        "Backward_Euler",
         "reset_displacements":                true,
         "newmark_beta":                       0.25,

--- a/applications/GeoMechanicsApplication/tests/test_soil_weight_van_genuchten_above_phreatic_quad_4n.gid/ProjectParameters.json
+++ b/applications/GeoMechanicsApplication/tests/test_soil_weight_van_genuchten_above_phreatic_quad_4n.gid/ProjectParameters.json
@@ -30,7 +30,7 @@
         "reform_dofs_at_each_step":           true,
         "nodal_smoothing":                    false,
         "block_builder":                      true,
-        "solution_type":                      "K0-Procedure",
+        "solution_type":                      "quasi_static",
         "scheme_type":                        "Backward_Euler",
         "reset_displacements":                true,
         "newmark_beta":                       0.25,

--- a/applications/GeoMechanicsApplication/tests/test_soil_weight_van_genuchten_above_phreatic_quad_8n.gid/ProjectParameters.json
+++ b/applications/GeoMechanicsApplication/tests/test_soil_weight_van_genuchten_above_phreatic_quad_8n.gid/ProjectParameters.json
@@ -30,7 +30,7 @@
         "reform_dofs_at_each_step":           true,
         "nodal_smoothing":                    false,
         "block_builder":                      true,
-        "solution_type":                      "K0-Procedure",
+        "solution_type":                      "quasi_static",
         "scheme_type":                        "Backward_Euler",
         "reset_displacements":                true,
         "newmark_beta":                       0.25,


### PR DESCRIPTION
**📝 Description**
A brief description of the PR.

- Replaced the "solution_type" = "K0-procedure" by "quasi_static" in the project parameters .json files
- Removeed the possibility from geomechanics_UPw_solver.py.

