### PR TITLE
[StructApp] Adapting the StructuralMechanicsBossak scheme to rototational dofs

### DIFF
--- a/applications/StructuralMechanicsApplication/custom_strategies/custom_schemes/structural_mechanics_bossak_scheme.h
+++ b/applications/StructuralMechanicsApplication/custom_strategies/custom_schemes/structural_mechanics_bossak_scheme.h
@@ -191,7 +191,6 @@ public:
                         if (rNode.GetDof(*ang_acc_components[i_dim], ang_acc_pos + i_dim).IsFixed()) {
                             r_delta_rotation[i_dim] = (r_current_angular_acceleration[i_dim] + this->mBossak.c3 * r_previous_angular_acceleration[i_dim] +  this->mBossak.c2 * r_previous_angular_velocity[i_dim])/(this->mBossak.c0);
                             r_current_rotation[i_dim] = r_previous_rotation[i_dim] + r_delta_rotation[i_dim];
-                            std::cout << "Updating rotation by angular acceleration" << std::endl;
                             r_predicted[i_dim] = true;
                         }
                     }
@@ -201,7 +200,6 @@ public:
                         if (rNode.GetDof(*ang_vel_components[i_dim], ang_vel_pos + i_dim).IsFixed() && !r_predicted[i_dim]) {
                             r_delta_rotation[i_dim] = (r_current_angular_velocity[i_dim] + this->mBossak.c4 * r_previous_angular_velocity[i_dim] + this->mBossak.c5 * r_previous_angular_acceleration[i_dim])/(this->mBossak.c1);
                             r_current_rotation[i_dim] = r_previous_rotation[i_dim] + r_delta_rotation[i_dim];
-                            std::cout << "Updating rotation by angular velocity" << std::endl;
                             r_predicted[i_dim] = true;
                         }
                     }

--- a/applications/StructuralMechanicsApplication/custom_strategies/custom_schemes/structural_mechanics_bossak_scheme.h
+++ b/applications/StructuralMechanicsApplication/custom_strategies/custom_schemes/structural_mechanics_bossak_scheme.h
@@ -17,6 +17,8 @@
 // External includes
 
 // Project includes
+#include "includes/variables.h"
+#include "structural_mechanics_application_variables.h"
 #include "includes/cfd_variables.h" //TODO: For OSS_SWITCH (think about a better place for this variable)
 #include "processes/calculate_nodal_area_process.h"
 
@@ -53,6 +55,9 @@ public:
 
     /// Class type for the scheme
     using ClassType = StructuralMechanicsBossakScheme<TSparseSpace, TDenseSpace>;
+
+    /// Type for the dofs array within BossakBaseType
+    using DofsArrayType = typename BossakBaseType::DofsArrayType;
 
     /// Type for the system matrix within BossakBaseType
     using TSystemMatrixType = typename BossakBaseType::TSystemMatrixType;
@@ -121,13 +126,14 @@ public:
             });
         }
     }
