### PR TITLE
if param is integer, read it as double, it's not a mistake

### DIFF
--- a/applications/ConvectionDiffusionApplication/python_scripts/convection_diffusion_solver.py
+++ b/applications/ConvectionDiffusionApplication/python_scripts/convection_diffusion_solver.py
@@ -472,7 +472,7 @@ class ConvectionDiffusionSolver(PythonSolver):
             for key, value in mat["Variables"].items():
                 var = KratosMultiphysics.KratosGlobals.GetVariable(key)
                 if (self._check_variable_to_set(var)):
-                    if value.IsDouble() or value.IsInt():
+                    if value.IsNumber():
                         KratosMultiphysics.VariableUtils().SetVariable(var, value.GetDouble(), model_part.Nodes)
                     elif value.IsVector():
                         KratosMultiphysics.VariableUtils().SetVariable(var, value.GetVector(), model_part.Nodes)

--- a/applications/ConvectionDiffusionApplication/python_scripts/convection_diffusion_solver.py
+++ b/applications/ConvectionDiffusionApplication/python_scripts/convection_diffusion_solver.py
@@ -472,7 +472,7 @@ class ConvectionDiffusionSolver(PythonSolver):
             for key, value in mat["Variables"].items():
                 var = KratosMultiphysics.KratosGlobals.GetVariable(key)
                 if (self._check_variable_to_set(var)):
-                    if value.IsDouble():
+                    if value.IsDouble() or value.IsInt():
                         KratosMultiphysics.VariableUtils().SetVariable(var, value.GetDouble(), model_part.Nodes)
                     elif value.IsVector():
                         KratosMultiphysics.VariableUtils().SetVariable(var, value.GetVector(), model_part.Nodes)


### PR DESCRIPTION
Having this input in ConvectionDiffusionMaterials.json
```json

{
    "properties" : [{
        "model_part_name" : "ThermalModelPart.Heating",
        "properties_id"   : 2,
        "Material"        : {
            "Variables" : {
                "DENSITY"       : 0.0,
                "CONDUCTIVITY"  : 10,
                "SPECIFIC_HEAT" : 0.0
            },
            "Tables"    : null
        }
    }]
}

```
fails, because the read function says that conductivity value is not properly set.

This allows the user to set 10 instead of 10.0

@rubenzorrilla  (lo pongo como draft porque no se si es mejor esta solución, o hacer un mensaje de error más explicativo sobre cual de los parámetros falla, y que el usuario lo corrija)