### PR TITLE
[GeoMechanicsApplication] Fix inactive element workflow in time integration schemes

### DIFF
--- a/applications/GeoMechanicsApplication/custom_strategies/schemes/geomechanics_time_integration_scheme.hpp
+++ b/applications/GeoMechanicsApplication/custom_strategies/schemes/geomechanics_time_integration_scheme.hpp
@@ -77,46 +77,6 @@ public:
         KRATOS_CATCH("")
     }
 
-    void GetDofList(const Element& rElement, Element::DofsVectorType& rDofList, const ProcessInfo& rCurrentProcessInfo) override
-    {
-        GetDofListImpl(rElement, rDofList, rCurrentProcessInfo);
-    }
-
-    void GetDofList(const Condition& rCondition, Condition::DofsVectorType& rDofList, const ProcessInfo& rCurrentProcessInfo) override
-    {
-        GetDofListImpl(rCondition, rDofList, rCurrentProcessInfo);
-    }
-
-    template <typename T>
-    void GetDofListImpl(const T& rElementOrCondition, typename T::DofsVectorType& rDofList, const ProcessInfo& rCurrentProcessInfo)
-    {
-        if (IsActive(rElementOrCondition))
-            rElementOrCondition.GetDofList(rDofList, rCurrentProcessInfo);
-    }
-
-    void EquationId(const Element&                 rElement,
-                    Element::EquationIdVectorType& rEquationId,
-                    const ProcessInfo&             rCurrentProcessInfo) override
-    {
-        EquationIdImpl(rElement, rEquationId, rCurrentProcessInfo);
-    }
-
-    void EquationId(const Condition&                 rCondition,
-                    Condition::EquationIdVectorType& rEquationId,
-                    const ProcessInfo&               rCurrentProcessInfo) override
-    {
-        EquationIdImpl(rCondition, rEquationId, rCurrentProcessInfo);
-    }
-
-    template <typename T>
-    void EquationIdImpl(const T&                          rElementOrCondition,
-                        typename T::EquationIdVectorType& rEquationId,
-                        const ProcessInfo&                rCurrentProcessInfo)
-    {
-        if (IsActive(rElementOrCondition))
-            rElementOrCondition.EquationIdVector(rEquationId, rCurrentProcessInfo);
-    }
-
     void Predict(ModelPart& rModelPart, DofsArrayType&, TSystemMatrixType&, TSystemVectorType&, TSystemVectorType&) override
     {
         this->UpdateVariablesDerivatives(rModelPart);

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/test_geomechanics_time_integration_scheme.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/test_geomechanics_time_integration_scheme.cpp
@@ -80,7 +80,7 @@ public:
             function_on_component(inactive_component);
 
             KRATOS_EXPECT_TRUE(function_has_been_called_on_component(active_component))
-            KRATOS_EXPECT_FALSE(function_has_been_called_on_component(inactive_component))
+            KRATOS_EXPECT_TRUE(function_has_been_called_on_component(inactive_component))
         }
     }
 

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/test_geomechanics_time_integration_scheme.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/test_geomechanics_time_integration_scheme.cpp
@@ -57,7 +57,7 @@ public:
     }
 
     template <class T>
