### PR TITLE
[Core] Remove unused members from containers

### DIFF
--- a/kratos/containers/global_pointers_vector.h
+++ b/kratos/containers/global_pointers_vector.h
@@ -199,6 +199,21 @@ public:
         return mData[i];
     }
 
+    /**
+     * @brief Equality comparison operator to check if two GlobalPointersVector objects are equal.
+     * @details This function checks if the sizes are equal and then compares the elements for equality
+     * using the EqualKeyTo() function.
+     * @param r The GlobalPointersVector to compare with.
+     * @return True if the containers are equal, false otherwise.
+     */
+    bool operator==(const GlobalPointersVector& r) const // nothrow
+    {
+        if (size() != r.size())
+            return false;
+        else
+            return std::equal(mData.begin(), mData.end(), r.mData.begin(), this->EqualKeyTo());
+    }
+
     ///@}
     ///@name Operations
     ///@{

--- a/kratos/containers/global_pointers_vector.h
+++ b/kratos/containers/global_pointers_vector.h
@@ -200,18 +200,21 @@ public:
     }
 
     /**
-     * @brief Equality comparison operator to check if two GlobalPointersVector objects are equal.
-     * @details This function checks if the sizes are equal and then compares the elements for equality
-     * using the EqualKeyTo() function.
-     * @param r The GlobalPointersVector to compare with.
-     * @return True if the containers are equal, false otherwise.
+     * @brief Equality comparison operator to check if two @å GlobalPointersVector objects are equal.
+     * @details This function checks if the sizes are equal and then compares the elements using @a operator==.
+     * @param rRhs The GlobalPointersVector to compare with.
+     * @return True if the containers have identical sizes and store identical items in the exact same order.
      */
-    bool operator==(const GlobalPointersVector& r) const // nothrow
+    bool operator==(const GlobalPointersVector& rRhs) const noexcept
     {
-        if (size() != r.size())
-            return false;
-        else
-            return std::equal(mData.begin(), mData.end(), r.mData.begin(), this->EqualKeyTo());
+        return this->size() == rRhs.size() && std::equal(
+            mData.begin(),
+            mData.end(),
+            rRhs.begin(),
+            [](const data_type& rLhs, const data_type& rRhs) -> bool {
+                return rLhs == rRhs;
+            }
+        );
     }
 
     ///@}

--- a/kratos/containers/global_pointers_vector.h
+++ b/kratos/containers/global_pointers_vector.h
@@ -199,21 +199,6 @@ public:
         return mData[i];
     }
 
-    /**
-     * @brief Equality comparison operator to check if two GlobalPointersVector objects are equal.
-     * @details This function checks if the sizes are equal and then compares the elements for equality
-     * using the EqualKeyTo() function.
-     * @param r The GlobalPointersVector to compare with.
-     * @return True if the containers are equal, false otherwise.
-     */
-    bool operator==(const GlobalPointersVector& r) const // nothrow
-    {
-        if (size() != r.size())
-            return false;
-        else
-            return std::equal(mData.begin(), mData.end(), r.mData.begin(), this->EqualKeyTo());
-    }
-
     ///@}
     ///@name Operations
     ///@{

--- a/kratos/containers/pointer_vector.h
+++ b/kratos/containers/pointer_vector.h
@@ -2,14 +2,14 @@
 //    ' /   __| _` | __|  _ \   __|
 //    . \  |   (   | |   (   |\__ `
 //   _|\_\_|  \__,_|\__|\___/ ____/
-//                   Multi-Physics
+//                   Multi-Physics 
 //
-//  License:		 BSD License
+//  License:		 BSD License 
 //					 Kratos default license: kratos/license.txt
 //
 //  Main authors:    Pooyan Dadvand
 //                   Riccardo Rossi
-//
+//                    
 //
 
 
@@ -154,6 +154,14 @@ public:
         return mData[i];
     }
 
+    bool operator==( const PointerVector& r ) const // nothrow
+    {
+        if( size() != r.size() )
+            return false;
+        else
+            return std::equal(mData.begin(), mData.end(), r.mData.begin(), this->EqualKeyTo());
+    }
+
     ///@}
     ///@name Operations
     ///@{
@@ -270,7 +278,7 @@ public:
     }
 
     template<class... Args>
