### PR TITLE
[GeoMechanicsApplication] Avoid hiding of overloaded `virtual` members

### DIFF
--- a/applications/GeoMechanicsApplication/custom_conditions/U_Pw_condition.cpp
+++ b/applications/GeoMechanicsApplication/custom_conditions/U_Pw_condition.cpp
@@ -24,7 +24,15 @@ Condition::Pointer UPwCondition<TDim, TNumNodes>::Create(IndexType              
                                                          NodesArrayType const&   ThisNodes,
                                                          PropertiesType::Pointer pProperties) const
 {
-    return Condition::Pointer(new UPwCondition(NewId, GetGeometry().Create(ThisNodes), pProperties));
+    return this->Create(NewId, GetGeometry().Create(ThisNodes), pProperties);
+}
+
+template <unsigned int TDim, unsigned int TNumNodes>
+Condition::Pointer UPwCondition<TDim, TNumNodes>::Create(IndexType               NewId,
+                                                         GeometryType::Pointer   pGeom,
+                                                         PropertiesType::Pointer pProperties) const
+{
+    return make_intrusive<UPwCondition<TDim, TNumNodes>>(NewId, pGeom, pProperties);
 }
 
 template <unsigned int TDim, unsigned int TNumNodes>

--- a/applications/GeoMechanicsApplication/custom_conditions/U_Pw_condition.hpp
+++ b/applications/GeoMechanicsApplication/custom_conditions/U_Pw_condition.hpp
@@ -54,6 +54,7 @@ public:
     Condition::Pointer Create(IndexType               NewId,
                               NodesArrayType const&   ThisNodes,
                               PropertiesType::Pointer pProperties) const override;
+    Condition::Pointer Create(IndexType NewId, GeometryType::Pointer pGeom, PropertiesType::Pointer pProperties) const override;
 
     void GetDofList(DofsVectorType& rConditionDofList, const ProcessInfo&) const override;
 

