### PR TITLE
[GeoMechanicsApplication] First experiment with GMock

### DIFF
--- a/applications/GeoMechanicsApplication/tests/cpp_tests/test_time_stepping.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/test_time_stepping.cpp
@@ -39,29 +39,17 @@ public:
     }
 
     MOCK_METHOD(std::size_t, GetNumberOfIterations, (), (const, override));
-
-    [[nodiscard]] double GetEndTime() const override { return 10.; };
-
+    MOCK_METHOD(double, GetEndTime, (), (const, override));
     MOCK_METHOD(void, SetEndTime, (double EndTime), (override));
-
-    [[nodiscard]] double GetTimeIncrement() const override { return 0.0; }
-
+    MOCK_METHOD(double, GetTimeIncrement, (), (const, override));
     MOCK_METHOD(void, SetTimeIncrement, (double TimeIncrement), (override));
-
-    [[nodiscard]] std::size_t GetStepNumber() const override { return 0; }
-
+    MOCK_METHOD(std::size_t, GetStepNumber, (), (const, override));
     MOCK_METHOD(void, IncrementStepNumber, (), (override));
-
     MOCK_METHOD(void, CloneTimeStep, (), (override));
-
     MOCK_METHOD(void, RestorePositionsAndDOFVectorToStartOfStep, (), (override));
-
     MOCK_METHOD(void, SaveTotalDisplacementFieldAtStartOfTimeLoop, (), (override));
-
     MOCK_METHOD(void, AccumulateTotalDisplacementField, (), (override));
-
     MOCK_METHOD(void, ComputeIncrementalDisplacementField, (),  (override));
