### PR TITLE
[GeoMechanicsApplication] Clean up strategies

### DIFF
--- a/applications/GeoMechanicsApplication/custom_python/add_custom_strategies_to_python.cpp
+++ b/applications/GeoMechanicsApplication/custom_python/add_custom_strategies_to_python.cpp
@@ -121,7 +121,7 @@ void AddCustomStrategiesToPython(pybind11::module& m)
 
     py::class_<GeoMechanicsRammArcLengthStrategyType, typename GeoMechanicsRammArcLengthStrategyType::Pointer, BaseSolvingStrategyType>(
         m, "GeoMechanicsRammArcLengthStrategy")
-        .def(py::init<ModelPart&, BaseSchemeType::Pointer, LinearSolverType::Pointer, ConvergenceCriteriaType::Pointer,
+        .def(py::init<ModelPart&, BaseSchemeType::Pointer, ConvergenceCriteriaType::Pointer,
                       BuilderAndSolverType::Pointer, Parameters&, int, bool, bool, bool>())
         .def("UpdateLoads", &GeoMechanicsRammArcLengthStrategyType::UpdateLoads);
 

--- a/applications/GeoMechanicsApplication/custom_python/add_custom_strategies_to_python.cpp
+++ b/applications/GeoMechanicsApplication/custom_python/add_custom_strategies_to_python.cpp
@@ -110,7 +110,7 @@ void AddCustomStrategiesToPython(pybind11::module& m)
 
     py::class_<GeoMechanicsNewtonRaphsonStrategyType, typename GeoMechanicsNewtonRaphsonStrategyType::Pointer, BaseSolvingStrategyType>(
         m, "GeoMechanicsNewtonRaphsonStrategy")
-        .def(py::init<ModelPart&, BaseSchemeType::Pointer, LinearSolverType::Pointer, ConvergenceCriteriaType::Pointer,
+        .def(py::init<ModelPart&, BaseSchemeType::Pointer, ConvergenceCriteriaType::Pointer,
                       BuilderAndSolverType::Pointer, Parameters&, int, bool, bool, bool>());
 
     py::class_<GeoMechanicsNewtonRaphsonErosionProcessStrategyType,

--- a/applications/GeoMechanicsApplication/custom_python/add_custom_strategies_to_python.cpp
+++ b/applications/GeoMechanicsApplication/custom_python/add_custom_strategies_to_python.cpp
@@ -116,7 +116,7 @@ void AddCustomStrategiesToPython(pybind11::module& m)
     py::class_<GeoMechanicsNewtonRaphsonErosionProcessStrategyType,
                typename GeoMechanicsNewtonRaphsonErosionProcessStrategyType::Pointer, BaseSolvingStrategyType>(
         m, "GeoMechanicsNewtonRaphsonErosionProcessStrategy")
-        .def(py::init<ModelPart&, BaseSchemeType::Pointer, LinearSolverType::Pointer, ConvergenceCriteriaType::Pointer,
+        .def(py::init<ModelPart&, BaseSchemeType::Pointer, ConvergenceCriteriaType::Pointer,
                       BuilderAndSolverType::Pointer, Parameters&, int, bool, bool, bool>());
 
     py::class_<GeoMechanicsRammArcLengthStrategyType, typename GeoMechanicsRammArcLengthStrategyType::Pointer, BaseSolvingStrategyType>(

--- a/applications/GeoMechanicsApplication/custom_strategies/strategies/geo_mechanics_newton_raphson_erosion_process_strategy.hpp
+++ b/applications/GeoMechanicsApplication/custom_strategies/strategies/geo_mechanics_newton_raphson_erosion_process_strategy.hpp
@@ -54,7 +54,7 @@ public:
 
     GeoMechanicsNewtonRaphsonErosionProcessStrategy(ModelPart&                    model_part,
                                                     typename TSchemeType::Pointer pScheme,
-                                                    typename TLinearSolver::Pointer pNewLinearSolver,
+                                                    typename TLinearSolver::Pointer,
                                                     typename TConvergenceCriteriaType::Pointer pNewConvergenceCriteria,
                                                     typename TBuilderAndSolverType::Pointer pNewBuilderAndSolver,
                                                     Parameters& rParameters,
@@ -63,16 +63,7 @@ public:
                                                     bool        ReformDofSetAtEachStep = false,
                                                     bool        MoveMeshFlag           = false)
         : GeoMechanicsNewtonRaphsonStrategy<TSparseSpace, TDenseSpace, TLinearSolver>(
-              model_part,
-              pScheme,
-              pNewLinearSolver,
-              pNewConvergenceCriteria,
-              pNewBuilderAndSolver,
-              rParameters,
-              MaxIterations,
-              CalculateReactions,
-              ReformDofSetAtEachStep,
-              MoveMeshFlag)
+              model_part, pScheme, pNewConvergenceCriteria, pNewBuilderAndSolver, rParameters, MaxIterations, CalculateReactions, ReformDofSetAtEachStep, MoveMeshFlag)
     {
         rank              = model_part.GetCommunicator().MyPID();
         mPipingIterations = rParameters["max_piping_iterations"].GetInt();

--- a/applications/GeoMechanicsApplication/custom_strategies/strategies/geo_mechanics_newton_raphson_erosion_process_strategy.hpp
+++ b/applications/GeoMechanicsApplication/custom_strategies/strategies/geo_mechanics_newton_raphson_erosion_process_strategy.hpp
@@ -54,7 +54,6 @@ public:
 
     GeoMechanicsNewtonRaphsonErosionProcessStrategy(ModelPart&                    model_part,
                                                     typename TSchemeType::Pointer pScheme,
-                                                    typename TLinearSolver::Pointer,
                                                     typename TConvergenceCriteriaType::Pointer pNewConvergenceCriteria,
                                                     typename TBuilderAndSolverType::Pointer pNewBuilderAndSolver,
                                                     Parameters& rParameters,

--- a/applications/GeoMechanicsApplication/custom_strategies/strategies/geo_mechanics_newton_raphson_strategy.hpp
+++ b/applications/GeoMechanicsApplication/custom_strategies/strategies/geo_mechanics_newton_raphson_strategy.hpp
@@ -52,16 +52,15 @@ public:
      * @brief Default constructor
      * @param rModelPart The model part of the problem
      * @param pScheme The integration scheme
-     * @param pNewLinearSolver The linear solver employed
      * @param pNewConvergenceCriteria The convergence criteria employed
      * @param MaxIterations The maximum number of iterations
      * @param CalculateReactions The flag for the reaction calculation
      * @param ReformDofSetAtEachStep The flag that allows to compute the modification of the DOF
      * @param MoveMeshFlag The flag that allows to move the mesh
      */
-    GeoMechanicsNewtonRaphsonStrategy(ModelPart&                      model_part,
-                                      typename TSchemeType::Pointer   pScheme,
-                                      typename TLinearSolver::Pointer pNewLinearSolver,
+    GeoMechanicsNewtonRaphsonStrategy(ModelPart&                    model_part,
+                                      typename TSchemeType::Pointer pScheme,
+                                      typename TLinearSolver::Pointer,
                                       typename TConvergenceCriteriaType::Pointer pNewConvergenceCriteria,
                                       typename TBuilderAndSolverType::Pointer pNewBuilderAndSolver,
                                       Parameters&                             rParameters,
@@ -70,15 +69,7 @@ public:
                                       bool ReformDofSetAtEachStep                           = false,
                                       bool MoveMeshFlag                                     = false)
         : ResidualBasedNewtonRaphsonStrategy<TSparseSpace, TDenseSpace, TLinearSolver>(
-              model_part,
-              pScheme,
-              /*pNewLinearSolver,*/
-              pNewConvergenceCriteria,
-              pNewBuilderAndSolver,
-              MaxIterations,
-              CalculateReactions,
-              ReformDofSetAtEachStep,
-              MoveMeshFlag)
+              model_part, pScheme, pNewConvergenceCriteria, pNewBuilderAndSolver, MaxIterations, CalculateReactions, ReformDofSetAtEachStep, MoveMeshFlag)
     {
         // only include validation with c++11 since raw_literals do not exist in c++03
         Parameters default_parameters(R"(

--- a/applications/GeoMechanicsApplication/custom_strategies/strategies/geo_mechanics_newton_raphson_strategy.hpp
+++ b/applications/GeoMechanicsApplication/custom_strategies/strategies/geo_mechanics_newton_raphson_strategy.hpp
@@ -122,32 +122,6 @@ protected:
     /// Member Variables
     std::vector<ModelPart*> mSubModelPartList; /// List of every SubModelPart associated to an external load
     std::vector<std::string> mVariableNames; /// Name of the nodal variable associated to every SubModelPart
-
-    double CalculateReferenceDofsNorm(DofsArrayType& rDofSet)
-    {
-        double ReferenceDofsNorm = 0.0;
-
-        int                          NumThreads = ParallelUtilities::GetNumThreads();
-        OpenMPUtils::PartitionVector DofSetPartition;
-        OpenMPUtils::DivideInPartitions(rDofSet.size(), NumThreads, DofSetPartition);
-
-#pragma omp parallel reduction(+ : ReferenceDofsNorm)
-        {
-            int k = OpenMPUtils::ThisThread();
-
-            typename DofsArrayType::iterator DofsBegin = rDofSet.begin() + DofSetPartition[k];
-            typename DofsArrayType::iterator DofsEnd   = rDofSet.begin() + DofSetPartition[k + 1];
-
-            for (typename DofsArrayType::iterator itDof = DofsBegin; itDof != DofsEnd; ++itDof) {
-                if (itDof->IsFree()) {
-                    const double& temp = itDof->GetSolutionStepValue();
-                    ReferenceDofsNorm += temp * temp;
-                }
-            }
-        }
-
-        return sqrt(ReferenceDofsNorm);
-    }
 }; // Class GeoMechanicsNewtonRaphsonStrategy
 
 } // namespace Kratos

--- a/applications/GeoMechanicsApplication/custom_strategies/strategies/geo_mechanics_newton_raphson_strategy.hpp
+++ b/applications/GeoMechanicsApplication/custom_strategies/strategies/geo_mechanics_newton_raphson_strategy.hpp
@@ -123,15 +123,6 @@ protected:
     std::vector<ModelPart*> mSubModelPartList; /// List of every SubModelPart associated to an external load
     std::vector<std::string> mVariableNames; /// Name of the nodal variable associated to every SubModelPart
 
-    int Check() override
-    {
-        KRATOS_TRY
-
-        return MotherType::Check();
-
-        KRATOS_CATCH("")
-    }
-
     double CalculateReferenceDofsNorm(DofsArrayType& rDofSet)
     {
         double ReferenceDofsNorm = 0.0;

--- a/applications/GeoMechanicsApplication/custom_strategies/strategies/geo_mechanics_newton_raphson_strategy.hpp
+++ b/applications/GeoMechanicsApplication/custom_strategies/strategies/geo_mechanics_newton_raphson_strategy.hpp
@@ -60,7 +60,6 @@ public:
      */
     GeoMechanicsNewtonRaphsonStrategy(ModelPart&                    model_part,
                                       typename TSchemeType::Pointer pScheme,
-                                      typename TLinearSolver::Pointer,
                                       typename TConvergenceCriteriaType::Pointer pNewConvergenceCriteria,
                                       typename TBuilderAndSolverType::Pointer pNewBuilderAndSolver,
                                       Parameters&                             rParameters,

--- a/applications/GeoMechanicsApplication/custom_strategies/strategies/geo_mechanics_newton_raphson_strategy.hpp
+++ b/applications/GeoMechanicsApplication/custom_strategies/strategies/geo_mechanics_newton_raphson_strategy.hpp
@@ -100,28 +100,7 @@ public:
 
         // Validate against defaults -- this also ensures no type mismatch
         rParameters.ValidateAndAssignDefaults(default_parameters);
-
-        // Set Load SubModelParts and Variable names
-        if (rParameters["loads_sub_model_part_list"].size() > 0) {
-            mSubModelPartList.resize(rParameters["loads_sub_model_part_list"].size());
-            mVariableNames.resize(rParameters["loads_variable_list"].size());
-
-            if (mSubModelPartList.size() != mVariableNames.size())
-                KRATOS_ERROR << "For each SubModelPart there must be a corresponding nodal Variable"
-                             << std::endl;
-
-            for (unsigned int i = 0; i < mVariableNames.size(); ++i) {
-                mSubModelPartList[i] =
-                    &(model_part.GetSubModelPart(rParameters["loads_sub_model_part_list"][i].GetString()));
-                mVariableNames[i] = rParameters["loads_variable_list"][i].GetString();
-            }
-        }
     }
-
-protected:
-    /// Member Variables
-    std::vector<ModelPart*> mSubModelPartList; /// List of every SubModelPart associated to an external load
-    std::vector<std::string> mVariableNames; /// Name of the nodal variable associated to every SubModelPart
 }; // Class GeoMechanicsNewtonRaphsonStrategy
 
 } // namespace Kratos

--- a/applications/GeoMechanicsApplication/custom_strategies/strategies/geo_mechanics_ramm_arc_length_strategy.hpp
+++ b/applications/GeoMechanicsApplication/custom_strategies/strategies/geo_mechanics_ramm_arc_length_strategy.hpp
@@ -578,6 +578,7 @@ private:
 
     std::vector<ModelPart*> mSubModelPartList; // List of every SubModelPart associated to an external load
     std::vector<std::string> mVariableNames; // Name of the nodal variable associated to every SubModelPart
+
 }; // Class GeoMechanicsRammArcLengthStrategy
 
 } // namespace Kratos

--- a/applications/GeoMechanicsApplication/custom_strategies/strategies/geo_mechanics_ramm_arc_length_strategy.hpp
+++ b/applications/GeoMechanicsApplication/custom_strategies/strategies/geo_mechanics_ramm_arc_length_strategy.hpp
@@ -313,7 +313,7 @@ public:
             else if (mRadius < mMinRadiusFactor * mRadius_0) mRadius = mMinRadiusFactor * mRadius_0;
 
             // Update Norm of x
-            mNormxEquilibrium = this->CalculateReferenceDofsNorm(rDofSet);
+            mNormxEquilibrium = CalculateReferenceDofsNorm(rDofSet);
         } else {
             std::cout << "************ NO CONVERGENCE: restoring equilibrium path ************" << std::endl;
 
@@ -543,7 +543,7 @@ protected:
     }
 
 private:
-    double CalculateReferenceDofsNorm(DofsArrayType& rDofSet)
+    static double CalculateReferenceDofsNorm(DofsArrayType& rDofSet)
     {
         auto is_free_dof = [](const auto& rDof) { return rDof.IsFree(); };
         auto free_dofs   = rDofSet | boost::adaptors::filtered(is_free_dof);

--- a/applications/GeoMechanicsApplication/custom_strategies/strategies/geo_mechanics_ramm_arc_length_strategy.hpp
+++ b/applications/GeoMechanicsApplication/custom_strategies/strategies/geo_mechanics_ramm_arc_length_strategy.hpp
@@ -50,8 +50,6 @@ public:
     using GrandMotherType::mpDx; // Delta x of iteration i
     using GrandMotherType::mpScheme;
     using GrandMotherType::mReformDofSetAtEachStep;
-    using MotherType::mSubModelPartList;
-    using MotherType::mVariableNames;
 
     GeoMechanicsRammArcLengthStrategy(ModelPart&                      model_part,
                                       typename TSchemeType::Pointer   pScheme,
@@ -75,6 +73,22 @@ public:
               ReformDofSetAtEachStep,
               MoveMeshFlag)
     {
+        // Set Load SubModelParts and Variable names
+        if (rParameters["loads_sub_model_part_list"].size() > 0) {
+            mSubModelPartList.resize(rParameters["loads_sub_model_part_list"].size());
+            mVariableNames.resize(rParameters["loads_variable_list"].size());
+
+            if (mSubModelPartList.size() != mVariableNames.size())
+                KRATOS_ERROR << "For each SubModelPart there must be a corresponding nodal Variable"
+                             << std::endl;
+
+            for (unsigned int i = 0; i < mVariableNames.size(); ++i) {
+                mSubModelPartList[i] =
+                    &(model_part.GetSubModelPart(rParameters["loads_sub_model_part_list"][i].GetString()));
+                mVariableNames[i] = rParameters["loads_variable_list"][i].GetString();
+            }
+        }
+
         mDesiredIterations = rParameters["desired_iterations"].GetInt();
         mMaxRadiusFactor   = rParameters["max_radius_factor"].GetDouble();
         mMinRadiusFactor   = rParameters["min_radius_factor"].GetDouble();
@@ -561,6 +575,9 @@ private:
 
         return sqrt(ReferenceDofsNorm);
     }
+
+    std::vector<ModelPart*> mSubModelPartList; // List of every SubModelPart associated to an external load
+    std::vector<std::string> mVariableNames; // Name of the nodal variable associated to every SubModelPart
 }; // Class GeoMechanicsRammArcLengthStrategy
 
 } // namespace Kratos