-    void TestFunctionCalledOnComponent_IsOnlyCalledWhenComponentIsActive()
+    void TestFunctionCalledOnComponent_IsCalledOnActiveAndInactiveElements()
     {
         typename T::EquationIdVectorType r_equation_id_vector;
         ProcessInfo                      r_process_info;
@@ -216,13 +216,13 @@ KRATOS_TEST_CASE_IN_SUITE(FunctionCallsOnAllConditions_AreOnlyCalledForActiveCon
 KRATOS_TEST_CASE_IN_SUITE(FunctionCalledOnCondition_IsOnlyCalledWhenConditionIsActive, KratosGeoMechanicsFastSuiteWithoutKernel)
 {
     GeoMechanicsSchemeTester tester;
-    tester.TestFunctionCalledOnComponent_IsOnlyCalledWhenComponentIsActive<SpyCondition>();
+    tester.TestFunctionCalledOnComponent_IsCalledOnActiveAndInactiveElements<SpyCondition>();
 }
 
 KRATOS_TEST_CASE_IN_SUITE(FunctionCalledOnElement_IsOnlyCalledWhenElementIsActive, KratosGeoMechanicsFastSuiteWithoutKernel)
 {
     GeoMechanicsSchemeTester tester;
-    tester.TestFunctionCalledOnComponent_IsOnlyCalledWhenComponentIsActive<SpyElement>();
+    tester.TestFunctionCalledOnComponent_IsCalledOnActiveAndInactiveElements<SpyElement>();
 }
 
 KRATOS_TEST_CASE_IN_SUITE(ForInvalidBufferSize_CheckGeoMechanicsTimeIntegrationScheme_Throws,

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/test_geomechanics_time_integration_scheme.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/test_geomechanics_time_integration_scheme.cpp
@@ -38,7 +38,7 @@ public:
     }
 
 protected:
-    MOCK_METHOD(void, UpdateVariablesDerivatives, (ModelPart & rModelPart), (override));
+    MOCK_METHOD(void, UpdateVariablesDerivatives, (ModelPart&), (override));
 };
 
 class GeoMechanicsSchemeTester

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/test_utilities/spy_condition.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/test_utilities/spy_condition.cpp
@@ -34,16 +34,6 @@ void SpyCondition::FinalizeNonLinearIteration(const ProcessInfo& rCurrentProcess
     mNonLinIterationFinalized = true;
 }
 
-void SpyCondition::EquationIdVector(Condition::EquationIdVectorType& rResult, const ProcessInfo& rCurrentProcessInfo) const
-{
-    mIsEquationIdRetrieved = true;
-}
-
-void SpyCondition::GetDofList(Condition::DofsVectorType& rElementalDofList, const ProcessInfo& rCurrentProcessInfo) const
-{
-    mIsGetDofListCalled = true;
-}
-
 bool SpyCondition::IsSolutionStepInitialized() const { return mSolutionStepInitialized; }
 
 bool SpyCondition::IsSolutionStepFinalized() const { return mSolutionStepFinalized; }
@@ -51,9 +41,5 @@ bool SpyCondition::IsSolutionStepFinalized() const { return mSolutionStepFinaliz
 bool SpyCondition::IsNonLinIterationInitialized() const { return mNonLinIterationInitialized; }
 
 bool SpyCondition::IsNonLinIterationFinalized() const { return mNonLinIterationFinalized; }
-
-bool SpyCondition::IsEquationIdRetrieved() const { return mIsEquationIdRetrieved; }
-
-bool SpyCondition::IsGetDofListCalled() const { return mIsGetDofListCalled; }
 
 } // namespace Kratos::Testing

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/test_utilities/spy_condition.h
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/test_utilities/spy_condition.h
@@ -13,6 +13,7 @@
 #pragma once
 
 #include "includes/condition.h"
+#include <gmock/gmock.h>
 
 namespace Kratos::Testing
 {
@@ -25,9 +26,14 @@ public:
     void InitializeNonLinearIteration(const ProcessInfo& rCurrentProcessInfo) override;
     void FinalizeNonLinearIteration(const ProcessInfo& rCurrentProcessInfo) override;
 
-    void EquationIdVector(EquationIdVectorType& rResult, const ProcessInfo& rCurrentProcessInfo) const override;
-
-    void GetDofList(DofsVectorType& rElementalDofList, const ProcessInfo& rCurrentProcessInfo) const override;
+    MOCK_METHOD(void,
+                EquationIdVector,
+                (EquationIdVectorType & rResult, const ProcessInfo& rCurrentProcessInfo),
+                (const, override));
+    MOCK_METHOD(void,
+                GetDofList,
+                (DofsVectorType & rElementalDofList, const ProcessInfo& rCurrentProcessInfo),
+                (const, override));
 
     bool IsSolutionStepInitialized() const;
     bool IsSolutionStepFinalized() const;
@@ -41,8 +47,6 @@ private:
     bool         mSolutionStepFinalized      = false;
     bool         mNonLinIterationInitialized = false;
     bool         mNonLinIterationFinalized   = false;
-    mutable bool mIsEquationIdRetrieved      = false;
-    mutable bool mIsGetDofListCalled         = false;
 };
 
 } // namespace Kratos::Testing

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/test_utilities/spy_condition.h
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/test_utilities/spy_condition.h
@@ -43,10 +43,10 @@ public:
     bool IsGetDofListCalled() const;
 
 private:
-    bool         mSolutionStepInitialized    = false;
-    bool         mSolutionStepFinalized      = false;
-    bool         mNonLinIterationInitialized = false;
-    bool         mNonLinIterationFinalized   = false;
+    bool mSolutionStepInitialized    = false;
+    bool mSolutionStepFinalized      = false;
+    bool mNonLinIterationInitialized = false;
+    bool mNonLinIterationFinalized   = false;
 };
 
 } // namespace Kratos::Testing

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/test_utilities/spy_condition.h
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/test_utilities/spy_condition.h
@@ -26,14 +26,8 @@ public:
     void InitializeNonLinearIteration(const ProcessInfo& rCurrentProcessInfo) override;
     void FinalizeNonLinearIteration(const ProcessInfo& rCurrentProcessInfo) override;
 
-    MOCK_METHOD(void,
-                EquationIdVector,
-                (EquationIdVectorType & rResult, const ProcessInfo& rCurrentProcessInfo),
-                (const, override));
-    MOCK_METHOD(void,
-                GetDofList,
-                (DofsVectorType & rElementalDofList, const ProcessInfo& rCurrentProcessInfo),
-                (const, override));
+    MOCK_METHOD(void, EquationIdVector, (EquationIdVectorType&, const ProcessInfo&), (const, override));
+    MOCK_METHOD(void, GetDofList, (DofsVectorType&, const ProcessInfo&), (const, override));
 
     bool IsSolutionStepInitialized() const;
     bool IsSolutionStepFinalized() const;

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/test_utilities/spy_element.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/test_utilities/spy_element.cpp
@@ -34,16 +34,6 @@ void SpyElement::FinalizeNonLinearIteration(const ProcessInfo& rCurrentProcessIn
     mNonLinIterationFinalized = true;
 }
 
-void SpyElement::EquationIdVector(Element::EquationIdVectorType& rResult, const ProcessInfo& rCurrentProcessInfo) const
-{
-    mIsEquationIdRetrieved = true;
-}
-
-void SpyElement::GetDofList(Element::DofsVectorType& rElementalDofList, const ProcessInfo& rCurrentProcessInfo) const
-{
-    mIsGetDofListCalled = true;
-}
-
 bool SpyElement::IsSolutionStepInitialized() const { return mSolutionStepInitialized; }
 
 bool SpyElement::IsSolutionStepFinalized() const { return mSolutionStepFinalized; }
@@ -51,9 +41,5 @@ bool SpyElement::IsSolutionStepFinalized() const { return mSolutionStepFinalized
 bool SpyElement::IsNonLinIterationInitialized() const { return mNonLinIterationInitialized; }
 
 bool SpyElement::IsNonLinIterationFinalized() const { return mNonLinIterationFinalized; }
-
-bool SpyElement::IsEquationIdRetrieved() const { return mIsEquationIdRetrieved; }
-
-bool SpyElement::IsGetDofListCalled() const { return mIsGetDofListCalled; }
 
 } // namespace Kratos::Testing

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/test_utilities/spy_element.h
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/test_utilities/spy_element.h
@@ -25,14 +25,8 @@ public:
     void InitializeNonLinearIteration(const ProcessInfo& rCurrentProcessInfo) override;
     void FinalizeNonLinearIteration(const ProcessInfo& rCurrentProcessInfo) override;
 
