### PR TITLE
[GeoMechanicsApplication] Fixed a typo: 'PlainStrain' => 'PlaneStrain'

### DIFF
--- a/applications/GeoMechanicsApplication/geo_mechanics_application.cpp
+++ b/applications/GeoMechanicsApplication/geo_mechanics_application.cpp
@@ -155,8 +155,8 @@ void KratosGeoMechanicsApplication::Register()
     KRATOS_REGISTER_ELEMENT("UPwSmallStrainLinkInterfaceElement3D6N", mUPwSmallStrainLinkInterfaceElement3D6N)
     KRATOS_REGISTER_ELEMENT("UPwSmallStrainLinkInterfaceElement3D8N", mUPwSmallStrainLinkInterfaceElement3D8N)
 
-    KRATOS_REGISTER_ELEMENT("Geo_UPwLineInterfacePlaneStrainElement2Plus2N", mUPwLineInterfacePlaneStrainElement2Plus2N)
-    KRATOS_REGISTER_ELEMENT("Geo_UPwLineInterfacePlaneStrainElement3Plus3N", mUPwLineInterfacePlaneStrainElement3Plus3N)
+    KRATOS_REGISTER_ELEMENT("Geo_ULineInterfacePlaneStrainElement2Plus2N", mULineInterfacePlaneStrainElement2Plus2N)
+    KRATOS_REGISTER_ELEMENT("Geo_ULineInterfacePlaneStrainElement3Plus3N", mULineInterfacePlaneStrainElement3Plus3N)
 
     // Updated-Lagranian elements
     KRATOS_REGISTER_ELEMENT("UPwUpdatedLagrangianElement2D3N", mUPwUpdatedLagrangianElement2D3N)

--- a/applications/GeoMechanicsApplication/geo_mechanics_application.cpp
+++ b/applications/GeoMechanicsApplication/geo_mechanics_application.cpp
@@ -155,8 +155,8 @@ void KratosGeoMechanicsApplication::Register()
     KRATOS_REGISTER_ELEMENT("UPwSmallStrainLinkInterfaceElement3D6N", mUPwSmallStrainLinkInterfaceElement3D6N)
     KRATOS_REGISTER_ELEMENT("UPwSmallStrainLinkInterfaceElement3D8N", mUPwSmallStrainLinkInterfaceElement3D8N)
 
-    KRATOS_REGISTER_ELEMENT("Geo_UPwLineInterfacePlainStrainElement2Plus2N", mUPwLineInterfacePlaneStrainElement2Plus2N)
-    KRATOS_REGISTER_ELEMENT("Geo_UPwLineInterfacePlainStrainElement3Plus3N", mUPwLineInterfacePlaneStrainElement3Plus3N)
+    KRATOS_REGISTER_ELEMENT("Geo_UPwLineInterfacePlaneStrainElement2Plus2N", mUPwLineInterfacePlaneStrainElement2Plus2N)
+    KRATOS_REGISTER_ELEMENT("Geo_UPwLineInterfacePlaneStrainElement3Plus3N", mUPwLineInterfacePlaneStrainElement3Plus3N)
 
     // Updated-Lagranian elements
     KRATOS_REGISTER_ELEMENT("UPwUpdatedLagrangianElement2D3N", mUPwUpdatedLagrangianElement2D3N)

--- a/applications/GeoMechanicsApplication/geo_mechanics_application.h
+++ b/applications/GeoMechanicsApplication/geo_mechanics_application.h
@@ -560,10 +560,10 @@ private:
         0, Kratos::make_shared<HexahedraInterface3D8<NodeType>>(Element::GeometryType::PointsArrayType(8)),
         std::make_unique<ThreeDimensionalStressState>()};
 
