### PR TITLE
[Core][PVS] Fixing the operators to make PVS always sorted.

### DIFF
--- a/kratos/containers/pointer_vector_set.h
+++ b/kratos/containers/pointer_vector_set.h
@@ -72,36 +72,6 @@ template<class TDataType,
 class PointerVectorSet final
 {
 public:
-    ///@name Class definitions
-    ///@{
-
-    /// @brief Unrestricted accessor for the pointer vector set
-    /// @details This class provides unrestricted access the underlying std::vector of the pointer vector
-    ///          set which may make the pointer vector set unsorted. Hence, once an object of this is created, the
-    ///          methods which utilize the sorted property of pointer vector set are frozen. At the destruction of this class,
-    ///          pointer vector set is sorted and made unique, and the frozen methods are released.
-    /// @param
-    /// @return
-    class UnrestrictedAccessor
-    {
-    private:
-        UnrestrictedAccessor(PointerVectorSet::WeakPointer pPointerVectorSet)
-            : mpData(pPointerVectorSet)
-        {
-        }
-
-    public:
-
-    private:
-        ///@name Member variables
-        ///@{
-
-        PointerVectorSet::WeakPointer mpData
-
-        ///@}
-    }
-
-    ///@}
     ///@name Type Definitions
     ///@{
 

--- a/kratos/containers/pointer_vector_set.h
+++ b/kratos/containers/pointer_vector_set.h
@@ -180,10 +180,10 @@ public:
     TDataType& operator[](const key_type& Key)
     {
         ptr_iterator i(std::lower_bound(mData.begin(), mData.end(), Key, CompareKey()));
-        if (EqualKeyTo(Key)(*i)) {
+        if (i != mData.end() && EqualKeyTo(Key)(*i)) {
             return **i;
         } else {
-            static_assert(!std::is_same_v<TDataType*, TPointerType>, "Raw pointers are not supported.");
+            static_assert(!std::is_pointer_v<TPointerType>, "Raw pointers are not supported.");
             return **mData.insert(i, TPointerType(new TDataType(Key)));
         }
     }
@@ -199,10 +199,10 @@ public:
     pointer& operator()(const key_type& Key)
     {
         ptr_iterator i(std::lower_bound(mData.begin(), mData.end(), Key, CompareKey()));
-        if (EqualKeyTo(Key)(*i)) {
+        if (i != mData.end() && EqualKeyTo(Key)(*i)) {
             return *i;
         } else {
-            static_assert(!std::is_same_v<TDataType*, TPointerType>, "Raw pointers are not supported.");
+            static_assert(!std::is_pointer_v<TPointerType>, "Raw pointers are not supported.");
             return *mData.insert(i, TPointerType(new TDataType(Key)));
         }
     }

--- a/kratos/containers/pointer_vector_set.h
+++ b/kratos/containers/pointer_vector_set.h
@@ -178,29 +178,12 @@ public:
      */
     TDataType& operator[](const key_type& Key)
     {
-        ptr_iterator sorted_part_end;
-
-        if (mData.size() - mSortedPartSize >= mMaxBufferSize) {
-            Sort();
-            sorted_part_end = mData.end();
+        ptr_iterator i(std::lower_bound(mData.begin(), mData.end(), Key, CompareKey()));
+        if (EqualKeyTo(Key)(*i)) {
+            return **i;
         } else {
-            sorted_part_end = mData.begin() + mSortedPartSize;
+            return **mData.insert(i, TPointerType(new TDataType(Key)));
         }
-
-        ptr_iterator i(std::lower_bound(mData.begin(), sorted_part_end, Key, CompareKey()));
-        if (i == sorted_part_end) {
-            mSortedPartSize++;
-            return **mData.insert(sorted_part_end, TPointerType(new TDataType(Key)));
-        }
-
-        if (!EqualKeyTo(Key)(*i)) {
-            if ((i = std::find_if(sorted_part_end, mData.end(), EqualKeyTo(Key))) == mData.end()) {
-                mData.push_back(TPointerType(new TDataType(Key)));
-                return **(mData.end() - 1);
-            }
-        }
-
-        return **i;
     }
 
     /**
@@ -213,27 +196,12 @@ public:
      */
     pointer& operator()(const key_type& Key)
     {
-        ptr_iterator sorted_part_end;
-
-        if (mData.size() - mSortedPartSize >= mMaxBufferSize) {
-            Sort();
-            sorted_part_end = mData.end();
-        } else
-            sorted_part_end = mData.begin() + mSortedPartSize;
-
-        ptr_iterator i(std::lower_bound(mData.begin(), sorted_part_end, Key, CompareKey()));
-        if (i == sorted_part_end) {
-            mSortedPartSize++;
-            return *mData.insert(sorted_part_end, TPointerType(new TDataType(Key)));
+        ptr_iterator i(std::lower_bound(mData.begin(), mData.end(), Key, CompareKey()));
+        if (EqualKeyTo(Key)(*i)) {
+            return *i;
+        } else {
+            return *mData.insert(i, TPointerType(new TDataType(Key)));
         }
-
-        if (!EqualKeyTo(Key)(*i))
-            if ((i = std::find_if(sorted_part_end, mData.end(), EqualKeyTo(Key))) == mData.end()) {
-                mData.push_back(TPointerType(new TDataType(Key)));
-                return *(mData.end() - 1);
-            }
-
-        return *i;
     }
 
     /**

--- a/kratos/containers/pointer_vector_set.h
+++ b/kratos/containers/pointer_vector_set.h
@@ -20,6 +20,7 @@
 #include <sstream>
 #include <cstddef>
 #include <utility>
+#include <type_traits>
 
 // External includes
 #include <boost/iterator/indirect_iterator.hpp>
@@ -71,6 +72,36 @@ template<class TDataType,
 class PointerVectorSet final
 {
 public:
+    ///@name Class definitions
+    ///@{
+
+    /// @brief Unrestricted accessor for the pointer vector set
+    /// @details This class provides unrestricted access the underlying std::vector of the pointer vector
+    ///          set which may make the pointer vector set unsorted. Hence, once an object of this is created, the
+    ///          methods which utilize the sorted property of pointer vector set are frozen. At the destruction of this class,
+    ///          pointer vector set is sorted and made unique, and the frozen methods are released.
+    /// @param
+    /// @return
+    class UnrestrictedAccessor
+    {
+    private:
+        UnrestrictedAccessor(PointerVectorSet::WeakPointer pPointerVectorSet)
+            : mpData(pPointerVectorSet)
+        {
+        }
+
+    public:
+
+    private:
+        ///@name Member variables
+        ///@{
+
+        PointerVectorSet::WeakPointer mpData
+
+        ///@}
+    }
+
+    ///@}
     ///@name Type Definitions
     ///@{
 
@@ -182,6 +213,7 @@ public:
         if (EqualKeyTo(Key)(*i)) {
             return **i;
         } else {
+            static_assert(!std::is_same_v<TDataType*, TPointerType>, "Raw pointers are not supported.");
             return **mData.insert(i, TPointerType(new TDataType(Key)));
         }
     }
@@ -200,6 +232,7 @@ public:
         if (EqualKeyTo(Key)(*i)) {
             return *i;
         } else {
+            static_assert(!std::is_same_v<TDataType*, TPointerType>, "Raw pointers are not supported.");
             return *mData.insert(i, TPointerType(new TDataType(Key)));
         }
     }


### PR DESCRIPTION
**📝 Description**
As stated in the title.

**🆕 Changelog**
- Fixes the `PointerVectorSet::operator()` and `PointerVectorSet::operator[]`
