### PR TITLE
[Core] Identical geometries in model part and geometry container

### DIFF
--- a/kratos/containers/geometry_container.h
+++ b/kratos/containers/geometry_container.h
@@ -128,11 +128,12 @@ public:
             return mGeometries.insert(pNewGeometry);
         } else if (&(*i) == pNewGeometry.get()) { // check if the pointee coincides
             return i;
-        } else { // check if the connectivities coincide
-            // first check for the geometry type
+        } else { // Check if the connectivities coincide
+            // First check for the geometry type
             KRATOS_ERROR_IF_NOT(TGeometryType::HasSameGeometryType(*i, *pNewGeometry)) << "Attempting to add geometry with Id: " << pNewGeometry->Id() << ". A different geometry with the same Id already exists." << std::endl;
-            // check that the connectivities are the same
+            // Check that the connectivities are the same
             // note that we deliberately check the node ids and not the pointer adresses as there might be very rare situations
+
             // (e.g., creating nodes bypassing the model part interface) with same connectivities but different pointer addresses
             for (IndexType i_node = 0; i_node < i->PointsNumber(); ++i_node) {
                 KRATOS_ERROR_IF((*i)[i_node].Id() != (*pNewGeometry)[i_node].Id()) << "Attempting to add a new geometry with Id: " << pNewGeometry->Id() << ". A same type geometry with same Id but different connectivities already exists." << std::endl;

--- a/kratos/containers/geometry_container.h
+++ b/kratos/containers/geometry_container.h
@@ -135,7 +135,7 @@ public:
             // note that we deliberately check the node ids and not the pointer adresses as there might be very rare situations
             // (e.g., creating nodes bypassing the model part interface) with same connectivities but different pointer addresses
             for (IndexType i_node = 0; i_node < i->PointsNumber(); ++i_node) {
-                KRATOS_ERROR_IF((*i)[i_node].Id() != (*pNewGeometry)[i_node].Id()) << "Attempting to add a new geometry with Id :" << pNewGeometry->Id() << ". A same type geometry with same Id but different connectivities already exists." << std::endl;
+                KRATOS_ERROR_IF((*i)[i_node].Id() != (*pNewGeometry)[i_node].Id()) << "Attempting to add a new geometry with Id: " << pNewGeometry->Id() << ". A same type geometry with same Id but different connectivities already exists." << std::endl;
             }
             return i;
         }

--- a/kratos/containers/geometry_container.h
+++ b/kratos/containers/geometry_container.h
@@ -128,8 +128,16 @@ public:
             return mGeometries.insert(pNewGeometry);
         } else if (&(*i) == pNewGeometry.get()) { // check if the pointee coincides
             return i;
-        } else {
-            KRATOS_ERROR << "Attempting to add Geometry with Id: " << pNewGeometry->Id() << ", unfortunately a (different) geometry with the same Id already exists!" << std::endl;
+        } else { // check if the connectivities coincide
+            // first check for the geometry type
+            KRATOS_ERROR_IF_NOT(TGeometryType::HasSameGeometryType(*i, *pNewGeometry)) << "Attempting to add geometry with Id: " << pNewGeometry->Id() << ". A different geometry with the same Id already exists." << std::endl;
+            // check that the connectivities are the same
+            // note that we deliberately check the node ids and not the pointer adresses as there might be very rare situations
+            // (e.g., creating nodes bypassing the model part interface) with same connectivities but different pointer addresses
+            for (IndexType i_node = 0; i_node < i->PointsNumber(); ++i_node) {
+                KRATOS_ERROR_IF((*i)[i_node].Id() != (*pNewGeometry)[i_node].Id()) << "Attempting to add a new geometry with Id :" << pNewGeometry->Id() << ". A same type geometry with same Id but different connectivities already exists." << std::endl;
+            }
+            return i;
         }
     }
 

