### PR TITLE
[StructuralMechanicsApplication] Remove deprecated mesh_id parameter from validation test

### DIFF
--- a/applications/StructuralMechanicsApplication/tests/shell_test/Shell_T3andQ4_linear_static_unstruct_pinched_cylinder_parameters.json
+++ b/applications/StructuralMechanicsApplication/tests/shell_test/Shell_T3andQ4_linear_static_unstruct_pinched_cylinder_parameters.json
@@ -132,7 +132,6 @@
         "check"         : "DirectorVectorNonZero direction",
         "process_name"  : "AssignVectorByDirectionToConditionProcess",
         "Parameters"    : {
-            "mesh_id"         : 0,
             "model_part_name" : "Structure.PointLoad3D_Neumann",
             "variable_name"   : "POINT_LOAD",
             "modulus"         : 0.25,


### PR DESCRIPTION
This was deprecated some time ago
https://github.com/KratosMultiphysics/Kratos/pull/12581