### PR TITLE
[GeoMechanicsApplication] Removed the strain calculation from geo constitutive laws

### DIFF
--- a/applications/GeoMechanicsApplication/custom_constitutive/elastic_isotropic_K0_3d_law.cpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/elastic_isotropic_K0_3d_law.cpp
@@ -117,22 +117,4 @@ void ElasticIsotropicK03DLaw::CalculatePK2Stress(const Vector&                rS
     }
 }
 
-void ElasticIsotropicK03DLaw::CalculateCauchyGreenStrain(ConstitutiveLaw::Parameters& rValues, Vector& rStrainVector)
-{
-    const SizeType space_dimension = this->WorkingSpaceDimension();
-
-    // 1.-Compute total deformation gradient
-    const Matrix& F = rValues.GetDeformationGradientF();
-    KRATOS_DEBUG_ERROR_IF(F.size1() != space_dimension || F.size2() != space_dimension)
-        << "expected size of F " << space_dimension << "x" << space_dimension << ", got "
-        << F.size1() << "x" << F.size2() << std::endl;
-
-    Matrix E_tensor = prod(trans(F), F);
-    for (unsigned int i = 0; i < space_dimension; ++i)
-        E_tensor(i, i) -= 1.0;
-    E_tensor *= 0.5;
-
-    noalias(rStrainVector) = MathUtils<double>::StrainTensorToVector(E_tensor);
-}
-
 } // Namespace Kratos

--- a/applications/GeoMechanicsApplication/custom_constitutive/elastic_isotropic_K0_3d_law.h
+++ b/applications/GeoMechanicsApplication/custom_constitutive/elastic_isotropic_K0_3d_law.h
@@ -138,13 +138,6 @@ protected:
                             Vector&                      rStressVector,
                             ConstitutiveLaw::Parameters& rValues) override;
 
-    /**
-     * @brief It calculates the strain vector
-     * @param rValues The internal values of the law
-     * @param rStrainVector The strain vector in Voigt notation
-     */
-    void CalculateCauchyGreenStrain(ConstitutiveLaw::Parameters& rValues, Vector& rStrainVector) override;
-
     ///@}
 
 private:

--- a/applications/GeoMechanicsApplication/custom_constitutive/linear_elastic_law.cpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/linear_elastic_law.cpp
@@ -52,6 +52,9 @@ void GeoLinearElasticLaw::CalculateMaterialResponsePK2(ConstitutiveLaw::Paramete
 
     const Flags& r_options = rValues.GetOptions();
 
+    KRATOS_DEBUG_ERROR_IF(r_options.IsNot(ConstitutiveLaw::USE_ELEMENT_PROVIDED_STRAIN))
+        << "The GeoLinearElasticLaw needs an element provided strain" << std::endl;
+
     KRATOS_ERROR_IF(!rValues.IsSetStrainVector() || rValues.GetStrainVector().size() != GetStrainSize())
         << "Constitutive laws in the geomechanics application need a valid provided strain"
         << std::endl;

--- a/applications/GeoMechanicsApplication/custom_constitutive/linear_elastic_law.cpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/linear_elastic_law.cpp
@@ -53,7 +53,7 @@ void GeoLinearElasticLaw::CalculateMaterialResponsePK2(ConstitutiveLaw::Paramete
     const Flags& r_options = rValues.GetOptions();
 
     KRATOS_ERROR_IF(!rValues.IsSetStrainVector() || rValues.GetStrainVector().size() != GetStrainSize())
-        << "Constitutive laws in the geomechanics application need a valid element provided strain"
+        << "Constitutive laws in the geomechanics application need a valid provided strain"
         << std::endl;
 
     if (r_options.Is(ConstitutiveLaw::COMPUTE_CONSTITUTIVE_TENSOR)) {

--- a/applications/GeoMechanicsApplication/custom_constitutive/linear_elastic_law.cpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/linear_elastic_law.cpp
@@ -52,19 +52,16 @@ void GeoLinearElasticLaw::CalculateMaterialResponsePK2(ConstitutiveLaw::Paramete
 
     const Flags& r_options = rValues.GetOptions();
 
-    Vector& r_strain_vector = rValues.GetStrainVector();
-
-    KRATOS_ERROR_IF_NOT(r_options.Is(ConstitutiveLaw::USE_ELEMENT_PROVIDED_STRAIN))
-        << "The GeoLinearElasticLaw needs an element provided strain" << std::endl;
+    KRATOS_ERROR_IF(!rValues.IsSetStrainVector() || rValues.GetStrainVector().size() != GetStrainSize())
+        << "Constitutive laws in the geomechanics application need a valid element provided strain"
+        << std::endl;
 
     if (r_options.Is(ConstitutiveLaw::COMPUTE_CONSTITUTIVE_TENSOR)) {
-        Matrix& r_constitutive_matrix = rValues.GetConstitutiveMatrix();
-        CalculateElasticMatrix(r_constitutive_matrix, rValues);
+        CalculateElasticMatrix(rValues.GetConstitutiveMatrix(), rValues);
     }
 
     if (r_options.Is(ConstitutiveLaw::COMPUTE_STRESS)) {
-        Vector& r_stress_vector = rValues.GetStressVector();
-        CalculatePK2Stress(r_strain_vector, r_stress_vector, rValues);
+        CalculatePK2Stress(rValues.GetStrainVector(), rValues.GetStressVector(), rValues);
     }
 
     KRATOS_CATCH("")

--- a/applications/GeoMechanicsApplication/custom_constitutive/linear_elastic_law.cpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/linear_elastic_law.cpp
@@ -54,10 +54,8 @@ void GeoLinearElasticLaw::CalculateMaterialResponsePK2(ConstitutiveLaw::Paramete
 
     Vector& r_strain_vector = rValues.GetStrainVector();
 
-    // NOTE: SINCE THE ELEMENT IS IN SMALL STRAINS WE CAN USE ANY STRAIN MEASURE. HERE EMPLOYING THE CAUCHY_GREEN
-    if (r_options.IsNot(ConstitutiveLaw::USE_ELEMENT_PROVIDED_STRAIN)) {
-        CalculateCauchyGreenStrain(rValues, r_strain_vector);
-    }
+    KRATOS_ERROR_IF_NOT(r_options.Is(ConstitutiveLaw::USE_ELEMENT_PROVIDED_STRAIN))
+        << "The GeoLinearElasticLaw needs an element provided strain" << std::endl;
 
     if (r_options.Is(ConstitutiveLaw::COMPUTE_CONSTITUTIVE_TENSOR)) {
         Matrix& r_constitutive_matrix = rValues.GetConstitutiveMatrix();
@@ -89,7 +87,6 @@ double& GeoLinearElasticLaw::CalculateValue(ConstitutiveLaw::Parameters& rParame
     if (rThisVariable == STRAIN_ENERGY) {
         Vector& r_strain_vector = rParameterValues.GetStrainVector();
         Vector& r_stress_vector = rParameterValues.GetStressVector();
-        this->CalculateCauchyGreenStrain(rParameterValues, r_strain_vector);
         this->CalculatePK2Stress(r_strain_vector, r_stress_vector, rParameterValues);
 
         rValue = 0.5 * inner_prod(r_strain_vector, r_stress_vector); // Strain energy = 0.5*E:C:E
@@ -102,11 +99,8 @@ Vector& GeoLinearElasticLaw::CalculateValue(ConstitutiveLaw::Parameters& rParame
                                             const Variable<Vector>&      rThisVariable,
                                             Vector&                      rValue)
 {
-    if (rThisVariable == STRAIN || rThisVariable == GREEN_LAGRANGE_STRAIN_VECTOR ||
-        rThisVariable == ALMANSI_STRAIN_VECTOR) {
-        this->CalculateCauchyGreenStrain(rParameterValues, rValue);
-    } else if (rThisVariable == STRESSES || rThisVariable == CAUCHY_STRESS_VECTOR ||
-               rThisVariable == KIRCHHOFF_STRESS_VECTOR || rThisVariable == PK2_STRESS_VECTOR) {
+    if (rThisVariable == STRESSES || rThisVariable == CAUCHY_STRESS_VECTOR ||
+        rThisVariable == KIRCHHOFF_STRESS_VECTOR || rThisVariable == PK2_STRESS_VECTOR) {
         // Get Values to compute the constitutive law:
         Flags& r_flags = rParameterValues.GetOptions();
 

--- a/applications/GeoMechanicsApplication/custom_constitutive/linear_elastic_law.h
+++ b/applications/GeoMechanicsApplication/custom_constitutive/linear_elastic_law.h
@@ -55,7 +55,6 @@ public:
 
 protected:
     virtual void CalculateElasticMatrix(Matrix& rConstitutiveMatrix, ConstitutiveLaw::Parameters& rValues) = 0;
-    virtual void CalculateCauchyGreenStrain(ConstitutiveLaw::Parameters& rValues, Vector& rStrainVector) = 0;
     virtual void CalculatePK2Stress(const Vector&                rStrainVector,
                                     Vector&                      rStressVector,
                                     ConstitutiveLaw::Parameters& rValues) = 0;

--- a/applications/GeoMechanicsApplication/custom_constitutive/linear_elastic_plane_strain_K0_law.cpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/linear_elastic_plane_strain_K0_law.cpp
@@ -132,24 +132,4 @@ void LinearPlaneStrainK0Law::CalculatePK2Stress(const Vector&                rSt
     KRATOS_CATCH("")
 }
 
-void LinearPlaneStrainK0Law::CalculateCauchyGreenStrain(Parameters& rValues, Vector& rStrainVector)
-{
-    // 1.-Compute total deformation gradient
-    const Matrix& F = rValues.GetDeformationGradientF();
-
-    // for shells/membranes in case the DeformationGradient is of size 3x3
-    BoundedMatrix<double, 2, 2> F2x2;
-    for (unsigned int i = 0; i < 2; ++i)
-        for (unsigned int j = 0; j < 2; ++j)
-            F2x2(i, j) = F(i, j);
-
-    Matrix E_tensor = prod(trans(F2x2), F2x2);
-
-    for (unsigned int i = 0; i < 2; ++i)
-        E_tensor(i, i) -= 1.0;
-
-    E_tensor *= 0.5;
-    noalias(rStrainVector) = MathUtils<double>::StrainTensorToVector(E_tensor);
-}
-
 } // Namespace Kratos

--- a/applications/GeoMechanicsApplication/custom_constitutive/linear_elastic_plane_strain_K0_law.h
+++ b/applications/GeoMechanicsApplication/custom_constitutive/linear_elastic_plane_strain_K0_law.h
@@ -159,13 +159,6 @@ protected:
                             Vector&                      rStressVector,
                             ConstitutiveLaw::Parameters& rValues) override;
 
-    /**
-     * @brief It calculates the strain vector
-     * @param rValues The internal values of the law
-     * @param rStrainVector The strain vector in Voigt notation
-     */
-    void CalculateCauchyGreenStrain(ConstitutiveLaw::Parameters& rValues, Vector& rStrainVector) override;
-
     ///@}
 
 private:

--- a/applications/GeoMechanicsApplication/custom_constitutive/linear_elastic_plane_stress_2D_law.cpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/linear_elastic_plane_stress_2D_law.cpp
@@ -76,25 +76,4 @@ void GeoLinearElasticPlaneStress2DLaw::CalculatePK2Stress(const Vector& rStrainV
     noalias(rStressVector) = prod(C, rStrainVector);
 }
 
-void GeoLinearElasticPlaneStress2DLaw::CalculateCauchyGreenStrain(Parameters& rValues, Vector& rStrainVector)
-{
-    // 1.-Compute total deformation gradient
-    const Matrix& F = rValues.GetDeformationGradientF();
-
-    // for shells/membranes in case the DeformationGradient is of size 3x3
-    BoundedMatrix<double, 2, 2> F2x2;
-    for (unsigned int i = 0; i < 2; ++i)
-        for (unsigned int j = 0; j < 2; ++j)
-            F2x2(i, j) = F(i, j);
-
-    Matrix E_tensor = prod(trans(F2x2), F2x2);
-
-    for (unsigned int i = 0; i < 2; ++i)
-        E_tensor(i, i) -= 1.0;
-
-    E_tensor *= 0.5;
-
-    noalias(rStrainVector) = MathUtils<double>::StrainTensorToVector(E_tensor);
-}
-
 } // namespace Kratos

--- a/applications/GeoMechanicsApplication/custom_constitutive/linear_elastic_plane_stress_2D_law.h
+++ b/applications/GeoMechanicsApplication/custom_constitutive/linear_elastic_plane_stress_2D_law.h
@@ -152,13 +152,6 @@ protected:
                             Vector&                      rStressVector,
                             ConstitutiveLaw::Parameters& rValues) override;
 
-    /**
-     * It calculates the strain vector
-     * @param rValues The internal values of the law
-     * @param rStrainVector The strain vector in Voigt notation
-     */
-    void CalculateCauchyGreenStrain(ConstitutiveLaw::Parameters& rValues, Vector& rStrainVector) override;
-
     ///@}
 
 private:

--- a/applications/GeoMechanicsApplication/custom_constitutive/small_strain_udsm_2D_interface_law.cpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/small_strain_udsm_2D_interface_law.cpp
@@ -90,13 +90,6 @@ indexStress3D SmallStrainUDSM2DInterfaceLaw::getIndex3D(const indexStress2DInter
     }
 }
 
-void SmallStrainUDSM2DInterfaceLaw::CalculateCauchyGreenStrain(ConstitutiveLaw::Parameters& rValues,
-                                                               Vector& rStrainVector)
-{
-    KRATOS_ERROR << "CalculateCauchyGreenStrain is not implemented in SmallStrainUDSM2DInterfaceLaw"
-                 << std::endl;
-}
-
 Vector& SmallStrainUDSM2DInterfaceLaw::GetValue(const Variable<Vector>& rThisVariable, Vector& rValue)
 {
     if (rThisVariable == STATE_VARIABLES) {

--- a/applications/GeoMechanicsApplication/custom_constitutive/small_strain_udsm_2D_interface_law.hpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/small_strain_udsm_2D_interface_law.hpp
@@ -100,13 +100,6 @@ public:
      */
     StressMeasure GetStressMeasure() override { return StressMeasure_Cauchy; }
 
-    /**
-     * @brief It calculates the strain vector
-     * @param rValues The internal values of the law
-     * @param rStrainVector The strain vector in Voigt notation
-     */
-    void CalculateCauchyGreenStrain(ConstitutiveLaw::Parameters& rValues, Vector& rStrainVector) override;
-
     ///@}
     ///@name Inquiry
     ///@{

--- a/applications/GeoMechanicsApplication/custom_constitutive/small_strain_udsm_2D_plane_strain_law.cpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/small_strain_udsm_2D_plane_strain_law.cpp
@@ -84,27 +84,6 @@ void SmallStrainUDSM2DPlaneStrainLaw::CopyConstitutiveMatrix(ConstitutiveLaw::Pa
     KRATOS_CATCH("")
 }
 
-void SmallStrainUDSM2DPlaneStrainLaw::CalculateCauchyGreenStrain(ConstitutiveLaw::Parameters& rValues,
-                                                                 Vector& rStrainVector)
-{
-    // 1.-Compute total deformation gradient
-    const Matrix& F = rValues.GetDeformationGradientF();
-
-    // for shells/membranes in case the DeformationGradient is of size 3x3
-    BoundedMatrix<double, 2, 2> F2x2;
-    for (unsigned int i = 0; i < 2; ++i)
-        for (unsigned int j = 0; j < 2; ++j)
-            F2x2(i, j) = F(i, j);
-
-    Matrix E_tensor = prod(trans(F2x2), F2x2);
-
-    for (unsigned int i = 0; i < 2; ++i)
-        E_tensor(i, i) -= 1.0;
-
-    E_tensor *= 0.5;
-    noalias(rStrainVector) = MathUtils<double>::StrainTensorToVector(E_tensor);
-}
-
 Vector& SmallStrainUDSM2DPlaneStrainLaw::GetValue(const Variable<Vector>& rThisVariable, Vector& rValue)
 {
     if (rThisVariable == STATE_VARIABLES) {

--- a/applications/GeoMechanicsApplication/custom_constitutive/small_strain_udsm_2D_plane_strain_law.hpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/small_strain_udsm_2D_plane_strain_law.hpp
@@ -100,13 +100,6 @@ public:
      */
     StressMeasure GetStressMeasure() override { return StressMeasure_Cauchy; }
 
-    /**
-     * @brief It calculates the strain vector
-     * @param rValues The internal values of the law
-     * @param rStrainVector The strain vector in Voigt notation
-     */
-    void CalculateCauchyGreenStrain(ConstitutiveLaw::Parameters& rValues, Vector& rStrainVector) override;
-
     ///@}
     ///@name Inquiry
     ///@{

--- a/applications/GeoMechanicsApplication/custom_constitutive/small_strain_udsm_3D_interface_law.cpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/small_strain_udsm_3D_interface_law.cpp
@@ -101,13 +101,6 @@ indexStress3D SmallStrainUDSM3DInterfaceLaw::getIndex3D(const indexStress3DInter
     }
 }
 
-void SmallStrainUDSM3DInterfaceLaw::CalculateCauchyGreenStrain(ConstitutiveLaw::Parameters& rValues,
-                                                               Vector& rStrainVector)
-{
-    KRATOS_ERROR << "CalculateCauchyGreenStrain is not implemented in SmallStrainUDSM3DInterfaceLaw"
-                 << std::endl;
-}
-
 Vector& SmallStrainUDSM3DInterfaceLaw::GetValue(const Variable<Vector>& rThisVariable, Vector& rValue)
 {
     if (rThisVariable == STATE_VARIABLES) {

--- a/applications/GeoMechanicsApplication/custom_constitutive/small_strain_udsm_3D_interface_law.hpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/small_strain_udsm_3D_interface_law.hpp
@@ -99,13 +99,6 @@ public:
      */
     StressMeasure GetStressMeasure() override { return StressMeasure_Cauchy; }
 
-    /**
-     * @brief It calculates the strain vector
-     * @param rValues The internal values of the law
-     * @param rStrainVector The strain vector in Voigt notation
-     */
-    void CalculateCauchyGreenStrain(ConstitutiveLaw::Parameters& rValues, Vector& rStrainVector) override;
-
     ///@}
     ///@name Inquiry
     ///@{

--- a/applications/GeoMechanicsApplication/custom_constitutive/small_strain_udsm_3D_law.cpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/small_strain_udsm_3D_law.cpp
@@ -588,6 +588,9 @@ void SmallStrainUDSM3DLaw::CalculateMaterialResponseCauchy(ConstitutiveLaw::Para
     // Get Values to compute the constitutive law:
     const Flags& rOptions = rValues.GetOptions();
 
+    KRATOS_DEBUG_ERROR_IF(rOptions.IsNot(ConstitutiveLaw::USE_ELEMENT_PROVIDED_STRAIN))
+        << "The GeoLinearElasticLaw needs an element provided strain" << std::endl;
+
     KRATOS_ERROR_IF(!rValues.IsSetStrainVector() || rValues.GetStrainVector().size() != GetStrainSize())
     << "Constitutive laws in the geomechanics application need a valid provided strain"
     << std::endl;

--- a/applications/GeoMechanicsApplication/custom_constitutive/small_strain_udsm_3D_law.cpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/small_strain_udsm_3D_law.cpp
@@ -589,7 +589,7 @@ void SmallStrainUDSM3DLaw::CalculateMaterialResponseCauchy(ConstitutiveLaw::Para
     const Flags& rOptions = rValues.GetOptions();
 
     KRATOS_ERROR_IF(!rValues.IsSetStrainVector() || rValues.GetStrainVector().size() != GetStrainSize())
-    << "Constitutive laws in the geomechanics application need a valid element provided strain"
+    << "Constitutive laws in the geomechanics application need a valid provided strain"
     << std::endl;
 
     if (rOptions.Is(ConstitutiveLaw::COMPUTE_CONSTITUTIVE_TENSOR)) {

--- a/applications/GeoMechanicsApplication/custom_constitutive/small_strain_udsm_3D_law.cpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/small_strain_udsm_3D_law.cpp
@@ -588,11 +588,9 @@ void SmallStrainUDSM3DLaw::CalculateMaterialResponseCauchy(ConstitutiveLaw::Para
     // Get Values to compute the constitutive law:
     const Flags& rOptions = rValues.GetOptions();
 
-    // NOTE: SINCE THE ELEMENT IS IN SMALL STRAINS WE CAN USE ANY STRAIN MEASURE. HERE EMPLOYING THE CAUCHY_GREEN
-    if (rOptions.IsNot(ConstitutiveLaw::USE_ELEMENT_PROVIDED_STRAIN)) {
-        Vector& rStrainVector = rValues.GetStrainVector();
-        CalculateCauchyGreenStrain(rValues, rStrainVector);
-    }
+    KRATOS_ERROR_IF(!rValues.IsSetStrainVector() || rValues.GetStrainVector().size() != GetStrainSize())
+    << "Constitutive laws in the geomechanics application need a valid element provided strain"
+    << std::endl;
 
     if (rOptions.Is(ConstitutiveLaw::COMPUTE_CONSTITUTIVE_TENSOR)) {
         // Constitutive matrix (D matrix)
@@ -815,31 +813,12 @@ void SmallStrainUDSM3DLaw::UpdateInternalStrainVectorFinalized(ConstitutiveLaw::
     this->SetInternalStrainVector(rStrainVector);
 }
 
-void SmallStrainUDSM3DLaw::CalculateCauchyGreenStrain(ConstitutiveLaw::Parameters& rValues, Vector& rStrainVector)
-{
-    const SizeType space_dimension = this->WorkingSpaceDimension();
-
-    //-Compute total deformation gradient
-    const Matrix& F = rValues.GetDeformationGradientF();
-    KRATOS_DEBUG_ERROR_IF(F.size1() != space_dimension || F.size2() != space_dimension)
-        << "expected size of F " << space_dimension << "x" << space_dimension << ", got "
-        << F.size1() << "x" << F.size2() << std::endl;
-
-    Matrix E_tensor = prod(trans(F), F);
-    for (unsigned int i = 0; i < space_dimension; ++i)
-        E_tensor(i, i) -= 1.0;
-    E_tensor *= 0.5;
-
-    noalias(rStrainVector) = MathUtils<double>::StrainTensorToVector(E_tensor);
-}
-
 double& SmallStrainUDSM3DLaw::CalculateValue(ConstitutiveLaw::Parameters& rParameterValues,
                                              const Variable<double>&      rThisVariable,
                                              double&                      rValue)
 {
     if (rThisVariable == STRAIN_ENERGY) {
         Vector& rStrainVector = rParameterValues.GetStrainVector();
-        this->CalculateCauchyGreenStrain(rParameterValues, rStrainVector);
         Vector& rStressVector = rParameterValues.GetStressVector();
         this->CalculateStress(rParameterValues, rStressVector);
 
@@ -852,11 +831,8 @@ Vector& SmallStrainUDSM3DLaw::CalculateValue(ConstitutiveLaw::Parameters& rParam
                                              const Variable<Vector>&      rThisVariable,
                                              Vector&                      rValue)
 {
-    if (rThisVariable == STRAIN || rThisVariable == GREEN_LAGRANGE_STRAIN_VECTOR ||
-        rThisVariable == ALMANSI_STRAIN_VECTOR) {
-        this->CalculateCauchyGreenStrain(rParameterValues, rValue);
-    } else if (rThisVariable == STRESSES || rThisVariable == CAUCHY_STRESS_VECTOR ||
-               rThisVariable == KIRCHHOFF_STRESS_VECTOR || rThisVariable == PK2_STRESS_VECTOR) {
+    if (rThisVariable == STRESSES || rThisVariable == CAUCHY_STRESS_VECTOR ||
+        rThisVariable == KIRCHHOFF_STRESS_VECTOR || rThisVariable == PK2_STRESS_VECTOR) {
         // Get Values to compute the constitutive law:
         Flags& rFlags = rParameterValues.GetOptions();
 

--- a/applications/GeoMechanicsApplication/custom_constitutive/small_strain_udsm_3D_law.hpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/small_strain_udsm_3D_law.hpp
@@ -285,13 +285,6 @@ public:
     void InitializeMaterialResponseKirchhoff(ConstitutiveLaw::Parameters& rValues) override;
 
     /**
-     * @brief It calculates the strain vector
-     * @param rValues The internal values of the law
-     * @param rStrainVector The strain vector in Voigt notation
-     */
-    virtual void CalculateCauchyGreenStrain(ConstitutiveLaw::Parameters& rValues, Vector& rStrainVector);
-
-    /**
      * This can be used in order to reset all internal variables of the
      * constitutive law (e.g. if a model should be reset to its reference state)
      * @param rMaterialProperties the Properties instance of the current element

--- a/applications/GeoMechanicsApplication/custom_constitutive/small_strain_umat_2D_interface_law.cpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/small_strain_umat_2D_interface_law.cpp
@@ -86,13 +86,6 @@ indexStress3D SmallStrainUMAT2DInterfaceLaw::getIndex3D(indexStress2DInterface i
     }
 }
 
-void SmallStrainUMAT2DInterfaceLaw::CalculateCauchyGreenStrain(ConstitutiveLaw::Parameters& rValues,
-                                                               Vector& rStrainVector)
-{
-    KRATOS_ERROR << "CalculateCauchyGreenStrain is not implemented in SmallStrainUMAT2DInterfaceLaw"
-                 << std::endl;
-}
-
 Vector& SmallStrainUMAT2DInterfaceLaw::GetValue(const Variable<Vector>& rThisVariable, Vector& rValue)
 {
     if (rThisVariable == STATE_VARIABLES) {

--- a/applications/GeoMechanicsApplication/custom_constitutive/small_strain_umat_2D_interface_law.hpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/small_strain_umat_2D_interface_law.hpp
@@ -98,13 +98,6 @@ public:
      */
     StressMeasure GetStressMeasure() override { return StressMeasure_Cauchy; }
 
-    /**
-     * @brief It calculates the strain vector
-     * @param rValues The internal values of the law
-     * @param rStrainVector The strain vector in Voigt notation
-     */
-    void CalculateCauchyGreenStrain(ConstitutiveLaw::Parameters& rValues, Vector& rStrainVector) override;
-
     ///@}
     ///@name Inquiry
     ///@{

--- a/applications/GeoMechanicsApplication/custom_constitutive/small_strain_umat_2D_plane_strain_law.cpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/small_strain_umat_2D_plane_strain_law.cpp
@@ -77,26 +77,6 @@ void SmallStrainUMAT2DPlaneStrainLaw::CopyConstitutiveMatrix(ConstitutiveLaw::Pa
     KRATOS_CATCH("")
 }
 
-void SmallStrainUMAT2DPlaneStrainLaw::CalculateCauchyGreenStrain(ConstitutiveLaw::Parameters& rValues,
-                                                                 Vector& rStrainVector)
-{
-    // 1.-Compute total deformation gradient
-    const Matrix& F = rValues.GetDeformationGradientF();
-
-    // for shells/membranes in case the DeformationGradient is of size 3x3
-    BoundedMatrix<double, 2, 2> F2x2;
-    for (unsigned int i = 0; i < 2; ++i)
-        for (unsigned int j = 0; j < 2; ++j)
-            F2x2(i, j) = F(i, j);
-
-    Matrix E_tensor = prod(trans(F2x2), F2x2);
-    for (unsigned int i = 0; i < 2; ++i)
-        E_tensor(i, i) -= 1.0;
-    E_tensor *= 0.5;
-
-    noalias(rStrainVector) = MathUtils<double>::StrainTensorToVector(E_tensor);
-}
-
 Vector& SmallStrainUMAT2DPlaneStrainLaw::GetValue(const Variable<Vector>& rThisVariable, Vector& rValue)
 {
     if (rThisVariable == STATE_VARIABLES) {

--- a/applications/GeoMechanicsApplication/custom_constitutive/small_strain_umat_2D_plane_strain_law.hpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/small_strain_umat_2D_plane_strain_law.hpp
@@ -98,13 +98,6 @@ public:
      */
     StressMeasure GetStressMeasure() override { return StressMeasure_Cauchy; }
 
-    /**
-     * @brief It calculates the strain vector
-     * @param rValues The internal values of the law
-     * @param rStrainVector The strain vector in Voigt notation
-     */
-    void CalculateCauchyGreenStrain(ConstitutiveLaw::Parameters& rValues, Vector& rStrainVector) override;
-
     ///@}
     ///@name Inquiry
     ///@{

--- a/applications/GeoMechanicsApplication/custom_constitutive/small_strain_umat_3D_interface_law.cpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/small_strain_umat_3D_interface_law.cpp
@@ -94,13 +94,6 @@ indexStress3D SmallStrainUMAT3DInterfaceLaw::getIndex3D(const indexStress3DInter
     }
 }
 
-void SmallStrainUMAT3DInterfaceLaw::CalculateCauchyGreenStrain(ConstitutiveLaw::Parameters& rValues,
-                                                               Vector& rStrainVector)
-{
-    KRATOS_ERROR << "CalculateCauchyGreenStrain is not implemented in SmallStrainUMAT3DInterfaceLaw"
-                 << std::endl;
-}
-
 Vector& SmallStrainUMAT3DInterfaceLaw::GetValue(const Variable<Vector>& rThisVariable, Vector& rValue)
 {
     if (rThisVariable == STATE_VARIABLES) {

--- a/applications/GeoMechanicsApplication/custom_constitutive/small_strain_umat_3D_interface_law.hpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/small_strain_umat_3D_interface_law.hpp
@@ -102,13 +102,6 @@ public:
      */
     StressMeasure GetStressMeasure() override { return StressMeasure_Cauchy; }
 
-    /**
-     * @brief It calculates the strain vector
-     * @param rValues The internal values of the law
-     * @param rStrainVector The strain vector in Voigt notation
-     */
-    void CalculateCauchyGreenStrain(ConstitutiveLaw::Parameters& rValues, Vector& rStrainVector) override;
-
     ///@}
     ///@name Inquiry
     ///@{

--- a/applications/GeoMechanicsApplication/custom_constitutive/small_strain_umat_3D_law.cpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/small_strain_umat_3D_law.cpp
@@ -384,11 +384,8 @@ void SmallStrainUMAT3DLaw::CalculateMaterialResponseCauchy(ConstitutiveLaw::Para
     // Get Values to compute the constitutive law:
     const Flags& rOptions = rValues.GetOptions();
 
-    // NOTE: SINCE THE ELEMENT IS IN SMALL STRAINS WE CAN USE ANY STRAIN MEASURE. HERE EMPLOYING THE CAUCHY_GREEN
-    if (rOptions.IsNot(ConstitutiveLaw::USE_ELEMENT_PROVIDED_STRAIN)) {
-        Vector& rStrainVector = rValues.GetStrainVector();
-        CalculateCauchyGreenStrain(rValues, rStrainVector);
-    }
+    KRATOS_ERROR_IF(!rValues.IsSetStrainVector() || rValues.GetStrainVector().size() != GetStrainSize())
+        << "Constitutive laws in the geomechanics application need a valid provided strain" << std::endl;
 
     if (rOptions.Is(ConstitutiveLaw::COMPUTE_STRESS)) {
         Vector& rStressVector = rValues.GetStressVector();
@@ -593,24 +590,6 @@ void SmallStrainUMAT3DLaw::UpdateInternalStrainVectorFinalized(ConstitutiveLaw::
     this->SetInternalStrainVector(rStrainVector);
 }
 
-void SmallStrainUMAT3DLaw::CalculateCauchyGreenStrain(ConstitutiveLaw::Parameters& rValues, Vector& rStrainVector)
-{
-    const SizeType space_dimension = this->WorkingSpaceDimension();
-
-    //-Compute total deformation gradient
-    const Matrix& F = rValues.GetDeformationGradientF();
-    KRATOS_DEBUG_ERROR_IF(F.size1() != space_dimension || F.size2() != space_dimension)
-        << "expected size of F " << space_dimension << "x" << space_dimension << ", got "
-        << F.size1() << "x" << F.size2() << std::endl;
-
-    Matrix E_tensor = prod(trans(F), F);
-    for (unsigned int i = 0; i < space_dimension; ++i)
-        E_tensor(i, i) -= 1.0;
-    E_tensor *= 0.5;
-
-    noalias(rStrainVector) = MathUtils<double>::StrainTensorToVector(E_tensor);
-}
-
 double& SmallStrainUMAT3DLaw::CalculateValue(ConstitutiveLaw::Parameters& rParameterValues,
                                              const Variable<double>&      rThisVariable,
                                              double&                      rValue)
@@ -619,7 +598,6 @@ double& SmallStrainUMAT3DLaw::CalculateValue(ConstitutiveLaw::Parameters& rParam
     Vector& rStressVector = rParameterValues.GetStressVector();
 
     if (rThisVariable == STRAIN_ENERGY) {
-        this->CalculateCauchyGreenStrain(rParameterValues, rStrainVector);
         this->CalculateStress(rParameterValues, rStressVector);
 
         rValue = 0.5 * inner_prod(rStrainVector, rStressVector); // Strain energy = 0.5*E:C:E
@@ -632,12 +610,8 @@ Vector& SmallStrainUMAT3DLaw::CalculateValue(ConstitutiveLaw::Parameters& rParam
                                              const Variable<Vector>&      rThisVariable,
                                              Vector&                      rValue)
 {
-    if (rThisVariable == STRAIN || rThisVariable == GREEN_LAGRANGE_STRAIN_VECTOR ||
-        rThisVariable == ALMANSI_STRAIN_VECTOR) {
-        this->CalculateCauchyGreenStrain(rParameterValues, rValue);
-
-    } else if (rThisVariable == STRESSES || rThisVariable == CAUCHY_STRESS_VECTOR ||
-               rThisVariable == KIRCHHOFF_STRESS_VECTOR || rThisVariable == PK2_STRESS_VECTOR) {
+    if (rThisVariable == STRESSES || rThisVariable == CAUCHY_STRESS_VECTOR ||
+        rThisVariable == KIRCHHOFF_STRESS_VECTOR || rThisVariable == PK2_STRESS_VECTOR) {
         // Get Values to compute the constitutive law:
         Flags& rFlags = rParameterValues.GetOptions();
 

--- a/applications/GeoMechanicsApplication/custom_constitutive/small_strain_umat_3D_law.cpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/small_strain_umat_3D_law.cpp
@@ -384,6 +384,9 @@ void SmallStrainUMAT3DLaw::CalculateMaterialResponseCauchy(ConstitutiveLaw::Para
     // Get Values to compute the constitutive law:
     const Flags& rOptions = rValues.GetOptions();
 
+    KRATOS_DEBUG_ERROR_IF(rOptions.IsNot(ConstitutiveLaw::USE_ELEMENT_PROVIDED_STRAIN))
+    << "The GeoLinearElasticLaw needs an element provided strain" << std::endl;
+
     KRATOS_ERROR_IF(!rValues.IsSetStrainVector() || rValues.GetStrainVector().size() != GetStrainSize())
         << "Constitutive laws in the geomechanics application need a valid provided strain" << std::endl;
 

--- a/applications/GeoMechanicsApplication/custom_constitutive/small_strain_umat_3D_law.hpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/small_strain_umat_3D_law.hpp
@@ -276,13 +276,6 @@ public:
     void InitializeMaterialResponseKirchhoff(ConstitutiveLaw::Parameters& rValues) override;
 
     /**
-     * @brief It calculates the strain vector
-     * @param rValues The internal values of the law
-     * @param rStrainVector The strain vector in Voigt notation
-     */
-    virtual void CalculateCauchyGreenStrain(ConstitutiveLaw::Parameters& rValues, Vector& rStrainVector);
-
-    /**
      * This can be used in order to reset all internal variables of the
      * constitutive law (e.g. if a model should be reset to its reference state)
      * @param rMaterialProperties the Properties instance of the current element

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/stub_linear_elastic_law.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/stub_linear_elastic_law.cpp
@@ -19,13 +19,8 @@ void StubLinearElasticLaw::CalculateElasticMatrix(Matrix& rConstitutiveMatrix, C
     // Deliberately no implementation (it's a stub, remember?)
 }
 
-void StubLinearElasticLaw::CalculateCauchyGreenStrain(ConstitutiveLaw::Parameters& rValues, Vector& rStrainVector)
-{
-    // Deliberately no implementation (it's a stub, remember?)
-}
-
-void StubLinearElasticLaw::CalculatePK2Stress(const Vector& rStrainVector,
-                                              Vector& rStressVector,
+void StubLinearElasticLaw::CalculatePK2Stress(const Vector&                rStrainVector,
+                                              Vector&                      rStressVector,
                                               ConstitutiveLaw::Parameters& rValues)
 {
     // Deliberately no implementation (it's a stub, remember?)

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/stub_linear_elastic_law.h
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/stub_linear_elastic_law.h
@@ -21,7 +21,6 @@ class StubLinearElasticLaw : public Kratos::GeoLinearElasticLaw
 {
 protected:
     void CalculateElasticMatrix(Matrix& rConstitutiveMatrix, Parameters& rValues) override;
-    void CalculateCauchyGreenStrain(Parameters& rValues, Vector& rStrainVector) override;
     void CalculatePK2Stress(const Vector& rStrainVector, Vector& rStressVector, Parameters& rValues) override;
 };
 


### PR DESCRIPTION
**📝 Description**
For the geomechanics application we have made the decision that the geo constitutive laws are **not** responsible for calculating strains. They should always get a strain and use that to calculate constitutive matrices or stresses. The reason is that the strain measure depends on the element and therefore it should be the responsibility of the element to provide it.

This PR removes the strain calculation from the families of geo linear elastic laws, UMAT laws and UDSM laws.