-
     MOCK_METHOD(void, OutputProcess, (), (override));
 
     void Initialize() override { ++mSolverStrategyInitializeCalls; }

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/test_time_stepping.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/test_time_stepping.cpp
@@ -33,6 +33,14 @@ public:
 class DummyStrategyWrapper : public StrategyWrapper
 {
 public:
+    DummyStrategyWrapper()
+    {
+        ON_CALL(*this, GetNumberOfIterations()).WillByDefault(testing::Return(4));
+        ON_CALL(*this, GetEndTime()).WillByDefault(testing::Return(10.0));
+        ON_CALL(*this, GetTimeIncrement()).WillByDefault(testing::Return(0.0));
+        ON_CALL(*this, GetStepNumber()).WillByDefault(testing::Return(0));
+    }
+
     MOCK_METHOD(std::size_t, GetNumberOfIterations, (), (const, override));
     MOCK_METHOD(double, GetEndTime, (), (const, override));
     MOCK_METHOD(void, SetEndTime, (double EndTime), (override));

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/test_time_stepping.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/test_time_stepping.cpp
@@ -27,22 +27,7 @@ class ProcessSpy : public Process
 {
 public:
     MOCK_METHOD(void, ExecuteInitializeSolutionStep, (), (override));
-
-    void ExecuteFinalizeSolutionStep() override { ++mSolutionStepFinalizedCalls; }
-
-    [[nodiscard]] unsigned int NumberOfExecuteInitializeSolutionStepCalls() const
-    {
-        return mSolutionStepInitializedCalls;
-    }
-
-    [[nodiscard]] unsigned int NumberOfExecuteFinalizeSolutionStepCalls() const
-    {
-        return mSolutionStepFinalizedCalls;
-    }
-
-private:
-    unsigned int mSolutionStepInitializedCalls = 0;
-    unsigned int mSolutionStepFinalizedCalls   = 0;
+    MOCK_METHOD(void, ExecuteFinalizeSolutionStep, (), (override));
 };
 
 class DummyStrategyWrapper : public StrategyWrapper
@@ -186,6 +171,7 @@ KRATOS_TEST_CASE_IN_SUITE(ProcessMemberFunctionsAllCalledOnce, KratosGeoMechanic
     executor.SetSolverStrategy(converging_strategy);
     auto spy = std::make_shared<ProcessSpy>();
     EXPECT_CALL(*spy, ExecuteInitializeSolutionStep()).Times(1);
+    EXPECT_CALL(*spy, ExecuteFinalizeSolutionStep()).Times(1);
 
     std::vector<std::shared_ptr<Process>> processes{spy};
     std::vector<std::weak_ptr<Process>>   process_observables{spy};
@@ -193,8 +179,6 @@ KRATOS_TEST_CASE_IN_SUITE(ProcessMemberFunctionsAllCalledOnce, KratosGeoMechanic
     const auto time = 0.0;
 
     executor.Run(time);
-
-    KRATOS_EXPECT_EQ(1, spy->NumberOfExecuteFinalizeSolutionStepCalls());
 }
 
 KRATOS_TEST_CASE_IN_SUITE(SolverStrategyMemberFunctionsAllExceptInitializeAndFinalizeCalledOnce,

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/test_time_stepping.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/test_time_stepping.cpp
@@ -42,50 +42,31 @@ public:
 
     [[nodiscard]] double GetEndTime() const override { return 10.; };
 
-    void SetEndTime(double EndTime) override
-    {
-        // intentionally empty
-    }
+    MOCK_METHOD(void, SetEndTime, (double EndTime), (override));
 
     [[nodiscard]] double GetTimeIncrement() const override { return 0.0; }
 
-    void SetTimeIncrement(double TimeIncrement) override
-    {
-        // intentionally empty
-    }
+    MOCK_METHOD(void, SetTimeIncrement, (double TimeIncrement), (override));
 
     [[nodiscard]] std::size_t GetStepNumber() const override { return 0; }
 
-    void IncrementStepNumber() override
-    {
-        // intentionally empty
-    }
+    MOCK_METHOD(void, IncrementStepNumber, (), (override));
 
-    void CloneTimeStep() override {
-        // intentionally empty
-    };
-    void RestorePositionsAndDOFVectorToStartOfStep() override {
-        // intentionally empty
-    };
-    void SaveTotalDisplacementFieldAtStartOfTimeLoop() override {
-        // intentionally empty
-    };
-    void AccumulateTotalDisplacementField() override {
-        // intentionally empty
-    };
-    void ComputeIncrementalDisplacementField() override {
-        // intentionally empty
-    };
-    void OutputProcess() override {
-        // intentionally empty
-    };
+    MOCK_METHOD(void, CloneTimeStep, (), (override));
+
+    MOCK_METHOD(void, RestorePositionsAndDOFVectorToStartOfStep, (), (override));
+
+    MOCK_METHOD(void, SaveTotalDisplacementFieldAtStartOfTimeLoop, (), (override));
+
+    MOCK_METHOD(void, AccumulateTotalDisplacementField, (), (override));
+
+    MOCK_METHOD(void, ComputeIncrementalDisplacementField, (),  (override));
+
+    MOCK_METHOD(void, OutputProcess, (), (override));
 
     void Initialize() override { ++mSolverStrategyInitializeCalls; }
 
-    void InitializeOutput() override
-    {
-        // Intentionally empty
-    }
+    MOCK_METHOD(void, InitializeOutput, (), (override));
 
     void InitializeSolutionStep() override { ++mSolverStrategyInitializeSolutionStepCalls; }
 
@@ -124,10 +105,7 @@ public:
         return mSolverStrategyFinalizeSolutionStepCalls;
     }
 
-    void FinalizeOutput() override
-    {
-        // intentionally empty
-    }
+    MOCK_METHOD(void, FinalizeOutput, (), (override));
 
 private:
     TimeStepEndState::ConvergenceState mConvergenceState;

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/test_time_stepping.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/test_time_stepping.cpp
@@ -33,11 +33,6 @@ public:
 class DummyStrategyWrapper : public StrategyWrapper
 {
 public:
-    explicit DummyStrategyWrapper(TimeStepEndState::ConvergenceState ConvergenceState)
-        : mConvergenceState(ConvergenceState)
-    {
-    }
-
     MOCK_METHOD(std::size_t, GetNumberOfIterations, (), (const, override));
     MOCK_METHOD(double, GetEndTime, (), (const, override));
     MOCK_METHOD(void, SetEndTime, (double EndTime), (override));
@@ -49,59 +44,15 @@ public:
     MOCK_METHOD(void, RestorePositionsAndDOFVectorToStartOfStep, (), (override));
     MOCK_METHOD(void, SaveTotalDisplacementFieldAtStartOfTimeLoop, (), (override));
     MOCK_METHOD(void, AccumulateTotalDisplacementField, (), (override));
-    MOCK_METHOD(void, ComputeIncrementalDisplacementField, (),  (override));
+    MOCK_METHOD(void, ComputeIncrementalDisplacementField, (), (override));
     MOCK_METHOD(void, OutputProcess, (), (override));
-
-    void Initialize() override { ++mSolverStrategyInitializeCalls; }
-
+    MOCK_METHOD(void, Initialize, (), (override));
     MOCK_METHOD(void, InitializeOutput, (), (override));
-
-    void InitializeSolutionStep() override { ++mSolverStrategyInitializeSolutionStepCalls; }
-
-    void Predict() override { ++mSolverStrategyPredictCalls; }
-
-    TimeStepEndState::ConvergenceState SolveSolutionStep() override
-    {
-        ++mSolverStrategySolveSolutionsStepCalls;
-        return mConvergenceState;
-    }
-
-    void FinalizeSolutionStep() override { ++mSolverStrategyFinalizeSolutionStepCalls; }
-
-    [[nodiscard]] unsigned int NumberOfSolverStrategyInitializeCalls() const
-    {
-        return mSolverStrategyInitializeCalls;
-    }
-
-    [[nodiscard]] unsigned int NumberOfSolverStrategyInitializeSolutionStepCalls() const
-    {
-        return mSolverStrategyInitializeSolutionStepCalls;
-    }
-
-    [[nodiscard]] unsigned int NumberOfSolverStrategyPredictCalls() const
-    {
-        return mSolverStrategyPredictCalls;
-    }
-
-    [[nodiscard]] unsigned int NumberOfSolverStrategySolveSolutionStepCalls() const
-    {
-        return mSolverStrategySolveSolutionsStepCalls;
-    }
-
-    [[nodiscard]] unsigned int NumberOfSolverStrategyFinalizeSolutionStepCalls() const
-    {
-        return mSolverStrategyFinalizeSolutionStepCalls;
-    }
-
+    MOCK_METHOD(void, InitializeSolutionStep, (), (override));
+    MOCK_METHOD(void, Predict, (), (override));
+    MOCK_METHOD(TimeStepEndState::ConvergenceState, SolveSolutionStep, (), (override));
+    MOCK_METHOD(void, FinalizeSolutionStep, (), (override));
     MOCK_METHOD(void, FinalizeOutput, (), (override));
-
-private:
-    TimeStepEndState::ConvergenceState mConvergenceState;
-    unsigned int                       mSolverStrategyInitializeCalls             = 0;
-    unsigned int                       mSolverStrategyInitializeSolutionStepCalls = 0;
-    unsigned int                       mSolverStrategyPredictCalls                = 0;
-    unsigned int                       mSolverStrategySolveSolutionsStepCalls     = 0;
-    unsigned int                       mSolverStrategyFinalizeSolutionStepCalls   = 0;
 };
 
 } // namespace
@@ -112,28 +63,32 @@ namespace Kratos::Testing
 KRATOS_TEST_CASE_IN_SUITE(RunReturnsNonConvergedWhenStrategyDoesNotConverge, KratosGeoMechanicsFastSuiteWithoutKernel)
 {
     TimeStepExecutor executor;
-    auto             nonconverging_strategy =
-        std::make_shared<DummyStrategyWrapper>(TimeStepEndState::ConvergenceState::non_converged);
+    auto             nonconverging_strategy = std::make_shared<DummyStrategyWrapper>();
+    EXPECT_CALL(*nonconverging_strategy, SolveSolutionStep())
+        .WillOnce(testing::Return(TimeStepEndState::ConvergenceState::non_converged));
+
     executor.SetSolverStrategy(nonconverging_strategy);
-    const auto time = 0.0;
+    constexpr auto time = 0.0;
     KRATOS_EXPECT_TRUE(executor.Run(time).NonConverged())
 }
 
 KRATOS_TEST_CASE_IN_SUITE(RunReturnsConvergedWhenStrategyConverged, KratosGeoMechanicsFastSuiteWithoutKernel)
 {
     TimeStepExecutor executor;
-    auto             converging_strategy =
-        std::make_shared<DummyStrategyWrapper>(TimeStepEndState::ConvergenceState::converged);
+    auto             converging_strategy = std::make_shared<DummyStrategyWrapper>();
+    EXPECT_CALL(*converging_strategy, SolveSolutionStep()).WillOnce(testing::Return(TimeStepEndState::ConvergenceState::converged));
+
     executor.SetSolverStrategy(converging_strategy);
-    const auto time = 0.0;
+    constexpr auto time = 0.0;
     KRATOS_EXPECT_TRUE(executor.Run(time).Converged())
 }
 
 KRATOS_TEST_CASE_IN_SUITE(ProcessMemberFunctionsAllCalledOnce, KratosGeoMechanicsFastSuiteWithoutKernel)
 {
     TimeStepExecutor executor;
-    auto             converging_strategy =
-        std::make_shared<DummyStrategyWrapper>(TimeStepEndState::ConvergenceState::converged);
+    auto             converging_strategy = std::make_shared<DummyStrategyWrapper>();
+    EXPECT_CALL(*converging_strategy, SolveSolutionStep()).WillOnce(testing::Return(TimeStepEndState::ConvergenceState::converged));
+
     executor.SetSolverStrategy(converging_strategy);
     auto spy = std::make_shared<ProcessSpy>();
     EXPECT_CALL(*spy, ExecuteInitializeSolutionStep()).Times(1);
@@ -142,7 +97,7 @@ KRATOS_TEST_CASE_IN_SUITE(ProcessMemberFunctionsAllCalledOnce, KratosGeoMechanic
     std::vector<std::shared_ptr<Process>> processes{spy};
     std::vector<std::weak_ptr<Process>>   process_observables{spy};
     executor.SetProcessObservables(process_observables);
-    const auto time = 0.0;
+    constexpr auto time = 0.0;
 
     executor.Run(time);
 }
@@ -151,49 +106,53 @@ KRATOS_TEST_CASE_IN_SUITE(SolverStrategyMemberFunctionsAllExceptInitializeAndFin
                           KratosGeoMechanicsFastSuiteWithoutKernel)
 {
     TimeStepExecutor executor;
-    auto             converging_strategy =
-        std::make_shared<DummyStrategyWrapper>(TimeStepEndState::ConvergenceState::converged);
+    auto             converging_strategy = std::make_shared<DummyStrategyWrapper>();
+
     executor.SetSolverStrategy(converging_strategy);
-    const auto time = 0.0;
+    constexpr auto time = 0.0;
+
+    EXPECT_CALL(*converging_strategy, Initialize()).Times(0);
+    EXPECT_CALL(*converging_strategy, InitializeSolutionStep()).Times(1);
+    EXPECT_CALL(*converging_strategy, Predict()).Times(1);
+    EXPECT_CALL(*converging_strategy, SolveSolutionStep()).WillOnce(testing::Return(TimeStepEndState::ConvergenceState::converged));
+    EXPECT_CALL(*converging_strategy, FinalizeSolutionStep()).Times(0);
 
     executor.Run(time);
-
-    KRATOS_EXPECT_EQ(0, converging_strategy->NumberOfSolverStrategyInitializeCalls());
-    KRATOS_EXPECT_EQ(1, converging_strategy->NumberOfSolverStrategyInitializeSolutionStepCalls());
-    KRATOS_EXPECT_EQ(1, converging_strategy->NumberOfSolverStrategyPredictCalls());
-    KRATOS_EXPECT_EQ(1, converging_strategy->NumberOfSolverStrategySolveSolutionStepCalls());
-    KRATOS_EXPECT_EQ(0, converging_strategy->NumberOfSolverStrategyFinalizeSolutionStepCalls());
 }
 
 KRATOS_TEST_CASE_IN_SUITE(ConvergingTimeStepExecutionReturnsGivenTime, KratosGeoMechanicsFastSuiteWithoutKernel)
 {
     TimeStepExecutor executor;
-    auto             converging_strategy =
-        std::make_shared<DummyStrategyWrapper>(TimeStepEndState::ConvergenceState::converged);
+    auto             converging_strategy = std::make_shared<DummyStrategyWrapper>();
+    EXPECT_CALL(*converging_strategy, SolveSolutionStep()).WillOnce(testing::Return(TimeStepEndState::ConvergenceState::converged));
+
     executor.SetSolverStrategy(converging_strategy);
-    const auto time = 2.0;
+    constexpr auto time = 2.0;
     KRATOS_EXPECT_DOUBLE_EQ(time, executor.Run(time).time);
 }
 
 KRATOS_TEST_CASE_IN_SUITE(NonConvergingTimeStepExecutionReturnsGivenTime, KratosGeoMechanicsFastSuiteWithoutKernel)
 {
     TimeStepExecutor executor;
-    auto             non_converging_strategy =
-        std::make_shared<DummyStrategyWrapper>(TimeStepEndState::ConvergenceState::non_converged);
+    auto             non_converging_strategy = std::make_shared<DummyStrategyWrapper>();
+    EXPECT_CALL(*non_converging_strategy, SolveSolutionStep())
+        .WillOnce(testing::Return(TimeStepEndState::ConvergenceState::non_converged));
+
     executor.SetSolverStrategy(non_converging_strategy);
-    const auto time = 2.0;
+    constexpr auto time = 2.0;
     KRATOS_EXPECT_DOUBLE_EQ(time, executor.Run(time).time);
 }
 
 KRATOS_TEST_CASE_IN_SUITE(TimeStepExecutionReturnsNumberOfIterations, KratosGeoMechanicsFastSuiteWithoutKernel)
 {
     TimeStepExecutor executor;
-    auto             converging_strategy =
-        std::make_shared<DummyStrategyWrapper>(TimeStepEndState::ConvergenceState::converged);
+    auto             converging_strategy = std::make_shared<DummyStrategyWrapper>();
+    EXPECT_CALL(*converging_strategy, SolveSolutionStep()).WillOnce(testing::Return(TimeStepEndState::ConvergenceState::converged));
+
     EXPECT_CALL(*converging_strategy, GetNumberOfIterations()).WillOnce(testing::Return(4));
 
     executor.SetSolverStrategy(converging_strategy);
-    const auto time = 2.0;
+    constexpr auto time = 2.0;
     KRATOS_EXPECT_EQ(4, executor.Run(time).num_of_iterations);
 }
 

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/test_time_stepping.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/test_time_stepping.cpp
@@ -16,6 +16,8 @@
 #include "geo_mechanics_fast_suite.h"
 #include "solving_strategies/strategies/solving_strategy.h"
 
+#include <gmock/gmock.h>
+
 using namespace Kratos;
 
 namespace
@@ -24,7 +26,7 @@ namespace
 class ProcessSpy : public Process
 {
 public:
-    void ExecuteInitializeSolutionStep() override { ++mSolutionStepInitializedCalls; }
+    MOCK_METHOD(void, ExecuteInitializeSolutionStep, (), (override));
 
     void ExecuteFinalizeSolutionStep() override { ++mSolutionStepFinalizedCalls; }
 
@@ -183,6 +185,7 @@ KRATOS_TEST_CASE_IN_SUITE(ProcessMemberFunctionsAllCalledOnce, KratosGeoMechanic
         std::make_shared<DummyStrategyWrapper>(TimeStepEndState::ConvergenceState::converged);
     executor.SetSolverStrategy(converging_strategy);
     auto spy = std::make_shared<ProcessSpy>();
+    EXPECT_CALL(*spy, ExecuteInitializeSolutionStep()).Times(1);
 
     std::vector<std::shared_ptr<Process>> processes{spy};
     std::vector<std::weak_ptr<Process>>   process_observables{spy};
@@ -191,7 +194,6 @@ KRATOS_TEST_CASE_IN_SUITE(ProcessMemberFunctionsAllCalledOnce, KratosGeoMechanic
 
     executor.Run(time);
 
-    KRATOS_EXPECT_EQ(1, spy->NumberOfExecuteInitializeSolutionStepCalls());
     KRATOS_EXPECT_EQ(1, spy->NumberOfExecuteFinalizeSolutionStepCalls());
 }
 

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/test_time_stepping.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/test_time_stepping.cpp
@@ -38,7 +38,7 @@ public:
     {
     }
 
-    [[nodiscard]] std::size_t GetNumberOfIterations() const override { return 4; };
+    MOCK_METHOD(std::size_t, GetNumberOfIterations, (), (const, override));
 
     [[nodiscard]] double GetEndTime() const override { return 10.; };
 
@@ -202,6 +202,8 @@ KRATOS_TEST_CASE_IN_SUITE(TimeStepExecutionReturnsNumberOfIterations, KratosGeoM
     TimeStepExecutor executor;
     auto             converging_strategy =
         std::make_shared<DummyStrategyWrapper>(TimeStepEndState::ConvergenceState::converged);
+    EXPECT_CALL(*converging_strategy, GetNumberOfIterations()).WillOnce(testing::Return(4));
+
     executor.SetSolverStrategy(converging_strategy);
     const auto time = 2.0;
     KRATOS_EXPECT_EQ(4, executor.Run(time).num_of_iterations);

--- a/cmake_modules/KratosGTest.cmake
+++ b/cmake_modules/KratosGTest.cmake
@@ -25,7 +25,7 @@ macro(kratos_add_gtests)
         add_executable("${KRATOS_ADD_GTEST_TARGET}Test" ${KRATOS_ADD_GTEST_SOURCES} ${KRATOS_GTEST_MAIN_SOURCE})
         target_link_libraries("${KRATOS_ADD_GTEST_TARGET}Test" ${KRATOS_ADD_GTEST_TARGET} KratosCoreTestUtilities "${TESTING_MPI_UTILITIES}" GTest::gmock_main)
         set_target_properties("${KRATOS_ADD_GTEST_TARGET}Test" PROPERTIES COMPILE_DEFINITIONS "KRATOS_TEST_CORE=IMPORT,API")
-
+        target_compile_definitions("${KRATOS_ADD_GTEST_TARGET}Test" PUBLIC GTEST_LINKED_AS_SHARED_LIBRARY)
         install(TARGETS ${KRATOS_ADD_GTEST_TARGET}Test DESTINATION test)
 
         if(DEFINED KRATOS_ADD_GTEST_WORKING_DIRECTORY)


### PR DESCRIPTION
**📝 Description**
This PR replaces manually created functions for two Mock/Stub/Spy classes with the MOCK_METHOD macro implemented in GMock. This has a couple of advantages:
1. If we have to override functions (i.e. base class has purely virtual functions), this can be done easily with the MOCK_METHOD macro
2. Functions created with these macro can be checked using the EXPECT_CALL macro. You can set the expectation for how many times a function is called (for example `EXPECT_CALL(*converging_strategy, Predict()).Times(1)`), you can also control what it will output (for example `EXPECT_CALL(*converging_strategy, GetNumberOfIterations()).WillOnce(testing::Return(4));` or `ON_CALL(*this, GetNumberOfIterations()).WillByDefault(testing::Return(4));`)