### PR TITLE
[Hotfix][Geo] Fixing minor segfaults

### DIFF
--- a/applications/GeoMechanicsApplication/custom_elements/U_Pw_base_element.hpp
+++ b/applications/GeoMechanicsApplication/custom_elements/U_Pw_base_element.hpp
@@ -139,8 +139,7 @@ public:
     std::string Info() const override
     {
         const std::string constitutive_info = !mConstitutiveLawVector.empty() ? mConstitutiveLawVector[0]->Info() : "not defined";
-        return "U-Pw Base class Element #" + std::to_string(Id()) +
-               "\nConstitutive law: " + claw_buffer.str();
+        return "U-Pw Base class Element #" + std::to_string(Id()) + "\nConstitutive law: " + constitutive_info;
     }
 
     void PrintInfo(std::ostream& rOStream) const override { rOStream << Info(); }

--- a/applications/GeoMechanicsApplication/custom_elements/U_Pw_base_element.hpp
+++ b/applications/GeoMechanicsApplication/custom_elements/U_Pw_base_element.hpp
@@ -138,7 +138,8 @@ public:
 
     std::string Info() const override
     {
-        const std::string constitutive_info = !mConstitutiveLawVector.empty() ? mConstitutiveLawVector[0]->Info() : "not defined";
+        const std::string constitutive_info =
+            !mConstitutiveLawVector.empty() ? mConstitutiveLawVector[0]->Info() : "not defined";
         return "U-Pw Base class Element #" + std::to_string(Id()) + "\nConstitutive law: " + constitutive_info;
     }
 

--- a/applications/GeoMechanicsApplication/custom_elements/U_Pw_base_element.hpp
+++ b/applications/GeoMechanicsApplication/custom_elements/U_Pw_base_element.hpp
@@ -138,12 +138,7 @@ public:
 
     std::string Info() const override
     {
-        std::stringstream claw_buffer;
-        if (mConstitutiveLawVector.size() != 0) {
-            claw_buffer << mConstitutiveLawVector[0]->Info();
-        } else {
-            claw_buffer << "not defined";
-        }
+        const std::string constitutive_info = !mConstitutiveLawVector.empty() ? mConstitutiveLawVector[0]->Info() : "not defined";
         return "U-Pw Base class Element #" + std::to_string(Id()) +
                "\nConstitutive law: " + claw_buffer.str();
     }

--- a/applications/GeoMechanicsApplication/custom_elements/U_Pw_base_element.hpp
+++ b/applications/GeoMechanicsApplication/custom_elements/U_Pw_base_element.hpp
@@ -138,8 +138,14 @@ public:
 
     std::string Info() const override
     {
+        std::stringstream claw_buffer;
+        if (mConstitutiveLawVector.size() != 0) {
+            claw_buffer << mConstitutiveLawVector[0]->Info();
+        } else {
+            claw_buffer << "not defined";
+        }
         return "U-Pw Base class Element #" + std::to_string(Id()) +
-               "\nConstitutive law: " + mConstitutiveLawVector[0]->Info();
+               "\nConstitutive law: " + claw_buffer.str();
     }
 
     void PrintInfo(std::ostream& rOStream) const override { rOStream << Info(); }

--- a/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_FIC_element.hpp
+++ b/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_FIC_element.hpp
@@ -105,16 +105,21 @@ public:
     std::string Info() const override
     {
         std::stringstream buffer;
+        std::stringstream claw_buffer;
+        if (mConstitutiveLawVector.size() != 0) {
+            claw_buffer << mConstitutiveLawVector[0]->Info();
+        } else {
+            claw_buffer << "not defined";
+        }
         buffer << "U-Pw smal strain FIC Element #" << this->Id()
-               << "\nConstitutive law: " << mConstitutiveLawVector[0]->Info();
+               << "\nConstitutive law: " << claw_buffer.str();
         return buffer.str();
     }
 
     // Print information about this object.
     void PrintInfo(std::ostream& rOStream) const override
     {
-        rOStream << "U-Pw smal strain FIC Element #" << this->Id()
-                 << "\nConstitutive law: " << mConstitutiveLawVector[0]->Info();
+        rOStream << Info();
     }
 
     ///----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

--- a/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_FIC_element.hpp
+++ b/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_FIC_element.hpp
@@ -104,23 +104,13 @@ public:
     // Turn back information as a string.
     std::string Info() const override
     {
-        std::stringstream buffer;
-        std::stringstream claw_buffer;
-        if (mConstitutiveLawVector.size() != 0) {
-            claw_buffer << mConstitutiveLawVector[0]->Info();
-        } else {
-            claw_buffer << "not defined";
-        }
-        buffer << "U-Pw smal strain FIC Element #" << this->Id()
-               << "\nConstitutive law: " << claw_buffer.str();
-        return buffer.str();
+        const std::string constitutive_info =
+            !mConstitutiveLawVector.empty() ? mConstitutiveLawVector[0]->Info() : "not defined";
+        return "U-Pw smal strain FIC Element #" + std::to_string(this->Id()) + "\nConstitutive law: " + constitutive_info;
     }
 
     // Print information about this object.
-    void PrintInfo(std::ostream& rOStream) const override
-    {
-        rOStream << Info();
-    }
+    void PrintInfo(std::ostream& rOStream) const override { rOStream << Info(); }
 
     ///----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 

