### PR TITLE
[Core][PVS] Add PointerVectorSet::MutablePass to allow push_back safely.

### DIFF
--- a/applications/HDF5Application/custom_io/hdf5_connectivities_data.cpp
+++ b/applications/HDF5Application/custom_io/hdf5_connectivities_data.cpp
@@ -78,7 +78,8 @@ void ConnectivitiesData::CreateEntities(NodesContainerType& rNodes,
     const unsigned geometry_size = r_elem.GetGeometry().size();
     KRATOS_ERROR_IF(geometry_size != mConnectivities.size2())
         << "Non-matching geometry and connectivity sizes." << std::endl;
-    rElements.reserve(rElements.size() + num_new_elems);
+    auto mutable_pass = rElements.GetMutablePass();
+    mutable_pass.reserve(rElements.size() + num_new_elems);
     ElementType::NodesArrayType nodes(geometry_size);
 
     for (unsigned i = 0; i < num_new_elems; ++i)
@@ -90,7 +91,7 @@ void ConnectivitiesData::CreateEntities(NodesContainerType& rNodes,
         }
         ElementType::Pointer p_elem =
             r_elem.Create(mIds[i], nodes, rProperties(mPropertiesIds[i]));
-        rElements.push_back(p_elem);
+        mutable_pass.push_back(p_elem);
     }
     KRATOS_CATCH("");
 }
@@ -107,7 +108,8 @@ void ConnectivitiesData::CreateEntities(NodesContainerType& rNodes,
     const unsigned geometry_size = r_cond.GetGeometry().size();
     KRATOS_ERROR_IF(geometry_size != mConnectivities.size2())
         << "Non-matching geometry and connectivity sizes." << std::endl;
-    rConditions.reserve(rConditions.size() + num_new_conds);
+    auto mutable_pass = rConditions.GetMutablePass();
+    mutable_pass.reserve(rConditions.size() + num_new_conds);
     ConditionType::NodesArrayType nodes(geometry_size);
 
     for (unsigned i = 0; i < num_new_conds; ++i)
@@ -119,7 +121,7 @@ void ConnectivitiesData::CreateEntities(NodesContainerType& rNodes,
         }
         Condition::Pointer p_cond =
             r_cond.Create(mIds[i], nodes, rProperties(mPropertiesIds[i]));
-        rConditions.push_back(p_cond);
+        mutable_pass.push_back(p_cond);
     }
     KRATOS_CATCH("");
 }

