### PR TITLE
[CORE] Fix memory issue in ublas_space.h

### DIFF
--- a/kratos/spaces/ublas_space.h
+++ b/kratos/spaces/ublas_space.h
@@ -710,8 +710,8 @@ public:
     {
         const std::size_t system_size = rA.size1();
 
-        const double* Avalues = rA.value_data().begin();
-        const std::size_t* Arow_indices = rA.index1_data().begin();
+        const auto& Avalues = rA.value_data();
+        const auto& Arow_indices = rA.index1_data();
 
         // Define  zero value tolerance
         const double zero_tolerance = std::numeric_limits<double>::epsilon();
@@ -778,9 +778,9 @@ public:
      */
     static double GetDiagonalNorm(const MatrixType& rA)
     {
-        const double* Avalues = rA.value_data().begin();
-        const std::size_t* Arow_indices = rA.index1_data().begin();
-        const std::size_t* Acol_indices = rA.index2_data().begin();
+        const auto& Avalues = rA.value_data();
+        const auto& Arow_indices = rA.index1_data();
+        const auto& Acol_indices = rA.index2_data();
 
         const double diagonal_norm = IndexPartition<std::size_t>(Size1(rA)).for_each<SumReduction<double>>([&](std::size_t Index){
             const std::size_t col_begin = Arow_indices[Index];
@@ -813,9 +813,9 @@ public:
      */
     static double GetMaxDiagonal(const MatrixType& rA)
     {
-        const double* Avalues = rA.value_data().begin();
-        const std::size_t* Arow_indices = rA.index1_data().begin();
-        const std::size_t* Acol_indices = rA.index2_data().begin();
+        const auto& Avalues = rA.value_data();
+        const auto& Arow_indices = rA.index1_data();
+        const auto& Acol_indices = rA.index2_data();
 
         return IndexPartition<std::size_t>(Size1(rA)).for_each<MaxReduction<double>>([&](std::size_t Index){
             const std::size_t col_begin = Arow_indices[Index];
@@ -836,9 +836,9 @@ public:
      */
     static double GetMinDiagonal(const MatrixType& rA)
     {
-        const double* Avalues = rA.value_data().begin();
-        const std::size_t* Arow_indices = rA.index1_data().begin();
-        const std::size_t* Acol_indices = rA.index2_data().begin();
+        const auto& Avalues = rA.value_data();
+        const auto& Arow_indices = rA.index1_data();
+        const auto& Acol_indices = rA.index2_data();
 
         return IndexPartition<std::size_t>(Size1(rA)).for_each<MinReduction<double>>([&](std::size_t Index){
             const std::size_t col_begin = Arow_indices[Index];


### PR DESCRIPTION
**📝 Description**
In our TeamCity windows pipeline, tests started failing with a memory violation error. When tracking down the place where invalid memory was accessed, it turned out to be in `ublas_space.h` in the `CheckAndCorrectZeroDiagonalValues` function.

In that function, the values of matrix `rA` are fetched using a double*, initialized with the begin iterator of `rA.value_data()`. However, in the loop (the `IndexPartition` from line 723-734), `rA` is actually changed. This means the `rA.value_data()` also changes. Therefore, it could happen that the underlying vector (obtained using `value_data()`) has to be re-allocated because values are added to the vector that no longer fit in the allocated/reserved space. Indeed when printing `rA.value_data().size()` in the loop, I saw that the size doubled (which points to the vector being re-allocated), just before the crash. The crash then occurs because, the `double* Avalues` is invalidated when the underlying vector gets re-allocated.

This PR fixes the issue by storing the vector reference returned by `value_data()` instead of using the `double*`. This reference does not have the same issue with being invalidated when the vector is re-allocated. Note that we do not make a copy here, since the `value_data()`, `index_1data()` and `index2_data()` functions are returning a reference, which we are storing (not by value).

Since this practice with using a `double*` to point to the begin iterator is very tricky and can lead to these hard-to-find issues (it only occurs in very specific situations), I also changed the other places in this file where this was happening with the same strategy.