--- a/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_element.hpp
+++ b/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_element.hpp
@@ -119,14 +119,9 @@ public:
 
     std::string Info() const override
     {
-        std::stringstream claw_buffer;
-        if (mConstitutiveLawVector.size() != 0) {
-            claw_buffer << mConstitutiveLawVector[0]->Info();
-        } else {
-            claw_buffer << "not defined";
-        }
-        return "U-Pw small strain Element #" + std::to_string(this->Id()) +
-               "\nConstitutive law: " + claw_buffer.str();
+        const std::string constitutive_info =
+            !mConstitutiveLawVector.empty() ? mConstitutiveLawVector[0]->Info() : "not defined";
+        return "U-Pw small strain Element #" + std::to_string(this->Id()) + "\nConstitutive law: " + constitutive_info;
     }
 
     void PrintInfo(std::ostream& rOStream) const override { rOStream << Info(); }

--- a/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_element.hpp
+++ b/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_element.hpp
@@ -119,8 +119,14 @@ public:
 
     std::string Info() const override
     {
+        std::stringstream claw_buffer;
+        if (mConstitutiveLawVector.size() != 0) {
+            claw_buffer << mConstitutiveLawVector[0]->Info();
+        } else {
+            claw_buffer << "not defined";
+        }
         return "U-Pw small strain Element #" + std::to_string(this->Id()) +
-               "\nConstitutive law: " + mConstitutiveLawVector[0]->Info();
+               "\nConstitutive law: " + claw_buffer.str();
     }
 
     void PrintInfo(std::ostream& rOStream) const override { rOStream << Info(); }

--- a/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_link_interface_element.hpp
+++ b/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_link_interface_element.hpp
@@ -94,16 +94,21 @@ public:
     std::string Info() const override
     {
         std::stringstream buffer;
+        std::stringstream claw_buffer;
+        if (mConstitutiveLawVector.size() != 0) {
+            claw_buffer << mConstitutiveLawVector[0]->Info();
+        } else {
+            claw_buffer << "not defined";
+        }
         buffer << "U-Pw small strain link interface Element #" << this->Id()
-               << "\nConstitutive law: " << mConstitutiveLawVector[0]->Info();
+               << "\nConstitutive law: " << claw_buffer.str();
         return buffer.str();
     }
 
     // Print information about this object.
     void PrintInfo(std::ostream& rOStream) const override
     {
-        rOStream << "U-Pw small strain link interface Element #" << this->Id()
-                 << "\nConstitutive law: " << mConstitutiveLawVector[0]->Info();
+        rOStream << Info();
     }
 
     //----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

--- a/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_link_interface_element.hpp
+++ b/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_link_interface_element.hpp
@@ -93,23 +93,14 @@ public:
     // Turn back information as a string.
     std::string Info() const override
     {
-        std::stringstream buffer;
-        std::stringstream claw_buffer;
-        if (mConstitutiveLawVector.size() != 0) {
-            claw_buffer << mConstitutiveLawVector[0]->Info();
-        } else {
-            claw_buffer << "not defined";
-        }
-        buffer << "U-Pw small strain link interface Element #" << this->Id()
-               << "\nConstitutive law: " << claw_buffer.str();
-        return buffer.str();
+        const std::string constitutive_info =
+            !mConstitutiveLawVector.empty() ? mConstitutiveLawVector[0]->Info() : "not defined";
+        return "U-Pw small strain link interface Element #" + std::to_string(this->Id()) +
+               "\nConstitutive law: " + constitutive_info;
     }
 
     // Print information about this object.
-    void PrintInfo(std::ostream& rOStream) const override
-    {
-        rOStream << Info();
-    }
+    void PrintInfo(std::ostream& rOStream) const override { rOStream << Info(); }
 
     //----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 

--- a/applications/GeoMechanicsApplication/custom_elements/U_Pw_updated_lagrangian_FIC_element.hpp
+++ b/applications/GeoMechanicsApplication/custom_elements/U_Pw_updated_lagrangian_FIC_element.hpp
@@ -173,23 +173,14 @@ public:
     /// Turn back information as a string.
     std::string Info() const override
     {
-        std::stringstream buffer;
-        std::stringstream claw_buffer;
-        if (mConstitutiveLawVector.size() != 0) {
-            claw_buffer << mConstitutiveLawVector[0]->Info();
-        } else {
-            claw_buffer << "not defined";
-        }
-        buffer << "Updated Lagrangian U-Pw FIC Element #" << this->Id()
-               << "\nConstitutive law: " << claw_buffer.str();
-        return buffer.str();
+        const std::string constitutive_info =
+            !mConstitutiveLawVector.empty() ? mConstitutiveLawVector[0]->Info() : "not defined";
+        return "Updated Lagrangian U-Pw FIC Element #" + std::to_string(this->Id()) +
+               "\nConstitutive law: " + constitutive_info;
     }
 
     /// Print information about this object.
-    void PrintInfo(std::ostream& rOStream) const override
-    {
-        rOStream << Info();
-    }
+    void PrintInfo(std::ostream& rOStream) const override { rOStream << Info(); }
 
     /// Print object's data.
     void PrintData(std::ostream& rOStream) const override

