### PR TITLE
[GeoMechanicsApplication] Make element provided strain the default for our constitutive laws

### DIFF
--- a/applications/GeoMechanicsApplication/custom_constitutive/linear_elastic_law.cpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/linear_elastic_law.cpp
@@ -52,7 +52,8 @@ void GeoLinearElasticLaw::CalculateMaterialResponsePK2(ConstitutiveLaw::Paramete
 
     const Flags& r_options = rValues.GetOptions();
 
-    KRATOS_DEBUG_ERROR_IF(r_options.IsNot(ConstitutiveLaw::USE_ELEMENT_PROVIDED_STRAIN))
+    KRATOS_DEBUG_ERROR_IF(r_options.IsDefined(ConstitutiveLaw::USE_ELEMENT_PROVIDED_STRAIN) &&
+                          r_options.IsNot(ConstitutiveLaw::USE_ELEMENT_PROVIDED_STRAIN))
         << "The GeoLinearElasticLaw needs an element provided strain" << std::endl;
 
     KRATOS_ERROR_IF(!rValues.IsSetStrainVector() || rValues.GetStrainVector().size() != GetStrainSize())

--- a/applications/GeoMechanicsApplication/custom_constitutive/linear_elastic_plane_strain_2D_law.cpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/linear_elastic_plane_strain_2D_law.cpp
@@ -56,7 +56,8 @@ GeoLinearElasticPlaneStrain2DLaw& GeoLinearElasticPlaneStrain2DLaw::operator=(co
 }
 
 GeoLinearElasticPlaneStrain2DLaw::GeoLinearElasticPlaneStrain2DLaw(GeoLinearElasticPlaneStrain2DLaw&& rOther) noexcept = default;
-GeoLinearElasticPlaneStrain2DLaw& GeoLinearElasticPlaneStrain2DLaw::operator=(GeoLinearElasticPlaneStrain2DLaw&& rOther) noexcept = default;
+GeoLinearElasticPlaneStrain2DLaw& GeoLinearElasticPlaneStrain2DLaw::operator=(
+    GeoLinearElasticPlaneStrain2DLaw&& rOther) noexcept               = default;
 GeoLinearElasticPlaneStrain2DLaw::~GeoLinearElasticPlaneStrain2DLaw() = default;
 
 ConstitutiveLaw::Pointer GeoLinearElasticPlaneStrain2DLaw::Clone() const

--- a/applications/GeoMechanicsApplication/custom_constitutive/small_strain_udsm_3D_law.cpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/small_strain_udsm_3D_law.cpp
@@ -588,8 +588,9 @@ void SmallStrainUDSM3DLaw::CalculateMaterialResponseCauchy(ConstitutiveLaw::Para
     // Get Values to compute the constitutive law:
     const Flags& rOptions = rValues.GetOptions();
 
-    KRATOS_DEBUG_ERROR_IF(rOptions.IsNot(ConstitutiveLaw::USE_ELEMENT_PROVIDED_STRAIN))
-        << "The GeoLinearElasticLaw needs an element provided strain" << std::endl;
+    KRATOS_DEBUG_ERROR_IF(rOptions.IsDefined(ConstitutiveLaw::USE_ELEMENT_PROVIDED_STRAIN) &&
+                          rOptions.IsNot(ConstitutiveLaw::USE_ELEMENT_PROVIDED_STRAIN))
+        << "The SmallStrainUDSM3DLaw needs an element provided strain" << std::endl;
 
     KRATOS_ERROR_IF(!rValues.IsSetStrainVector() || rValues.GetStrainVector().size() != GetStrainSize())
         << "Constitutive laws in the geomechanics application need a valid provided strain" << std::endl;

--- a/applications/GeoMechanicsApplication/custom_constitutive/small_strain_umat_3D_law.cpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/small_strain_umat_3D_law.cpp
@@ -384,8 +384,9 @@ void SmallStrainUMAT3DLaw::CalculateMaterialResponseCauchy(ConstitutiveLaw::Para
     // Get Values to compute the constitutive law:
     const Flags& rOptions = rValues.GetOptions();
 
-    KRATOS_DEBUG_ERROR_IF(rOptions.IsNot(ConstitutiveLaw::USE_ELEMENT_PROVIDED_STRAIN))
-        << "The GeoLinearElasticLaw needs an element provided strain" << std::endl;
+    KRATOS_DEBUG_ERROR_IF(rOptions.IsDefined(ConstitutiveLaw::USE_ELEMENT_PROVIDED_STRAIN) &&
+                          rOptions.IsNot(ConstitutiveLaw::USE_ELEMENT_PROVIDED_STRAIN))
+        << "The SmallStrainUMAT3DLaw needs an element provided strain" << std::endl;
 
     KRATOS_ERROR_IF(!rValues.IsSetStrainVector() || rValues.GetStrainVector().size() != GetStrainSize())
         << "Constitutive laws in the geomechanics application need a valid provided strain" << std::endl;

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_constitutive/test_linear_elastic_plane_strain_2D_law.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_constitutive/test_linear_elastic_plane_strain_2D_law.cpp
@@ -24,7 +24,6 @@ using namespace Kratos;
 Vector CalculateStress(GeoLinearElasticPlaneStrain2DLaw& rConstitutiveLaw)
 {
     ConstitutiveLaw::Parameters parameters;
-    parameters.Set(ConstitutiveLaw::USE_ELEMENT_PROVIDED_STRAIN);
     parameters.Set(ConstitutiveLaw::COMPUTE_CONSTITUTIVE_TENSOR);
     parameters.Set(ConstitutiveLaw::COMPUTE_STRESS);
 
@@ -184,6 +183,42 @@ KRATOS_TEST_CASE_IN_SUITE(GeoLinearElasticPlaneStrain2DLawReturnsExpectedStress_
     Vector expected_stress{4};
     expected_stress <<= 6e+06, 6e+06, 6e+06, 1.76923e+06;
     KRATOS_EXPECT_VECTOR_RELATIVE_NEAR(expected_stress, stress, 1e-3);
+}
+
+KRATOS_TEST_CASE_IN_SUITE(GeoLinearElasticPlaneStrain2DLawThrows_WhenNoElementProvidedStrain,
+                          KratosGeoMechanicsFastSuiteWithoutKernel)
+{
+    auto law = CreateLinearElasticPlaneStrainLaw();
+
+    ConstitutiveLaw::Parameters initial_parameters;
+    auto                        initial_strain = Vector{ScalarVector{4, 0.5}};
+    initial_parameters.SetStrainVector(initial_strain);
+    auto initial_stress = Vector{ScalarVector{4, 1e6}};
+    initial_parameters.SetStressVector(initial_stress);
+    law.InitializeMaterialResponseCauchy(initial_parameters);
+
+    ConstitutiveLaw::Parameters parameters;
+    parameters.Set(ConstitutiveLaw::COMPUTE_CONSTITUTIVE_TENSOR);
+    parameters.Set(ConstitutiveLaw::COMPUTE_STRESS);
+    parameters.GetOptions().Set(ConstitutiveLaw::USE_ELEMENT_PROVIDED_STRAIN, false);
+
+    auto strain = Vector{ScalarVector{4, 1.0}};
+    parameters.SetStrainVector(strain);
+
+    Vector stress;
+    parameters.SetStressVector(stress);
+
+    Matrix constitutive_matrix;
+    parameters.SetConstitutiveMatrix(constitutive_matrix);
+
+    Properties properties;
+    properties.SetValue(YOUNG_MODULUS, 1.0e7);
+    properties.SetValue(POISSON_RATIO, 0.3);
+    parameters.SetMaterialProperties(properties);
+
+    KRATOS_EXPECT_EXCEPTION_IS_THROWN(
+        law.CalculateMaterialResponsePK2(parameters),
+        "The GeoLinearElasticLaw needs an element provided strain");
 }
 
 } // namespace Kratos::Testing

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_constitutive/test_linear_elastic_plane_strain_2D_law.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_constitutive/test_linear_elastic_plane_strain_2D_law.cpp
@@ -185,6 +185,7 @@ KRATOS_TEST_CASE_IN_SUITE(GeoLinearElasticPlaneStrain2DLawReturnsExpectedStress_
     KRATOS_EXPECT_VECTOR_RELATIVE_NEAR(expected_stress, stress, 1e-3);
 }
 
+#ifdef KRATOS_DEBUG
 KRATOS_TEST_CASE_IN_SUITE(GeoLinearElasticPlaneStrain2DLawThrows_WhenElementProvidedStrainIsSetToFalse,
                           KratosGeoMechanicsFastSuiteWithoutKernel)
 {
@@ -196,5 +197,6 @@ KRATOS_TEST_CASE_IN_SUITE(GeoLinearElasticPlaneStrain2DLawThrows_WhenElementProv
     KRATOS_EXPECT_EXCEPTION_IS_THROWN(law.CalculateMaterialResponsePK2(parameters),
                                       "The GeoLinearElasticLaw needs an element provided strain");
 }
+#endif
 
 } // namespace Kratos::Testing

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_constitutive/test_linear_elastic_plane_strain_2D_law.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_constitutive/test_linear_elastic_plane_strain_2D_law.cpp
@@ -193,9 +193,8 @@ KRATOS_TEST_CASE_IN_SUITE(GeoLinearElasticPlaneStrain2DLawThrows_WhenElementProv
     ConstitutiveLaw::Parameters parameters;
     parameters.GetOptions().Set(ConstitutiveLaw::USE_ELEMENT_PROVIDED_STRAIN, false);
 
-    KRATOS_EXPECT_EXCEPTION_IS_THROWN(
-        law.CalculateMaterialResponsePK2(parameters),
-        "The GeoLinearElasticLaw needs an element provided strain");
+    KRATOS_EXPECT_EXCEPTION_IS_THROWN(law.CalculateMaterialResponsePK2(parameters),
+                                      "The GeoLinearElasticLaw needs an element provided strain");
 }
 
 } // namespace Kratos::Testing

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_constitutive/test_linear_elastic_plane_strain_2D_law.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_constitutive/test_linear_elastic_plane_strain_2D_law.cpp
@@ -185,7 +185,7 @@ KRATOS_TEST_CASE_IN_SUITE(GeoLinearElasticPlaneStrain2DLawReturnsExpectedStress_
     KRATOS_EXPECT_VECTOR_RELATIVE_NEAR(expected_stress, stress, 1e-3);
 }
 
-KRATOS_TEST_CASE_IN_SUITE(GeoLinearElasticPlaneStrain2DLawThrows_WhenNoElementProvidedStrain,
+KRATOS_TEST_CASE_IN_SUITE(GeoLinearElasticPlaneStrain2DLawThrows_WhenElementProvidedStrainIsSetToFalse,
                           KratosGeoMechanicsFastSuiteWithoutKernel)
 {
     auto law = CreateLinearElasticPlaneStrainLaw();

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_constitutive/test_linear_elastic_plane_strain_2D_law.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_constitutive/test_linear_elastic_plane_strain_2D_law.cpp
@@ -190,31 +190,8 @@ KRATOS_TEST_CASE_IN_SUITE(GeoLinearElasticPlaneStrain2DLawThrows_WhenNoElementPr
 {
     auto law = CreateLinearElasticPlaneStrainLaw();
 
-    ConstitutiveLaw::Parameters initial_parameters;
-    auto                        initial_strain = Vector{ScalarVector{4, 0.5}};
-    initial_parameters.SetStrainVector(initial_strain);
-    auto initial_stress = Vector{ScalarVector{4, 1e6}};
-    initial_parameters.SetStressVector(initial_stress);
-    law.InitializeMaterialResponseCauchy(initial_parameters);
-
     ConstitutiveLaw::Parameters parameters;
-    parameters.Set(ConstitutiveLaw::COMPUTE_CONSTITUTIVE_TENSOR);
-    parameters.Set(ConstitutiveLaw::COMPUTE_STRESS);
     parameters.GetOptions().Set(ConstitutiveLaw::USE_ELEMENT_PROVIDED_STRAIN, false);
-
-    auto strain = Vector{ScalarVector{4, 1.0}};
-    parameters.SetStrainVector(strain);
-
-    Vector stress;
-    parameters.SetStressVector(stress);
-
-    Matrix constitutive_matrix;
-    parameters.SetConstitutiveMatrix(constitutive_matrix);
-
-    Properties properties;
-    properties.SetValue(YOUNG_MODULUS, 1.0e7);
-    properties.SetValue(POISSON_RATIO, 0.3);
-    parameters.SetMaterialProperties(properties);
 
     KRATOS_EXPECT_EXCEPTION_IS_THROWN(
         law.CalculateMaterialResponsePK2(parameters),


### PR DESCRIPTION
Currently, we have to provide the flag USE_ELEMENT_PROVIDED_STRAIN to our constitutive laws. However, as we have made the decision in Geo that the constitutive laws are only responsible for calculating stresses/constitutive matrices from input strains (see https://github.com/KratosMultiphysics/Kratos/pull/12719), this should be the default behavior.