### PR TITLE
[CI] Change CentOS images to Rocky images for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -301,17 +301,17 @@ jobs:
         python kratos/python_scripts/testing/run_python_tests.py -l nightly -c python
 
 
-  centos:
+  rocky:
     runs-on: ubuntu-latest
     needs: changed-files
     env:
       KRATOS_BUILD_TYPE: Custom
       KRATOS_CI_CHANGED_FILES: ${{needs.changed-files.outputs.files}}
-      KRATOS_CI_APPLICATIONS: ".github/workflows/ci_apps_centos.json"
+      KRATOS_CI_APPLICATIONS: ".github/workflows/ci_apps_rocky.json"
       ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
 
     container:
-      image: kratosmultiphysics/kratos-image-ci-centos7:latest
+      image: kratosmultiphysics/kratos-image-ci-rockylinux-8:latest
       options: --user 1001
 
     steps:
@@ -322,13 +322,13 @@ jobs:
 
     - name: CI configuration
       shell: bash
-      run: python3.8 kratos/python_scripts/testing/ci_utilities.py
+      run: python3 kratos/python_scripts/testing/ci_utilities.py
 
     - name: Build
       run: |
         export KRATOS_CMAKE_CXX_FLAGS="-Werror -Wno-deprecated-declarations -Wignored-qualifiers"
-        cp .github/workflows/centos_configure.sh centos_configure.sh
-        bash centos_configure.sh
+        cp .github/workflows/rocky_configure.sh rocky_configure.sh
+        bash rocky_configure.sh
 
     - name: Running C++ tests
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -322,7 +322,7 @@ jobs:
 
     - name: CI configuration
       shell: bash
-      run: python3 kratos/python_scripts/testing/ci_utilities.py
+      run: python3.8 kratos/python_scripts/testing/ci_utilities.py
 
     - name: Build
       run: |

--- a/.github/workflows/ci_apps_centos.json
+++ b/.github/workflows/ci_apps_centos.json
@@ -1,9 +1,0 @@
-[
-    "FluidDynamicsApplication",
-    "MappingApplication",
-    "StructuralMechanicsApplication",
-    "MeshingApplication",
-    "LinearSolversApplication",
-    "ConstitutiveLawsApplication",
-    "CoSimulationApplication"
-]

--- a/.github/workflows/ci_apps_rocky.json
+++ b/.github/workflows/ci_apps_rocky.json
@@ -1,0 +1,9 @@
+[
+    "FluidDynamicsApplication",
+    "MappingApplication",
+    "StructuralMechanicsApplication",
+    "MeshingApplication",
+    "LinearSolversApplication",
+    "ConstitutiveLawsApplication",
+    "CoSimulationApplication"
+]

--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -131,13 +131,20 @@ jobs:
         bash configure.sh
         rm -r ${GITHUB_WORKSPACE}/build       
 
+    - name: Running C++ tests
+      run: |
+        source /opt/intel/oneapi/setvars.sh
+        export PYTHONPATH=${PYTHONPATH}:${GITHUB_WORKSPACE}/bin/${KRATOS_BUILD_TYPE}
+        export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${GITHUB_WORKSPACE}/bin/${KRATOS_BUILD_TYPE}/libs
+        python3 kratos/python_scripts/testing/run_cpp_tests.py
+
     - name: Running tests
       shell: bash
       run: |
         source /opt/intel/oneapi/setvars.sh
         export PYTHONPATH=${PYTHONPATH}:${GITHUB_WORKSPACE}/bin/${KRATOS_BUILD_TYPE}
         export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${GITHUB_WORKSPACE}/bin/${KRATOS_BUILD_TYPE}/libs
-        python3 kratos/python_scripts/testing/run_tests.py -l nightly -c python3
+        python3 kratos/python_scripts/testing/run_python_tests.py -l nightly -c python3
 
     - name: Running Python MPI tests (2 Cores)
       shell: bash
@@ -201,12 +208,18 @@ jobs:
         copy .\.github\workflows\configure.cmd
         configure.cmd
 
+    - name: Running C++ tests
+      run: |
+        set PYTHONPATH=%PYTHONPATH%;%GITHUB_WORKSPACE%/bin/%KRATOS_BUILD_TYPE%
+        set PATH=%PATH%;%GITHUB_WORKSPACE%/bin/%KRATOS_BUILD_TYPE%/libs
+        python kratos/python_scripts/testing/run_cpp_tests.py
+
     - name: Running nightly tests
       shell: cmd
       run: |
         set PYTHONPATH=%PYTHONPATH%;%GITHUB_WORKSPACE%/bin/%KRATOS_BUILD_TYPE%
         set PATH=%PATH%;%GITHUB_WORKSPACE%/bin/%KRATOS_BUILD_TYPE%/libs
-        python kratos/python_scripts/testing/run_tests.py -l nightly -c python
+        python kratos/python_scripts/testing/run_python_tests.py -l nightly -c python
 
   rocky-nightly:
     runs-on: ubuntu-latest