-    const LineInterfaceElement mUPwLineInterfacePlaneStrainElement2Plus2N{
+    const LineInterfaceElement mULineInterfacePlaneStrainElement2Plus2N{
         0, Kratos::make_shared<LineInterfaceGeometry<Line2D2<NodeType>>>(
                Element::GeometryType::PointsArrayType(4))};
-    const LineInterfaceElement mUPwLineInterfacePlaneStrainElement3Plus3N{
+    const LineInterfaceElement mULineInterfacePlaneStrainElement3Plus3N{
         0, Kratos::make_shared<LineInterfaceGeometry<Line2D3<NodeType>>>(
                Element::GeometryType::PointsArrayType(6))};
 

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/test_geo_mechanics_application.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/test_geo_mechanics_application.cpp
@@ -76,8 +76,8 @@ KRATOS_TEST_CASE_IN_SUITE(LineInterfaceElementsAreAvailableAfterGeoAppRegistrati
 {
     KratosGeoMechanicsApplication geo_app;
     const auto                    element_type_names =
-        std::vector<std::string>{"Geo_UPwLineInterfacePlaneStrainElement2Plus2N",
-                                 "Geo_UPwLineInterfacePlaneStrainElement3Plus3N"};
+        std::vector<std::string>{"Geo_ULineInterfacePlaneStrainElement2Plus2N",
+                                 "Geo_ULineInterfacePlaneStrainElement3Plus3N"};
 
     for (const auto& r_name : element_type_names) {
         KRATOS_EXPECT_FALSE(KratosComponents<Element>::Has(r_name))

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/test_geo_mechanics_application.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/test_geo_mechanics_application.cpp
@@ -76,8 +76,8 @@ KRATOS_TEST_CASE_IN_SUITE(LineInterfaceElementsAreAvailableAfterGeoAppRegistrati
 {
     KratosGeoMechanicsApplication geo_app;
     const auto                    element_type_names =
-        std::vector<std::string>{"Geo_UPwLineInterfacePlainStrainElement2Plus2N",
-                                 "Geo_UPwLineInterfacePlainStrainElement3Plus3N"};
+        std::vector<std::string>{"Geo_UPwLineInterfacePlaneStrainElement2Plus2N",
+                                 "Geo_UPwLineInterfacePlaneStrainElement3Plus3N"};
 
     for (const auto& r_name : element_type_names) {
         KRATOS_EXPECT_FALSE(KratosComponents<Element>::Has(r_name))

--- a/applications/GeoMechanicsApplication/tests/line_interface_elements/Dirichlet_multi_stage/3+3_line.mdpa
+++ b/applications/GeoMechanicsApplication/tests/line_interface_elements/Dirichlet_multi_stage/3+3_line.mdpa
@@ -26,7 +26,7 @@ Begin Nodes
  13  7.0000000000 0.0000000000 0.0000000000
 End Nodes
 
-Begin Elements Geo_UPwLineInterfacePlainStrainElement3Plus3N
+Begin Elements Geo_UPwLineInterfacePlaneStrainElement3Plus3N
   1  1   1   3   2  11  13  12
 End Elements
 

--- a/applications/GeoMechanicsApplication/tests/line_interface_elements/Dirichlet_multi_stage/3+3_line.mdpa
+++ b/applications/GeoMechanicsApplication/tests/line_interface_elements/Dirichlet_multi_stage/3+3_line.mdpa
@@ -26,7 +26,7 @@ Begin Nodes
  13  7.0000000000 0.0000000000 0.0000000000
 End Nodes
 
-Begin Elements Geo_UPwLineInterfacePlaneStrainElement3Plus3N
+Begin Elements Geo_ULineInterfacePlaneStrainElement3Plus3N
   1  1   1   3   2  11  13  12
 End Elements
 

--- a/applications/GeoMechanicsApplication/tests/line_interface_elements/Dirichlet_single_stage/line_interface_3_plus_3N.mdpa
+++ b/applications/GeoMechanicsApplication/tests/line_interface_elements/Dirichlet_single_stage/line_interface_3_plus_3N.mdpa
@@ -20,7 +20,7 @@ Begin Nodes
  33  0.0000000000 7.0000000000 0.0000000000
 End Nodes
 
-Begin Elements Geo_UPwLineInterfacePlainStrainElement3Plus3N
+Begin Elements Geo_UPwLineInterfacePlaneStrainElement3Plus3N
   1  1   1   3   2  11  13  12
  11  1  31  33  32  21  23  22
 End Elements

--- a/applications/GeoMechanicsApplication/tests/line_interface_elements/Dirichlet_single_stage/line_interface_3_plus_3N.mdpa
+++ b/applications/GeoMechanicsApplication/tests/line_interface_elements/Dirichlet_single_stage/line_interface_3_plus_3N.mdpa
@@ -20,7 +20,7 @@ Begin Nodes
  33  0.0000000000 7.0000000000 0.0000000000
 End Nodes
 
-Begin Elements Geo_UPwLineInterfacePlaneStrainElement3Plus3N
+Begin Elements Geo_ULineInterfacePlaneStrainElement3Plus3N
   1  1   1   3   2  11  13  12
  11  1  31  33  32  21  23  22
 End Elements

--- a/applications/GeoMechanicsApplication/tests/line_interface_elements/Neumann_multi_stage/3+3_line.mdpa
+++ b/applications/GeoMechanicsApplication/tests/line_interface_elements/Neumann_multi_stage/3+3_line.mdpa
@@ -29,7 +29,7 @@ Begin Nodes
  13  7.0000000000 0.0000000000 0.0000000000
 End Nodes
 
-Begin Elements Geo_UPwLineInterfacePlaneStrainElement3Plus3N
+Begin Elements Geo_ULineInterfacePlaneStrainElement3Plus3N
   1  1   1   3   2  11  13  12
 End Elements
 

--- a/applications/GeoMechanicsApplication/tests/line_interface_elements/Neumann_multi_stage/3+3_line.mdpa
+++ b/applications/GeoMechanicsApplication/tests/line_interface_elements/Neumann_multi_stage/3+3_line.mdpa
@@ -29,7 +29,7 @@ Begin Nodes
  13  7.0000000000 0.0000000000 0.0000000000
 End Nodes
 
-Begin Elements Geo_UPwLineInterfacePlainStrainElement3Plus3N
+Begin Elements Geo_UPwLineInterfacePlaneStrainElement3Plus3N
   1  1   1   3   2  11  13  12
 End Elements
 

--- a/applications/GeoMechanicsApplication/tests/line_interface_elements/Neumann_single_stage/line_interface_3_plus_3N.mdpa
+++ b/applications/GeoMechanicsApplication/tests/line_interface_elements/Neumann_single_stage/line_interface_3_plus_3N.mdpa
@@ -20,7 +20,7 @@ Begin Nodes
  33  0.0000000000 7.0000000000 0.0000000000
 End Nodes
 
-Begin Elements Geo_UPwLineInterfacePlainStrainElement3Plus3N
+Begin Elements Geo_UPwLineInterfacePlaneStrainElement3Plus3N
   1  1   1   3   2  11  13  12
  11  1  31  33  32  21  23  22
 End Elements

--- a/applications/GeoMechanicsApplication/tests/line_interface_elements/Neumann_single_stage/line_interface_3_plus_3N.mdpa
+++ b/applications/GeoMechanicsApplication/tests/line_interface_elements/Neumann_single_stage/line_interface_3_plus_3N.mdpa
@@ -20,7 +20,7 @@ Begin Nodes
  33  0.0000000000 7.0000000000 0.0000000000
 End Nodes
 
-Begin Elements Geo_UPwLineInterfacePlaneStrainElement3Plus3N
+Begin Elements Geo_ULineInterfacePlaneStrainElement3Plus3N
   1  1   1   3   2  11  13  12
  11  1  31  33  32  21  23  22
 End Elements


### PR DESCRIPTION
**📝 Description**

Fixed a typo in two element type names: 'PlainStrain' => 'PlaneStrain'.
