### PR TITLE
[Core] Adding hashed containers (currently STL)

### DIFF
--- a/kratos/containers/unordered_map.h
+++ b/kratos/containers/unordered_map.h
@@ -1,0 +1,29 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
+//
+//  Main authors:    Vicente Mataix Ferrandiz
+//
+
+#pragma once
+
+// System includes
+#include <unordered_map>
+// TODO: Replace with more suited and advanced implementations
+
+// External includes
+
+// Project includes
+
+namespace Kratos {
+
+template<class T1, class T2>
+using unordered_map = std::unordered_map<T1, T2>;
+
+
+} // namespace Kratos

--- a/kratos/containers/unordered_set.h
+++ b/kratos/containers/unordered_set.h
@@ -1,0 +1,29 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
+//
+//  Main authors:    Vicente Mataix Ferrandiz
+//
+
+#pragma once
+
+// System includes
+#include <unordered_set>
+// TODO: Replace with more suited and advanced implementations
+
+// External includes
+
+// Project includes
+
+namespace Kratos {
+
+template<class T1, class T2>
+using unordered_set = std::unordered_set<T1, T2>;
+
+
+} // namespace Kratos

--- a/kratos/containers/unordered_set.h
+++ b/kratos/containers/unordered_set.h
@@ -22,8 +22,8 @@
 
 namespace Kratos {
 
-template<class T1, class T2>
-using unordered_set = std::unordered_set<T1, T2>;
+template<class T>
+using unordered_set = std::unordered_set<T>;
 
 
 } // namespace Kratos


### PR DESCRIPTION
**📝 Description**

This PR introduces `unordered_set` and `unordered_map` aliases, in line with the way Kratos defines smart pointers as replacements for STL ones. Historically, this practice originated from our use of Boost smart pointers.

### Implementation Details

- The aliases currently use STL implementations.
- In the future, I plan to propose faster alternatives. Initial testing during efforts to modernize `data_value_container` showed that for scenarios with fewer than 1000 variables, the current brute-force approach outperforms more modern methods.

This lays the groundwork for potential optimizations while maintaining compatibility with existing functionality.

**🆕 Changelog**

- [Adding hashed containers (currently STL)](https://github.com/KratosMultiphysics/Kratos/commit/ef32496631346b2b3e80101db4ec97efd1bc8f81)