@@ -230,8 +243,14 @@ jobs:
         cp .github/workflows/rocky_configure.sh rocky_configure.sh
         bash rocky_configure.sh
 
+    - name: Running C++ tests
+      run: |
+        export PYTHONPATH=${PYTHONPATH}:${GITHUB_WORKSPACE}/bin/Custom
+        export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${GITHUB_WORKSPACE}/bin/Custom/libs
+        python3.8 kratos/python_scripts/testing/run_cpp_tests.py
+
     - name: Running nightly tests
       run: |
         export PYTHONPATH=${PYTHONPATH}:${GITHUB_WORKSPACE}/bin/Custom
         export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${GITHUB_WORKSPACE}/bin/Custom/libs
-        python3.8 kratos/python_scripts/testing/run_tests.py -l nightly -c python3.8
+        python3.8 kratos/python_scripts/testing/run_python_tests.py -l nightly -c python3.8

--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -6,7 +6,7 @@ on:
     - '.github/workflows/nightly_build.yml'
     - '.github/workflows/configure.sh'
     - '.github/workflows/configure.cmd'
-    - '.github/workflows/centos_configure.sh'
+    - '.github/workflows/rocky_configure.sh'
 
   schedule:
     - cron:  '0 1 * * *'
@@ -208,13 +208,13 @@ jobs:
         set PATH=%PATH%;%GITHUB_WORKSPACE%/bin/%KRATOS_BUILD_TYPE%/libs
         python kratos/python_scripts/testing/run_tests.py -l nightly -c python
 
-  centos-nightly:
+  rocky-nightly:
     runs-on: ubuntu-latest
     env:
       KRATOS_BUILD_TYPE: Custom
 
     container:
-      image: kratosmultiphysics/kratos-image-ci-centos7:latest
+      image: kratosmultiphysics/kratos-image-ci-rockylinux-8:latest
       options: --user 1001
 
     steps:
@@ -227,8 +227,8 @@ jobs:
 
     - name: Build
       run: |
-        cp .github/workflows/centos_configure.sh centos_configure.sh
-        bash centos_configure.sh
+        cp .github/workflows/rocky_configure.sh rocky_configure.sh
+        bash rocky_configure.sh
 
     - name: Running nightly tests
       run: |

--- a/.github/workflows/rocky_configure.sh
+++ b/.github/workflows/rocky_configure.sh
@@ -35,14 +35,10 @@ rm -rf "${KRATOS_BUILD}/${KRATOS_BUILD_TYPE}/CMakeFiles"
 
 echo "Kratos build type is ${KRATOS_BUILD_TYPE}"
 
-# Enable devtoolset-8
-source scl_source enable devtoolset-8
-
 # Configure
 cmake -H"${KRATOS_SOURCE}" -B"${KRATOS_BUILD}/${KRATOS_BUILD_TYPE}" \
 ${KRATOS_CMAKE_OPTIONS_FLAGS}                                       \
 -DUSE_MPI=OFF                                                       \
--DPYBIND11_PYTHON_VERSION="3.8"                                     \
 -DCMAKE_CXX_FLAGS="${KRATOS_CMAKE_CXX_FLAGS} -O0 -Wall"             \
 -DCMAKE_UNITY_BUILD=ON                                              \
 

--- a/.github/workflows/rocky_configure.sh
+++ b/.github/workflows/rocky_configure.sh
@@ -39,6 +39,7 @@ echo "Kratos build type is ${KRATOS_BUILD_TYPE}"
 cmake -H"${KRATOS_SOURCE}" -B"${KRATOS_BUILD}/${KRATOS_BUILD_TYPE}" \
 ${KRATOS_CMAKE_OPTIONS_FLAGS}                                       \
 -DUSE_MPI=OFF                                                       \
+-DPYBIND11_PYTHON_VERSION="3.8"                                     \
 -DCMAKE_CXX_FLAGS="${KRATOS_CMAKE_CXX_FLAGS} -O0 -Wall"             \
 -DCMAKE_UNITY_BUILD=ON                                              \
 

--- a/.github/workflows/rocky_configure.sh
+++ b/.github/workflows/rocky_configure.sh
@@ -19,6 +19,27 @@ export KRATOS_APP_DIR="${KRATOS_SOURCE}/applications"
 export PYTHON_EXECUTABLE=${PYTHON_EXECUTABLE:-"/usr/bin/python3"}
 export KRATOS_INSTALL_PYTHON_USING_LINKS=ON
 