--- a/applications/GeoMechanicsApplication/custom_strategies/strategies/geo_mechanics_ramm_arc_length_strategy.hpp
+++ b/applications/GeoMechanicsApplication/custom_strategies/strategies/geo_mechanics_ramm_arc_length_strategy.hpp
@@ -51,9 +51,9 @@ public:
     using GrandMotherType::mpScheme;
     using GrandMotherType::mReformDofSetAtEachStep;
 
-    GeoMechanicsRammArcLengthStrategy(ModelPart&                      model_part,
-                                      typename TSchemeType::Pointer   pScheme,
-                                      typename TLinearSolver::Pointer pNewLinearSolver,
+    GeoMechanicsRammArcLengthStrategy(ModelPart&                    model_part,
+                                      typename TSchemeType::Pointer pScheme,
+                                      typename TLinearSolver::Pointer,
                                       typename TConvergenceCriteriaType::Pointer pNewConvergenceCriteria,
                                       typename TBuilderAndSolverType::Pointer pNewBuilderAndSolver,
                                       Parameters&                             rParameters,
@@ -62,16 +62,7 @@ public:
                                       bool ReformDofSetAtEachStep                           = false,
                                       bool MoveMeshFlag                                     = false)
         : GeoMechanicsNewtonRaphsonStrategy<TSparseSpace, TDenseSpace, TLinearSolver>(
-              model_part,
-              pScheme,
-              pNewLinearSolver,
-              pNewConvergenceCriteria,
-              pNewBuilderAndSolver,
-              rParameters,
-              MaxIterations,
-              CalculateReactions,
-              ReformDofSetAtEachStep,
-              MoveMeshFlag)
+              model_part, pScheme, pNewConvergenceCriteria, pNewBuilderAndSolver, rParameters, MaxIterations, CalculateReactions, ReformDofSetAtEachStep, MoveMeshFlag)
     {
         // Set Load SubModelParts and Variable names
         if (rParameters["loads_sub_model_part_list"].size() > 0) {

--- a/applications/GeoMechanicsApplication/custom_strategies/strategies/geo_mechanics_ramm_arc_length_strategy.hpp
+++ b/applications/GeoMechanicsApplication/custom_strategies/strategies/geo_mechanics_ramm_arc_length_strategy.hpp
@@ -53,7 +53,6 @@ public:
 
     GeoMechanicsRammArcLengthStrategy(ModelPart&                    model_part,
                                       typename TSchemeType::Pointer pScheme,
-                                      typename TLinearSolver::Pointer,
                                       typename TConvergenceCriteriaType::Pointer pNewConvergenceCriteria,
                                       typename TBuilderAndSolverType::Pointer pNewBuilderAndSolver,
                                       Parameters&                             rParameters,

--- a/applications/GeoMechanicsApplication/custom_utilities/solving_strategy_factory.hpp
+++ b/applications/GeoMechanicsApplication/custom_utilities/solving_strategy_factory.hpp
@@ -69,7 +69,7 @@ public:
                 ParametersUtilities::CopyOptionalParameters(rSolverSettings, strategy_entries);
             auto result =
                 std::make_unique<GeoMechanicsNewtonRaphsonStrategy<TSparseSpace, TDenseSpace, TLinearSolver>>(
-                    rModelPart, scheme, solver, criteria, builder_and_solver, strategy_parameters,
+                    rModelPart, scheme, criteria, builder_and_solver, strategy_parameters,
                     max_iterations, calculate_reactions, reform_dof_set_at_each_step, move_mesh_flag);
             result->SetEchoLevel(echo_level);
             return result;

--- a/applications/GeoMechanicsApplication/custom_workflows/dgeoflow.cpp
+++ b/applications/GeoMechanicsApplication/custom_workflows/dgeoflow.cpp
@@ -138,8 +138,8 @@ KratosExecute::GeoMechanicsNewtonRaphsonErosionProcessStrategyType::Pointer Krat
 
     auto pSolvingStrategy =
         Kratos::make_unique<GeoMechanicsNewtonRaphsonErosionProcessStrategy<SparseSpaceType, LocalSpaceType, KratosExecute::LinearSolverType>>(
-            rModelPart, p_scheme, p_solver, p_criteria, p_builder_and_solver, p_parameters,
-            MaxIterations, CalculateReactions, ReformDofSetAtEachStep, MoveMeshFlag);
+            rModelPart, p_scheme, p_criteria, p_builder_and_solver, p_parameters, MaxIterations,
+            CalculateReactions, ReformDofSetAtEachStep, MoveMeshFlag);
 
     pSolvingStrategy->Check();
     return pSolvingStrategy;

--- a/applications/GeoMechanicsApplication/python_scripts/geomechanics_solver.py
+++ b/applications/GeoMechanicsApplication/python_scripts/geomechanics_solver.py
@@ -544,7 +544,6 @@ class GeoMechanicalSolver(PythonSolver):
             self.strategy_params.AddValue("loads_variable_list",self.settings["loads_variable_list"])
             solving_strategy = GeoMechanicsApplication.GeoMechanicsRammArcLengthStrategy(self.computing_model_part,
                                                                                          self.scheme,
-                                                                                         self.linear_solver,
                                                                                          self.convergence_criterion,
                                                                                          builder_and_solver,
                                                                                          self.strategy_params,

--- a/applications/GeoMechanicsApplication/python_scripts/geomechanics_solver.py
+++ b/applications/GeoMechanicsApplication/python_scripts/geomechanics_solver.py
@@ -503,7 +503,6 @@ class GeoMechanicalSolver(PythonSolver):
             self.strategy_params.AddValue("max_piping_iterations", self.settings["max_piping_iterations"])
             solving_strategy = GeoMechanicsApplication.GeoMechanicsNewtonRaphsonErosionProcessStrategy(self.computing_model_part,
                                                                                                        self.scheme,
-                                                                                                       self.linear_solver,
                                                                                                        self.convergence_criterion,
                                                                                                        builder_and_solver,
                                                                                                        self.strategy_params,

--- a/applications/GeoMechanicsApplication/python_scripts/geomechanics_solver.py
+++ b/applications/GeoMechanicsApplication/python_scripts/geomechanics_solver.py
@@ -489,7 +489,6 @@ class GeoMechanicalSolver(PythonSolver):
             self.strategy_params.AddValue("loads_variable_list",self.settings["loads_variable_list"])
             solving_strategy = GeoMechanicsApplication.GeoMechanicsNewtonRaphsonStrategy(self.computing_model_part,
                                                                                          self.scheme,
-                                                                                         self.linear_solver,
                                                                                          self.convergence_criterion,
                                                                                          builder_and_solver,
                                                                                          self.strategy_params,


### PR DESCRIPTION
**📝 Description**

Cleaned up the strategies that are offered by the GeoMechanicsApplication.

**🆕 Changelog**

Changes include:
- Removed unused function parameters (all related to linear solvers) from the constructors of the strategies. The base class of all our strategies (`GeoMechanicsNewtonRaphsonStrategy`) used to receive a pointer to a linear solver, but that parameter was never used. Consequently, there is no point in supplying one. In fact, requesting one but not using it is very confusing. The constructors of the derived classes simply forwarded the linear solver pointers to the base class constructor. Also there, the corresponding parameters have been removed from the constructors.
- Moved a few member functions and data members that were defined in class `GeoMechanicsNewtonRaphsonStrategy` to one of the derived classes (`GeoMechanicsRammArcLengthStrategy`), since only there they were actually being used. As a result, the moved members could be made `private` rather than `protected`.
- Replaced a local implementation of the L2 norm calculation by calling Boost's `norm_2` function. There is one thing we need to keep in mind here: the local implementation used to be done in parallel (although it was using deprecated functionality to achieve that). In other words, there might be a performance impact here. The changes made will probably also fix three code smells found by SonarQube.
