### PR TITLE
[GeoMechanicsApplication] Fix ordering issue for reset displacement

### DIFF
--- a/applications/GeoMechanicsApplication/custom_elements/compressibility_calculator.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/compressibility_calculator.cpp
@@ -38,7 +38,7 @@ Vector CompressibilityCalculator::RHSContribution(const Matrix& rCompressibility
 
 Matrix CompressibilityCalculator::LHSContribution(const Matrix& rCompressibilityMatrix) const
 {
-    return mInputProvider.GetMatrixScalarFactor()* rCompressibilityMatrix;
+    return mInputProvider.GetMatrixScalarFactor() * rCompressibilityMatrix;
 }
 
 std::pair<Matrix, Vector> CompressibilityCalculator::LocalSystemContribution()

--- a/applications/GeoMechanicsApplication/custom_elements/permeability_calculator.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/permeability_calculator.cpp
@@ -44,11 +44,11 @@ Vector PermeabilityCalculator::RHSContribution(const Matrix& rPermeabilityMatrix
 Matrix PermeabilityCalculator::CalculatePermeabilityMatrix() const
 {
     RetentionLaw::Parameters retention_parameters(mInputProvider.GetElementProperties());
-    const auto&              r_properties = mInputProvider.GetElementProperties();
-    auto integration_coefficients = mInputProvider.GetIntegrationCoefficients();
-    const auto   shape_function_gradients = mInputProvider.GetShapeFunctionGradients();
-    const auto   local_dimension          = shape_function_gradients[0].size2();
-    const Matrix constitutive_matrix =
+    const auto&              r_properties             = mInputProvider.GetElementProperties();
+    auto                     integration_coefficients = mInputProvider.GetIntegrationCoefficients();
+    const auto               shape_function_gradients = mInputProvider.GetShapeFunctionGradients();
+    const auto               local_dimension          = shape_function_gradients[0].size2();
+    const Matrix             constitutive_matrix =
         GeoElementUtilities::FillPermeabilityMatrix(r_properties, local_dimension);
 
     const auto   number_of_nodes           = shape_function_gradients[0].size1();

--- a/applications/GeoMechanicsApplication/custom_elements/permeability_calculator.h
+++ b/applications/GeoMechanicsApplication/custom_elements/permeability_calculator.h
@@ -26,7 +26,7 @@ public:
     class InputProvider
     {
     public:
-        InputProvider(std::function<const Properties&()>                         GetElementProperties,
+        InputProvider(std::function<const Properties&()> GetElementProperties,
                       std::function<const std::vector<RetentionLaw::Pointer>&()> GetRetentionLaws,
                       std::function<Vector()>                        GetIntegrationCoefficients,
                       std::function<Vector(const Variable<double>&)> GetNodalValuesOf,
@@ -39,9 +39,9 @@ public:
         {
         }
 
-        [[nodiscard]] const Properties& GetElementProperties() const;
+        [[nodiscard]] const Properties&                         GetElementProperties() const;
         [[nodiscard]] const std::vector<RetentionLaw::Pointer>& GetRetentionLaws() const;
-        [[nodiscard]] Vector GetIntegrationCoefficients() const;
+        [[nodiscard]] Vector                                    GetIntegrationCoefficients() const;
         [[nodiscard]] Vector GetNodalValues(const Variable<double>& rVariable) const;
         [[nodiscard]] Geometry<Node>::ShapeFunctionsGradientsType GetShapeFunctionGradients() const;
 

--- a/applications/GeoMechanicsApplication/custom_python/add_custom_utilities_to_python.cpp
+++ b/applications/GeoMechanicsApplication/custom_python/add_custom_utilities_to_python.cpp
@@ -21,9 +21,9 @@
 namespace Kratos::Python
 {
 
-void AddCustomUtilitiesToPython(pybind11::module& m)
+void AddCustomUtilitiesToPython(pybind11::module& rModule)
 {
-    pybind11::class_<NodeUtilities>(m, "NodeUtilities")
+    pybind11::class_<NodeUtilities>(rModule, "NodeUtilities")
         .def("AssignUpdatedVectorVariableToNonFixedComponentsOfNodes",
              &NodeUtilities::AssignUpdatedVectorVariableToNonFixedComponentsOfNodes);
 }

--- a/applications/GeoMechanicsApplication/custom_python/add_custom_utilities_to_python.cpp
+++ b/applications/GeoMechanicsApplication/custom_python/add_custom_utilities_to_python.cpp
@@ -15,15 +15,18 @@
 
 // Project includes
 #include "custom_python/add_custom_utilities_to_python.h"
-#include "includes/kratos_parameters.h"
 
-#include "custom_utilities/condition_utilities.hpp"
-#include "custom_utilities/element_utilities.hpp"
-#include "custom_utilities/interface_element_utilities.h"
+#include "custom_utilities/node_utilities.h"
 
 namespace Kratos::Python
 {
 
-void AddCustomUtilitiesToPython(pybind11::module&) { namespace py = pybind11; }
+void AddCustomUtilitiesToPython(pybind11::module& m)
+{
+    pybind11::class_<NodeUtilities>(m, "NodeUtilities")
+        .def(pybind11::init<>())
+        .def("AssignUpdatedVectorVariableToNonFixedComponentsOfNodes",
+             &NodeUtilities::AssignUpdatedVectorVariableToNonFixedComponentsOfNodes);
+}
 
 } // Namespace Kratos::Python.

--- a/applications/GeoMechanicsApplication/custom_python/add_custom_utilities_to_python.cpp
+++ b/applications/GeoMechanicsApplication/custom_python/add_custom_utilities_to_python.cpp
@@ -21,7 +21,7 @@
 namespace Kratos::Python
 {
 
-void AddCustomUtilitiesToPython(pybind11::module& rModule)
+void AddCustomUtilitiesToPython(const pybind11::module& rModule)
 {
     pybind11::class_<NodeUtilities>(rModule, "NodeUtilities")
         .def("AssignUpdatedVectorVariableToNonFixedComponentsOfNodes",

--- a/applications/GeoMechanicsApplication/custom_python/add_custom_utilities_to_python.cpp
+++ b/applications/GeoMechanicsApplication/custom_python/add_custom_utilities_to_python.cpp
@@ -24,7 +24,6 @@ namespace Kratos::Python
 void AddCustomUtilitiesToPython(pybind11::module& m)
 {
     pybind11::class_<NodeUtilities>(m, "NodeUtilities")
-        .def(pybind11::init<>())
         .def("AssignUpdatedVectorVariableToNonFixedComponentsOfNodes",
              &NodeUtilities::AssignUpdatedVectorVariableToNonFixedComponentsOfNodes);
 }

--- a/applications/GeoMechanicsApplication/custom_python/add_custom_utilities_to_python.h
+++ b/applications/GeoMechanicsApplication/custom_python/add_custom_utilities_to_python.h
@@ -25,7 +25,7 @@
 namespace Kratos::Python
 {
 
-void AddCustomUtilitiesToPython(pybind11::module& rModule);
+void AddCustomUtilitiesToPython(const pybind11::module& rModule);
 
 } // namespace Kratos::Python.
 

--- a/applications/GeoMechanicsApplication/custom_python/add_custom_utilities_to_python.h
+++ b/applications/GeoMechanicsApplication/custom_python/add_custom_utilities_to_python.h
@@ -25,7 +25,7 @@
 namespace Kratos::Python
 {
 
-void AddCustomUtilitiesToPython(pybind11::module&);
+void AddCustomUtilitiesToPython(pybind11::module& rModule);
 
 } // namespace Kratos::Python.
 

--- a/applications/GeoMechanicsApplication/custom_utilities/node_utilities.cpp
+++ b/applications/GeoMechanicsApplication/custom_utilities/node_utilities.cpp
@@ -43,7 +43,7 @@ void NodeUtilities::AssignUpdatedVectorVariableToNonFixedComponentsOfNodes(
     const ModelPart::NodesContainerType& rNodes,
     const Variable<array_1d<double, 3>>& rDestinationVariable,
     const array_1d<double, 3>&           rNewValues,
-    IndexType SolutionStepIndex)
+    IndexType                            SolutionStepIndex)
 {
     block_for_each(rNodes, [&rDestinationVariable, &rNewValues, SolutionStepIndex](Node& rNode) {
         AssignUpdatedVectorVariableToNonFixedComponents(rNode, rDestinationVariable, rNewValues, SolutionStepIndex);

--- a/applications/GeoMechanicsApplication/custom_utilities/node_utilities.cpp
+++ b/applications/GeoMechanicsApplication/custom_utilities/node_utilities.cpp
@@ -38,4 +38,14 @@ void NodeUtilities::AssignUpdatedVectorVariableToNonFixedComponents(Node& rNode,
     }
 }
 
+void NodeUtilities::AssignUpdatedVectorVariableToNonFixedComponentsOfNodes(
+    const ModelPart::NodesContainerType& rNodes,
+    const Variable<array_1d<double, 3>>& rDestinationVariable,
+    const array_1d<double, 3>&           rNewValues)
+{
+    block_for_each(rNodes, [&rDestinationVariable, &rNewValues](Node& rNode) {
+        AssignUpdatedVectorVariableToNonFixedComponents(rNode, rDestinationVariable, rNewValues);
+    });
+}
+
 } // namespace Kratos

--- a/applications/GeoMechanicsApplication/custom_utilities/node_utilities.cpp
+++ b/applications/GeoMechanicsApplication/custom_utilities/node_utilities.cpp
@@ -22,7 +22,8 @@ namespace Kratos
 
 void NodeUtilities::AssignUpdatedVectorVariableToNonFixedComponents(Node& rNode,
                                                                     const Variable<array_1d<double, 3>>& rDestinationVariable,
-                                                                    const array_1d<double, 3>& rNewValues)
+                                                                    const array_1d<double, 3>& rNewValues,
+                                                                    IndexType SolutionStepIndex)
 {
     const std::vector<std::string> components = {"X", "Y", "Z"};
     for (const auto& zipped : boost::combine(rNewValues, components)) {
@@ -33,7 +34,7 @@ void NodeUtilities::AssignUpdatedVectorVariableToNonFixedComponents(Node& rNode,
         if (const auto& component_variable =
                 VariablesUtilities::GetComponentFromVectorVariable(rDestinationVariable.Name(), component);
             !rNode.IsFixed(component_variable)) {
-            rNode.FastGetSolutionStepValue(component_variable, 0) = new_value;
+            rNode.FastGetSolutionStepValue(component_variable, SolutionStepIndex) = new_value;
         }
     }
 }
@@ -41,10 +42,11 @@ void NodeUtilities::AssignUpdatedVectorVariableToNonFixedComponents(Node& rNode,
 void NodeUtilities::AssignUpdatedVectorVariableToNonFixedComponentsOfNodes(
     const ModelPart::NodesContainerType& rNodes,
     const Variable<array_1d<double, 3>>& rDestinationVariable,
-    const array_1d<double, 3>&           rNewValues)
+    const array_1d<double, 3>&           rNewValues,
+    IndexType SolutionStepIndex)
 {
-    block_for_each(rNodes, [&rDestinationVariable, &rNewValues](Node& rNode) {
-        AssignUpdatedVectorVariableToNonFixedComponents(rNode, rDestinationVariable, rNewValues);
+    block_for_each(rNodes, [&rDestinationVariable, &rNewValues, SolutionStepIndex](Node& rNode) {
+        AssignUpdatedVectorVariableToNonFixedComponents(rNode, rDestinationVariable, rNewValues, SolutionStepIndex);
     });
 }
 

--- a/applications/GeoMechanicsApplication/custom_utilities/node_utilities.h
+++ b/applications/GeoMechanicsApplication/custom_utilities/node_utilities.h
@@ -14,6 +14,7 @@
 
 #include "containers/array_1d.h"
 #include "containers/variable.h"
+#include "includes/model_part.h"
 
 namespace Kratos
 {

--- a/applications/GeoMechanicsApplication/custom_utilities/node_utilities.h
+++ b/applications/GeoMechanicsApplication/custom_utilities/node_utilities.h
@@ -27,11 +27,13 @@ public:
 
     static void AssignUpdatedVectorVariableToNonFixedComponents(Node& rNode,
                                                                 const Variable<array_1d<double, 3>>& rDestinationVariable,
-                                                                const array_1d<double, 3>& rNewValues);
+                                                                const array_1d<double, 3>& rNewValues,
+                                                                IndexType SolutionStepIndex = 0);
 
     static void AssignUpdatedVectorVariableToNonFixedComponentsOfNodes(const ModelPart::NodesContainerType& rNodes,
                                                                        const Variable<array_1d<double, 3>>& rDestinationVariable,
-                                                                       const array_1d<double, 3>& rNewValues);
+                                                                       const array_1d<double, 3>& rNewValues,
+                                                                       IndexType SolutionStepIndex = 0);
 };
 
 } // namespace Kratos

--- a/applications/GeoMechanicsApplication/custom_utilities/node_utilities.h
+++ b/applications/GeoMechanicsApplication/custom_utilities/node_utilities.h
@@ -23,9 +23,15 @@ class Node;
 class KRATOS_API(GEO_MECHANICS_APPLICATION) NodeUtilities
 {
 public:
+    KRATOS_CLASS_POINTER_DEFINITION(NodeUtilities);
+
     static void AssignUpdatedVectorVariableToNonFixedComponents(Node& rNode,
                                                                 const Variable<array_1d<double, 3>>& rDestinationVariable,
                                                                 const array_1d<double, 3>& rNewValues);
+
+    static void AssignUpdatedVectorVariableToNonFixedComponentsOfNodes(const ModelPart::NodesContainerType& rNodes,
+                                                                       const Variable<array_1d<double, 3>>& rDestinationVariable,
+                                                                       const array_1d<double, 3>& rNewValues);
 };
 
 } // namespace Kratos

--- a/applications/GeoMechanicsApplication/custom_workflows/dgeosettlement.cpp
+++ b/applications/GeoMechanicsApplication/custom_workflows/dgeosettlement.cpp
@@ -339,10 +339,8 @@ std::shared_ptr<StrategyWrapper> KratosGeoSettlement::MakeStrategyWrapper(const 
     GetMainModelPart().CloneTimeStep();
 
     if (rProjectParameters["solver_settings"]["reset_displacements"].GetBool()) {
-        constexpr auto source_index      = std::size_t{0};
-        constexpr auto destination_index = std::size_t{1};
-        RestoreValuesOfNodalVariable(DISPLACEMENT, source_index, destination_index);
-        RestoreValuesOfNodalVariable(ROTATION, source_index, destination_index);
+        ResetValuesOfNodalVariable(DISPLACEMENT);
+        ResetValuesOfNodalVariable(ROTATION);
 
         VariableUtils{}.UpdateCurrentToInitialConfiguration(GetComputationalModelPart().Nodes());
     }

--- a/applications/GeoMechanicsApplication/custom_workflows/dgeosettlement.cpp
+++ b/applications/GeoMechanicsApplication/custom_workflows/dgeosettlement.cpp
@@ -191,14 +191,6 @@ int KratosGeoSettlement::RunStage(const std::filesystem::path&            rWorki
         std::vector<std::shared_ptr<Process>> processes = GetProcesses(project_parameters);
         std::vector<std::weak_ptr<Process>> process_observables(processes.begin(), processes.end());
 
-        if (mpTimeLoopExecutor) {
-            mpTimeLoopExecutor->SetCancelDelegate(rShouldCancel);
-            mpTimeLoopExecutor->SetProgressDelegate(rProgressDelegate);
-            mpTimeLoopExecutor->SetProcessObservables(process_observables);
-            mpTimeLoopExecutor->SetTimeIncrementor(MakeTimeIncrementor(project_parameters));
-            mpTimeLoopExecutor->SetSolverStrategyWrapper(MakeStrategyWrapper(project_parameters, rWorkingDirectory));
-        }
-
         for (const auto& process : processes) {
             process->ExecuteInitialize();
         }
@@ -208,6 +200,12 @@ int KratosGeoSettlement::RunStage(const std::filesystem::path&            rWorki
         }
 
         if (mpTimeLoopExecutor) {
+            mpTimeLoopExecutor->SetCancelDelegate(rShouldCancel);
+            mpTimeLoopExecutor->SetProgressDelegate(rProgressDelegate);
+            mpTimeLoopExecutor->SetProcessObservables(process_observables);
+            mpTimeLoopExecutor->SetTimeIncrementor(MakeTimeIncrementor(project_parameters));
+            mpTimeLoopExecutor->SetSolverStrategyWrapper(MakeStrategyWrapper(project_parameters, rWorkingDirectory));
+
             // For now, pass a dummy state. THIS PROBABLY NEEDS TO BE REFINED AT SOME POINT!
             TimeStepEndState start_of_loop_state;
             start_of_loop_state.convergence_state = TimeStepEndState::ConvergenceState::converged;

--- a/applications/GeoMechanicsApplication/custom_workflows/dgeosettlement.h
+++ b/applications/GeoMechanicsApplication/custom_workflows/dgeosettlement.h
@@ -79,9 +79,9 @@ private:
         if (!GetComputationalModelPart().HasNodalSolutionStepVariable(rVariable)) return;
 
         NodeUtilities::AssignUpdatedVectorVariableToNonFixedComponentsOfNodes(
-            GetComputationalModelPart().Nodes(), rVariable, ZeroVector{3}, 0);
+            GetComputationalModelPart().Nodes(), rVariable, rVariable.Zero(), 0);
         NodeUtilities::AssignUpdatedVectorVariableToNonFixedComponentsOfNodes(
-            GetComputationalModelPart().Nodes(), rVariable, ZeroVector{3}, 1);
+            GetComputationalModelPart().Nodes(), rVariable, rVariable.Zero(), 1);
     }
 
     template <typename ProcessType>

--- a/applications/GeoMechanicsApplication/custom_workflows/dgeosettlement.h
+++ b/applications/GeoMechanicsApplication/custom_workflows/dgeosettlement.h
@@ -77,13 +77,10 @@ private:
     {
         if (!GetComputationalModelPart().HasNodalSolutionStepVariable(rVariable)) return;
 
-        VariableUtils{}.SetHistoricalVariableToZero(rVariable, GetComputationalModelPart().Nodes());
-
-        block_for_each(GetComputationalModelPart().Nodes(),
-                       [&rVariable, SourceIndex, DestinationIndex](auto& node) {
-            node.GetSolutionStepValue(rVariable, DestinationIndex) =
-                node.GetSolutionStepValue(rVariable, SourceIndex);
-        });
+        NodeUtilities::AssignUpdatedVectorVariableToNonFixedComponentsOfNodes(
+            GetComputationalModelPart().Nodes(), rVariable, ZeroVector{3}, 0);
+        NodeUtilities::AssignUpdatedVectorVariableToNonFixedComponentsOfNodes(
+            GetComputationalModelPart().Nodes(), rVariable, ZeroVector{3}, 1);
     }
 
     template <typename ProcessType>

--- a/applications/GeoMechanicsApplication/custom_workflows/dgeosettlement.h
+++ b/applications/GeoMechanicsApplication/custom_workflows/dgeosettlement.h
@@ -19,6 +19,7 @@
 #include "includes/kernel.h"
 #include "includes/kratos_export_api.h"
 
+#include "custom_utilities/node_utilities.h"
 #include "custom_utilities/process_factory.hpp"
 #include "geo_mechanics_application.h"
 #include "linear_solvers_application.h"

--- a/applications/GeoMechanicsApplication/custom_workflows/dgeosettlement.h
+++ b/applications/GeoMechanicsApplication/custom_workflows/dgeosettlement.h
@@ -74,7 +74,7 @@ private:
                             const std::stringstream&                rKratosLogBuffer) const;
 
     template <typename TVariableType>
-    void RestoreValuesOfNodalVariable(const TVariableType& rVariable, Node::IndexType SourceIndex, Node::IndexType DestinationIndex)
+    void ResetValuesOfNodalVariable(const TVariableType& rVariable)
     {
         if (!GetComputationalModelPart().HasNodalSolutionStepVariable(rVariable)) return;
 

--- a/applications/GeoMechanicsApplication/python_scripts/geomechanics_analysis.py
+++ b/applications/GeoMechanicsApplication/python_scripts/geomechanics_analysis.py
@@ -67,9 +67,6 @@ class GeoMechanicsAnalysisBase(AnalysisStage):
         # The reset needs to take place befor the Initialize of the processes, as these will set the Dirichlet condition.
         self._GetSolver().main_model_part.ProcessInfo[KratosGeo.RESET_DISPLACEMENTS] = self.reset_displacements
         if self.reset_displacements:
-            self.ResetIfHasNodalSolutionStepVariable(KratosMultiphysics.DISPLACEMENT)
-            self.ResetIfHasNodalSolutionStepVariable(KratosMultiphysics.ROTATION)
-
             KratosMultiphysics.VariableUtils().UpdateCurrentToInitialConfiguration(self._GetSolver().GetComputingModelPart().Nodes)
 
     def Finalize(self):

--- a/applications/GeoMechanicsApplication/python_scripts/geomechanics_analysis.py
+++ b/applications/GeoMechanicsApplication/python_scripts/geomechanics_analysis.py
@@ -57,23 +57,16 @@ class GeoMechanicsAnalysisBase(AnalysisStage):
 
     def ResetIfHasNodalSolutionStepVariable(self, variable):
         if self._GetSolver().main_model_part.HasNodalSolutionStepVariable(variable):
-            for node in self._GetSolver().GetComputingModelPart().Nodes:
-                if not node.IsFixed(variable):
-                    node.SetSolutionStepValue(variable, 0, 0.0)
-                    new_value = node.GetSolutionStepValue(variable, 0)
-                    node.SetSolutionStepValue(variable, 1, new_value)
+            KratosGeo.NodeUtilities.AssignUpdatedVectorVariableToNonFixedComponentsOfNodes(
+                self._GetSolver().GetComputingModelPart().Nodes, variable, Kratos.Array3([0.0, 0.0, 0.0]))
 
-    def ModifyAfterSolverInitialize(self):
-        # Overrides the base class. Necessary to let reset_displacements function correctly i.c.w. prescribed displacements/rotations.
-        # The reset needs to take place befor the Initialize of the processes, as these will set the Dirichlet condition.
+    def Initialize(self):
+        super().Initialize()
+
         self._GetSolver().main_model_part.ProcessInfo[KratosGeo.RESET_DISPLACEMENTS] = self.reset_displacements
         if self.reset_displacements:
-            self.ResetIfHasNodalSolutionStepVariable(KratosMultiphysics.DISPLACEMENT_X)
-            self.ResetIfHasNodalSolutionStepVariable(KratosMultiphysics.DISPLACEMENT_Y)
-            self.ResetIfHasNodalSolutionStepVariable(KratosMultiphysics.DISPLACEMENT_Z)
-            self.ResetIfHasNodalSolutionStepVariable(KratosMultiphysics.ROTATION_X)
-            self.ResetIfHasNodalSolutionStepVariable(KratosMultiphysics.ROTATION_Y)
-            self.ResetIfHasNodalSolutionStepVariable(KratosMultiphysics.ROTATION_Z)
+            self.ResetIfHasNodalSolutionStepVariable(KratosMultiphysics.DISPLACEMENT)
+            self.ResetIfHasNodalSolutionStepVariable(KratosMultiphysics.ROTATION)
 
             KratosMultiphysics.VariableUtils().UpdateCurrentToInitialConfiguration(self._GetSolver().GetComputingModelPart().Nodes)
 

--- a/applications/GeoMechanicsApplication/python_scripts/geomechanics_analysis.py
+++ b/applications/GeoMechanicsApplication/python_scripts/geomechanics_analysis.py
@@ -57,8 +57,11 @@ class GeoMechanicsAnalysisBase(AnalysisStage):
 
     def ResetIfHasNodalSolutionStepVariable(self, variable):
         if self._GetSolver().main_model_part.HasNodalSolutionStepVariable(variable):
+            zero_vector = Kratos.Array3([0.0, 0.0, 0.0])
             KratosGeo.NodeUtilities.AssignUpdatedVectorVariableToNonFixedComponentsOfNodes(
-                self._GetSolver().GetComputingModelPart().Nodes, variable, Kratos.Array3([0.0, 0.0, 0.0]))
+                self._GetSolver().GetComputingModelPart().Nodes, variable, zero_vector, 0)
+            KratosGeo.NodeUtilities.AssignUpdatedVectorVariableToNonFixedComponentsOfNodes(
+                self._GetSolver().GetComputingModelPart().Nodes, variable, zero_vector, 1)
 
     def Initialize(self):
         super().Initialize()

--- a/applications/GeoMechanicsApplication/python_scripts/geomechanics_analysis.py
+++ b/applications/GeoMechanicsApplication/python_scripts/geomechanics_analysis.py
@@ -67,6 +67,9 @@ class GeoMechanicsAnalysisBase(AnalysisStage):
         # The reset needs to take place befor the Initialize of the processes, as these will set the Dirichlet condition.
         self._GetSolver().main_model_part.ProcessInfo[KratosGeo.RESET_DISPLACEMENTS] = self.reset_displacements
         if self.reset_displacements:
+            self.ResetIfHasNodalSolutionStepVariable(KratosMultiphysics.DISPLACEMENT)
+            self.ResetIfHasNodalSolutionStepVariable(KratosMultiphysics.ROTATION)
+
             KratosMultiphysics.VariableUtils().UpdateCurrentToInitialConfiguration(self._GetSolver().GetComputingModelPart().Nodes)
 
     def Finalize(self):

--- a/applications/GeoMechanicsApplication/python_scripts/geomechanics_analysis.py
+++ b/applications/GeoMechanicsApplication/python_scripts/geomechanics_analysis.py
@@ -57,18 +57,23 @@ class GeoMechanicsAnalysisBase(AnalysisStage):
 
     def ResetIfHasNodalSolutionStepVariable(self, variable):
         if self._GetSolver().main_model_part.HasNodalSolutionStepVariable(variable):
-            KratosMultiphysics.VariableUtils().SetHistoricalVariableToZero(variable, self._GetSolver().GetComputingModelPart().Nodes)
             for node in self._GetSolver().GetComputingModelPart().Nodes:
-                new_value = node.GetSolutionStepValue(variable, 0)
-                node.SetSolutionStepValue(variable, 1, new_value)
+                if not node.IsFixed(variable):
+                    node.SetSolutionStepValue(variable, 0, 0.0)
+                    new_value = node.GetSolutionStepValue(variable, 0)
+                    node.SetSolutionStepValue(variable, 1, new_value)
 
-    def ModifyInitialGeometry(self):
+    def ModifyAfterSolverInitialize(self):
         # Overrides the base class. Necessary to let reset_displacements function correctly i.c.w. prescribed displacements/rotations.
         # The reset needs to take place befor the Initialize of the processes, as these will set the Dirichlet condition.
         self._GetSolver().main_model_part.ProcessInfo[KratosGeo.RESET_DISPLACEMENTS] = self.reset_displacements
         if self.reset_displacements:
-            self.ResetIfHasNodalSolutionStepVariable(KratosMultiphysics.DISPLACEMENT)
-            self.ResetIfHasNodalSolutionStepVariable(KratosMultiphysics.ROTATION)
+            self.ResetIfHasNodalSolutionStepVariable(KratosMultiphysics.DISPLACEMENT_X)
+            self.ResetIfHasNodalSolutionStepVariable(KratosMultiphysics.DISPLACEMENT_Y)
+            self.ResetIfHasNodalSolutionStepVariable(KratosMultiphysics.DISPLACEMENT_Z)
+            self.ResetIfHasNodalSolutionStepVariable(KratosMultiphysics.ROTATION_X)
+            self.ResetIfHasNodalSolutionStepVariable(KratosMultiphysics.ROTATION_Y)
+            self.ResetIfHasNodalSolutionStepVariable(KratosMultiphysics.ROTATION_Z)
 
             KratosMultiphysics.VariableUtils().UpdateCurrentToInitialConfiguration(self._GetSolver().GetComputingModelPart().Nodes)
 

--- a/applications/GeoMechanicsApplication/tests/truss_with_reset_displacement/ProjectParameters_stage2.json
+++ b/applications/GeoMechanicsApplication/tests/truss_with_reset_displacement/ProjectParameters_stage2.json
@@ -30,7 +30,7 @@
         "block_builder":                      true,
         "solution_type":                      "Quasi-Static",
         "scheme_type":                        "Newmark",
-        "reset_displacements":                false,
+        "reset_displacements":                true,
         "newmark_beta":                       0.25,
         "newmark_gamma":                      0.5,
         "newmark_theta":                      0.5,


### PR DESCRIPTION
**📝 Description**
We found an ordering issue with the resetting of the displacements, which was done before executing the processes for Dirichlet conditions, such that prescribed displacements were not overwritten. However, for the reset displacement process, we need the displacements of the elements to not have been reset yet. Therefore, we revert the fix made in https://github.com/KratosMultiphysics/Kratos/pull/11933, but make sure that fixed Dofs are not overwritten to make sure reset displacements and prescribed displacements still work in a single stage.