### PR TITLE
[GeoMechanicsApplication] Investigate the occasional failure of the "test_parameter_field_with_python_umat_parameters" test on the build server 2nd

### DIFF
--- a/applications/GeoMechanicsApplication/tests/test_parameter_field.py
+++ b/applications/GeoMechanicsApplication/tests/test_parameter_field.py
@@ -64,7 +64,7 @@ class KratosGeoMechanicsParameterFieldTests(KratosUnittest.TestCase):
         custom_script_name = "custom_field_umat_parameters.py"
         custom_python_file = os.path.join(file_path, custom_script_name)
         if not os.path.isfile(custom_python_file):
-            print(f"Source file does not exist. {custom_python_file}")
+            raise RuntimeError(f"Source file does not exist. {custom_python_file}")
 
         # copy user defined python script to installation folder
         new_custom_script_path = os.path.join(os.path.dirname(KratosGeo.__file__), "user_defined_scripts")
@@ -76,25 +76,25 @@ class KratosGeoMechanicsParameterFieldTests(KratosUnittest.TestCase):
             print(f"Source and destination represents the same file. {e}")
             raise
         except PermissionError as e:
-            print(f"Permission denied: {e}")
-            raise
+            raise RuntimeError(f"Permission denied.") from e
         except IOError as e:
             print(f"Try to change the destination file permission {e}")
             os.chmod(new_custom_script_path, stat.S_IRWXU)
             shutil.copy(custom_python_file, new_custom_script_path)
         except Exception as e:
-            print(f"Error occurred while copying the file {e}.")
-            raise
+            raise RuntimeError(f"Error occurred while copying the file.") from e
+        except BaseException as e:
+            raise RuntimeError(f"An unknown error occurred while copying the file.") from e
 
         custom_python_file_new_location = os.path.join(new_custom_script_path, custom_script_name)
 
         if not os.path.isfile(custom_python_file_new_location):
-            print(f"File {custom_python_file_new_location} does not exist after copying the source.")
+            raise RuntimeError(f"File {custom_python_file_new_location} does not exist after copying the source.")
 
         simulation = test_helper.run_kratos(file_path)
 
         if not os.path.isfile(custom_python_file_new_location):
-            print(f"File {custom_python_file_new_location} does not exist after run_kratos.")
+            raise RuntimeError(f"File {custom_python_file_new_location} does not exist after run_kratos.")
 
         # get element centers
         elements = simulation._list_of_output_processes[0].model_part.Elements
@@ -109,7 +109,7 @@ class KratosGeoMechanicsParameterFieldTests(KratosUnittest.TestCase):
             self.assertAlmostEqual(expected_res, res[0][0])
 
         if not os.path.isfile(custom_python_file_new_location):
-            print(f"File {custom_python_file_new_location} does not exist before removal.")
+            raise RuntimeError(f"File {custom_python_file_new_location} does not exist before removal.")
 
         # remove user defined python script from installation folder
         os.remove(os.path.join(new_custom_script_path, custom_script_name))

--- a/applications/GeoMechanicsApplication/tests/test_parameter_field.py
+++ b/applications/GeoMechanicsApplication/tests/test_parameter_field.py
@@ -73,8 +73,7 @@ class KratosGeoMechanicsParameterFieldTests(KratosUnittest.TestCase):
         try:
             shutil.copy(custom_python_file, new_custom_script_path)
         except shutil.SameFileError as e:
-            print(f"Source and destination represents the same file. {e}")
-            raise
+            raise RuntimeError(f"Source and destination represents the same file.") from e
         except PermissionError as e:
             raise RuntimeError(f"Permission denied.") from e
         except IOError as e:

--- a/applications/GeoMechanicsApplication/tests/test_parameter_field.py
+++ b/applications/GeoMechanicsApplication/tests/test_parameter_field.py
@@ -63,6 +63,8 @@ class KratosGeoMechanicsParameterFieldTests(KratosUnittest.TestCase):
 
         custom_script_name = "custom_field_umat_parameters.py"
         custom_python_file = os.path.join(file_path, custom_script_name)
+        if not os.path.isfile(custom_python_file):
+            print(f"Source file does not exist. {custom_python_file}")
 
         # copy user defined python script to installation folder
         new_custom_script_path = os.path.join(os.path.dirname(KratosGeo.__file__), "user_defined_scripts")
@@ -71,20 +73,28 @@ class KratosGeoMechanicsParameterFieldTests(KratosUnittest.TestCase):
         try:
             shutil.copy(custom_python_file, new_custom_script_path)
         except shutil.SameFileError as e:
-             print(f"Source and destination represents the same file. {e}")
-             raise
+            print(f"Source and destination represents the same file. {e}")
+            raise
         except PermissionError as e:
-             print(f"Permission denied: {e}")
-             raise
+            print(f"Permission denied: {e}")
+            raise
         except IOError as e:
-             print(f"Try to change the destination file permission {e}")
-             os.chmod(new_custom_script_path, stat.S_IRWXU)
-             shutil.copy(custom_python_file, new_custom_script_path)
+            print(f"Try to change the destination file permission {e}")
+            os.chmod(new_custom_script_path, stat.S_IRWXU)
+            shutil.copy(custom_python_file, new_custom_script_path)
         except Exception as e:
-             print(f"Error occurred while copying the file {e}.")
-             raise
+            print(f"Error occurred while copying the file {e}.")
+            raise
+
+        custom_python_file_new_location = os.path.join(new_custom_script_path, custom_script_name)
+
+        if not os.path.isfile(custom_python_file_new_location):
+            print(f"File {custom_python_file_new_location} does not exist after copying the source.")
 
         simulation = test_helper.run_kratos(file_path)
+
+        if not os.path.isfile(custom_python_file_new_location):
+            print(f"File {custom_python_file_new_location} does not exist after run_kratos.")
 
         # get element centers
         elements = simulation._list_of_output_processes[0].model_part.Elements
@@ -97,6 +107,9 @@ class KratosGeoMechanicsParameterFieldTests(KratosUnittest.TestCase):
         for center_coord, res in zip(center_coords, results):
             expected_res = 20000 * center_coord[0] + 30000 * center_coord[1]
             self.assertAlmostEqual(expected_res, res[0][0])
+
+        if not os.path.isfile(custom_python_file_new_location):
+            print(f"File {custom_python_file_new_location} does not exist before removal.")
 
         # remove user defined python script from installation folder
         os.remove(os.path.join(new_custom_script_path, custom_script_name))
@@ -124,7 +137,6 @@ class KratosGeoMechanicsParameterFieldTests(KratosUnittest.TestCase):
         for center_coord, res in zip(center_coords, results):
             expected_res = 20000 * center_coord[0] + 30000 * center_coord[1]
             self.assertAlmostEqual(expected_res, res[0][0])
-
 
     def test_parameter_field_with_function(self):
         """


### PR DESCRIPTION
**📝 Description**
The test failed and the following info is available.
 ======================================================================
09:03:34   ERROR: test_parameter_field_with_python_umat_parameters (test_parameter_field.KratosGeoMechanicsParameterFieldTests)
09:03:34   ----------------------------------------------------------------------
09:03:34   Traceback (most recent call last):
09:03:34     File "C:\BuildAgent\work\6b1b55f40e0ab639\bin\Release\applications\GeoMechanicsApplication\tests\test_parameter_field.py", line 87, in test_parameter_field_with_python_umat_parameters
09:03:34       simulation = test_helper.run_kratos(file_path)
09:03:34     File "C:\BuildAgent\work\6b1b55f40e0ab639\bin\Release\applications\GeoMechanicsApplication\tests\test_helper.py", line 43, in run_kratos
09:03:34       simulation.Run()
09:03:34     File "C:\BuildAgent\work\6b1b55f40e0ab639\bin\Release\KratosMultiphysics\analysis_stage.py", line 48, in Run
09:03:34       self.Initialize()
09:03:34     File "C:\BuildAgent\work\6b1b55f40e0ab639\bin\Release\KratosMultiphysics\analysis_stage.py", line 92, in Initialize
09:03:34       process.ExecuteInitialize()
09:03:34     File "C:\BuildAgent\work\6b1b55f40e0ab639\bin\Release\KratosMultiphysics\GeoMechanicsApplication\set_parameter_field_process.py", line 115, in ExecuteInitialize
09:03:34       custom_module = importlib.import_module("." + self.params["function"].GetString(),
09:03:34     File "C:\python\310\lib\importlib\__init__.py", line 126, in import_module
09:03:34       return _bootstrap._gcd_import(name[level:], package, level)
09:03:34     File "<frozen importlib._bootstrap>", line 1050, in _gcd_import
09:03:34     File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
09:03:34     File "<frozen importlib._bootstrap>", line 1004, in _find_and_load_unlocked
09:03:34   ModuleNotFoundError: No module named 'KratosMultiphysics.GeoMechanicsApplication.user_defined_scripts.custom_field_umat_parameters'
09:03:34   
09:03:34   Stdout:
09:03:34   Source file path: C:\BuildAgent\work\6b1b55f40e0ab639\bin\Release\applications\GeoMechanicsApplication\tests\test_parameter_field\parameter_field_python_umat_parameters\custom_field_umat_parameters.py
09:03:34   Destination file path: C:\BuildAgent\work\6b1b55f40e0ab639\bin\Release\KratosMultiphysics\GeoMechanicsApplication\user_defined_scripts
09:03:34   
It looks that shutil copied the required file to the installation folder. However, the file is not available for importing. 
Therefore, a few more prints where added to check this file in the installation folder. 
