### PR TITLE
[CORE] Removed redundant export which breaks the windows build

### DIFF
--- a/kratos/utilities/dof_utilities/block_build_dof_array_utility.h
+++ b/kratos/utilities/dof_utilities/block_build_dof_array_utility.h
@@ -37,7 +37,7 @@ namespace Kratos
  * handle the DOFs when doing a block build.
  * @author Ruben Zorrilla
  */
-class KRATOS_API(KRATOS_CORE) BlockBuildDofArrayUtility
+class BlockBuildDofArrayUtility
 {
 public:
     ///@name Type Definitions


### PR DESCRIPTION
**📝 Description**
Due to a recent change (see #12700), the windows build for structural mechanics got broken. Since the geomechanics application has a dependency on structural and we work on windows, we had a look into the issue. 

The linking problems that are encountered in the windows build are caused by the KRATOS_API call in the new utility header file. Since it is only a header file (and doesn't have functionality in a .cpp), the export is not necessary and apparently breaks the windows build.

This PR removes the KRATOS_API call, which fixes the issue for windows.

Since this issue is blocking geo development, it is a high priority/urgency hot fix for us.
