### PR TITLE
Error fix in ThermalDEM

### DIFF
--- a/applications/ThermalDEMApplication/custom_constitutive/sintering_continuum.cpp
+++ b/applications/ThermalDEMApplication/custom_constitutive/sintering_continuum.cpp
@@ -180,6 +180,7 @@ namespace Kratos
 		                                       double       equiv_young,
 		                                       double       equiv_shear,
 		                                       double       indentation,
+		                                       double       indentation_particle,
 		                                       double       calculation_area,
 		                                       double&      acumulated_damage,
 		                                       SphericContinuumParticle* element1,

--- a/applications/ThermalDEMApplication/custom_constitutive/sintering_continuum.h
+++ b/applications/ThermalDEMApplication/custom_constitutive/sintering_continuum.h
@@ -104,6 +104,7 @@ namespace Kratos
                            double             equiv_young,
                            double             equiv_shear,
                            double             indentation,
+                           double             indentation_particle,
                            double             calculation_area,
                            double&            acumulated_damage,
                            SphericContinuumParticle* element1,


### PR DESCRIPTION
ThermalDEM application was not compiling because an input parameter was added to a function of the base class in the DEM application, but not to the overwritten function in the derived class of ThermalDEM application.