--- a/applications/GeoMechanicsApplication/custom_elements/U_Pw_updated_lagrangian_FIC_element.hpp
+++ b/applications/GeoMechanicsApplication/custom_elements/U_Pw_updated_lagrangian_FIC_element.hpp
@@ -174,16 +174,21 @@ public:
     std::string Info() const override
     {
         std::stringstream buffer;
+        std::stringstream claw_buffer;
+        if (mConstitutiveLawVector.size() != 0) {
+            claw_buffer << mConstitutiveLawVector[0]->Info();
+        } else {
+            claw_buffer << "not defined";
+        }
         buffer << "Updated Lagrangian U-Pw FIC Element #" << this->Id()
-               << "\nConstitutive law: " << mConstitutiveLawVector[0]->Info();
+               << "\nConstitutive law: " << claw_buffer.str();
         return buffer.str();
     }
 
     /// Print information about this object.
     void PrintInfo(std::ostream& rOStream) const override
     {
-        rOStream << "Updated Lagrangian U-Pw FIC Element #" << this->Id()
-                 << "\nConstitutive law: " << mConstitutiveLawVector[0]->Info();
+        rOStream << Info();
     }
 
     /// Print object's data.

--- a/applications/GeoMechanicsApplication/custom_elements/U_Pw_updated_lagrangian_element.hpp
+++ b/applications/GeoMechanicsApplication/custom_elements/U_Pw_updated_lagrangian_element.hpp
@@ -172,23 +172,14 @@ public:
     /// Turn back information as a string.
     std::string Info() const override
     {
-        std::stringstream buffer;
-        std::stringstream claw_buffer;
-        if (mConstitutiveLawVector.size() != 0) {
-            claw_buffer << mConstitutiveLawVector[0]->Info();
-        } else {
-            claw_buffer << "not defined";
-        }
-        buffer << "Updated Lagrangian U-Pw Element #" << this->Id()
-               << "\nConstitutive law: " << claw_buffer.str();
-        return buffer.str();
+        const std::string constitutive_info =
+            !mConstitutiveLawVector.empty() ? mConstitutiveLawVector[0]->Info() : "not defined";
+        return "Updated Lagrangian U-Pw Element #" + std::to_string(this->Id()) +
+               "\nConstitutive law: " + constitutive_info;
     }
 
     /// Print information about this object.
-    void PrintInfo(std::ostream& rOStream) const override
-    {
-        rOStream << Info();
-    }
+    void PrintInfo(std::ostream& rOStream) const override { rOStream << Info(); }
 
     /// Print object's data.
     void PrintData(std::ostream& rOStream) const override

--- a/applications/GeoMechanicsApplication/custom_elements/U_Pw_updated_lagrangian_element.hpp
+++ b/applications/GeoMechanicsApplication/custom_elements/U_Pw_updated_lagrangian_element.hpp
@@ -173,16 +173,21 @@ public:
     std::string Info() const override
     {
         std::stringstream buffer;
+        std::stringstream claw_buffer;
+        if (mConstitutiveLawVector.size() != 0) {
+            claw_buffer << mConstitutiveLawVector[0]->Info();
+        } else {
+            claw_buffer << "not defined";
+        }
         buffer << "Updated Lagrangian U-Pw Element #" << this->Id()
-               << "\nConstitutive law: " << mConstitutiveLawVector[0]->Info();
+               << "\nConstitutive law: " << claw_buffer.str();
         return buffer.str();
     }
 
     /// Print information about this object.
     void PrintInfo(std::ostream& rOStream) const override
     {
-        rOStream << "Updated Lagrangian U-Pw Element #" << this->Id()
-                 << "\nConstitutive law: " << mConstitutiveLawVector[0]->Info();
+        rOStream << Info();
     }
 
     /// Print object's data.

--- a/applications/GeoMechanicsApplication/custom_elements/small_strain_U_Pw_diff_order_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/small_strain_U_Pw_diff_order_element.cpp
@@ -61,6 +61,9 @@ int SmallStrainUPwDiffOrderElement::Check(const ProcessInfo& rCurrentProcessInfo
     if (rGeom.DomainSize() < 1.0e-15)
         KRATOS_ERROR << "DomainSize < 1.0e-15 for the element " << this->Id() << std::endl;
 
+    // check pressure geometry pointer
+    KRATOS_DEBUG_ERROR_IF_NOT(mpPressureGeometry) << "Pressure Geometry is not defined\n";
+
     // verify that the variables are correctly initialized
     // Verify specific properties
     const PropertiesType& rProp = this->GetProperties();
@@ -160,20 +163,6 @@ int SmallStrainUPwDiffOrderElement::Check(const ProcessInfo& rCurrentProcessInfo
     }
 
     return 0;
-
-    KRATOS_CATCH("")
-}
-
-void SmallStrainUPwDiffOrderElement::Initialize(const ProcessInfo& rCurrentProcessInfo)
-{
-    KRATOS_TRY
-
-    UPwBaseElement::Initialize(rCurrentProcessInfo);
-
-    KRATOS_DEBUG_ERROR_IF_NOT(mpPressureGeometry) << "Pressure Geometry is not defined\n";
-    }
-
-    mIsInitialised = true;
 
     KRATOS_CATCH("")
 }

