### PR TITLE
[StructuralMechanicsApplication] The Timoshenko beam constitutive law takes into account initial state

### DIFF
--- a/applications/StructuralMechanicsApplication/custom_constitutive/timoshenko_beam_elastic_constitutive_law.cpp
+++ b/applications/StructuralMechanicsApplication/custom_constitutive/timoshenko_beam_elastic_constitutive_law.cpp
@@ -103,6 +103,7 @@ void TimoshenkoBeamElasticConstitutiveLaw::CalculateMaterialResponseCauchy(Const
     const auto& r_cl_law_options = rValues.GetOptions();
     auto &r_material_properties = rValues.GetMaterialProperties();
     auto &r_strain_vector = rValues.GetStrainVector();
+    AddInitialStrainVectorContribution(r_strain_vector);
     const auto strain_size = GetStrainSize();
 
     const double axial_strain = r_strain_vector[0]; // E_l
@@ -128,6 +129,8 @@ void TimoshenkoBeamElasticConstitutiveLaw::CalculateMaterialResponseCauchy(Const
         r_generalized_stress_vector[0] = EA * axial_strain;  // N
         r_generalized_stress_vector[1] = EI * curvature;     // M
         r_generalized_stress_vector[2] = GAs * shear_strain; // V
+
+        AddInitialStressVectorContribution(r_generalized_stress_vector);
 
         if (r_cl_law_options.Is(ConstitutiveLaw::COMPUTE_CONSTITUTIVE_TENSOR)) {
             auto &r_stress_derivatives = rValues.GetConstitutiveMatrix(); // dN_dEl, dM_dkappa, dV_dGamma_xy

--- a/applications/StructuralMechanicsApplication/tests/cpp_tests/test_timoshenko_beam_elastic_constitutive_law.cpp
+++ b/applications/StructuralMechanicsApplication/tests/cpp_tests/test_timoshenko_beam_elastic_constitutive_law.cpp
@@ -12,48 +12,64 @@
 #include "structural_mechanics_fast_suite.h"
 #include "custom_constitutive/timoshenko_beam_elastic_constitutive_law.h"
 
+namespace
+{
+using namespace Kratos;
+
+Vector MakeStrainVectorForTesting() {
+    constexpr auto number_of_strain_components = 3;
+    auto result = Vector{number_of_strain_components};
+    result[0] = 2.0e-3; // axial strain
+    result[1] = 3.0e-2; // curvature
+    result[2] = 4.0e-3; // shear strain
+    return result;
+}
+
+Properties MakePropertiesForTesting() {
+    auto result = Properties{};
+    result[YOUNG_MODULUS] = 1.0e6;
+    result[POISSON_RATIO] = 0.2;
+    result[CROSS_AREA] = 0.2;
+    result[I33] = 0.5;
+    result[AREA_EFFECTIVE_Y] = 0.3;
+    return result;
+}
+
+}
+
 namespace Kratos::Testing
 {
 
 KRATOS_TEST_CASE_IN_SUITE(TimoshenkoBeamElasticConstitutiveLaw_CalculatesCauchyStressVector, KratosStructuralMechanicsFastSuite) {
     TimoshenkoBeamElasticConstitutiveLaw law;
     ConstitutiveLaw::Parameters parameters;
-    constexpr auto axial_strain = 2.0e-3;
-    constexpr auto curvature = 3.0e-2;
-    constexpr auto shear_strain = 4.0e-3;
-    constexpr auto number_of_strain_components = 3;
-    auto strain_vector = Vector{number_of_strain_components};
-    strain_vector[0] = axial_strain;
-    strain_vector[1] = curvature;
-    strain_vector[2] = shear_strain;
+    auto strain_vector = MakeStrainVectorForTesting();
+    const auto number_of_strain_components = strain_vector.size();
+    const auto axial_strain = strain_vector[0];
+    const auto curvature = strain_vector[1];
+    const auto shear_strain = strain_vector[2];
     parameters.SetStrainVector(strain_vector);
     auto stress_vector = Vector{ZeroVector{number_of_strain_components}};
     parameters.SetStressVector(stress_vector);
 
-    Properties properties;
-    constexpr auto youngs_modulus = 1.0e6;
-    properties[YOUNG_MODULUS] = youngs_modulus;
-    constexpr auto poissons_ratio = 0.2;
-    properties[POISSON_RATIO] = poissons_ratio;
-    constexpr auto area = 0.2;
-    properties[CROSS_AREA] = area;
-    constexpr auto moment_of_inertia = 0.5;
-    properties[I33] = moment_of_inertia;
-    constexpr auto effective_shear_area = 0.3;
-    properties[AREA_EFFECTIVE_Y] = effective_shear_area;
+    auto properties = MakePropertiesForTesting();
+    const auto E = properties[YOUNG_MODULUS];
+    const auto nu = properties[POISSON_RATIO];
+    const auto A = properties[CROSS_AREA];
+    const auto I = properties[I33];
+    const auto As = properties[AREA_EFFECTIVE_Y];
     parameters.SetMaterialProperties(properties);
-    const auto shear_modulus = youngs_modulus / (2.0 * (1.0 + poissons_ratio));
+
+    const auto G = E / (2.0 * (1.0 + nu));
 
     parameters.GetOptions().Set(ConstitutiveLaw::COMPUTE_STRESS, true);
 
-    // We'd like to actually call `CalculateMaterialResponsePK2`, but since that requires Gennady's
-    // changes, we'll use `CalculateMaterialResponseCauchy` for now
     law.CalculateMaterialResponseCauchy(parameters);
 
     auto expected_stress_vector = Vector{number_of_strain_components};
-    expected_stress_vector[0] = youngs_modulus * area * axial_strain;
-    expected_stress_vector[1] = youngs_modulus * moment_of_inertia * curvature;
-    expected_stress_vector[2] = shear_modulus * effective_shear_area * shear_strain;
+    expected_stress_vector[0] = E * A * axial_strain;
+    expected_stress_vector[1] = E * I * curvature;
+    expected_stress_vector[2] = G * As * shear_strain;
 
     constexpr auto relative_tolerance = 1.0e-6;
     KRATOS_EXPECT_VECTOR_RELATIVE_NEAR(parameters.GetStressVector(), expected_stress_vector, relative_tolerance);

--- a/applications/StructuralMechanicsApplication/tests/cpp_tests/test_timoshenko_beam_elastic_constitutive_law.cpp
+++ b/applications/StructuralMechanicsApplication/tests/cpp_tests/test_timoshenko_beam_elastic_constitutive_law.cpp
@@ -16,8 +16,9 @@ namespace
 {
 using namespace Kratos;
 
+constexpr auto number_of_strain_components = 3;
+
 Vector MakeStrainVectorForTesting() {
-    constexpr auto number_of_strain_components = 3;
     auto result = Vector{number_of_strain_components};
     result[0] = 2.0e-3; // axial strain
     result[1] = 3.0e-2; // curvature
@@ -35,6 +36,22 @@ Properties MakePropertiesForTesting() {
     return result;
 }
 
+Vector MakeInitialStrainVectorForTesting() {
+    auto result = Vector{number_of_strain_components};
+    result[0] = 4.0e-3; // initial axial strain
+    result[1] = 5.0e-2; // initial curvature
+    result[2] = 2.0e-3; // initial shear strain
+    return result;
+}
+
+Vector MakeInitialStressVectorForTesting() {
+    auto result = Vector{number_of_strain_components};
+    result[0] = 5000.0;
+    result[1] = 3000.0;
+    result[2] = 2000.0;
+    return result;
+}
+
 }
 
 namespace Kratos::Testing
@@ -44,7 +61,6 @@ KRATOS_TEST_CASE_IN_SUITE(TimoshenkoBeamElasticConstitutiveLaw_CalculatesCauchyS
     TimoshenkoBeamElasticConstitutiveLaw law;
     ConstitutiveLaw::Parameters parameters;
     auto strain_vector = MakeStrainVectorForTesting();
-    const auto number_of_strain_components = strain_vector.size();
     const auto axial_strain = strain_vector[0];
     const auto curvature = strain_vector[1];
     const auto shear_strain = strain_vector[2];
@@ -70,6 +86,46 @@ KRATOS_TEST_CASE_IN_SUITE(TimoshenkoBeamElasticConstitutiveLaw_CalculatesCauchyS
     expected_stress_vector[0] = E * A * axial_strain;
     expected_stress_vector[1] = E * I * curvature;
     expected_stress_vector[2] = G * As * shear_strain;
+
+    constexpr auto relative_tolerance = 1.0e-6;
+    KRATOS_EXPECT_VECTOR_RELATIVE_NEAR(parameters.GetStressVector(), expected_stress_vector, relative_tolerance);
+}
+
+KRATOS_TEST_CASE_IN_SUITE(TimoshenkoBeamElasticConstitutiveLaw_CalculatesCauchyStressVector_WithInitialState, KratosStructuralMechanicsFastSuite) {
+    TimoshenkoBeamElasticConstitutiveLaw law;
+    ConstitutiveLaw::Parameters parameters;
+    auto strain_vector = MakeStrainVectorForTesting();
+    const auto axial_strain = strain_vector[0];
+    const auto curvature = strain_vector[1];
+    const auto shear_strain = strain_vector[2];
+    parameters.SetStrainVector(strain_vector);
+    auto stress_vector = Vector{ZeroVector{number_of_strain_components}};
+    parameters.SetStressVector(stress_vector);
+
+    auto properties = MakePropertiesForTesting();
+    const auto E = properties[YOUNG_MODULUS];
+    const auto nu = properties[POISSON_RATIO];
+    const auto A = properties[CROSS_AREA];
+    const auto I = properties[I33];
+    const auto As = properties[AREA_EFFECTIVE_Y];
+    parameters.SetMaterialProperties(properties);
+
+    const auto G = E / (2.0 * (1.0 + nu));
+
+    const auto initial_strain_vector = MakeInitialStrainVectorForTesting();
+    const auto initial_stress_vector = MakeInitialStressVectorForTesting();
+    const auto p_initial_state = make_intrusive<InitialState>(
+        initial_strain_vector, initial_stress_vector);
+    law.SetInitialState(p_initial_state);
+
+    parameters.GetOptions().Set(ConstitutiveLaw::COMPUTE_STRESS, true);
+
+    law.CalculateMaterialResponseCauchy(parameters);
+
+    auto expected_stress_vector = Vector{number_of_strain_components};
+    expected_stress_vector[0] = E * A * (axial_strain - initial_strain_vector[0]) + initial_stress_vector[0];
+    expected_stress_vector[1] = E * I * (curvature - initial_strain_vector[1]) + initial_stress_vector[1];
+    expected_stress_vector[2] = G * As * (shear_strain - initial_strain_vector[2]) + initial_stress_vector[2];
 
     constexpr auto relative_tolerance = 1.0e-6;
     KRATOS_EXPECT_VECTOR_RELATIVE_NEAR(parameters.GetStressVector(), expected_stress_vector, relative_tolerance);

--- a/applications/StructuralMechanicsApplication/tests/cpp_tests/test_timoshenko_beam_elastic_constitutive_law.cpp
+++ b/applications/StructuralMechanicsApplication/tests/cpp_tests/test_timoshenko_beam_elastic_constitutive_law.cpp
@@ -61,31 +61,21 @@ KRATOS_TEST_CASE_IN_SUITE(TimoshenkoBeamElasticConstitutiveLaw_CalculatesCauchyS
     TimoshenkoBeamElasticConstitutiveLaw law;
     ConstitutiveLaw::Parameters parameters;
     auto strain_vector = MakeStrainVectorForTesting();
-    const auto axial_strain = strain_vector[0];
-    const auto curvature = strain_vector[1];
-    const auto shear_strain = strain_vector[2];
     parameters.SetStrainVector(strain_vector);
     auto stress_vector = Vector{ZeroVector{number_of_strain_components}};
     parameters.SetStressVector(stress_vector);
 
-    auto properties = MakePropertiesForTesting();
-    const auto E = properties[YOUNG_MODULUS];
-    const auto nu = properties[POISSON_RATIO];
-    const auto A = properties[CROSS_AREA];
-    const auto I = properties[I33];
-    const auto As = properties[AREA_EFFECTIVE_Y];
+    const auto properties = MakePropertiesForTesting();
     parameters.SetMaterialProperties(properties);
-
-    const auto G = E / (2.0 * (1.0 + nu));
 
     parameters.GetOptions().Set(ConstitutiveLaw::COMPUTE_STRESS, true);
 
     law.CalculateMaterialResponseCauchy(parameters);
 
     auto expected_stress_vector = Vector{number_of_strain_components};
-    expected_stress_vector[0] = E * A * axial_strain;
-    expected_stress_vector[1] = E * I * curvature;
-    expected_stress_vector[2] = G * As * shear_strain;
+    expected_stress_vector[0] = 400.0;
+    expected_stress_vector[1] = 15000.0;
+    expected_stress_vector[2] = 500.0;
 
     constexpr auto relative_tolerance = 1.0e-6;
     KRATOS_EXPECT_VECTOR_RELATIVE_NEAR(parameters.GetStressVector(), expected_stress_vector, relative_tolerance);
@@ -95,22 +85,12 @@ KRATOS_TEST_CASE_IN_SUITE(TimoshenkoBeamElasticConstitutiveLaw_CalculatesCauchyS
     TimoshenkoBeamElasticConstitutiveLaw law;
     ConstitutiveLaw::Parameters parameters;
     auto strain_vector = MakeStrainVectorForTesting();
-    const auto axial_strain = strain_vector[0];
-    const auto curvature = strain_vector[1];
-    const auto shear_strain = strain_vector[2];
     parameters.SetStrainVector(strain_vector);
     auto stress_vector = Vector{ZeroVector{number_of_strain_components}};
     parameters.SetStressVector(stress_vector);
 
-    auto properties = MakePropertiesForTesting();
-    const auto E = properties[YOUNG_MODULUS];
-    const auto nu = properties[POISSON_RATIO];
-    const auto A = properties[CROSS_AREA];
-    const auto I = properties[I33];
-    const auto As = properties[AREA_EFFECTIVE_Y];
+    const auto properties = MakePropertiesForTesting();
     parameters.SetMaterialProperties(properties);
-
-    const auto G = E / (2.0 * (1.0 + nu));
 
     const auto initial_strain_vector = MakeInitialStrainVectorForTesting();
     const auto initial_stress_vector = MakeInitialStressVectorForTesting();
@@ -123,9 +103,9 @@ KRATOS_TEST_CASE_IN_SUITE(TimoshenkoBeamElasticConstitutiveLaw_CalculatesCauchyS
     law.CalculateMaterialResponseCauchy(parameters);
 
     auto expected_stress_vector = Vector{number_of_strain_components};
-    expected_stress_vector[0] = E * A * (axial_strain - initial_strain_vector[0]) + initial_stress_vector[0];
-    expected_stress_vector[1] = E * I * (curvature - initial_strain_vector[1]) + initial_stress_vector[1];
-    expected_stress_vector[2] = G * As * (shear_strain - initial_strain_vector[2]) + initial_stress_vector[2];
+    expected_stress_vector[0] = 4600.0;
+    expected_stress_vector[1] = -7000.0;
+    expected_stress_vector[2] = 2250.0;
 
     constexpr auto relative_tolerance = 1.0e-6;
     KRATOS_EXPECT_VECTOR_RELATIVE_NEAR(parameters.GetStressVector(), expected_stress_vector, relative_tolerance);

--- a/applications/StructuralMechanicsApplication/tests/cpp_tests/test_timoshenko_beam_elastic_constitutive_law.cpp
+++ b/applications/StructuralMechanicsApplication/tests/cpp_tests/test_timoshenko_beam_elastic_constitutive_law.cpp
@@ -1,0 +1,62 @@
+// KRATOS  ___|  |                   |                   |
+//       \___ \  __|  __| |   |  __| __| |   |  __| _` | |
+//             | |   |    |   | (    |   |   | |   (   | |
+//       _____/ \__|_|   \__,_|\___|\__|\__,_|_|  \__,_|_| MECHANICS
+//
+//  License:         BSD License
+//                   license: StructuralMechanicsApplication/license.txt
+//
+//  Main authors:    Anne van de Graaf
+//
+
+#include "structural_mechanics_fast_suite.h"
+#include "custom_constitutive/timoshenko_beam_elastic_constitutive_law.h"
+
+namespace Kratos::Testing
+{
+
+KRATOS_TEST_CASE_IN_SUITE(TimoshenkoBeamElasticConstitutiveLaw_CalculatesCauchyStressVector, KratosStructuralMechanicsFastSuite) {
+    TimoshenkoBeamElasticConstitutiveLaw law;
+    ConstitutiveLaw::Parameters parameters;
+    constexpr auto axial_strain = 2.0e-3;
+    constexpr auto curvature = 3.0e-2;
+    constexpr auto shear_strain = 4.0e-3;
+    constexpr auto number_of_strain_components = 3;
+    auto strain_vector = Vector{number_of_strain_components};
+    strain_vector[0] = axial_strain;
+    strain_vector[1] = curvature;
+    strain_vector[2] = shear_strain;
+    parameters.SetStrainVector(strain_vector);
+    auto stress_vector = Vector{ZeroVector{number_of_strain_components}};
+    parameters.SetStressVector(stress_vector);
+
+    Properties properties;
+    constexpr auto youngs_modulus = 1.0e6;
+    properties[YOUNG_MODULUS] = youngs_modulus;
+    constexpr auto poissons_ratio = 0.2;
+    properties[POISSON_RATIO] = poissons_ratio;
+    constexpr auto area = 0.2;
+    properties[CROSS_AREA] = area;
+    constexpr auto moment_of_inertia = 0.5;
+    properties[I33] = moment_of_inertia;
+    constexpr auto effective_shear_area = 0.3;
+    properties[AREA_EFFECTIVE_Y] = effective_shear_area;
+    parameters.SetMaterialProperties(properties);
+    const auto shear_modulus = youngs_modulus / (2.0 * (1.0 + poissons_ratio));
+
+    parameters.GetOptions().Set(ConstitutiveLaw::COMPUTE_STRESS, true);
+
+    // We'd like to actually call `CalculateMaterialResponsePK2`, but since that requires Gennady's
+    // changes, we'll use `CalculateMaterialResponseCauchy` for now
+    law.CalculateMaterialResponseCauchy(parameters);
+
+    auto expected_stress_vector = Vector{number_of_strain_components};
+    expected_stress_vector[0] = youngs_modulus * area * axial_strain;
+    expected_stress_vector[1] = youngs_modulus * moment_of_inertia * curvature;
+    expected_stress_vector[2] = shear_modulus * effective_shear_area * shear_strain;
+
+    constexpr auto relative_tolerance = 1.0e-6;
+    KRATOS_EXPECT_VECTOR_RELATIVE_NEAR(parameters.GetStressVector(), expected_stress_vector, relative_tolerance);
+}
+
+}


### PR DESCRIPTION
**📝 Description**
The changes in this PR allow for the Timoshenko beam constitutive law to account for any initial state when calculating the Cauchy material response. The proposed changes are in line with the changes we've proposed before for the truss element (see https://github.com/KratosMultiphysics/Kratos/pull/12525).

Added two C++ unit tests to cover the cases with and without initial state.