+# Boost setup
+BOOST_VERSION="1.86.0"
+BOOST_DIR_NAME="boost_1_86_0"
+BOOST_TARBALL_URL="https://archives.boost.io/release/${BOOST_VERSION}/source/${BOOST_DIR_NAME}.tar.gz"
+BOOST_DOWNLOAD_DIR="${KRATOS_SOURCE}/external_libraries"
+BOOST_EXTRACT_DIR="${BOOST_DOWNLOAD_DIR}/${BOOST_DIR_NAME}"
+
+# Download and extract Boost if not already done
+mkdir -p "${BOOST_DOWNLOAD_DIR}"
+if [ ! -d "${BOOST_EXTRACT_DIR}" ]; then
+    echo "Downloading Boost ${BOOST_VERSION}..."
+    curl -L "${BOOST_TARBALL_URL}" -o "${BOOST_DOWNLOAD_DIR}/${BOOST_DIR_NAME}.tar.gz"
+    echo "Extracting Boost..."
+    tar -xzf "${BOOST_DOWNLOAD_DIR}/${BOOST_DIR_NAME}.tar.gz" -C "${BOOST_DOWNLOAD_DIR}"
+fi
+
+# Define BOOST_ROOT
+export BOOST_ROOT="${BOOST_EXTRACT_DIR}"
+echo "BOOST_ROOT is set to ${BOOST_ROOT}"
+
+# Add applications
 add_app ${KRATOS_APP_DIR}/FluidDynamicsApplication;
 add_app ${KRATOS_APP_DIR}/MappingApplication;
 add_app ${KRATOS_APP_DIR}/StructuralMechanicsApplication;
@@ -40,6 +61,7 @@ cmake -H"${KRATOS_SOURCE}" -B"${KRATOS_BUILD}/${KRATOS_BUILD_TYPE}" \
 ${KRATOS_CMAKE_OPTIONS_FLAGS}                                       \
 -DUSE_MPI=OFF                                                       \
 -DPYBIND11_PYTHON_VERSION="3.8"                                     \
+-DBOOST_ROOT="${BOOST_ROOT}"                                        \
 -DCMAKE_CXX_FLAGS="${KRATOS_CMAKE_CXX_FLAGS} -O0 -Wall"             \
 -DCMAKE_UNITY_BUILD=ON                                              \
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -304,6 +304,9 @@ if(KRATOS_BUILD_TESTING MATCHES ON)
   # retrieve a copy of the current directory's `COMPILE_OPTIONS`
   get_directory_property(kratos_root_compile_options COMPILE_OPTIONS)
 
+  # Disable warnings (needed by Intel Compiler Legacy)
+  add_compile_options(-w)
+
   FetchContent_Declare(
     googletest
     URL https://github.com/google/googletest/archive/03597a01ee50ed33e9dfd640b249b4be3799d395.zip

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -304,9 +304,6 @@ if(KRATOS_BUILD_TESTING MATCHES ON)
   # retrieve a copy of the current directory's `COMPILE_OPTIONS`
   get_directory_property(kratos_root_compile_options COMPILE_OPTIONS)
 
-  # Disable warnings (needed by centos. We should all love centos, it clearly needs some affection)
-  add_compile_options(-w)
-
   FetchContent_Declare(
     googletest
     URL https://github.com/google/googletest/archive/03597a01ee50ed33e9dfd640b249b4be3799d395.zip

--- a/kratos/python/add_other_utilities_to_python.cpp
+++ b/kratos/python/add_other_utilities_to_python.cpp
@@ -73,7 +73,9 @@
 namespace Kratos::Python {
 
 /**
- * @brief A thin wrapper for GetSortedListOfFileNameData. The reason for having the wrapper is to replace the original lambda implementation as it causes gcc 4.8 to generate bad code on Centos7 which leads to memory corruption.
+ * @brief A thin wrapper for GetSortedListOfFileNameData. 
+ * @note The reason for having the wrapper is to replace the original lambda implementation as it causes gcc 4.8 to generate bad code on Centos7 which leads to memory corruption.
+ * @todo Now that Centos support is dropped this cna be removed
  */
 pybind11::list GetSortedListOfFileNameDataHelper(
     std::vector<FileNameDataCollector::FileNameData>& rFileNameDataList,


### PR DESCRIPTION
**📝 Description**

![9dizsh](https://github.com/user-attachments/assets/53208a19-3146-4dca-aa90-1128db1a5c57)

Centos Linux is officially out of support, in @KratosMultiphysics/altair we have already updated to Rocky, now updating here too.

**🆕 Changelog**

- [Rename centos configure to rocky](https://github.com/KratosMultiphysics/Kratos/commit/33a6e64f2c502d5dd0c59b8a66015983abc1b428)
- [Rename centos to rocky apps](https://github.com/KratosMultiphysics/Kratos/commit/d8866d299356c76823e22c3bf65c596e05cd74e3)
- [Remove legacy centos checks](https://github.com/KratosMultiphysics/Kratos/commit/ea8d235c6ab865c85cce06e9ba7e2bcb8a161325)
- [Prepare CI for Rocky Linux](https://github.com/KratosMultiphysics/Kratos/commit/8a4dd3e5ea68ee5a13e63b9e4d4fad66e7b1d11b)
- Changes https://github.com/KratosMultiphysics/Kratos/pull/12937