--- a/applications/GeoMechanicsApplication/custom_conditions/axisymmetric_line_normal_fluid_flux_2D_diff_order_condition.cpp
+++ b/applications/GeoMechanicsApplication/custom_conditions/axisymmetric_line_normal_fluid_flux_2D_diff_order_condition.cpp
@@ -41,8 +41,13 @@ AxisymmetricLineNormalFluidFlux2DDiffOrderCondition::AxisymmetricLineNormalFluid
 Condition::Pointer AxisymmetricLineNormalFluidFlux2DDiffOrderCondition::Create(
     IndexType NewId, NodesArrayType const& ThisNodes, PropertiesType::Pointer pProperties) const
 {
-    return Condition::Pointer(new AxisymmetricLineNormalFluidFlux2DDiffOrderCondition(
-        NewId, GetGeometry().Create(ThisNodes), pProperties));
+    return this->Create(NewId, GetGeometry().Create(ThisNodes), pProperties);
+}
+
+Condition::Pointer AxisymmetricLineNormalFluidFlux2DDiffOrderCondition::Create(
+    IndexType NewId, GeometryType::Pointer pGeom, PropertiesType::Pointer pProperties) const
+{
+    return make_intrusive<AxisymmetricLineNormalFluidFlux2DDiffOrderCondition>(NewId, pGeom, pProperties);
 }
 
 double AxisymmetricLineNormalFluidFlux2DDiffOrderCondition::CalculateIntegrationCoefficient(

--- a/applications/GeoMechanicsApplication/custom_conditions/axisymmetric_line_normal_fluid_flux_2D_diff_order_condition.cpp
+++ b/applications/GeoMechanicsApplication/custom_conditions/axisymmetric_line_normal_fluid_flux_2D_diff_order_condition.cpp
@@ -41,7 +41,7 @@ AxisymmetricLineNormalFluidFlux2DDiffOrderCondition::AxisymmetricLineNormalFluid
 Condition::Pointer AxisymmetricLineNormalFluidFlux2DDiffOrderCondition::Create(
     IndexType NewId, NodesArrayType const& ThisNodes, PropertiesType::Pointer pProperties) const
 {
-    return this->Create(NewId, GetGeometry().Create(ThisNodes), pProperties);
+    return Create(NewId, GetGeometry().Create(ThisNodes), pProperties);
 }
 
 Condition::Pointer AxisymmetricLineNormalFluidFlux2DDiffOrderCondition::Create(

--- a/applications/GeoMechanicsApplication/custom_conditions/axisymmetric_line_normal_fluid_flux_2D_diff_order_condition.hpp
+++ b/applications/GeoMechanicsApplication/custom_conditions/axisymmetric_line_normal_fluid_flux_2D_diff_order_condition.hpp
@@ -50,6 +50,7 @@ public:
     Condition::Pointer Create(IndexType               NewId,
                               NodesArrayType const&   ThisNodes,
                               PropertiesType::Pointer pProperties) const override;
+    Condition::Pointer Create(IndexType NewId, GeometryType::Pointer pGeom, PropertiesType::Pointer pProperties) const override;
 
     std::string Info() const override;
 

--- a/applications/GeoMechanicsApplication/custom_conditions/axisymmetric_line_normal_load_2D_diff_order_condition.cpp
+++ b/applications/GeoMechanicsApplication/custom_conditions/axisymmetric_line_normal_load_2D_diff_order_condition.cpp
@@ -42,7 +42,7 @@ Condition::Pointer AxisymmetricLineNormalLoad2DDiffOrderCondition::Create(IndexT
                                                                           NodesArrayType const& ThisNodes,
                                                                           PropertiesType::Pointer pProperties) const
 {
-    return this->Create(NewId, GetGeometry().Create(ThisNodes), pProperties);
+    return Create(NewId, GetGeometry().Create(ThisNodes), pProperties);
 }
 
 Condition::Pointer AxisymmetricLineNormalLoad2DDiffOrderCondition::Create(IndexType NewId,

--- a/applications/GeoMechanicsApplication/custom_conditions/axisymmetric_line_normal_load_2D_diff_order_condition.cpp
+++ b/applications/GeoMechanicsApplication/custom_conditions/axisymmetric_line_normal_load_2D_diff_order_condition.cpp
@@ -42,8 +42,14 @@ Condition::Pointer AxisymmetricLineNormalLoad2DDiffOrderCondition::Create(IndexT
                                                                           NodesArrayType const& ThisNodes,
                                                                           PropertiesType::Pointer pProperties) const
 {
-    return Condition::Pointer(new AxisymmetricLineNormalLoad2DDiffOrderCondition(
-        NewId, GetGeometry().Create(ThisNodes), pProperties));
+    return this->Create(NewId, GetGeometry().Create(ThisNodes), pProperties);
+}
+
+Condition::Pointer AxisymmetricLineNormalLoad2DDiffOrderCondition::Create(IndexType NewId,
+                                                                          GeometryType::Pointer pGeom,
+                                                                          PropertiesType::Pointer pProperties) const
+{
+    return make_intrusive<AxisymmetricLineNormalLoad2DDiffOrderCondition>(NewId, pGeom, pProperties);
 }
 
 double AxisymmetricLineNormalLoad2DDiffOrderCondition::CalculateIntegrationCoefficient(

--- a/applications/GeoMechanicsApplication/custom_conditions/axisymmetric_line_normal_load_2D_diff_order_condition.hpp
+++ b/applications/GeoMechanicsApplication/custom_conditions/axisymmetric_line_normal_load_2D_diff_order_condition.hpp
@@ -49,6 +49,7 @@ public:
     Condition::Pointer Create(IndexType               NewId,
                               NodesArrayType const&   ThisNodes,
                               PropertiesType::Pointer pProperties) const override;
+    Condition::Pointer Create(IndexType NewId, GeometryType::Pointer pGeom, PropertiesType::Pointer pProperties) const override;
 
     std::string Info() const override;
 

--- a/applications/GeoMechanicsApplication/custom_conditions/general_U_Pw_diff_order_condition.cpp
+++ b/applications/GeoMechanicsApplication/custom_conditions/general_U_Pw_diff_order_condition.cpp
@@ -29,7 +29,14 @@ Condition::Pointer GeneralUPwDiffOrderCondition::Create(IndexType               
                                                         NodesArrayType const&   ThisNodes,
                                                         PropertiesType::Pointer pProperties) const
 {
-    return Condition::Pointer(new GeneralUPwDiffOrderCondition(NewId, GetGeometry().Create(ThisNodes), pProperties));
+    return Create(NewId, GetGeometry().Create(ThisNodes), pProperties);
+}
+
+Condition::Pointer GeneralUPwDiffOrderCondition::Create(IndexType               NewId,
+                                                        GeometryType::Pointer   pGeom,
+                                                        PropertiesType::Pointer pProperties) const
+{
+    return make_intrusive<GeneralUPwDiffOrderCondition>(NewId, pGeom, pProperties);
 }
 
 void GeneralUPwDiffOrderCondition::Initialize(const ProcessInfo& rCurrentProcessInfo)

--- a/applications/GeoMechanicsApplication/custom_conditions/general_U_Pw_diff_order_condition.hpp
+++ b/applications/GeoMechanicsApplication/custom_conditions/general_U_Pw_diff_order_condition.hpp
@@ -57,6 +57,7 @@ public:
     Condition::Pointer Create(IndexType               NewId,
                               NodesArrayType const&   ThisNodes,
                               PropertiesType::Pointer pProperties) const override;
+    Condition::Pointer Create(IndexType NewId, GeometryType::Pointer pGeom, PropertiesType::Pointer pProperties) const override;
 
     void Initialize(const ProcessInfo& rCurrentProcessInfo) override;
 

--- a/applications/GeoMechanicsApplication/custom_conditions/line_load_2D_diff_order_condition.cpp
+++ b/applications/GeoMechanicsApplication/custom_conditions/line_load_2D_diff_order_condition.cpp
@@ -39,7 +39,14 @@ Condition::Pointer LineLoad2DDiffOrderCondition::Create(IndexType               
                                                         NodesArrayType const&   ThisNodes,
                                                         PropertiesType::Pointer pProperties) const
 {
-    return Condition::Pointer(new LineLoad2DDiffOrderCondition(NewId, GetGeometry().Create(ThisNodes), pProperties));
+    return Create(NewId, GetGeometry().Create(ThisNodes), pProperties);
+}
+
+Condition::Pointer LineLoad2DDiffOrderCondition::Create(IndexType               NewId,
+                                                        GeometryType::Pointer   pGeom,
+                                                        PropertiesType::Pointer pProperties) const
+{
+    return make_intrusive<LineLoad2DDiffOrderCondition>(NewId, pGeom, pProperties);
 }
 
 void LineLoad2DDiffOrderCondition::CalculateConditionVector(ConditionVariables& rVariables, unsigned int PointNumber)

--- a/applications/GeoMechanicsApplication/custom_conditions/line_load_2D_diff_order_condition.hpp
+++ b/applications/GeoMechanicsApplication/custom_conditions/line_load_2D_diff_order_condition.hpp
@@ -48,6 +48,7 @@ public:
     Condition::Pointer Create(IndexType               NewId,
                               NodesArrayType const&   ThisNodes,
                               PropertiesType::Pointer pProperties) const override;
+    Condition::Pointer Create(IndexType NewId, GeometryType::Pointer pGeom, PropertiesType::Pointer pProperties) const override;
 
     std::string Info() const override;
 

--- a/applications/GeoMechanicsApplication/custom_conditions/line_normal_fluid_flux_2D_diff_order_condition.cpp
+++ b/applications/GeoMechanicsApplication/custom_conditions/line_normal_fluid_flux_2D_diff_order_condition.cpp
@@ -42,8 +42,14 @@ Condition::Pointer LineNormalFluidFlux2DDiffOrderCondition::Create(IndexType    
                                                                    NodesArrayType const& ThisNodes,
                                                                    PropertiesType::Pointer pProperties) const
 {
-    return Condition::Pointer(new LineNormalFluidFlux2DDiffOrderCondition(
-        NewId, GetGeometry().Create(ThisNodes), pProperties));
+    return Create(NewId, GetGeometry().Create(ThisNodes), pProperties);
+}
+
+Condition::Pointer LineNormalFluidFlux2DDiffOrderCondition::Create(IndexType             NewId,
+                                                                   GeometryType::Pointer pGeom,
+                                                                   PropertiesType::Pointer pProperties) const
+{
+    return make_intrusive<LineNormalFluidFlux2DDiffOrderCondition>(NewId, pGeom, pProperties);
 }
 
 void LineNormalFluidFlux2DDiffOrderCondition::CalculateConditionVector(ConditionVariables& rVariables,

--- a/applications/GeoMechanicsApplication/custom_conditions/line_normal_fluid_flux_2D_diff_order_condition.hpp
+++ b/applications/GeoMechanicsApplication/custom_conditions/line_normal_fluid_flux_2D_diff_order_condition.hpp
@@ -50,6 +50,7 @@ public:
     Condition::Pointer Create(IndexType               NewId,
                               NodesArrayType const&   ThisNodes,
                               PropertiesType::Pointer pProperties) const override;
+    Condition::Pointer Create(IndexType NewId, GeometryType::Pointer pGeom, PropertiesType::Pointer pProperties) const override;
 
     std::string Info() const override;
 

--- a/applications/GeoMechanicsApplication/custom_conditions/line_normal_load_2D_diff_order_condition.cpp
+++ b/applications/GeoMechanicsApplication/custom_conditions/line_normal_load_2D_diff_order_condition.cpp
@@ -43,8 +43,14 @@ Condition::Pointer LineNormalLoad2DDiffOrderCondition::Create(IndexType         
                                                               NodesArrayType const& ThisNodes,
                                                               PropertiesType::Pointer pProperties) const
 {
-    return Condition::Pointer(
-        new LineNormalLoad2DDiffOrderCondition(NewId, GetGeometry().Create(ThisNodes), pProperties));
+    return Create(NewId, GetGeometry().Create(ThisNodes), pProperties);
+}
+
+Condition::Pointer LineNormalLoad2DDiffOrderCondition::Create(IndexType             NewId,
+                                                              GeometryType::Pointer pGeom,
+                                                              PropertiesType::Pointer pProperties) const
+{
+    return make_intrusive<LineNormalLoad2DDiffOrderCondition>(NewId, pGeom, pProperties);
 }
 
 void LineNormalLoad2DDiffOrderCondition::CalculateConditionVector(ConditionVariables& rVariables,

--- a/applications/GeoMechanicsApplication/custom_conditions/line_normal_load_2D_diff_order_condition.hpp
+++ b/applications/GeoMechanicsApplication/custom_conditions/line_normal_load_2D_diff_order_condition.hpp
@@ -48,6 +48,7 @@ public:
     Condition::Pointer Create(IndexType               NewId,
                               NodesArrayType const&   ThisNodes,
                               PropertiesType::Pointer pProperties) const override;
+    Condition::Pointer Create(IndexType NewId, GeometryType::Pointer pGeom, PropertiesType::Pointer pProperties) const override;
 
     std::string Info() const override;
 

--- a/applications/GeoMechanicsApplication/custom_conditions/surface_load_3D_diff_order_condition.cpp
+++ b/applications/GeoMechanicsApplication/custom_conditions/surface_load_3D_diff_order_condition.cpp
@@ -41,8 +41,14 @@ Condition::Pointer SurfaceLoad3DDiffOrderCondition::Create(IndexType            
                                                            NodesArrayType const& ThisNodes,
                                                            PropertiesType::Pointer pProperties) const
 {
-    return Condition::Pointer(
-        new SurfaceLoad3DDiffOrderCondition(NewId, GetGeometry().Create(ThisNodes), pProperties));
+    return Create(NewId, GetGeometry().Create(ThisNodes), pProperties);
+}
+
+Condition::Pointer SurfaceLoad3DDiffOrderCondition::Create(IndexType             NewId,
+                                                           GeometryType::Pointer pGeom,
+                                                           PropertiesType::Pointer pProperties) const
+{
+    return make_intrusive<SurfaceLoad3DDiffOrderCondition>(NewId, pGeom, pProperties);
 }
 
 void SurfaceLoad3DDiffOrderCondition::CalculateConditionVector(ConditionVariables& rVariables, unsigned int PointNumber)

--- a/applications/GeoMechanicsApplication/custom_conditions/surface_load_3D_diff_order_condition.hpp
+++ b/applications/GeoMechanicsApplication/custom_conditions/surface_load_3D_diff_order_condition.hpp
@@ -48,6 +48,7 @@ public:
     Condition::Pointer Create(IndexType               NewId,
                               NodesArrayType const&   ThisNodes,
                               PropertiesType::Pointer pProperties) const override;
+    Condition::Pointer Create(IndexType NewId, GeometryType::Pointer pGeom, PropertiesType::Pointer pProperties) const override;
 
     std::string Info() const override;
 

--- a/applications/GeoMechanicsApplication/custom_conditions/surface_normal_fluid_flux_3D_diff_order_condition.cpp
+++ b/applications/GeoMechanicsApplication/custom_conditions/surface_normal_fluid_flux_3D_diff_order_condition.cpp
@@ -42,8 +42,14 @@ Condition::Pointer SurfaceNormalFluidFlux3DDiffOrderCondition::Create(IndexType 
                                                                       NodesArrayType const& ThisNodes,
                                                                       PropertiesType::Pointer pProperties) const
 {
-    return Condition::Pointer(new SurfaceNormalFluidFlux3DDiffOrderCondition(
-        NewId, GetGeometry().Create(ThisNodes), pProperties));
+    return Create(NewId, GetGeometry().Create(ThisNodes), pProperties);
+}
+
+Condition::Pointer SurfaceNormalFluidFlux3DDiffOrderCondition::Create(IndexType             NewId,
+                                                                      GeometryType::Pointer pGeom,
+                                                                      PropertiesType::Pointer pProperties) const
+{
+    return make_intrusive<SurfaceNormalFluidFlux3DDiffOrderCondition>(NewId, pGeom, pProperties);
 }
 
 void SurfaceNormalFluidFlux3DDiffOrderCondition::CalculateConditionVector(ConditionVariables& rVariables,

--- a/applications/GeoMechanicsApplication/custom_conditions/surface_normal_fluid_flux_3D_diff_order_condition.hpp
+++ b/applications/GeoMechanicsApplication/custom_conditions/surface_normal_fluid_flux_3D_diff_order_condition.hpp
@@ -50,6 +50,7 @@ public:
     Condition::Pointer Create(IndexType               NewId,
                               NodesArrayType const&   ThisNodes,
                               PropertiesType::Pointer pProperties) const override;
+    Condition::Pointer Create(IndexType NewId, GeometryType::Pointer pGeom, PropertiesType::Pointer pProperties) const override;
 
     std::string Info() const override;
 

--- a/applications/GeoMechanicsApplication/custom_conditions/surface_normal_load_3D_diff_order_condition.cpp
+++ b/applications/GeoMechanicsApplication/custom_conditions/surface_normal_load_3D_diff_order_condition.cpp
@@ -45,8 +45,14 @@ Condition::Pointer SurfaceNormalLoad3DDiffOrderCondition::Create(IndexType      
                                                                  NodesArrayType const& ThisNodes,
                                                                  PropertiesType::Pointer pProperties) const
 {
-    return Condition::Pointer(new SurfaceNormalLoad3DDiffOrderCondition(
-        NewId, GetGeometry().Create(ThisNodes), pProperties));
+    return Create(NewId, GetGeometry().Create(ThisNodes), pProperties);
+}
+
+Condition::Pointer SurfaceNormalLoad3DDiffOrderCondition::Create(IndexType             NewId,
+                                                                 GeometryType::Pointer pGeom,
+                                                                 PropertiesType::Pointer pProperties) const
+{
+    return make_intrusive<SurfaceNormalLoad3DDiffOrderCondition>(NewId, pGeom, pProperties);
 }
 
 void SurfaceNormalLoad3DDiffOrderCondition::CalculateConditionVector(ConditionVariables& rVariables,

--- a/applications/GeoMechanicsApplication/custom_conditions/surface_normal_load_3D_diff_order_condition.hpp
+++ b/applications/GeoMechanicsApplication/custom_conditions/surface_normal_load_3D_diff_order_condition.hpp
@@ -42,6 +42,7 @@ public:
     Condition::Pointer Create(IndexType               NewId,
                               NodesArrayType const&   ThisNodes,
                               PropertiesType::Pointer pProperties) const override;
+    Condition::Pointer Create(IndexType NewId, GeometryType::Pointer pGeom, PropertiesType::Pointer pProperties) const;
 
     std::string Info() const override;
 

--- a/applications/GeoMechanicsApplication/custom_conditions/surface_normal_load_3D_diff_order_condition.hpp
+++ b/applications/GeoMechanicsApplication/custom_conditions/surface_normal_load_3D_diff_order_condition.hpp
@@ -42,7 +42,7 @@ public:
     Condition::Pointer Create(IndexType               NewId,
                               NodesArrayType const&   ThisNodes,
                               PropertiesType::Pointer pProperties) const override;
-    Condition::Pointer Create(IndexType NewId, GeometryType::Pointer pGeom, PropertiesType::Pointer pProperties) const;
+    Condition::Pointer Create(IndexType NewId, GeometryType::Pointer pGeom, PropertiesType::Pointer pProperties) const override;
 
     std::string Info() const override;
 

--- a/applications/GeoMechanicsApplication/custom_constitutive/linear_elastic_3D_interface_law.h
+++ b/applications/GeoMechanicsApplication/custom_constitutive/linear_elastic_3D_interface_law.h
@@ -122,6 +122,8 @@ public:
      */
     bool& GetValue(const Variable<bool>& rThisVariable, bool& rValue) override;
 
+    using LinearElastic2DInterfaceLaw::GetValue;
+
     ///@}
 
 protected:

--- a/applications/GeoMechanicsApplication/custom_constitutive/linear_elastic_3D_interface_law.h
+++ b/applications/GeoMechanicsApplication/custom_constitutive/linear_elastic_3D_interface_law.h
@@ -121,7 +121,6 @@ public:
      * @param rValue output: the value of the specified variable
      */
     bool& GetValue(const Variable<bool>& rThisVariable, bool& rValue) override;
-
     using LinearElastic2DInterfaceLaw::GetValue;
 
     ///@}

--- a/applications/GeoMechanicsApplication/custom_constitutive/small_strain_udsm_3D_interface_law.hpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/small_strain_udsm_3D_interface_law.hpp
@@ -73,6 +73,7 @@ public:
     ConstitutiveLaw::Pointer Clone() const override;
 
     Vector& GetValue(const Variable<Vector>& rThisVariable, Vector& rValue) override;
+    using SmallStrainUDSM3DLaw::GetValue;
 
     void SetValue(const Variable<Vector>& rVariable, const Vector& rValue, const ProcessInfo& rCurrentProcessInfo) override;
 

--- a/applications/GeoMechanicsApplication/custom_constitutive/small_strain_udsm_3D_interface_law.hpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/small_strain_udsm_3D_interface_law.hpp
@@ -76,6 +76,7 @@ public:
     using SmallStrainUDSM3DLaw::GetValue;
 
     void SetValue(const Variable<Vector>& rVariable, const Vector& rValue, const ProcessInfo& rCurrentProcessInfo) override;
+    using SmallStrainUDSM3DLaw::SetValue;
 
     /**
      * @brief Dimension of the law:

--- a/applications/GeoMechanicsApplication/custom_constitutive/small_strain_udsm_3D_law.hpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/small_strain_udsm_3D_law.hpp
@@ -301,8 +301,8 @@ public:
     using ConstitutiveLaw::GetValue;
 
     void SetValue(const Variable<double>& rVariable, const double& rValue, const ProcessInfo& rCurrentProcessInfo) override;
-
     void SetValue(const Variable<Vector>& rVariable, const Vector& rValue, const ProcessInfo& rCurrentProcessInfo) override;
+    using ConstitutiveLaw::SetValue;
 
     ///@}
     ///@name Inquiry

--- a/applications/GeoMechanicsApplication/custom_constitutive/small_strain_udsm_3D_law.hpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/small_strain_udsm_3D_law.hpp
@@ -298,6 +298,7 @@ public:
     double& GetValue(const Variable<double>& rThisVariable, double& rValue) override;
     int&    GetValue(const Variable<int>& rThisVariable, int& rValue) override;
     Vector& GetValue(const Variable<Vector>& rThisVariable, Vector& rValue) override;
+    using ConstitutiveLaw::GetValue;
 
     void SetValue(const Variable<double>& rVariable, const double& rValue, const ProcessInfo& rCurrentProcessInfo) override;
 

--- a/applications/GeoMechanicsApplication/custom_constitutive/small_strain_umat_2D_interface_law.hpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/small_strain_umat_2D_interface_law.hpp
@@ -73,8 +73,10 @@ public:
     ConstitutiveLaw::Pointer Clone() const override;
 
     Vector& GetValue(const Variable<Vector>& rThisVariable, Vector& rValue) override;
+    using SmallStrainUMAT3DLaw::GetValue;
 
     void SetValue(const Variable<Vector>& rVariable, const Vector& rValue, const ProcessInfo& rCurrentProcessInfo) override;
+    using SmallStrainUMAT3DLaw::SetValue;
 
     /**
      * @brief Dimension of the law:

--- a/applications/GeoMechanicsApplication/custom_constitutive/small_strain_umat_2D_plane_strain_law.hpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/small_strain_umat_2D_plane_strain_law.hpp
@@ -73,8 +73,10 @@ public:
     ConstitutiveLaw::Pointer Clone() const override;
 
     Vector& GetValue(const Variable<Vector>& rThisVariable, Vector& rValue) override;
+    using SmallStrainUMAT3DLaw::GetValue;
 
     void SetValue(const Variable<Vector>& rVariable, const Vector& rValue, const ProcessInfo& rCurrentProcessInfo) override;
+    using SmallStrainUMAT3DLaw::SetValue;
 
     /**
      * @brief Dimension of the law:

--- a/applications/GeoMechanicsApplication/custom_elements/compressibility_calculator.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/compressibility_calculator.cpp
@@ -38,7 +38,7 @@ Vector CompressibilityCalculator::RHSContribution(const Matrix& rCompressibility
 
 Matrix CompressibilityCalculator::LHSContribution(const Matrix& rCompressibilityMatrix) const
 {
-    return mInputProvider.GetMatrixScalarFactor()* rCompressibilityMatrix;
+    return mInputProvider.GetMatrixScalarFactor() * rCompressibilityMatrix;
 }
 
 std::pair<Matrix, Vector> CompressibilityCalculator::LocalSystemContribution()

--- a/applications/GeoMechanicsApplication/custom_elements/geo_cr_beam_element_2D2N.hpp
+++ b/applications/GeoMechanicsApplication/custom_elements/geo_cr_beam_element_2D2N.hpp
@@ -95,6 +95,7 @@ public:
     void CalculateOnIntegrationPoints(const Variable<array_1d<double, 3>>& rVariable,
                                       std::vector<array_1d<double, 3>>&    rOutput,
                                       const ProcessInfo& rCurrentProcessInfo) override;
+    using CrBeamElement2D2N::CalculateOnIntegrationPoints;
 
     void ResetConstitutiveLaw() override;
 

--- a/applications/GeoMechanicsApplication/custom_elements/geo_cr_beam_element_3D2N.hpp
+++ b/applications/GeoMechanicsApplication/custom_elements/geo_cr_beam_element_3D2N.hpp
@@ -88,6 +88,7 @@ public:
     void CalculateOnIntegrationPoints(const Variable<array_1d<double, 3>>& rVariable,
                                       std::vector<array_1d<double, 3>>&    rOutput,
                                       const ProcessInfo& rCurrentProcessInfo) override;
+    using CrBeamElement3D2N::CalculateOnIntegrationPoints;
 
     void ResetConstitutiveLaw() override;
 

--- a/applications/GeoMechanicsApplication/custom_elements/geo_cr_beam_element_linear_2D2N.hpp
+++ b/applications/GeoMechanicsApplication/custom_elements/geo_cr_beam_element_linear_2D2N.hpp
@@ -93,6 +93,7 @@ public:
     void CalculateOnIntegrationPoints(const Variable<array_1d<double, 3>>& rVariable,
                                       std::vector<array_1d<double, 3>>&    rOutput,
                                       const ProcessInfo& rCurrentProcessInfo) override;
+    using CrBeamElementLinear2D2N::CalculateOnIntegrationPoints;
 
     void ResetConstitutiveLaw() override;
 

--- a/applications/GeoMechanicsApplication/custom_elements/geo_cr_beam_element_linear_3D2N.hpp
+++ b/applications/GeoMechanicsApplication/custom_elements/geo_cr_beam_element_linear_3D2N.hpp
@@ -84,6 +84,7 @@ public:
     void CalculateOnIntegrationPoints(const Variable<array_1d<double, 3>>& rVariable,
                                       std::vector<array_1d<double, 3>>&    rOutput,
                                       const ProcessInfo& rCurrentProcessInfo) override;
+    using CrBeamElement3D2N::CalculateOnIntegrationPoints;
 
     void ResetConstitutiveLaw() override;
 

--- a/applications/GeoMechanicsApplication/custom_elements/geo_structural_base_element.hpp
+++ b/applications/GeoMechanicsApplication/custom_elements/geo_structural_base_element.hpp
@@ -90,6 +90,7 @@ public:
     void SetValuesOnIntegrationPoints(const Variable<double>&    rVariable,
                                       const std::vector<double>& rValues,
                                       const ProcessInfo&         rCurrentProcessInfo) override;
+    using Element::SetValuesOnIntegrationPoints;
 
 protected:
     static constexpr SizeType N_DOF_NODE    = (TDim == 2 ? 3 : 6);

--- a/applications/GeoMechanicsApplication/custom_elements/geo_truss_element_base.hpp
+++ b/applications/GeoMechanicsApplication/custom_elements/geo_truss_element_base.hpp
@@ -164,6 +164,8 @@ public:
                                  const Variable<array_1d<double, 3>>& rDestinationVariable,
                                  const ProcessInfo&                   rCurrentProcessInfo) override;
 
+    using Element::AddExplicitContribution;
+
     void GetValuesVector(Vector& rValues, int Step = 0) const override;
 
     void GetSecondDerivativesVector(Vector& rValues, int Step = 0) const override;

--- a/applications/GeoMechanicsApplication/custom_elements/geo_truss_element_base.hpp
+++ b/applications/GeoMechanicsApplication/custom_elements/geo_truss_element_base.hpp
@@ -96,8 +96,8 @@ public:
                                               const ProcessInfo& rCurrentProcessInfo);
 
     void Calculate(const Variable<Matrix>& rVariable, Matrix& rOutput, const ProcessInfo& rCurrentProcessInfo) override;
-
     void Calculate(const Variable<double>& rVariable, double& rOutput, const ProcessInfo& rCurrentProcessInfo) override;
+    using Element::Calculate;
 
     void CalculateOnIntegrationPoints(const Variable<double>& rVariable,
                                       std::vector<double>&    rOutput,

--- a/applications/GeoMechanicsApplication/custom_elements/geo_truss_element_base.hpp
+++ b/applications/GeoMechanicsApplication/custom_elements/geo_truss_element_base.hpp
@@ -102,14 +102,13 @@ public:
     void CalculateOnIntegrationPoints(const Variable<double>& rVariable,
                                       std::vector<double>&    rOutput,
                                       const ProcessInfo&      rCurrentProcessInfo) override;
-
     void CalculateOnIntegrationPoints(const Variable<array_1d<double, 3>>& rVariable,
                                       std::vector<array_1d<double, 3>>&    rOutput,
                                       const ProcessInfo& rCurrentProcessInfo) override;
-
     void CalculateOnIntegrationPoints(const Variable<Vector>& rVariable,
                                       std::vector<Vector>&    rOutput,
                                       const ProcessInfo&      rCurrentProcessInfo) override;
+    using Element::CalculateOnIntegrationPoints;
 
     /**
      * @brief This function updates the internal normal force w.r.t. the current deformations

--- a/applications/GeoMechanicsApplication/custom_elements/permeability_calculator.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/permeability_calculator.cpp
@@ -44,11 +44,11 @@ Vector PermeabilityCalculator::RHSContribution(const Matrix& rPermeabilityMatrix
 Matrix PermeabilityCalculator::CalculatePermeabilityMatrix() const
 {
     RetentionLaw::Parameters retention_parameters(mInputProvider.GetElementProperties());
-    const auto&              r_properties = mInputProvider.GetElementProperties();
-    auto integration_coefficients = mInputProvider.GetIntegrationCoefficients();
-    const auto   shape_function_gradients = mInputProvider.GetShapeFunctionGradients();
-    const auto   local_dimension          = shape_function_gradients[0].size2();
-    const Matrix constitutive_matrix =
+    const auto&              r_properties             = mInputProvider.GetElementProperties();
+    auto                     integration_coefficients = mInputProvider.GetIntegrationCoefficients();
+    const auto               shape_function_gradients = mInputProvider.GetShapeFunctionGradients();
+    const auto               local_dimension          = shape_function_gradients[0].size2();
+    const Matrix             constitutive_matrix =
         GeoElementUtilities::FillPermeabilityMatrix(r_properties, local_dimension);
 
     const auto   number_of_nodes           = shape_function_gradients[0].size1();

--- a/applications/GeoMechanicsApplication/custom_elements/permeability_calculator.h
+++ b/applications/GeoMechanicsApplication/custom_elements/permeability_calculator.h
@@ -26,7 +26,7 @@ public:
     class InputProvider
     {
     public:
-        InputProvider(std::function<const Properties&()>                         GetElementProperties,
+        InputProvider(std::function<const Properties&()> GetElementProperties,
                       std::function<const std::vector<RetentionLaw::Pointer>&()> GetRetentionLaws,
                       std::function<Vector()>                        GetIntegrationCoefficients,
                       std::function<Vector(const Variable<double>&)> GetNodalValuesOf,
@@ -39,9 +39,9 @@ public:
         {
         }
 
-        [[nodiscard]] const Properties& GetElementProperties() const;
+        [[nodiscard]] const Properties&                         GetElementProperties() const;
         [[nodiscard]] const std::vector<RetentionLaw::Pointer>& GetRetentionLaws() const;
-        [[nodiscard]] Vector GetIntegrationCoefficients() const;
+        [[nodiscard]] Vector                                    GetIntegrationCoefficients() const;
         [[nodiscard]] Vector GetNodalValues(const Variable<double>& rVariable) const;
         [[nodiscard]] Geometry<Node>::ShapeFunctionsGradientsType GetShapeFunctionGradients() const;
 

--- a/applications/GeoMechanicsApplication/custom_elements/updated_lagrangian_U_Pw_diff_order_element.hpp
+++ b/applications/GeoMechanicsApplication/custom_elements/updated_lagrangian_U_Pw_diff_order_element.hpp
@@ -140,11 +140,9 @@ public:
     void CalculateOnIntegrationPoints(const Variable<Matrix>& rVariable,
                                       std::vector<Matrix>&    rOutput,
                                       const ProcessInfo&      rCurrentProcessInfo) override;
-
     void CalculateOnIntegrationPoints(const Variable<Vector>& rVariable,
                                       std::vector<Vector>&    rOutput,
                                       const ProcessInfo&      rCurrentProcessInfo) override;
-
     using SmallStrainUPwDiffOrderElement::CalculateOnIntegrationPoints;
 
     ///@}

--- a/applications/GeoMechanicsApplication/custom_elements/updated_lagrangian_U_Pw_diff_order_element.hpp
+++ b/applications/GeoMechanicsApplication/custom_elements/updated_lagrangian_U_Pw_diff_order_element.hpp
@@ -145,6 +145,8 @@ public:
                                       std::vector<Vector>&    rOutput,
                                       const ProcessInfo&      rCurrentProcessInfo) override;
 
+    using SmallStrainUPwDiffOrderElement::CalculateOnIntegrationPoints;
+
     ///@}
     ///@name Access
     ///@{


### PR DESCRIPTION
**📝 Description**

SonarQube has found a significant number of code smells related to hiding of overloaded `virtual` members. This PR adds overloads of members `Create` where needed. In other places, `using` statements were sufficient to overcome the issues.
