### PR TITLE
[OptApp] Fix Response Routine

### DIFF
--- a/applications/OptimizationApplication/python_scripts/responses/response_routine.py
+++ b/applications/OptimizationApplication/python_scripts/responses/response_routine.py
@@ -17,7 +17,6 @@ class ResponseRoutine:
         # set the response
         self.__response = response
         self.__response_value = None
-        self.value_calculate_count = 0
         self.__contributing_controls_list: 'list[Control]' = []
         self.__required_physical_gradients: 'dict[SupportedSensitivityFieldVariableTypes, KratosOA.CollectiveExpression]' = {}
 

--- a/applications/OptimizationApplication/python_scripts/responses/response_routine.py
+++ b/applications/OptimizationApplication/python_scripts/responses/response_routine.py
@@ -4,6 +4,7 @@ from KratosMultiphysics.OptimizationApplication.controls.control import Control
 from KratosMultiphysics.OptimizationApplication.responses.response_function import ResponseFunction
 from KratosMultiphysics.OptimizationApplication.controls.master_control import MasterControl
 from KratosMultiphysics.OptimizationApplication.utilities.union_utilities import SupportedSensitivityFieldVariableTypes
+import math
 
 class ResponseRoutine:
     """A class which adds optimization-specific utilities to simplify routines
@@ -16,7 +17,7 @@ class ResponseRoutine:
         # set the response
         self.__response = response
         self.__response_value = None
-
+        self.value_calculate_count = 0
         self.__contributing_controls_list: 'list[Control]' = []
         self.__required_physical_gradients: 'dict[SupportedSensitivityFieldVariableTypes, KratosOA.CollectiveExpression]' = {}
 
@@ -55,6 +56,8 @@ class ResponseRoutine:
 
         if not self.__contributing_controls_list:
             raise RuntimeError(f"The controls does not have any influence over the response {self.GetResponseName()}.")
+        
+        self.my_current_control_field = self.__master_control.GetEmptyField()
 
     def Check(self):
         self.__response.Check()
@@ -86,13 +89,14 @@ class ResponseRoutine:
         compute_response_value_flag = False
         if self.__response_value is None:
             self.my_current_control_field = control_field.Clone()
-        diff = self.my_current_control_field - control_field
-        norm = KratosOA.ExpressionUtils.NormInf(diff)
-        if norm > 1e-12:
+        if not math.isclose(KratosOA.ExpressionUtils.NormInf(self.my_current_control_field), 0.0, abs_tol=1e-16):
+            rel_diff = (self.my_current_control_field - control_field) / KratosOA.ExpressionUtils.NormInf(self.my_current_control_field)
+        else:
+            rel_diff = (self.my_current_control_field - control_field)
+        norm = KratosOA.ExpressionUtils.NormInf(rel_diff)
+        if not math.isclose(norm, 0.0, abs_tol=1e-16):
             compute_response_value_flag = True
-        compute_response_value_flag = compute_response_value_flag or self.__response_value is None
-
-        # TODO: In the case of having two analysis with the same mesh (model parts) for two different
+        compute_response_value_flag = compute_response_value_flag or self.__response_value is None        # TODO: In the case of having two analysis with the same mesh (model parts) for two different
         #       responses, we need to flag all the anayses which are affected by the control update_state
         #       from the first call, otherwise the second call will not update anything, hence no execution
         #       policies will be executed.
@@ -107,6 +111,12 @@ class ResponseRoutine:
 
         if compute_response_value_flag:
             self.__response_value = self.__response.CalculateValue()
+            Kratos.Logger.PrintInfo(f"Response value is calculated for {self.GetResponseName()}.")
+        else:
+            Kratos.Logger.PrintInfo(f"The control field is not updated, hence the response value is not computed for {self.GetResponseName()}.")
+
+        # Update current control field state
+        self.my_current_control_field = control_field.Clone()
 
         return self.__response_value
 


### PR DESCRIPTION
This pull request includes several changes to the `ResponseRoutine` class in the `response_routine.py` file, aimed at improving the control field handling and logging for response value calculations. The most important changes include the addition of a new import, initialization of a new attribute, updates to the control field handling logic, and enhanced logging.

### Improvements to control field handling:

* [`applications/OptimizationApplication/python_scripts/responses/response_routine.py`](diffhunk://#diff-d9d412a04c150d0686c9ea0e5a265088e89b1b5c5ca5c490a2cd6fc736bc264aR7): Added `math` import to support new mathematical operations.
* `__init__` method: Initialized `value_calculate_count` attribute to track the number of times the response value is calculated.
* `Initialize` method: Added `my_current_control_field` initialization to store the current control field state.
* `CalculateValue` method: Updated the logic to use relative differences and `math.isclose` for more accurate control field comparisons.

### Enhanced logging:

* `CalculateValue` method: Added logging to indicate whether the response value was computed or skipped based on control field updates.**📝 Description**
