### PR TITLE
[Core] Adding suggestions to import failures

### DIFF
--- a/kratos/python_interface/__init__.py
+++ b/kratos/python_interface/__init__.py
@@ -32,7 +32,28 @@ class KratosPaths(object):
 # import core library (Kratos.so)
 sys.path.append(KratosPaths.kratos_libs)
 sys.path.append(KratosPaths.kratos_module_libs)
-from Kratos import *
+
+try:
+    from Kratos import *
+except ImportError as e:
+    var_name = {
+        "posix": "LD_LIBRARY_PATH or DYLD_LIBRARY_PATH",
+        "nt": "PATH"
+    }
+
+    if os.name in var_name.keys():
+        print(f"Unable to find KratosCore. Please make sure that your {var_name[os.name]} environment variable includes the path to the Kratos libraries.")
+    else:
+        print(f"Unable to find KratosCore. Your OS is unknown and we cannot provide further info. Please open an issue at https://github.com/KratosMultiphysics/Kratos")
+
+    raise e
+
+except OSError as e:
+    if os.name == 'nt':
+        print("Please download the latest Microsfot Visual C++ Redistributable from https://learn.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist")
+    else:
+        print("Please make sure that the Kratos libraries are compiled for your system.")
+    raise e
 
 Kernel.RegisterPythonVersion()
 


### PR DESCRIPTION
**📝 Description**
This PR aims to provide more insight when Kratos fails to import some of its modules.

Specifically this is aiming to guide windows users on installing the Microsoft Visual C++ Redistributable, as the default python message could be misleading.