-    void emplace_back(Args&&... args)
+    void emplace_back(Args&&... args) 
     {
         mData.emplace_back(std::forward<Args>(args)...);
     }
@@ -512,4 +520,4 @@ inline std::ostream& operator << (std::ostream& rOStream,
 
 }  // namespace Kratos.
 
-#endif // KRATOS_POINTER_VECTOR_SET_H_INCLUDED  defined
+#endif // KRATOS_POINTER_VECTOR_SET_H_INCLUDED  defined 

--- a/kratos/containers/pointer_vector.h
+++ b/kratos/containers/pointer_vector.h
@@ -2,14 +2,14 @@
 //    ' /   __| _` | __|  _ \   __|
 //    . \  |   (   | |   (   |\__ `
 //   _|\_\_|  \__,_|\__|\___/ ____/
-//                   Multi-Physics 
+//                   Multi-Physics
 //
-//  License:		 BSD License 
+//  License:		 BSD License
 //					 Kratos default license: kratos/license.txt
 //
 //  Main authors:    Pooyan Dadvand
 //                   Riccardo Rossi
-//                    
+//
 //
 
 
@@ -154,14 +154,6 @@ public:
         return mData[i];
     }
 
-    bool operator==( const PointerVector& r ) const // nothrow
-    {
-        if( size() != r.size() )
-            return false;
-        else
-            return std::equal(mData.begin(), mData.end(), r.mData.begin(), this->EqualKeyTo());
-    }
-
     ///@}
     ///@name Operations
     ///@{
@@ -278,7 +270,7 @@ public:
     }
 
     template<class... Args>
-    void emplace_back(Args&&... args) 
+    void emplace_back(Args&&... args)
     {
         mData.emplace_back(std::forward<Args>(args)...);
     }
@@ -520,4 +512,4 @@ inline std::ostream& operator << (std::ostream& rOStream,
 
 }  // namespace Kratos.
 
-#endif // KRATOS_POINTER_VECTOR_SET_H_INCLUDED  defined 
+#endif // KRATOS_POINTER_VECTOR_SET_H_INCLUDED  defined

--- a/kratos/containers/pointer_vector.h
+++ b/kratos/containers/pointer_vector.h
@@ -2,14 +2,14 @@
 //    ' /   __| _` | __|  _ \   __|
 //    . \  |   (   | |   (   |\__ `
 //   _|\_\_|  \__,_|\__|\___/ ____/
-//                   Multi-Physics 
+//                   Multi-Physics
 //
-//  License:		 BSD License 
+//  License:		 BSD License
 //					 Kratos default license: kratos/license.txt
 //
 //  Main authors:    Pooyan Dadvand
 //                   Riccardo Rossi
-//                    
+//
 //
 
 
@@ -154,12 +154,16 @@ public:
         return mData[i];
     }
 
-    bool operator==( const PointerVector& r ) const // nothrow
+    bool operator==(const PointerVector& rRhs) const noexcept
     {
-        if( size() != r.size() )
-            return false;
-        else
-            return std::equal(mData.begin(), mData.end(), r.mData.begin(), this->EqualKeyTo());
+        return this->size() == rRhs.size() && std::equal(
+            mData.begin(),
+            mData.end(),
+            rRhs.begin(),
+            [](const data_type& rLhs, const data_type& rRhs) -> bool {
+                return rLhs == rRhs;
+            }
+        );
     }
 
     ///@}
@@ -278,7 +282,7 @@ public:
     }
 
     template<class... Args>
-    void emplace_back(Args&&... args) 
+    void emplace_back(Args&&... args)
     {
         mData.emplace_back(std::forward<Args>(args)...);
     }
@@ -520,4 +524,4 @@ inline std::ostream& operator << (std::ostream& rOStream,
 
 }  // namespace Kratos.
 
-#endif // KRATOS_POINTER_VECTOR_SET_H_INCLUDED  defined 
+#endif // KRATOS_POINTER_VECTOR_SET_H_INCLUDED  defined


### PR DESCRIPTION
`GlobalPointersVector` and `PointerVector` referred to `EqualKeyTo` objects/members that don't exist.

This hasn't been a problem until now because these classes are templated and the member functions that referenced `EqualKeyTo` weren't used and so have never been instantiated. However, it seems like recent compiler versions (e.g.: clang19) introduced some static template analysis that catch this error. 