-    MOCK_METHOD(void,
-                EquationIdVector,
-                (EquationIdVectorType & rResult, const ProcessInfo& rCurrentProcessInfo),
-                (const, override));
-    MOCK_METHOD(void,
-                GetDofList,
-                (DofsVectorType & rElementalDofList, const ProcessInfo& rCurrentProcessInfo),
-                (const, override));
+    MOCK_METHOD(void, EquationIdVector, (EquationIdVectorType&, const ProcessInfo&), (const, override));
+    MOCK_METHOD(void, GetDofList, (DofsVectorType&, const ProcessInfo&), (const, override));
 
     bool IsSolutionStepInitialized() const;
     bool IsSolutionStepFinalized() const;

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/test_utilities/spy_element.h
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/test_utilities/spy_element.h
@@ -12,6 +12,7 @@
 #pragma once
 
 #include "includes/element.h"
+#include <gmock/gmock.h>
 
 namespace Kratos::Testing
 {
@@ -23,8 +24,15 @@ public:
     void FinalizeSolutionStep(const ProcessInfo& rCurrentProcessInfo) override;
     void InitializeNonLinearIteration(const ProcessInfo& rCurrentProcessInfo) override;
     void FinalizeNonLinearIteration(const ProcessInfo& rCurrentProcessInfo) override;
-    void EquationIdVector(EquationIdVectorType& rResult, const ProcessInfo& rCurrentProcessInfo) const override;
-    void GetDofList(DofsVectorType& rElementalDofList, const ProcessInfo& rCurrentProcessInfo) const override;
+
+    MOCK_METHOD(void,
+                EquationIdVector,
+                (EquationIdVectorType & rResult, const ProcessInfo& rCurrentProcessInfo),
+                (const, override));
+    MOCK_METHOD(void,
+                GetDofList,
+                (DofsVectorType & rElementalDofList, const ProcessInfo& rCurrentProcessInfo),
+                (const, override));
 
     bool IsSolutionStepInitialized() const;
     bool IsSolutionStepFinalized() const;
@@ -38,8 +46,6 @@ private:
     bool         mSolutionStepFinalized      = false;
     bool         mNonLinIterationInitialized = false;
     bool         mNonLinIterationFinalized   = false;
-    mutable bool mIsEquationIdRetrieved      = false;
-    mutable bool mIsGetDofListCalled         = false;
 };
 
 } // namespace Kratos::Testing

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/test_utilities/spy_element.h
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/test_utilities/spy_element.h
@@ -42,10 +42,10 @@ public:
     bool IsGetDofListCalled() const;
 
 private:
-    bool         mSolutionStepInitialized    = false;
-    bool         mSolutionStepFinalized      = false;
-    bool         mNonLinIterationInitialized = false;
-    bool         mNonLinIterationFinalized   = false;
+    bool mSolutionStepInitialized    = false;
+    bool mSolutionStepFinalized      = false;
+    bool mNonLinIterationInitialized = false;
+    bool mNonLinIterationFinalized   = false;
 };
 
 } // namespace Kratos::Testing


### PR DESCRIPTION
**📝 Description**
In the GeoMechanicsApplication, there is functionality to de-activate elements. Our time integration schemes therefore perform certain functions only on active elements. However, for constructing the system matrix, it is assumed in the block builder and solver (core) that certain functions can be called on any element/condition (regardless of active/inactive status). 

We see in the [code](https://github.com/KratosMultiphysics/Kratos/blob/master/kratos/solving_strategies/builder_and_solvers/residualbased_block_builder_and_solver.h#L1350-L1390), that the builder and solver uses a call to `pScheme->EquationId(rElem, rIdsTLS, CurrentProcessInfo);` to build up the matrix structure. However for our schemes, as you can see in this PR, this function would return without doing anything when an element was inactive. This leads to problems later on in the workflow, as the system matrix structure should be initialized for all elements/conditions, not only the active ones.

Therefore, this PR removes the conditionality for the `EquationId` function, as well as `GetDofList`, since they are so closely related, it makes sense to keep this symmetrical. This is done by removing our specific implementation and relying on the base implementation.

The unit tests that needed changing have also been refactored using GMock.