--- a/applications/HDF5Application/custom_io/hdf5_connectivities_data.cpp
+++ b/applications/HDF5Application/custom_io/hdf5_connectivities_data.cpp
@@ -78,8 +78,8 @@ void ConnectivitiesData::CreateEntities(NodesContainerType& rNodes,
     const unsigned geometry_size = r_elem.GetGeometry().size();
     KRATOS_ERROR_IF(geometry_size != mConnectivities.size2())
         << "Non-matching geometry and connectivity sizes." << std::endl;
+    rElements.reserve(rElements.size() + num_new_elems);
     auto mutable_pass = rElements.GetMutablePass();
-    mutable_pass.reserve(rElements.size() + num_new_elems);
     ElementType::NodesArrayType nodes(geometry_size);
 
     for (unsigned i = 0; i < num_new_elems; ++i)
@@ -108,8 +108,8 @@ void ConnectivitiesData::CreateEntities(NodesContainerType& rNodes,
     const unsigned geometry_size = r_cond.GetGeometry().size();
     KRATOS_ERROR_IF(geometry_size != mConnectivities.size2())
         << "Non-matching geometry and connectivity sizes." << std::endl;
+    rConditions.reserve(rConditions.size() + num_new_conds);
     auto mutable_pass = rConditions.GetMutablePass();
-    mutable_pass.reserve(rConditions.size() + num_new_conds);
     ConditionType::NodesArrayType nodes(geometry_size);
 
     for (unsigned i = 0; i < num_new_conds; ++i)

--- a/applications/HDF5Application/custom_io/hdf5_points_data.cpp
+++ b/applications/HDF5Application/custom_io/hdf5_points_data.cpp
@@ -30,9 +30,8 @@ void PointsData::CreateNodes(NodesContainerType& rNodes)
 {
     KRATOS_TRY;
     const unsigned num_new_nodes = mIds.size();
-
+    rNodes.reserve(rNodes.size() + num_new_nodes);
     auto mutable_pass = rNodes.GetMutablePass();
-    mutable_pass.reserve(rNodes.size() + num_new_nodes);
     for (unsigned i = 0; i < num_new_nodes; ++i)
     {
         const array_1d<double, 3>& r_coord = mCoords[i];

--- a/applications/HDF5Application/custom_io/hdf5_points_data.cpp
+++ b/applications/HDF5Application/custom_io/hdf5_points_data.cpp
@@ -30,13 +30,15 @@ void PointsData::CreateNodes(NodesContainerType& rNodes)
 {
     KRATOS_TRY;
     const unsigned num_new_nodes = mIds.size();
-    rNodes.reserve(rNodes.size() + num_new_nodes);
+
+    auto mutable_pass = rNodes.GetMutablePass();
+    mutable_pass.reserve(rNodes.size() + num_new_nodes);
     for (unsigned i = 0; i < num_new_nodes; ++i)
     {
         const array_1d<double, 3>& r_coord = mCoords[i];
         NodeType::Pointer p_node = Kratos::make_intrusive<NodeType>(
             mIds[i], r_coord[0], r_coord[1], r_coord[2]);
-        rNodes.push_back(p_node);
+        mutable_pass.push_back(p_node);
     }
     KRATOS_CATCH("");
 }

--- a/applications/HDF5Application/tests/test_hdf5_model_part_io_mpi.py
+++ b/applications/HDF5Application/tests/test_hdf5_model_part_io_mpi.py
@@ -203,8 +203,6 @@ class TestCase(KratosUnittest.TestCase):
                 self.assertEqual(read_node.Z, write_node.Z)
             # Check elements
             self.assertEqual(read_model_part.NumberOfElements(), write_model_part.NumberOfElements())
-            first_elem_id = next(iter(read_model_part.Elements)).Id
-            read_model_part.GetElement(first_elem_id) # Force a sort since order is mixed by openmp.
             for read_elem, write_elem in zip(read_model_part.Elements, write_model_part.Elements):
                 self.assertEqual(read_elem.Id, write_elem.Id)
                 self.assertEqual(read_elem.Properties.Id, write_elem.Properties.Id)
@@ -213,8 +211,6 @@ class TestCase(KratosUnittest.TestCase):
                     self.assertEqual(read_elem_node.Id, write_elem_node.Id)
             # Check conditions
             self.assertEqual(read_model_part.NumberOfConditions(), write_model_part.NumberOfConditions())
-            first_cond_id = next(iter(read_model_part.Conditions)).Id
-            read_model_part.GetCondition(first_cond_id) # Force a sort since order is mixed by openmp.
             for read_cond, write_cond in zip(read_model_part.Conditions, write_model_part.Conditions):
                 self.assertEqual(read_cond.Id, write_cond.Id)
                 self.assertEqual(read_cond.Properties.Id, write_cond.Properties.Id)

--- a/kratos/containers/pointer_vector_set.h
+++ b/kratos/containers/pointer_vector_set.h
@@ -72,36 +72,6 @@ template<class TDataType,
 class PointerVectorSet final
 {
 public:
-    ///@name Class definitions
-    ///@{
-
-    /// @brief Unrestricted accessor for the pointer vector set
-    /// @details This class provides unrestricted access the underlying std::vector of the pointer vector
-    ///          set which may make the pointer vector set unsorted. Hence, once an object of this is created, the
-    ///          methods which utilize the sorted property of pointer vector set are frozen. At the destruction of this class,
-    ///          pointer vector set is sorted and made unique, and the frozen methods are released.
-    /// @param
-    /// @return
-    class UnrestrictedAccessor
-    {
-    private:
-        UnrestrictedAccessor(PointerVectorSet::WeakPointer pPointerVectorSet)
-            : mpData(pPointerVectorSet)
-        {
-        }
-
-    public:
-
-    private:
-        ///@name Member variables
-        ///@{
-
-        PointerVectorSet::WeakPointer mpData
-
-        ///@}
-    }
-
-    ///@}
     ///@name Type Definitions
     ///@{
 

--- a/kratos/containers/pointer_vector_set.h
+++ b/kratos/containers/pointer_vector_set.h
@@ -152,7 +152,7 @@ public:
             std::sort(mrContainer.mData.begin(), mrContainer.mData.end(), CompareKey());
 
             // Make the entities unique
-            typename TContainerType::iterator new_end_it = std::unique(mrContainer.mData.begin(), mrContainer.mData.end(), EqualKeyTo());
+            auto new_end_it = std::unique(mrContainer.mData.begin(), mrContainer.mData.end(), EqualKeyTo());
 
             // remove the duplicated entities.
             mrContainer.mData.erase(new_end_it,  mrContainer.mData.end());

--- a/kratos/containers/pointer_vector_set.h
+++ b/kratos/containers/pointer_vector_set.h
@@ -170,16 +170,6 @@ public:
         ///@name Public methods
         ///@{
 
-        void shrink_to_fit()
-        {
-            mrContainer.mData.shrink_to_fit();
-        }
-
-        void reserve(size_type NewCapacity)
-        {
-            mrContainer.mData.reserve(NewCapacity);
-        }
-
         void push_back(TPointerType pValue)
         {
             mrContainer.mData.push_back(pValue);

--- a/kratos/containers/pointer_vector_set.h
+++ b/kratos/containers/pointer_vector_set.h
@@ -178,29 +178,12 @@ public:
      */
     TDataType& operator[](const key_type& Key)
     {
-        ptr_iterator sorted_part_end;
-
-        if (mData.size() - mSortedPartSize >= mMaxBufferSize) {
-            Sort();
-            sorted_part_end = mData.end();
+        ptr_iterator i(std::lower_bound(mData.begin(), mData.end(), Key, CompareKey()));
+        if (EqualKeyTo(Key)(*i)) {
+            return **i;
         } else {
-            sorted_part_end = mData.begin() + mSortedPartSize;
+            return **mData.insert(i, TPointerType(new TDataType(Key)));
         }
-
-        ptr_iterator i(std::lower_bound(mData.begin(), sorted_part_end, Key, CompareKey()));
-        if (i == sorted_part_end) {
-            mSortedPartSize++;
-            return **mData.insert(sorted_part_end, TPointerType(new TDataType(Key)));
-        }
-
-        if (!EqualKeyTo(Key)(*i)) {
-            if ((i = std::find_if(sorted_part_end, mData.end(), EqualKeyTo(Key))) == mData.end()) {
-                mData.push_back(TPointerType(new TDataType(Key)));
-                return **(mData.end() - 1);
-            }
-        }
-
-        return **i;
     }
 
     /**
@@ -213,27 +196,12 @@ public:
      */
     pointer& operator()(const key_type& Key)
     {
-        ptr_iterator sorted_part_end;
-
-        if (mData.size() - mSortedPartSize >= mMaxBufferSize) {
-            Sort();
-            sorted_part_end = mData.end();
-        } else
-            sorted_part_end = mData.begin() + mSortedPartSize;
-
-        ptr_iterator i(std::lower_bound(mData.begin(), sorted_part_end, Key, CompareKey()));
-        if (i == sorted_part_end) {
-            mSortedPartSize++;
-            return *mData.insert(sorted_part_end, TPointerType(new TDataType(Key)));
+        ptr_iterator i(std::lower_bound(mData.begin(), mData.end(), Key, CompareKey()));
+        if (EqualKeyTo(Key)(*i)) {
+            return *i;
+        } else {
+            return *mData.insert(i, TPointerType(new TDataType(Key)));
         }
-
-        if (!EqualKeyTo(Key)(*i))
-            if ((i = std::find_if(sorted_part_end, mData.end(), EqualKeyTo(Key))) == mData.end()) {
-                mData.push_back(TPointerType(new TDataType(Key)));
-                return *(mData.end() - 1);
-            }
-
-        return *i;
     }
 
     /**

--- a/kratos/containers/pointer_vector_set.h
+++ b/kratos/containers/pointer_vector_set.h
@@ -21,7 +21,6 @@
 #include <cstddef>
 #include <utility>
 #include <type_traits>
-#include <type_traits>
 
 // External includes
 #include <boost/iterator/indirect_iterator.hpp>
@@ -593,6 +592,7 @@ public:
     {
         std::swap(mSortedPartSize, rOther.mSortedPartSize);
         std::swap(mMaxBufferSize, rOther.mMaxBufferSize);
+        std::swap(mHasMutablePass, rOther.mHasMutablePass);
         mData.swap(rOther.mData);
     }
 
@@ -711,8 +711,6 @@ public:
     template <class InputIterator>
     void insert(InputIterator first, InputIterator last)
     {
-        KRATOS_ERROR_IF(mHasMutablePass)
-            << "A mutable pass is active. Hence, use of PointerVectorSet::insert(first, last) is prohibited.";
         // first sorts the input iterators and make the input unique.
         std::sort(first, last, CompareKey());
         auto new_last = std::unique(first, last, EqualKeyTo());
@@ -1150,6 +1148,9 @@ private:
                 mData.push_back(GetPointer(it));
             }
         } else {
+            KRATOS_ERROR_IF(mHasMutablePass)
+                << "A mutable pass is active. Hence, use of PointerVectorSet::insert(first, last) is prohibited.";            
+                
             if (KeyOf(GetReference(first)) > KeyOf(*(mData.back()))) {
                 // all are pointing to the end of the vector, hence pushing back.
                 mData.reserve(mData.size() + std::distance(first, last));

--- a/kratos/containers/pointer_vector_set.h
+++ b/kratos/containers/pointer_vector_set.h
@@ -1126,7 +1126,7 @@ private:
     /// The maximum buffer size for data storage.
     size_type mMaxBufferSize;
 
-    std::atomic<bool> mHasMutablePass = false;
+    bool mHasMutablePass = false;
 
     ///@}
     ///@name Private Operators

--- a/kratos/containers/pointer_vector_set.h
+++ b/kratos/containers/pointer_vector_set.h
@@ -20,6 +20,7 @@
 #include <sstream>
 #include <cstddef>
 #include <utility>
+#include <type_traits>
 
 // External includes
 #include <boost/iterator/indirect_iterator.hpp>
@@ -71,6 +72,36 @@ template<class TDataType,
 class PointerVectorSet final
 {
 public:
+    ///@name Class definitions
+    ///@{
+
+    /// @brief Unrestricted accessor for the pointer vector set
+    /// @details This class provides unrestricted access the underlying std::vector of the pointer vector
+    ///          set which may make the pointer vector set unsorted. Hence, once an object of this is created, the
+    ///          methods which utilize the sorted property of pointer vector set are frozen. At the destruction of this class,
+    ///          pointer vector set is sorted and made unique, and the frozen methods are released.
+    /// @param
+    /// @return
+    class UnrestrictedAccessor
+    {
+    private:
+        UnrestrictedAccessor(PointerVectorSet::WeakPointer pPointerVectorSet)
+            : mpData(pPointerVectorSet)
+        {
+        }
+
+    public:
+
+    private:
+        ///@name Member variables
+        ///@{
+
+        PointerVectorSet::WeakPointer mpData
+
+        ///@}
+    }
+
+    ///@}
     ///@name Type Definitions
     ///@{
 
@@ -182,6 +213,7 @@ public:
         if (EqualKeyTo(Key)(*i)) {
             return **i;
         } else {
+            static_assert(!std::is_same_v<TDataType*, TPointerType>, "Raw pointers are not supported.");
             return **mData.insert(i, TPointerType(new TDataType(Key)));
         }
     }
@@ -200,6 +232,7 @@ public:
         if (EqualKeyTo(Key)(*i)) {
             return *i;
         } else {
+            static_assert(!std::is_same_v<TDataType*, TPointerType>, "Raw pointers are not supported.");
             return *mData.insert(i, TPointerType(new TDataType(Key)));
         }
     }

--- a/kratos/containers/pointer_vector_set.h
+++ b/kratos/containers/pointer_vector_set.h
@@ -30,6 +30,7 @@
 #include "includes/define.h"
 #include "includes/serializer.h"
 #include "containers/key_generator.h"
+#include "utilities/parallel_utilities.h"
 
 namespace Kratos
 {

--- a/kratos/containers/pointer_vector_set.h
+++ b/kratos/containers/pointer_vector_set.h
@@ -73,6 +73,43 @@ template<class TDataType,
 class PointerVectorSet final
 {
 public:
+    ///@name Type Definitions
+    ///@{
+
+    /// Pointer definition of PointerVectorSet
+    KRATOS_CLASS_POINTER_DEFINITION(PointerVectorSet);
+
+    /// Key type for searching in this container.
+    using key_type = typename std::remove_reference<decltype(std::declval<TGetKeyType>()(std::declval<TDataType>()))>::type;
+
+    // Data type stored in this container.
+    using data_type = TDataType;
+    using value_type = TDataType;
+    using key_compare = TCompareType;
+    using pointer = TPointerType;
+    using reference = TDataType&;
+    using const_reference = const TDataType&;
+    using ContainerType = TContainerType;
+
+    /// @}
+    /// @name Iterators
+    /// @{
+    using iterator = boost::indirect_iterator<typename TContainerType::iterator>;
+    using const_iterator = boost::indirect_iterator<typename TContainerType::const_iterator>;
+    using reverse_iterator = boost::indirect_iterator<typename TContainerType::reverse_iterator>;
+    using const_reverse_iterator = boost::indirect_iterator<typename TContainerType::const_reverse_iterator>;
+
+    /// @}
+    /// @name Other definitions
+    /// @{
+    using size_type = typename TContainerType::size_type;
+    using ptr_iterator = typename TContainerType::iterator;
+    using ptr_const_iterator = typename TContainerType::const_iterator;
+    using ptr_reverse_iterator = typename TContainerType::reverse_iterator;
+    using ptr_const_reverse_iterator = typename TContainerType::const_reverse_iterator;
+    using difference_type = typename TContainerType::difference_type;
+
+    ///@}
     ///@name Class definitions
     ///@{
 
@@ -133,6 +170,16 @@ public:
         ///@name Public methods
         ///@{
 
+        void shrink_to_fit()
+        {
+            mrContainer.mData.shrink_to_fit();
+        }
+
+        void reserve(size_type NewCapacity)
+        {
+            mrContainer.mData.reserve(NewCapacity);
+        }
+
         void push_back(TPointerType pValue)
         {
             mrContainer.mData.push_back(pValue);
@@ -154,43 +201,6 @@ public:
 
         ///@}
     };
-
-    ///@}
-    ///@name Type Definitions
-    ///@{
-
-    /// Pointer definition of PointerVectorSet
-    KRATOS_CLASS_POINTER_DEFINITION(PointerVectorSet);
-
-    /// Key type for searching in this container.
-    using key_type = typename std::remove_reference<decltype(std::declval<TGetKeyType>()(std::declval<TDataType>()))>::type;
-
-    // Data type stored in this container.
-    using data_type = TDataType;
-    using value_type = TDataType;
-    using key_compare = TCompareType;
-    using pointer = TPointerType;
-    using reference = TDataType&;
-    using const_reference = const TDataType&;
-    using ContainerType = TContainerType;
-
-    /// @}
-    /// @name Iterators
-    /// @{
-    using iterator = boost::indirect_iterator<typename TContainerType::iterator>;
-    using const_iterator = boost::indirect_iterator<typename TContainerType::const_iterator>;
-    using reverse_iterator = boost::indirect_iterator<typename TContainerType::reverse_iterator>;
-    using const_reverse_iterator = boost::indirect_iterator<typename TContainerType::const_reverse_iterator>;
-
-    /// @}
-    /// @name Other definitions
-    /// @{
-    using size_type = typename TContainerType::size_type;
-    using ptr_iterator = typename TContainerType::iterator;
-    using ptr_const_iterator = typename TContainerType::const_iterator;
-    using ptr_reverse_iterator = typename TContainerType::reverse_iterator;
-    using ptr_const_reverse_iterator = typename TContainerType::const_reverse_iterator;
-    using difference_type = typename TContainerType::difference_type;
 
     ///@}
     ///@name Life Cycle

--- a/kratos/containers/pointer_vector_set.h
+++ b/kratos/containers/pointer_vector_set.h
@@ -93,7 +93,8 @@ public:
             : mrContainer(rContainer)
         {
             KRATOS_CRITICAL_SECTION
-            KRATOS_ERROR_IF(mrContainer.mHasMutablePass) << "A mutable pass is active. Hence, use of this function prohibited.";
+            KRATOS_ERROR_IF(mrContainer.mHasMutablePass)
+                << "A mutable pass is active. Hence, creation of an another MutablePass is prohibited.";
             mrContainer.mHasMutablePass = true;
         }
 
@@ -262,7 +263,8 @@ public:
      */
     TDataType& operator[](const key_type& Key)
     {
-        KRATOS_ERROR_IF(mHasMutablePass) << "A mutable pass is active. Hence, use of this function prohibited.";
+        KRATOS_ERROR_IF(mHasMutablePass)
+            << "A mutable pass is active. Hence, use of PointerVectorSet::operator[] is prohibited.";
         ptr_iterator i(std::lower_bound(mData.begin(), mData.end(), Key, CompareKey()));
         if (i != mData.end() && EqualKeyTo(Key)(*i)) {
             return **i;
@@ -282,7 +284,8 @@ public:
      */
     pointer& operator()(const key_type& Key)
     {
-        KRATOS_ERROR_IF(mHasMutablePass) << "A mutable pass is active. Hence, use of this function prohibited.";
+        KRATOS_ERROR_IF(mHasMutablePass)
+            << "A mutable pass is active. Hence, use of PointerVectorSet::operator() is prohibited.";
         ptr_iterator i(std::lower_bound(mData.begin(), mData.end(), Key, CompareKey()));
         if (i != mData.end() && EqualKeyTo(Key)(*i)) {
             return *i;
@@ -624,7 +627,8 @@ public:
      */
     iterator insert(const TPointerType& value)
     {
-        KRATOS_ERROR_IF(mHasMutablePass) << "A mutable pass is active. Hence, use of this function prohibited.";
+        KRATOS_ERROR_IF(mHasMutablePass)
+            << "A mutable pass is active. Hence, use of PointerVectorSet::insert(value) is prohibited.";
         auto itr_pos = std::lower_bound(mData.begin(), mData.end(), KeyOf(*value), CompareKey());
         if (itr_pos == mData.end()) {
             // the position to insert is at the end.
@@ -653,7 +657,8 @@ public:
      */
     iterator insert(const_iterator position_hint, const TPointerType& value)
     {
-        KRATOS_ERROR_IF(mHasMutablePass) << "A mutable pass is active. Hence, use of this function prohibited.";
+        KRATOS_ERROR_IF(mHasMutablePass)
+            << "A mutable pass is active. Hence, use of PointerVectorSet::insert(position_hint, value) is prohibited.";
         if (empty()) {
             // the dataset is empty. So use push back.
             mData.push_back(value);
@@ -705,7 +710,8 @@ public:
     template <class InputIterator>
     void insert(InputIterator first, InputIterator last)
     {
-        KRATOS_ERROR_IF(mHasMutablePass) << "A mutable pass is active. Hence, use of this function prohibited.";
+        KRATOS_ERROR_IF(mHasMutablePass)
+            << "A mutable pass is active. Hence, use of PointerVectorSet::insert(first, last) is prohibited.";
         // first sorts the input iterators and make the input unique.
         std::sort(first, last, CompareKey());
         auto new_last = std::unique(first, last, EqualKeyTo());
@@ -800,7 +806,8 @@ public:
      */
     iterator find(const key_type& Key)
     {
-        KRATOS_ERROR_IF(mHasMutablePass) << "A mutable pass is active. Hence, use of this function prohibited.";
+        KRATOS_ERROR_IF(mHasMutablePass)
+            << "A mutable pass is active. Hence, use of PointerVectorSet::find(key) is prohibited.";
         ptr_iterator i(std::lower_bound(mData.begin(), mData.end(), Key, CompareKey()));
         if (i != mData.end() && EqualKeyTo(Key)(*i)) {
             return i;
@@ -819,7 +826,8 @@ public:
      */
     const_iterator find(const key_type& Key) const
     {
-        KRATOS_ERROR_IF(mHasMutablePass) << "A mutable pass is active. Hence, use of this function prohibited.";
+        KRATOS_ERROR_IF(mHasMutablePass)
+            << "A mutable pass is active. Hence, use of PointerVectorSet::find(key) is prohibited.";
         ptr_const_iterator i(std::lower_bound(mData.begin(), mData.end(), Key, CompareKey()));
         if (i != mData.end() && EqualKeyTo(Key)(*i)) {
             return const_iterator(i);
@@ -891,7 +899,6 @@ public:
 
     MutablePass GetMutablePass()
     {
-
         return MutablePass(*this);
     }
 


### PR DESCRIPTION
**📝 Description**
This PR adds the `PointerVectorSet::MutablePass` with the following properties:
1. There can be only **one** `MutablePass` issued per `PointerVectorSet` at a time.
2. The construction of `MutablePass` **freezes** methods which uses the sorted property of the `PointerVectorSet`
3. Once the `MutablePass` is destroyed, it **sorts and makes the entities in `PointerVectorSet` unique. Then it unfreezes the methods which were frozen**.

This PR also fixes the `PointerVectorSet::operator[]` and `PointerVectorSet::operator()` methods assuming they will be always sorted. This introduces a :exclamation:**BEHAVIOUR CHANGE**:exclamation:.

**🆕 Changelog**
- Adds `MutablePass`
- Fixes the `PointerVectorSet::operator()` and `PointerVectorSet::operator[]`