--- a/kratos/includes/model_part.h
+++ b/kratos/includes/model_part.h
@@ -1534,8 +1534,13 @@ public:
                 aux_root.push_back( it.operator->() );
                 aux.push_back( it.operator->() );
             } else { // If it does exist verify it is the same geometry
-                if(&(*it_found) != &(*it)) { // Check if the pointee coincides
-                    KRATOS_ERROR << "Attempting to add a new geometry with Id :" << it_found->Id() << ", unfortunately a (different) element with the same Id already exists" << std::endl;
+                if (GeometryType::HasSameGeometryType(*it, *it_found)) { // Check the geometry type and connectivities
+                    for (IndexType i_pt = 0; i_pt < it->PointsNumber(); ++i_pt) {
+                        KRATOS_ERROR_IF((*it)[i_pt].Id() != (*it_found)[i_pt].Id()) << "Attempting to add a new geometry with Id: " << it->Id() << ". A same type geometry with same Id but different connectivities already exists." << std::endl;
+                    }
+                    aux.push_back( it_found.operator->() ); // If the Id, type and connectivities are the same add the existing geometry
+                } else if(&(*it_found) != &(*it)) { // Check if the pointee coincides
+                    KRATOS_ERROR << "Attempting to add a new geometry with Id: " << it_found->Id() << ". A different geometry with the same Id already exists." << std::endl;
                 } else {
                     aux.push_back( it.operator->() );
                 }

--- a/kratos/sources/model_part.cpp
+++ b/kratos/sources/model_part.cpp
@@ -1817,7 +1817,7 @@ ModelPart::GeometryType::Pointer ModelPart::CreateNewGeometry(
         KRATOS_ERROR_IF_NOT(GeometryType::HasSameGeometryType(*p_existing_geom, KratosComponents<GeometryType>::Get(rGeometryTypeName)))
             << "Attempting to add geometry with Id: " << GeometryId << ". A different geometry with the same Id already exists." << std::endl;
 
-        // Check if the connectivities (nodes) of the existing geometry match the ones of the new
+        // Check if the connectivities (nodes) of the existing geometry match that of the new
         for (IndexType i = 0; i < p_existing_geom->PointsNumber(); ++i) {
             KRATOS_ERROR_IF_NOT((p_existing_geom->operator()(i)).get() == &(pGeometryNodes[i]))
                 << "Attempting to add a new geometry with Id: " << GeometryId << ". A same type geometry with same Id but different connectivities already exists." << std::endl;
@@ -1863,7 +1863,7 @@ ModelPart::GeometryType::Pointer ModelPart::CreateNewGeometry(
         KRATOS_ERROR_IF_NOT(GeometryType::HasSameGeometryType(*p_existing_geom, KratosComponents<GeometryType>::Get(rGeometryTypeName)))
             << "Attempting to add geometry with Id: " << GeometryId << ". A different geometry with the same Id already exists." << std::endl;
 
-        // Check if the connectivities (nodes) of the existing geometry match the ones of the new
+        // Check if the connectivities (nodes) of the existing geometry match that of the new
         for (IndexType i = 0; i < p_existing_geom->PointsNumber(); ++i) {
             KRATOS_ERROR_IF_NOT((p_existing_geom->operator()(i)).get() == ((*pGeometry)(i)).get())
                 << "Attempting to add a new geometry with Id: " << GeometryId << ". A same type geometry with same Id but different connectivities already exists." << std::endl;
@@ -1914,13 +1914,30 @@ ModelPart::GeometryType::Pointer ModelPart::CreateNewGeometry(
 {
     KRATOS_TRY
 
-        if (IsSubModelPart()) {
-            GeometryType::Pointer p_new_geometry = mpParentModelPart->CreateNewGeometry(rGeometryTypeName, rGeometryIdentifierName, pGeometryNodes);
-            this->AddGeometry(p_new_geometry);
-            return p_new_geometry;
+    if (IsSubModelPart()) {
+        GeometryType::Pointer p_new_geometry = mpParentModelPart->CreateNewGeometry(rGeometryTypeName, rGeometryIdentifierName, pGeometryNodes);
+        this->AddGeometry(p_new_geometry);
+        return p_new_geometry;
+    }
+
+    // Check if the geometry already exists
+    if (this->HasGeometry(rGeometryIdentifierName)) {
+        // Get the existing geometry with the same Id
+        const auto p_existing_geom = this->pGetGeometry(rGeometryIdentifierName);
+
+        // Check if the existing geometry has the same type
+        KRATOS_ERROR_IF_NOT(GeometryType::HasSameGeometryType(*p_existing_geom, KratosComponents<GeometryType>::Get(rGeometryTypeName)))
+            << "Attempting to add geometry with Id: " << rGeometryIdentifierName << ". A different geometry with the same Id already exists." << std::endl;
+
+        // Check if the connectivities (nodes) of the existing geometry match that of the new
+        for (IndexType i = 0; i < p_existing_geom->PointsNumber(); ++i) {
+            KRATOS_ERROR_IF_NOT((p_existing_geom->operator()(i)).get() == &(pGeometryNodes[i]))
+                << "Attempting to add a new geometry with Id: " << rGeometryIdentifierName << ". A same type geometry with same Id but different connectivities already exists." << std::endl;
         }
 
-    KRATOS_ERROR_IF(this->HasGeometry(rGeometryIdentifierName)) << "Trying to construct an geometry with name: " << rGeometryIdentifierName << ". A geometry with the same name exists already." << std::endl;
+        // Return the existing geometry
+        return p_existing_geom;
+    }
 
     // Create the new geometry
     GeometryType const& r_clone_geometry = KratosComponents<GeometryType>::Get(rGeometryTypeName);
@@ -1942,13 +1959,30 @@ ModelPart::GeometryType::Pointer ModelPart::CreateNewGeometry(
 {
     KRATOS_TRY
 
-        if (IsSubModelPart()) {
-            GeometryType::Pointer p_new_geometry = mpParentModelPart->CreateNewGeometry(rGeometryTypeName, rGeometryIdentifierName, pGeometry);
-            this->AddGeometry(p_new_geometry);
-            return p_new_geometry;
+    if (IsSubModelPart()) {
+        GeometryType::Pointer p_new_geometry = mpParentModelPart->CreateNewGeometry(rGeometryTypeName, rGeometryIdentifierName, pGeometry);
+        this->AddGeometry(p_new_geometry);
+        return p_new_geometry;
+    }
+
+    // Check if the geometry already exists
+    if (this->HasGeometry(rGeometryIdentifierName)) {
+        // Get the existing geometry with the same Id
+        const auto p_existing_geom = this->pGetGeometry(rGeometryIdentifierName);
+
+        // Check if the existing geometry has the same type
+        KRATOS_ERROR_IF_NOT(GeometryType::HasSameGeometryType(*p_existing_geom, KratosComponents<GeometryType>::Get(rGeometryTypeName)))
+            << "Attempting to add geometry with Id: " << rGeometryIdentifierName << ". A different geometry with the same Id already exists." << std::endl;
+
+        // Check if the connectivities (nodes) of the existing geometry match that of the new
+        for (IndexType i = 0; i < p_existing_geom->PointsNumber(); ++i) {
+            KRATOS_ERROR_IF_NOT((p_existing_geom->operator()(i)).get() == ((*pGeometry)(i)).get())
+                << "Attempting to add a new geometry with Id: " << rGeometryIdentifierName << ". A same type geometry with same Id but different connectivities already exists." << std::endl;
         }
 
-    KRATOS_ERROR_IF(this->HasGeometry(rGeometryIdentifierName)) << "Trying to construct an geometry with name: " << rGeometryIdentifierName << ". A geometry with the same name exists already." << std::endl;
+        // Return the existing geometry
+        return p_existing_geom;
+    }
 
     // Create the new geometry
     GeometryType const& r_clone_geometry = KratosComponents<GeometryType>::Get(rGeometryTypeName);

--- a/kratos/sources/model_part.cpp
+++ b/kratos/sources/model_part.cpp
@@ -1514,7 +1514,7 @@ ModelPart::ConditionType::Pointer ModelPart::CreateNewCondition(std::string Cond
         ModelPart::PropertiesType::Pointer pProperties, ModelPart::IndexType ThisIndex)
 {
     KRATOS_TRY
-    
+
     if (IsSubModelPart()) {
         ConditionType::Pointer p_new_condition = mpParentModelPart->CreateNewCondition(ConditionName, Id, ConditionNodeIds, pProperties, ThisIndex);
         GetMesh(ThisIndex).AddCondition(p_new_condition);
@@ -1808,15 +1808,33 @@ ModelPart::GeometryType::Pointer ModelPart::CreateNewGeometry(
         return p_new_geometry;
     }
 
-    KRATOS_ERROR_IF(this->HasGeometry(GeometryId)) << "Trying to construct an geometry with ID: " << GeometryId << ". A geometry with the same Id exists already." << std::endl;
+    // Check if the geometry already exists
+    if (this->HasGeometry(GeometryId)) {
+        // Get the existing geometry with the same Id
+        const auto p_existing_geom = this->pGetGeometry(GeometryId);
+
+        // Check if the existing geometry has the same type
+        KRATOS_ERROR_IF_NOT(GeometryType::HasSameGeometryType(*p_existing_geom, KratosComponents<GeometryType>::Get(rGeometryTypeName)))
+            << "Attempting to add geometry with Id: " << GeometryId << ". A different geometry with the same Id already exists." << std::endl;
+
+        // Check if the connectivities (nodes) of the existing geometry match the ones of the new
+        for (IndexType i = 0; i < p_existing_geom->PointsNumber(); ++i) {
+            KRATOS_ERROR_IF_NOT((p_existing_geom->operator()(i)).get() == &(pGeometryNodes[i]))
+                << "Attempting to add a new geometry with Id: " << GeometryId << ". A same type geometry with same Id but different connectivities already exists." << std::endl;
+        }
+
+        // Return the existing geometry
+        return p_existing_geom;
+    }
 
     // Create the new geometry
     GeometryType const& r_clone_geometry = KratosComponents<GeometryType>::Get(rGeometryTypeName);
     GeometryType::Pointer p_geometry = r_clone_geometry.Create(GeometryId, pGeometryNodes);
 
-    //add the new geometry
+    // Add the new geometry
     this->AddGeometry(p_geometry);
 
+    // Return the new geometry
     return p_geometry;
 
     KRATOS_CATCH("")
@@ -1836,15 +1854,33 @@ ModelPart::GeometryType::Pointer ModelPart::CreateNewGeometry(
         return p_new_geometry;
     }
 
-    KRATOS_ERROR_IF(this->HasGeometry(GeometryId)) << "Trying to construct an geometry with ID: " << GeometryId << ". A geometry with the same Id exists already." << std::endl;
+    // Check if the geometry already exists
+    if (this->HasGeometry(GeometryId)) {
+        // Get the existing geometry with the same Id
+        const auto p_existing_geom = this->pGetGeometry(GeometryId);
+
+        // Check if the existing geometry has the same type
+        KRATOS_ERROR_IF_NOT(GeometryType::HasSameGeometryType(*p_existing_geom, KratosComponents<GeometryType>::Get(rGeometryTypeName)))
+            << "Attempting to add geometry with Id: " << GeometryId << ". A different geometry with the same Id already exists." << std::endl;
+
+        // Check if the connectivities (nodes) of the existing geometry match the ones of the new
+        for (IndexType i = 0; i < p_existing_geom->PointsNumber(); ++i) {
+            KRATOS_ERROR_IF_NOT((p_existing_geom->operator()(i)).get() == ((*pGeometry)(i)).get())
+                << "Attempting to add a new geometry with Id: " << GeometryId << ". A same type geometry with same Id but different connectivities already exists." << std::endl;
+        }
+
+        // Return the existing geometry
+        return p_existing_geom;
+    }
 
     // Create the new geometry
     GeometryType const& r_clone_geometry = KratosComponents<GeometryType>::Get(rGeometryTypeName);
     GeometryType::Pointer p_geometry = r_clone_geometry.Create(GeometryId, *pGeometry);
 
-    //add the new geometry
+    // Add the new geometry
     this->AddGeometry(p_geometry);
 
+    // Return the new geometry
     return p_geometry;
 
     KRATOS_CATCH("")

--- a/kratos/tests/cpp_tests/containers/test_geometry_container.cpp
+++ b/kratos/tests/cpp_tests/containers/test_geometry_container.cpp
@@ -24,16 +24,46 @@
 
 namespace Kratos::Testing {
 
-    Line3D2<Point>::Pointer GenerateLineGeometry() {
-        return Kratos::make_shared<Line3D2<Point>>(
-            Kratos::make_shared<Point>(0.0, 0.0, 0.0),
-            Kratos::make_shared<Point>(1.0, 1.0, 1.0)
-            );
-    }
+namespace
+{
+
+Line3D2<Node>::Pointer GenerateLineGeometry() {
+    Geometry<Node>::PointsArrayType nodes_vector;
+    nodes_vector.push_back(Kratos::make_intrusive<Node>(1, 0.0, 0.0, 0.0));
+    nodes_vector.push_back(Kratos::make_intrusive<Node>(2, 1.0, 1.0, 1.0));
+    return Kratos::make_shared<Line3D2<Node>>(nodes_vector);
+}
+
+void FillGeometryContainer(
+    Geometry<Node>::PointsArrayType& rAuxNodeList,
+    GeometryContainer<Geometry<Node>>& rGeometryContainer)
+{
+    rAuxNodeList.push_back(Kratos::make_intrusive<Node>(1, 0.0, 0.0, 0.0));
+    rAuxNodeList.push_back(Kratos::make_intrusive<Node>(2, 1.0, 0.0, 0.0));
+    rAuxNodeList.push_back(Kratos::make_intrusive<Node>(3, 0.0, 1.0, 0.0));
+    rAuxNodeList.push_back(Kratos::make_intrusive<Node>(4, 1.0, 1.0, 0.0));
+
+    Geometry<Node>::PointsArrayType nodes_vector_1;
+    nodes_vector_1.push_back(rAuxNodeList(0));
+    nodes_vector_1.push_back(rAuxNodeList(1));
+    nodes_vector_1.push_back(rAuxNodeList(3));
+    auto p_geom_1 = Kratos::make_shared<Triangle2D3<Node>>(1, nodes_vector_1);
+
+    Geometry<Node>::PointsArrayType nodes_vector_2;
+    nodes_vector_2.push_back(rAuxNodeList(0));
+    nodes_vector_2.push_back(rAuxNodeList(3));
+    nodes_vector_2.push_back(rAuxNodeList(2));
+    auto p_geom_2 = Kratos::make_shared<Triangle2D3<Node>>(2, nodes_vector_2);
+
+    rGeometryContainer.AddGeometry(p_geom_1);
+    rGeometryContainer.AddGeometry(p_geom_2);
+}
+
+}
 
     ///// Test Geometry Container
-    KRATOS_TEST_CASE_IN_SUITE(TestgeometryContainer, KratosCoreGeometryContainerFastSuite) {
-        auto geometry_container = GeometryContainer<Geometry<Point>>();
+    KRATOS_TEST_CASE_IN_SUITE(TestGeometryContainer, KratosCoreGeometryContainerFastSuite) {
+        auto geometry_container = GeometryContainer<Geometry<Node>>();
 
         auto p_line_1 = GenerateLineGeometry();
         p_line_1->SetId(1);
@@ -46,10 +76,8 @@ namespace Kratos::Testing {
         auto p_line_2 = GenerateLineGeometry();
         p_line_2->SetId(1);
 
-        // check correct error if multiple geometries with sam id are added
-        KRATOS_EXPECT_EXCEPTION_IS_THROWN(
-            geometry_container.AddGeometry(p_line_2),
-            "Error: Attempting to add Geometry with Id: 1, unfortunately a (different) geometry with the same Id already exists!");
+        // check that we do nothing if the same geometry (same id and connectivities) is to be added multiple times
+        KRATOS_EXPECT_EQ(geometry_container.NumberOfGeometries(), 1);
 
         p_line_2->SetId(2);
         geometry_container.AddGeometry(p_line_2);
@@ -74,4 +102,76 @@ namespace Kratos::Testing {
         KRATOS_EXPECT_EQ(geometry_container.NumberOfGeometries(), 1);
         KRATOS_EXPECT_FALSE(geometry_container.HasGeometry("GeometryLine1"));
     }
+
+    KRATOS_TEST_CASE_IN_SUITE(TestGeometryContainerWithRepeatedGeometries1, KratosCoreGeometryContainerFastSuite)
+    {
+        // Prepare geometry container
+        Geometry<Node>::PointsArrayType aux_node_pt_list;
+        GeometryContainer<Geometry<Node>> geometry_container;
+        FillGeometryContainer(aux_node_pt_list, geometry_container);
+
+        // Create and add a geometry with the same connectivities but different Id (valid)
+        Geometry<Node>::PointsArrayType nodes_vector_3;
+        nodes_vector_3.push_back(aux_node_pt_list(0));
+        nodes_vector_3.push_back(aux_node_pt_list(1));
+        nodes_vector_3.push_back(aux_node_pt_list(3));
+        auto p_geom_3 = Kratos::make_shared<Triangle2D3<Node>>(3, nodes_vector_3);
+        geometry_container.AddGeometry(p_geom_3);
+
+        // Check results
+        KRATOS_EXPECT_EQ(geometry_container.NumberOfGeometries(), 3);
+    }
+
+    KRATOS_TEST_CASE_IN_SUITE(TestGeometryContainerWithRepeatedGeometries2, KratosCoreGeometryContainerFastSuite)
+    {
+        // Prepare geometry container
+        Geometry<Node>::PointsArrayType aux_node_pt_list;
+        GeometryContainer<Geometry<Node>> geometry_container;
+        FillGeometryContainer(aux_node_pt_list, geometry_container);
+
+        // Keep the existing when trying to add an already existing geometry (same Id and same connectivities) (valid)
+        Geometry<Node>::PointsArrayType nodes_vector_2;
+        nodes_vector_2.push_back(aux_node_pt_list(0));
+        nodes_vector_2.push_back(aux_node_pt_list(3));
+        nodes_vector_2.push_back(aux_node_pt_list(2));
+        auto p_geom_2 = Kratos::make_shared<Triangle2D3<Node>>(2, nodes_vector_2);
+        geometry_container.AddGeometry(p_geom_2);
+
+        // Check results
+        KRATOS_EXPECT_EQ(geometry_container.NumberOfGeometries(), 2);
+    }
+
+    KRATOS_TEST_CASE_IN_SUITE(TestGeometryContainerWithRepeatedGeometries3, KratosCoreGeometryContainerFastSuite)
+    {
+        // Prepare geometry container
+        Geometry<Node>::PointsArrayType aux_node_pt_list;
+        GeometryContainer<Geometry<Node>> geometry_container;
+        FillGeometryContainer(aux_node_pt_list, geometry_container);
+
+        // Throw an error when trying to add a different geometry with an existing Id (not defined)
+        Geometry<Node>::PointsArrayType nodes_vector_2;
+        nodes_vector_2.push_back(aux_node_pt_list(0));
+        nodes_vector_2.push_back(aux_node_pt_list(1));
+        nodes_vector_2.push_back(aux_node_pt_list(3));
+        nodes_vector_2.push_back(aux_node_pt_list(2));
+        auto p_geom_2 = Kratos::make_shared<Quadrilateral2D4<Node>>(2, nodes_vector_2);
+        KRATOS_EXPECT_EXCEPTION_IS_THROWN(geometry_container.AddGeometry(p_geom_2), "Attempting to add geometry with Id: 2. A different geometry with the same Id already exists.")
+    }
+
+    KRATOS_TEST_CASE_IN_SUITE(TestGeometryContainerWithRepeatedGeometries4, KratosCoreGeometryContainerFastSuite)
+    {
+        // Prepare geometry container
+        Geometry<Node>::PointsArrayType aux_node_pt_list;
+        GeometryContainer<Geometry<Node>> geometry_container;
+        FillGeometryContainer(aux_node_pt_list, geometry_container);
+
+        // Throw an error when trying to add a same type geometry but with different connectivities and existing Id (not defined)
+        Geometry<Node>::PointsArrayType nodes_vector_2;
+        nodes_vector_2.push_back(aux_node_pt_list(2));
+        nodes_vector_2.push_back(aux_node_pt_list(3));
+        nodes_vector_2.push_back(aux_node_pt_list(0));
+        auto p_geom_2 = Kratos::make_shared<Triangle2D3<Node>>(2, nodes_vector_2);
+        KRATOS_EXPECT_EXCEPTION_IS_THROWN(geometry_container.AddGeometry(p_geom_2), "Attempting to add a new geometry with Id :2. A same type geometry with same Id but different connectivities already exists.")
+    }
+
 } // namespace Kratos::Testing.

--- a/kratos/tests/cpp_tests/containers/test_geometry_container.cpp
+++ b/kratos/tests/cpp_tests/containers/test_geometry_container.cpp
@@ -171,7 +171,7 @@ void FillGeometryContainer(
         nodes_vector_2.push_back(aux_node_pt_list(3));
         nodes_vector_2.push_back(aux_node_pt_list(0));
         auto p_geom_2 = Kratos::make_shared<Triangle2D3<Node>>(2, nodes_vector_2);
-        KRATOS_EXPECT_EXCEPTION_IS_THROWN(geometry_container.AddGeometry(p_geom_2), "Attempting to add a new geometry with Id :2. A same type geometry with same Id but different connectivities already exists.")
+        KRATOS_EXPECT_EXCEPTION_IS_THROWN(geometry_container.AddGeometry(p_geom_2), "Attempting to add a new geometry with Id: 2. A same type geometry with same Id but different connectivities already exists.")
     }
 
 } // namespace Kratos::Testing.

--- a/kratos/tests/cpp_tests/containers/test_model_part_geometry_container.cpp
+++ b/kratos/tests/cpp_tests/containers/test_model_part_geometry_container.cpp
@@ -22,8 +22,9 @@
 
 #include "containers/model.h"
 
-namespace Kratos {
-namespace Testing {
+namespace Kratos::Testing {
+
+namespace {
 
     Line3D2<Node>::Pointer GenerateLineModelPartGeometryContainer() {
         PointerVector<Node> points;
@@ -36,6 +37,7 @@ namespace Testing {
             );
     }
 
+}
     ///// Test Geometry Container
     KRATOS_TEST_CASE_IN_SUITE(TestModelPartGeometryContainer, KratosCoreGeometryContainerFastSuite) {
         Model model;
@@ -62,10 +64,9 @@ namespace Testing {
         auto p_line_2 = GenerateLineModelPartGeometryContainer();
         p_line_2->SetId(1);
 
-        // check correct error if multiple geometries with same id are added
-        KRATOS_EXPECT_EXCEPTION_IS_THROWN(
-            model_part_lines.AddGeometry(p_line_2),
-            "Error: Attempting to add Geometry with Id: 1, unfortunately a (different) geometry with the same Id already exists!");
+        // check that we do nothing if the same geometry (same id and connectivities) is to be added multiple times
+        model_part_lines.AddGeometry(p_line_2);
+        KRATOS_EXPECT_EQ(model_part_lines.NumberOfGeometries(), 1);
 
         p_line_2->SetId(2);
         model_part_lines.AddGeometry(p_line_2);
@@ -119,5 +120,5 @@ namespace Testing {
         KRATOS_EXPECT_FALSE(model_part_lines.HasGeometry(1));
         KRATOS_EXPECT_FALSE(model_part.HasGeometry(1));
     }
-} // namespace Testing.
-} // namespace Kratos.
+
+} // namespace Kratos::Testing.

--- a/kratos/tests/cpp_tests/containers/test_model_part_geometry_container.cpp
+++ b/kratos/tests/cpp_tests/containers/test_model_part_geometry_container.cpp
@@ -234,4 +234,29 @@ void SetUpTestModelPart(Model& rModel)
         KRATOS_EXPECT_EQ(model.GetModelPart("TestModelPart.SubModelPart2.SubSubModelPart").NumberOfGeometries(), 1);
     }
 
+    KRATOS_TEST_CASE_IN_SUITE(TestModelPartGeometryContainerRepeatedGeometries5, KratosCoreGeometryContainerFastSuite)
+    {
+        // Set up test model part
+        Model model;
+        SetUpTestModelPart(model);
+
+        // Check that creating the same geometry twice returns the already existing one
+        auto& r_model_part = model.GetModelPart("TestModelPart");
+        auto p_geom_3_string = r_model_part.CreateNewGeometry("Triangle2D3", "3", {1,3,4});
+        KRATOS_EXPECT_NE(p_geom_3_string, r_model_part.pGetGeometry(3));
+
+        // Check that adding the same geometry with the same string identifier but different connectivities throws an error
+        auto p_node_1 = r_model_part.pGetNode(1);
+        auto p_node_3 = r_model_part.pGetNode(3);
+        auto p_node_4 = r_model_part.pGetNode(4);
+        auto p_aux_geom = Kratos::make_shared<Triangle2D3<Node>>(p_node_1, p_node_4, p_node_3);
+        KRATOS_EXPECT_EXCEPTION_IS_THROWN(r_model_part.CreateNewGeometry("Triangle2D3", "3", p_aux_geom), "Attempting to add a new geometry with Id: 3. A same type geometry with same Id but different connectivities already exists")
+
+        // Check results
+        KRATOS_EXPECT_EQ(model.GetModelPart("TestModelPart").NumberOfGeometries(), 4);
+        KRATOS_EXPECT_EQ(model.GetModelPart("TestModelPart.SubModelPart1").NumberOfGeometries(), 1);
+        KRATOS_EXPECT_EQ(model.GetModelPart("TestModelPart.SubModelPart2").NumberOfGeometries(), 2);
+        KRATOS_EXPECT_EQ(model.GetModelPart("TestModelPart.SubModelPart2.SubSubModelPart").NumberOfGeometries(), 1);
+    }
+
 } // namespace Kratos::Testing.

--- a/kratos/tests/cpp_tests/containers/test_model_part_geometry_container.cpp
+++ b/kratos/tests/cpp_tests/containers/test_model_part_geometry_container.cpp
@@ -19,12 +19,14 @@
 // Project includes
 #include "testing/testing.h"
 #include "geometries/line_3d_2.h"
+#include "geometries/triangle_2d_3.h"
 
 #include "containers/model.h"
 
 namespace Kratos::Testing {
 
-namespace {
+namespace
+{
 
     Line3D2<Node>::Pointer GenerateLineModelPartGeometryContainer() {
         PointerVector<Node> points;
@@ -36,6 +38,23 @@ namespace {
             points
             );
     }
+
+void SetUpTestModelPart(Model& rModel)
+{
+    auto& r_model_part = rModel.CreateModelPart("TestModelPart");
+    r_model_part.CreateSubModelPart("SubModelPart1");
+    auto& r_sub_model_part_2 = r_model_part.CreateSubModelPart("SubModelPart2");
+    r_sub_model_part_2.CreateSubModelPart("SubSubModelPart");
+
+    auto p_node_1 = r_model_part.CreateNewNode(1, 0.0, 0.0, 0.0);
+    auto p_node_2 = r_model_part.CreateNewNode(2, 1.0, 0.0, 0.0);
+    auto p_node_3 = r_model_part.CreateNewNode(3, 0.0, 1.0, 0.0);
+    auto p_node_4 = r_model_part.CreateNewNode(4, 1.0, 1.0, 0.0);
+
+    rModel.GetModelPart("TestModelPart.SubModelPart1").CreateNewGeometry("Line2D2", 1, {{1, 2}});
+    rModel.GetModelPart("TestModelPart.SubModelPart2").CreateNewGeometry("Triangle2D3", 2, {{1, 2, 4}});
+    rModel.GetModelPart("TestModelPart.SubModelPart2.SubSubModelPart").CreateNewGeometry("Triangle2D3", 3, {{1, 4, 3}});
+}
 
 }
     ///// Test Geometry Container
@@ -119,6 +138,100 @@ namespace {
         // check if correct geometries are removed
         KRATOS_EXPECT_FALSE(model_part_lines.HasGeometry(1));
         KRATOS_EXPECT_FALSE(model_part.HasGeometry(1));
+    }
+
+    KRATOS_TEST_CASE_IN_SUITE(TestModelPartGeometryContainerRepeatedGeometries1, KratosCoreGeometryContainerFastSuite)
+    {
+        // Set up test model part
+        Model model;
+        SetUpTestModelPart(model);
+
+        // Add a same type and connectivity geometry with different Id (valid)
+        model.GetModelPart("TestModelPart.SubModelPart2").CreateNewGeometry("Triangle2D3", 4, {1,4,3});
+
+        // Check results
+        KRATOS_EXPECT_EQ(model.GetModelPart("TestModelPart").NumberOfGeometries(), 4);
+        KRATOS_EXPECT_EQ(model.GetModelPart("TestModelPart.SubModelPart1").NumberOfGeometries(), 1);
+        KRATOS_EXPECT_EQ(model.GetModelPart("TestModelPart.SubModelPart2").NumberOfGeometries(), 3);
+        KRATOS_EXPECT_EQ(model.GetModelPart("TestModelPart.SubModelPart2.SubSubModelPart").NumberOfGeometries(), 1);
+    }
+
+    KRATOS_TEST_CASE_IN_SUITE(TestModelPartGeometryContainerRepeatedGeometries2, KratosCoreGeometryContainerFastSuite)
+    {
+        // Set up test model part
+        Model model;
+        SetUpTestModelPart(model);
+
+        // Check that adding the same type and connectivity geometry with same Id returns the existing one (valid)
+        auto& r_model_part = model.GetModelPart("TestModelPart");
+        auto p_geom_3_old = r_model_part.pGetGeometry(3);
+        auto p_geom_3_new = r_model_part.CreateNewGeometry("Triangle2D3", 3, {1,4,3});
+
+        // Check that adding the same type and connectivity geometry with same Id returns the existing one (valid)
+        auto p_node_1 = r_model_part.pGetNode(1);
+        auto p_node_4 = r_model_part.pGetNode(4);
+        auto p_node_3 = r_model_part.pGetNode(3);
+        auto p_aux_geom = Kratos::make_shared<Triangle2D3<Node>>(p_node_1, p_node_4, p_node_3);
+        auto p_geom_3_new_2 = r_model_part.CreateNewGeometry("Triangle2D3", 3, p_aux_geom);
+
+        // Check results
+        KRATOS_EXPECT_EQ(p_geom_3_new, p_geom_3_old);
+        KRATOS_EXPECT_EQ(p_geom_3_new_2, p_geom_3_old);
+        KRATOS_EXPECT_EQ(model.GetModelPart("TestModelPart").NumberOfGeometries(), 3);
+        KRATOS_EXPECT_EQ(model.GetModelPart("TestModelPart.SubModelPart1").NumberOfGeometries(), 1);
+        KRATOS_EXPECT_EQ(model.GetModelPart("TestModelPart.SubModelPart2").NumberOfGeometries(), 2);
+        KRATOS_EXPECT_EQ(model.GetModelPart("TestModelPart.SubModelPart2.SubSubModelPart").NumberOfGeometries(), 1);
+    }
+
+    KRATOS_TEST_CASE_IN_SUITE(TestModelPartGeometryContainerRepeatedGeometries3, KratosCoreGeometryContainerFastSuite)
+    {
+        // Set up test model part
+        Model model;
+        SetUpTestModelPart(model);
+
+        // Check that adding a different geometry with the same Id throws an error
+        auto& r_model_part = model.GetModelPart("TestModelPart");
+        auto p_geom_3_old = r_model_part.pGetGeometry(3);
+        KRATOS_EXPECT_EXCEPTION_IS_THROWN(r_model_part.CreateNewGeometry("Quadrilateral2D4", 3, {1,2,4,3}), "Attempting to add geometry with Id: 3. A different geometry with the same Id already exists.")
+
+        // Check that adding a different geometry with the same Id throws an error
+        auto p_node_1 = r_model_part.pGetNode(1);
+        auto p_node_2 = r_model_part.pGetNode(2);
+        auto p_node_3 = r_model_part.pGetNode(3);
+        auto p_node_4 = r_model_part.pGetNode(4);
+        auto p_aux_geom = Kratos::make_shared<Quadrilateral2D4<Node>>(p_node_1, p_node_2, p_node_4, p_node_3);
+        KRATOS_EXPECT_EXCEPTION_IS_THROWN(r_model_part.CreateNewGeometry("Quadrilateral2D4", 3, p_aux_geom), "Attempting to add geometry with Id: 3. A different geometry with the same Id already exists.")
+
+        // Check results
+        KRATOS_EXPECT_EQ(model.GetModelPart("TestModelPart").NumberOfGeometries(), 3);
+        KRATOS_EXPECT_EQ(model.GetModelPart("TestModelPart.SubModelPart1").NumberOfGeometries(), 1);
+        KRATOS_EXPECT_EQ(model.GetModelPart("TestModelPart.SubModelPart2").NumberOfGeometries(), 2);
+        KRATOS_EXPECT_EQ(model.GetModelPart("TestModelPart.SubModelPart2.SubSubModelPart").NumberOfGeometries(), 1);
+    }
+
+    KRATOS_TEST_CASE_IN_SUITE(TestModelPartGeometryContainerRepeatedGeometries4, KratosCoreGeometryContainerFastSuite)
+    {
+        // Set up test model part
+        Model model;
+        SetUpTestModelPart(model);
+
+        // Check that adding the same geometry with the same Id but different connectivities throws an error
+        auto& r_model_part = model.GetModelPart("TestModelPart");
+        auto p_geom_3_old = r_model_part.pGetGeometry(3);
+        KRATOS_EXPECT_EXCEPTION_IS_THROWN(r_model_part.CreateNewGeometry("Triangle2D3", 3, {1,3,4}), "Attempting to add a new geometry with Id: 3. A same type geometry with same Id but different connectivities already exists")
+
+        // Check that adding the same geometry with the same Id but different connectivities throws an error
+        auto p_node_1 = r_model_part.pGetNode(1);
+        auto p_node_3 = r_model_part.pGetNode(3);
+        auto p_node_4 = r_model_part.pGetNode(4);
+        auto p_aux_geom = Kratos::make_shared<Triangle2D3<Node>>(p_node_1, p_node_3, p_node_4);
+        KRATOS_EXPECT_EXCEPTION_IS_THROWN(r_model_part.CreateNewGeometry("Triangle2D3", 3, p_aux_geom), "Attempting to add a new geometry with Id: 3. A same type geometry with same Id but different connectivities already exists")
+
+        // Check results
+        KRATOS_EXPECT_EQ(model.GetModelPart("TestModelPart").NumberOfGeometries(), 3);
+        KRATOS_EXPECT_EQ(model.GetModelPart("TestModelPart.SubModelPart1").NumberOfGeometries(), 1);
+        KRATOS_EXPECT_EQ(model.GetModelPart("TestModelPart.SubModelPart2").NumberOfGeometries(), 2);
+        KRATOS_EXPECT_EQ(model.GetModelPart("TestModelPart.SubModelPart2.SubSubModelPart").NumberOfGeometries(), 1);
     }
 
 } // namespace Kratos::Testing.


### PR DESCRIPTION
**📝 Description**
This PR introduces modifies the `ModelPart` and `GeometryContainer` implementation according to the conclusions reached in #12564. Long story short,
- trying to add an existing geometry (by existing we understand same Id, type  and connectivity) returns the already existing one rather than throwing an error
- trying to add a geometry with an already existing Id but different type or connectivity (i.e., a different geometry with same Id) throws an error
- trying to add a geometry with different Id but already existent connectivity is perfectly valid as this is considered a different entity (current behavior)

@jginternational this should solve your current issues.
@KratosMultiphysics/technical-committee I wonder if we should update the element and condition create methods accordingly.

Closes #12564.