+
     void Update(
-    ModelPart& rModelPart,
-    DofsArrayType& rDofSet,
-    TSystemMatrixType& rA,
-    TSystemVectorType& rDx,
-    TSystemVectorType& rb
-    ) override
+        ModelPart& rModelPart,
+        DofsArrayType& rDofSet,
+        TSystemMatrixType& rA,
+        TSystemVectorType& rDx,
+        TSystemVectorType& rb
+        ) override
     {
         KRATOS_TRY
 

--- a/applications/StructuralMechanicsApplication/custom_strategies/custom_schemes/structural_mechanics_bossak_scheme.h
+++ b/applications/StructuralMechanicsApplication/custom_strategies/custom_schemes/structural_mechanics_bossak_scheme.h
@@ -188,18 +188,20 @@ public:
 
                 if(ang_acc_pos > -1) {
                     for (std::size_t i_dim = 0; i_dim < dimension; ++i_dim) {
-                        if (!rNode.GetDof(*ang_acc_components[i_dim], ang_acc_pos + i_dim).IsFixed()) {
+                        if (rNode.GetDof(*ang_acc_components[i_dim], ang_acc_pos + i_dim).IsFixed()) {
                             r_delta_rotation[i_dim] = (r_current_angular_acceleration[i_dim] + this->mBossak.c3 * r_previous_angular_acceleration[i_dim] +  this->mBossak.c2 * r_previous_angular_velocity[i_dim])/(this->mBossak.c0);
                             r_current_rotation[i_dim] = r_previous_rotation[i_dim] + r_delta_rotation[i_dim];
+                            std::cout << "Updating rotation by angular acceleration" << std::endl;
                             r_predicted[i_dim] = true;
                         }
                     }
                 }
                 if(ang_vel_pos > -1) {
                     for (std::size_t i_dim = 0; i_dim < dimension; ++i_dim) {
-                        if (!rNode.GetDof(*ang_vel_components[i_dim], ang_vel_pos + i_dim).IsFixed() && !r_predicted[i_dim]) {
+                        if (rNode.GetDof(*ang_vel_components[i_dim], ang_vel_pos + i_dim).IsFixed() && !r_predicted[i_dim]) {
                             r_delta_rotation[i_dim] = (r_current_angular_velocity[i_dim] + this->mBossak.c4 * r_previous_angular_velocity[i_dim] + this->mBossak.c5 * r_previous_angular_acceleration[i_dim])/(this->mBossak.c1);
                             r_current_rotation[i_dim] = r_previous_rotation[i_dim] + r_delta_rotation[i_dim];
+                            std::cout << "Updating rotation by angular velocity" << std::endl;
                             r_predicted[i_dim] = true;
                         }
                     }

--- a/applications/StructuralMechanicsApplication/custom_strategies/custom_schemes/structural_mechanics_bossak_scheme.h
+++ b/applications/StructuralMechanicsApplication/custom_strategies/custom_schemes/structural_mechanics_bossak_scheme.h
@@ -130,6 +130,15 @@ public:
         }
     }
 
+    /**
+     * @brief Apply the predictor.
+     * @details @f[ x_{k+1} = x_{k} + \dot x_{k} \Delta t + \frac{1}{2} \ddot x_{k} \Delta t^2 @f]
+     * @param rModelPart @ref ModelPart to update.
+     * @param rDofSet Set of all primary variables.
+     * @param rA Left hand side matrix.
+     * @param rDx Primary variable updates.
+     * @param rb Right hand side vector.
+     */
     void Predict(
         ModelPart& rModelPart,
         DofsArrayType& rDofSet,
@@ -147,8 +156,7 @@ public:
         const double delta_time = r_current_process_info[DELTA_TIME];
 
         // Updating angular time derivatives if they are available (nodally for efficiency)
-        if(rModelPart.HasNodalSolutionStepVariable(ROTATION))
-        {
+        if(rModelPart.HasNodalSolutionStepVariable(ROTATION)){
             const auto it_node_begin = rModelPart.Nodes().begin();
 
             // Getting position
@@ -221,6 +229,14 @@ public:
         KRATOS_CATCH("")
     }
 
+    /** @brief Update state variables and its time derivatives.
+     *  @details @f[ x_{n+1}^{k+1} = x_{n+1}^k+ \Delta x @f]
+     *  @param rModelPart @ref ModelPart to update.
+     *  @param rDofSet Set of all primary variables.
+     *  @param rA Left hand side matrix.
+     *  @param rDx Primary variable updates.
+     *  @param rb Right hand side vector.
+     */
     void Update(
         ModelPart& rModelPart,
         DofsArrayType& rDofSet,
@@ -235,8 +251,7 @@ public:
         BossakBaseType::Update(rModelPart, rDofSet, rA, rDx, rb);
 
         // Updating angular time derivatives if they are available (nodally for efficiency)
-        if(rModelPart.HasNodalSolutionStepVariable(ROTATION))
-        {
+        if(rModelPart.HasNodalSolutionStepVariable(ROTATION)){
             block_for_each(rModelPart.Nodes(), array_1d<double,3>(), [&](Node& rNode, array_1d<double,3>& rDeltaRotationTLS){
                     noalias(rDeltaRotationTLS) = rNode.FastGetSolutionStepValue(ROTATION) - rNode.FastGetSolutionStepValue(ROTATION, 1);
 
@@ -269,8 +284,7 @@ public:
         const auto& r_current_process_info = rModelPart.GetProcessInfo();
 
         // Updating angular time derivatives if they are available (nodally for efficiency)
-        if(rModelPart.HasNodalSolutionStepVariable(ROTATION))
-        {
+        if(rModelPart.HasNodalSolutionStepVariable(ROTATION)){
             const auto it_node_begin = rModelPart.Nodes().begin();
 
             // Getting dimension


### PR DESCRIPTION
**📝 Description**
Current situation:
The current implementation of `StructuralMechanicsBossakScheme` does not update the angular time derivatives `ANGULAR_VELOCITY` and `ANGULAR_ACCELERATION`.

This PR adapts the `StructuralMechanicsBossakScheme` to allow transient simulations of structures containing elements with rotational dofs. Therefore the methods `Predict`, `Update` and `InitializeSolutionStep` are extended. The extended implementations are analogous to those of the base methods in the `ResidualBasedBossakDisplacementScheme`, whereby the corresponding degrees of freedom are replaced by their angular counterparts.


**🆕 Changelog**
- Added `StructuralMechanicsBossakScheme::Update` method to update `ANGULAR_VELOCITY` and `ANGULAR_ACCELERATION` dofs
- Added `StructuralMechanicsBossakScheme::Predict`  method to predict the `ROTATION` dof
- Adapted `StructuralMechanicsBossakScheme::InitializeSolutionStep` method to fix the dofs consistently