--- a/applications/GeoMechanicsApplication/custom_elements/small_strain_U_Pw_diff_order_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/small_strain_U_Pw_diff_order_element.cpp
@@ -170,49 +170,8 @@ void SmallStrainUPwDiffOrderElement::Initialize(const ProcessInfo& rCurrentProce
 
     UPwBaseElement::Initialize(rCurrentProcessInfo);
 
-    const auto& r_geometry        = GetGeometry();
-    const auto  number_of_U_nodes = r_geometry.PointsNumber();
-    const auto  dimension         = r_geometry.WorkingSpaceDimension();
-
-    switch (number_of_U_nodes) {
-    case 6: // 2D T6P3
-        mpPressureGeometry = make_shared<Triangle2D3<Node>>(r_geometry(0), r_geometry(1), r_geometry(2));
-        break;
-    case 8: // 2D Q8P4
-        mpPressureGeometry = make_shared<Quadrilateral2D4<Node>>(r_geometry(0), r_geometry(1),
-                                                                 r_geometry(2), r_geometry(3));
-        break;
-    case 9: // 2D Q9P4
-        mpPressureGeometry = make_shared<Quadrilateral2D4<Node>>(r_geometry(0), r_geometry(1),
-                                                                 r_geometry(2), r_geometry(3));
-        break;
-    case 10: // 3D T10P4  //2D T10P6
-        if (dimension == 3)
-            mpPressureGeometry = make_shared<Tetrahedra3D4<Node>>(r_geometry(0), r_geometry(1),
-                                                                  r_geometry(2), r_geometry(3));
-        else if (dimension == 2)
-            mpPressureGeometry = make_shared<Triangle2D6<Node>>(
-                r_geometry(0), r_geometry(1), r_geometry(2), r_geometry(3), r_geometry(4), r_geometry(5));
-        break;
-    case 15: // 2D T15P10
-        mpPressureGeometry = make_shared<Triangle2D10<Node>>(
-            r_geometry(0), r_geometry(1), r_geometry(2), r_geometry(3), r_geometry(4),
-            r_geometry(5), r_geometry(6), r_geometry(7), r_geometry(8), r_geometry(9));
-        break;
-    case 20: // 3D H20P8
-        mpPressureGeometry =
-            make_shared<Hexahedra3D8<Node>>(r_geometry(0), r_geometry(1), r_geometry(2), r_geometry(3),
-                                            r_geometry(4), r_geometry(5), r_geometry(6), r_geometry(7));
-        break;
-    case 27: // 3D H27P8
-        mpPressureGeometry =
-            make_shared<Hexahedra3D8<Node>>(r_geometry(0), r_geometry(1), r_geometry(2), r_geometry(3),
-                                            r_geometry(4), r_geometry(5), r_geometry(6), r_geometry(7));
-        break;
-    default:
-        KRATOS_ERROR << "Unexpected geometry type for different order "
-                        "interpolation element"
-                     << this->Id() << std::endl;
+    if (mpPressureGeometry == nullptr) {
+        this->SetUpPressureGeometryPointer();
     }
 
     mIsInitialised = true;
@@ -1585,6 +1544,41 @@ Element::DofsVectorType SmallStrainUPwDiffOrderElement::GetDofs() const
 {
     return Geo::DofUtilities::ExtractUPwDofsFromNodes(GetGeometry(), *mpPressureGeometry,
                                                       GetGeometry().WorkingSpaceDimension());
+}
+
+void SmallStrainUPwDiffOrderElement::SetUpPressureGeometryPointer()
+{
+    const auto& r_geometry = GetGeometry();
+    const auto number_of_U_nodes = r_geometry.PointsNumber();
+    const auto dimension = r_geometry.WorkingSpaceDimension();
+    switch (number_of_U_nodes) {
+        case 6: // 2D T6P3
+            mpPressureGeometry = make_shared<Triangle2D3<Node>>(r_geometry(0), r_geometry(1), r_geometry(2));
+            break;
+        case 8: // 2D Q8P4
+            mpPressureGeometry = make_shared<Quadrilateral2D4<Node>>(r_geometry(0), r_geometry(1), r_geometry(2), r_geometry(3));
+            break;
+        case 9: // 2D Q9P4
+            mpPressureGeometry = make_shared<Quadrilateral2D4<Node>>(r_geometry(0), r_geometry(1), r_geometry(2), r_geometry(3));
+            break;
+        case 10:
+            if (dimension == 3) // 3D T10P4
+                mpPressureGeometry = make_shared<Tetrahedra3D4<Node>>(r_geometry(0), r_geometry(1), r_geometry(2), r_geometry(3));
+            else if (dimension == 2) //2D T10P6
+                mpPressureGeometry = make_shared<Triangle2D6<Node>>(r_geometry(0), r_geometry(1), r_geometry(2), r_geometry(3), r_geometry(4), r_geometry(5));
+            break;
+        case 15: // 2D T15P10
+            mpPressureGeometry = make_shared<Triangle2D10<Node>>(r_geometry(0), r_geometry(1), r_geometry(2), r_geometry(3), r_geometry(4), r_geometry(5), r_geometry(6), r_geometry(7), r_geometry(8), r_geometry(9));
+            break;
+        case 20: // 3D H20P8
+            mpPressureGeometry = make_shared<Hexahedra3D8<Node>>(r_geometry(0), r_geometry(1), r_geometry(2), r_geometry(3), r_geometry(4), r_geometry(5), r_geometry(6), r_geometry(7));
+            break;
+        case 27: // 3D H27P8
+            mpPressureGeometry = make_shared<Hexahedra3D8<Node>>(r_geometry(0), r_geometry(1), r_geometry(2), r_geometry(3), r_geometry(4), r_geometry(5), r_geometry(6), r_geometry(7));
+            break;
+        default:
+            KRATOS_ERROR << "Unexpected geometry type for different order interpolation element " << this->Id() << std::endl;
+    }
 }
 
 Vector SmallStrainUPwDiffOrderElement::GetPressureSolutionVector()

--- a/applications/GeoMechanicsApplication/custom_elements/small_strain_U_Pw_diff_order_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/small_strain_U_Pw_diff_order_element.cpp
@@ -170,8 +170,7 @@ void SmallStrainUPwDiffOrderElement::Initialize(const ProcessInfo& rCurrentProce
 
     UPwBaseElement::Initialize(rCurrentProcessInfo);
 
-    if (mpPressureGeometry == nullptr) {
-        this->SetUpPressureGeometryPointer();
+    KRATOS_DEBUG_ERROR_IF_NOT(mpPressureGeometry) << "Pressure Geometry is not defined\n";
     }
 
     mIsInitialised = true;

--- a/applications/GeoMechanicsApplication/custom_elements/small_strain_U_Pw_diff_order_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/small_strain_U_Pw_diff_order_element.cpp
@@ -1536,36 +1536,47 @@ Element::DofsVectorType SmallStrainUPwDiffOrderElement::GetDofs() const
 
 void SmallStrainUPwDiffOrderElement::SetUpPressureGeometryPointer()
 {
-    const auto& r_geometry = GetGeometry();
-    const auto number_of_U_nodes = r_geometry.PointsNumber();
-    const auto dimension = r_geometry.WorkingSpaceDimension();
+    const auto& r_geometry        = GetGeometry();
+    const auto  number_of_U_nodes = r_geometry.PointsNumber();
+    const auto  dimension         = r_geometry.WorkingSpaceDimension();
     switch (number_of_U_nodes) {
-        case 6: // 2D T6P3
-            mpPressureGeometry = make_shared<Triangle2D3<Node>>(r_geometry(0), r_geometry(1), r_geometry(2));
-            break;
-        case 8: // 2D Q8P4
-            mpPressureGeometry = make_shared<Quadrilateral2D4<Node>>(r_geometry(0), r_geometry(1), r_geometry(2), r_geometry(3));
-            break;
-        case 9: // 2D Q9P4
-            mpPressureGeometry = make_shared<Quadrilateral2D4<Node>>(r_geometry(0), r_geometry(1), r_geometry(2), r_geometry(3));
-            break;
-        case 10:
-            if (dimension == 3) // 3D T10P4
-                mpPressureGeometry = make_shared<Tetrahedra3D4<Node>>(r_geometry(0), r_geometry(1), r_geometry(2), r_geometry(3));
-            else if (dimension == 2) //2D T10P6
-                mpPressureGeometry = make_shared<Triangle2D6<Node>>(r_geometry(0), r_geometry(1), r_geometry(2), r_geometry(3), r_geometry(4), r_geometry(5));
-            break;
-        case 15: // 2D T15P10
-            mpPressureGeometry = make_shared<Triangle2D10<Node>>(r_geometry(0), r_geometry(1), r_geometry(2), r_geometry(3), r_geometry(4), r_geometry(5), r_geometry(6), r_geometry(7), r_geometry(8), r_geometry(9));
-            break;
-        case 20: // 3D H20P8
-            mpPressureGeometry = make_shared<Hexahedra3D8<Node>>(r_geometry(0), r_geometry(1), r_geometry(2), r_geometry(3), r_geometry(4), r_geometry(5), r_geometry(6), r_geometry(7));
-            break;
-        case 27: // 3D H27P8
-            mpPressureGeometry = make_shared<Hexahedra3D8<Node>>(r_geometry(0), r_geometry(1), r_geometry(2), r_geometry(3), r_geometry(4), r_geometry(5), r_geometry(6), r_geometry(7));
-            break;
-        default:
-            KRATOS_ERROR << "Unexpected geometry type for different order interpolation element " << this->Id() << std::endl;
+    case 6: // 2D T6P3
+        mpPressureGeometry = make_shared<Triangle2D3<Node>>(r_geometry(0), r_geometry(1), r_geometry(2));
+        break;
+    case 8: // 2D Q8P4
+        mpPressureGeometry = make_shared<Quadrilateral2D4<Node>>(r_geometry(0), r_geometry(1),
+                                                                 r_geometry(2), r_geometry(3));
+        break;
+    case 9: // 2D Q9P4
+        mpPressureGeometry = make_shared<Quadrilateral2D4<Node>>(r_geometry(0), r_geometry(1),
+                                                                 r_geometry(2), r_geometry(3));
+        break;
+    case 10:
+        if (dimension == 3) // 3D T10P4
+            mpPressureGeometry = make_shared<Tetrahedra3D4<Node>>(r_geometry(0), r_geometry(1),
+                                                                  r_geometry(2), r_geometry(3));
+        else if (dimension == 2) // 2D T10P6
+            mpPressureGeometry = make_shared<Triangle2D6<Node>>(
+                r_geometry(0), r_geometry(1), r_geometry(2), r_geometry(3), r_geometry(4), r_geometry(5));
+        break;
+    case 15: // 2D T15P10
+        mpPressureGeometry = make_shared<Triangle2D10<Node>>(
+            r_geometry(0), r_geometry(1), r_geometry(2), r_geometry(3), r_geometry(4),
+            r_geometry(5), r_geometry(6), r_geometry(7), r_geometry(8), r_geometry(9));
+        break;
+    case 20: // 3D H20P8
+        mpPressureGeometry =
+            make_shared<Hexahedra3D8<Node>>(r_geometry(0), r_geometry(1), r_geometry(2), r_geometry(3),
+                                            r_geometry(4), r_geometry(5), r_geometry(6), r_geometry(7));
+        break;
+    case 27: // 3D H27P8
+        mpPressureGeometry =
+            make_shared<Hexahedra3D8<Node>>(r_geometry(0), r_geometry(1), r_geometry(2), r_geometry(3),
+                                            r_geometry(4), r_geometry(5), r_geometry(6), r_geometry(7));
+        break;
+    default:
+        KRATOS_ERROR << "Unexpected geometry type for different order interpolation element "
+                     << this->Id() << std::endl;
     }
 }
 

--- a/applications/GeoMechanicsApplication/custom_elements/small_strain_U_Pw_diff_order_element.hpp
+++ b/applications/GeoMechanicsApplication/custom_elements/small_strain_U_Pw_diff_order_element.hpp
@@ -71,8 +71,6 @@ public:
 
     int Check(const ProcessInfo& rCurrentProcessInfo) const override;
 
-    void Initialize(const ProcessInfo& rCurrentProcessInfo) override;
-
     void InitializeSolutionStep(const ProcessInfo& rCurrentProcessInfo) override;
 
     void FinalizeSolutionStep(const ProcessInfo& rCurrentProcessInfo) override;

--- a/applications/GeoMechanicsApplication/custom_elements/small_strain_U_Pw_diff_order_element.hpp
+++ b/applications/GeoMechanicsApplication/custom_elements/small_strain_U_Pw_diff_order_element.hpp
@@ -108,23 +108,14 @@ public:
     // Turn back information as a string.
     std::string Info() const override
     {
-        std::stringstream buffer;
-        std::stringstream claw_buffer;
-        if (mConstitutiveLawVector.size() != 0) {
-            claw_buffer << mConstitutiveLawVector[0]->Info();
-        } else {
-            claw_buffer << "not defined";
-        }
-        buffer << "U-Pw small strain different order Element #" << Id()
-               << "\nConstitutive law: " << claw_buffer.str();
-        return buffer.str();
+        const std::string constitutive_info =
+            !mConstitutiveLawVector.empty() ? mConstitutiveLawVector[0]->Info() : "not defined";
+        return "U-Pw small strain different order Element #" + std::to_string(Id()) +
+               "\nConstitutive law: " + constitutive_info;
     }
 
     // Print information about this object.
-    void PrintInfo(std::ostream& rOStream) const override
-    {
-        rOStream << Info();
-    }
+    void PrintInfo(std::ostream& rOStream) const override { rOStream << Info(); }
 
 protected:
     struct ElementVariables {

--- a/applications/GeoMechanicsApplication/custom_elements/small_strain_U_Pw_diff_order_element.hpp
+++ b/applications/GeoMechanicsApplication/custom_elements/small_strain_U_Pw_diff_order_element.hpp
@@ -49,7 +49,7 @@ public:
                                    std::unique_ptr<StressStatePolicy> pStressStatePolicy)
         : UPwBaseElement(NewId, pGeometry, std::move(pStressStatePolicy))
     {
-        this->SetUpPressureGeometryPointer();
+        SetUpPressureGeometryPointer();
     }
 
     SmallStrainUPwDiffOrderElement(IndexType                          NewId,

--- a/applications/GeoMechanicsApplication/custom_elements/small_strain_U_Pw_diff_order_element.hpp
+++ b/applications/GeoMechanicsApplication/custom_elements/small_strain_U_Pw_diff_order_element.hpp
@@ -58,7 +58,7 @@ public:
                                    std::unique_ptr<StressStatePolicy> pStressStatePolicy)
         : UPwBaseElement(NewId, pGeometry, pProperties, std::move(pStressStatePolicy))
     {
-        this->SetUpPressureGeometryPointer();
+        SetUpPressureGeometryPointer();
     }
 
     ~SmallStrainUPwDiffOrderElement() override = default;

--- a/applications/GeoMechanicsApplication/custom_elements/small_strain_U_Pw_diff_order_element.hpp
+++ b/applications/GeoMechanicsApplication/custom_elements/small_strain_U_Pw_diff_order_element.hpp
@@ -49,6 +49,7 @@ public:
                                    std::unique_ptr<StressStatePolicy> pStressStatePolicy)
         : UPwBaseElement(NewId, pGeometry, std::move(pStressStatePolicy))
     {
+        this->SetUpPressureGeometryPointer();
     }
 
     SmallStrainUPwDiffOrderElement(IndexType                          NewId,
@@ -57,6 +58,7 @@ public:
                                    std::unique_ptr<StressStatePolicy> pStressStatePolicy)
         : UPwBaseElement(NewId, pGeometry, pProperties, std::move(pStressStatePolicy))
     {
+        this->SetUpPressureGeometryPointer();
     }
 
     ~SmallStrainUPwDiffOrderElement() override = default;
@@ -109,16 +111,21 @@ public:
     std::string Info() const override
     {
         std::stringstream buffer;
+        std::stringstream claw_buffer;
+        if (mConstitutiveLawVector.size() != 0) {
+            claw_buffer << mConstitutiveLawVector[0]->Info();
+        } else {
+            claw_buffer << "not defined";
+        }
         buffer << "U-Pw small strain different order Element #" << Id()
-               << "\nConstitutive law: " << mConstitutiveLawVector[0]->Info();
+               << "\nConstitutive law: " << claw_buffer.str();
         return buffer.str();
     }
 
     // Print information about this object.
     void PrintInfo(std::ostream& rOStream) const override
     {
-        rOStream << "U-Pw small strain different order Element #" << Id()
-                 << "\nConstitutive law: " << mConstitutiveLawVector[0]->Info();
+        rOStream << Info();
     }
 
 protected:
@@ -261,6 +268,13 @@ private:
     GeometryType::Pointer mpPressureGeometry;
 
     [[nodiscard]] DofsVectorType GetDofs() const override;
+
+    /**
+     * @brief Sets the up the pressure geometry pointer object
+     * This function sets the pointer for the auxiliary geometry for the pressure problem
+     * The pressure geometry pointer is set according to the element geometry number of nodes and dimension
+     */
+    void SetUpPressureGeometryPointer();
 
     // Serialization
 

--- a/applications/GeoMechanicsApplication/custom_elements/steady_state_Pw_element.hpp
+++ b/applications/GeoMechanicsApplication/custom_elements/steady_state_Pw_element.hpp
@@ -94,23 +94,13 @@ public:
     // Turn back information as a string.
     std::string Info() const override
     {
-        std::stringstream buffer;
-        std::stringstream retention_law_buffer;
-        if (mConstitutiveLawVector.size() != 0) {
-            retention_law_buffer << mRetentionLawVector[0]->Info();
-        } else {
-            retention_law_buffer << "not defined";
-        }
-        buffer << "steady-state Pw flow Element #" << this->Id()
-               << "\nRetention law: " << retention_law_buffer.str();
-        return buffer.str();
+        const std::string retention_info =
+            !mRetentionLawVector.empty() ? mRetentionLawVector[0]->Info() : "not defined";
+        return "steady-state Pw flow Element #" + std::to_string(this->Id()) + "\nRetention law: " + retention_info;
     }
 
     // Print information about this object.
-    void PrintInfo(std::ostream& rOStream) const override
-    {
-        rOStream << Info();
-    }
+    void PrintInfo(std::ostream& rOStream) const override { rOStream << Info(); }
 
     ///----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 

--- a/applications/GeoMechanicsApplication/custom_elements/steady_state_Pw_element.hpp
+++ b/applications/GeoMechanicsApplication/custom_elements/steady_state_Pw_element.hpp
@@ -95,16 +95,21 @@ public:
     std::string Info() const override
     {
         std::stringstream buffer;
+        std::stringstream retention_law_buffer;
+        if (mConstitutiveLawVector.size() != 0) {
+            retention_law_buffer << mRetentionLawVector[0]->Info();
+        } else {
+            retention_law_buffer << "not defined";
+        }
         buffer << "steady-state Pw flow Element #" << this->Id()
-               << "\nRetention law: " << mRetentionLawVector[0]->Info();
+               << "\nRetention law: " << retention_law_buffer.str();
         return buffer.str();
     }
 
     // Print information about this object.
     void PrintInfo(std::ostream& rOStream) const override
     {
-        rOStream << "steady-state Pw flow Element #" << this->Id()
-                 << "\nRetention law: " << mRetentionLawVector[0]->Info();
+        rOStream << Info();
     }
 
     ///----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

--- a/applications/GeoMechanicsApplication/custom_elements/transient_Pw_element.hpp
+++ b/applications/GeoMechanicsApplication/custom_elements/transient_Pw_element.hpp
@@ -119,22 +119,13 @@ public:
     std::string Info() const override
     {
         std::stringstream buffer;
-        std::stringstream retention_law_buffer;
-        if (mConstitutiveLawVector.size() != 0) {
-            retention_law_buffer << mRetentionLawVector[0]->Info();
-        } else {
-            retention_law_buffer << "not defined";
-        }
-        buffer << "transient Pw flow Element #" << this->Id()
-               << "\nRetention law: " << retention_law_buffer.str();
-        return buffer.str();
+        const std::string retention_info =
+            !mRetentionLawVector.empty() ? mRetentionLawVector[0]->Info() : "not defined";
+        return "transient Pw flow Element #" + std::to_string(this->Id()) + "\nRetention law: " + retention_info;
     }
 
     // Print information about this object.
-    void PrintInfo(std::ostream& rOStream) const override
-    {
-        rOStream << Info();
-    }
+    void PrintInfo(std::ostream& rOStream) const override { rOStream << Info(); }
 
 protected:
     void CalculateAll(MatrixType&        rLeftHandSideMatrix,

--- a/applications/GeoMechanicsApplication/custom_elements/transient_Pw_element.hpp
+++ b/applications/GeoMechanicsApplication/custom_elements/transient_Pw_element.hpp
@@ -118,7 +118,6 @@ public:
     // Turn back information as a string.
     std::string Info() const override
     {
-        std::stringstream buffer;
         const std::string retention_info =
             !mRetentionLawVector.empty() ? mRetentionLawVector[0]->Info() : "not defined";
         return "transient Pw flow Element #" + std::to_string(this->Id()) + "\nRetention law: " + retention_info;

--- a/applications/GeoMechanicsApplication/custom_elements/transient_Pw_element.hpp
+++ b/applications/GeoMechanicsApplication/custom_elements/transient_Pw_element.hpp
@@ -119,16 +119,21 @@ public:
     std::string Info() const override
     {
         std::stringstream buffer;
+        std::stringstream retention_law_buffer;
+        if (mConstitutiveLawVector.size() != 0) {
+            retention_law_buffer << mRetentionLawVector[0]->Info();
+        } else {
+            retention_law_buffer << "not defined";
+        }
         buffer << "transient Pw flow Element #" << this->Id()
-               << "\nRetention law: " << mRetentionLawVector[0]->Info();
+               << "\nRetention law: " << retention_law_buffer.str();
         return buffer.str();
     }
 
     // Print information about this object.
     void PrintInfo(std::ostream& rOStream) const override
     {
-        rOStream << "transient Pw flow Element #" << this->Id()
-                 << "\nRetention law: " << mRetentionLawVector[0]->Info();
+        rOStream << Info();
     }
 
 protected:

--- a/applications/GeoMechanicsApplication/custom_elements/undrained_U_Pw_small_strain_element.hpp
+++ b/applications/GeoMechanicsApplication/custom_elements/undrained_U_Pw_small_strain_element.hpp
@@ -95,23 +95,14 @@ public:
     // Turn back information as a string.
     std::string Info() const override
     {
-        std::stringstream buffer;
-        std::stringstream claw_buffer;
-        if (mConstitutiveLawVector.size() != 0) {
-            claw_buffer << mConstitutiveLawVector[0]->Info();
-        } else {
-            claw_buffer << "not defined";
-        }
-        buffer << "undrained small strain Element #" << this->Id()
-               << "\nConstitutive law: " << claw_buffer.str();
-        return buffer.str();
+        const std::string constitutive_info =
+            !mConstitutiveLawVector.empty() ? mConstitutiveLawVector[0]->Info() : "not defined";
+        return "undrained small strain Element #" + std::to_string(this->Id()) +
+               "\nConstitutive law: " + constitutive_info;
     }
 
     // Print information about this object.
-    void PrintInfo(std::ostream& rOStream) const override
-    {
-        rOStream << Info();
-    }
+    void PrintInfo(std::ostream& rOStream) const override { rOStream << Info(); }
 
     ///----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 

--- a/applications/GeoMechanicsApplication/custom_elements/undrained_U_Pw_small_strain_element.hpp
+++ b/applications/GeoMechanicsApplication/custom_elements/undrained_U_Pw_small_strain_element.hpp
@@ -96,16 +96,21 @@ public:
     std::string Info() const override
     {
         std::stringstream buffer;
+        std::stringstream claw_buffer;
+        if (mConstitutiveLawVector.size() != 0) {
+            claw_buffer << mConstitutiveLawVector[0]->Info();
+        } else {
+            claw_buffer << "not defined";
+        }
         buffer << "undrained small strain Element #" << this->Id()
-               << "\nConstitutive law: " << mConstitutiveLawVector[0]->Info();
+               << "\nConstitutive law: " << claw_buffer.str();
         return buffer.str();
     }
 
     // Print information about this object.
     void PrintInfo(std::ostream& rOStream) const override
     {
-        rOStream << "undrained small strain Element #" << this->Id()
-                 << "\nConstitutive law: " << mConstitutiveLawVector[0]->Info();
+        rOStream << Info();
     }
 
     ///----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

--- a/applications/GeoMechanicsApplication/custom_elements/updated_lagrangian_U_Pw_diff_order_element.hpp
+++ b/applications/GeoMechanicsApplication/custom_elements/updated_lagrangian_U_Pw_diff_order_element.hpp
@@ -162,16 +162,21 @@ public:
     std::string Info() const override
     {
         std::stringstream buffer;
+        std::stringstream claw_buffer;
+        if (mConstitutiveLawVector.size() != 0) {
+            claw_buffer << mConstitutiveLawVector[0]->Info();
+        } else {
+            claw_buffer << "not defined";
+        }
         buffer << "Updated Lagrangian U-Pw different order Element #" << this->Id()
-               << "\nConstitutive law: " << mConstitutiveLawVector[0]->Info();
+               << "\nConstitutive law: " << claw_buffer.str();
         return buffer.str();
     }
 
     /// Print information about this object.
     void PrintInfo(std::ostream& rOStream) const override
     {
-        rOStream << "Updated Lagrangian U-Pw different order Element #" << this->Id()
-                 << "\nConstitutive law: " << mConstitutiveLawVector[0]->Info();
+        rOStream << Info();
     }
 
     /// Print object's data.

--- a/applications/GeoMechanicsApplication/custom_elements/updated_lagrangian_U_Pw_diff_order_element.hpp
+++ b/applications/GeoMechanicsApplication/custom_elements/updated_lagrangian_U_Pw_diff_order_element.hpp
@@ -161,23 +161,14 @@ public:
     /// Turn back information as a string.
     std::string Info() const override
     {
-        std::stringstream buffer;
-        std::stringstream claw_buffer;
-        if (mConstitutiveLawVector.size() != 0) {
-            claw_buffer << mConstitutiveLawVector[0]->Info();
-        } else {
-            claw_buffer << "not defined";
-        }
-        buffer << "Updated Lagrangian U-Pw different order Element #" << this->Id()
-               << "\nConstitutive law: " << claw_buffer.str();
-        return buffer.str();
+        const std::string constitutive_info =
+            !mConstitutiveLawVector.empty() ? mConstitutiveLawVector[0]->Info() : "not defined";
+        return "Updated Lagrangian U-Pw different order Element #" + std::to_string(this->Id()) +
+               "\nConstitutive law: " + constitutive_info;
     }
 
     /// Print information about this object.
-    void PrintInfo(std::ostream& rOStream) const override
-    {
-        rOStream << Info();
-    }
+    void PrintInfo(std::ostream& rOStream) const override { rOStream << Info(); }
 
     /// Print object's data.
     void PrintData(std::ostream& rOStream) const override


### PR DESCRIPTION
**📝 Description**
While checking the CI for #12700 I realized of these segfaults in the `GeoMechanicsApplication`. Most of them only raise while debugging. I mean the `PrintData` ones, which previous implementation used to segfault if the constitutive law pointer was not defined. However, the most important one is the __u__ -p element, which pressure geometry pointer was defined in the `Initialize`. In my opinion, this should be done at construction time.

EDIT: note that the issue of the geometry pointer is quite important, as the depending on the strategy implementation chances are that the dof-set is created before the `Initialize` call of the entities. This is on the safe-side.
