### PR TITLE
Update and Fix `Profiler`

### DIFF
--- a/kratos/sources/profiler.cpp
+++ b/kratos/sources/profiler.cpp
@@ -24,6 +24,7 @@
 #include <fstream>
 #include <sstream>
 #include <atomic>
+#include <limits> // std::numeric_limits
 
 
 namespace Kratos::Internals {
@@ -59,11 +60,11 @@ std::string GetTimeUnit<std::chrono::nanoseconds>()
 
 template <class T>
 Profiler<T>::Item::Item(CodeLocation&& rLocation)
-    : Item(0,
-           Duration(0),
-           Duration(0),
-           Duration(0),
-           std::move(rLocation))
+    : Item(0,                                                               // <== .mCallCount
+           Duration(0),                                                     // <== .mCumulative
+           Duration(std::numeric_limits<typename Duration::rep>::max()),    // <== .mMin
+           Duration(0),                                                     // <== .mMax
+           std::move(rLocation))                                            // <== .mLocation
 {
 }
 

--- a/kratos/sources/profiler.cpp
+++ b/kratos/sources/profiler.cpp
@@ -267,19 +267,19 @@ template <class T>
 std::mutex ProfilerSingleton<T>::mMutex;
 
 
-template class Profiler<std::chrono::milliseconds>;
-template class ProfilerSingleton<std::chrono::milliseconds>;
-template std::ostream& operator<<(std::ostream&, const Profiler<std::chrono::milliseconds>&);
+template class KRATOS_API(KRATOS_CORE) Profiler<std::chrono::milliseconds>;
+template class KRATOS_API(KRATOS_CORE) ProfilerSingleton<std::chrono::milliseconds>;
+template KRATOS_API(KRATOS_CORE) std::ostream& operator<<(std::ostream&, const Profiler<std::chrono::milliseconds>&);
 
 
-template class Profiler<std::chrono::microseconds>;
-template class ProfilerSingleton<std::chrono::microseconds>;
-template std::ostream& operator<<(std::ostream&, const Profiler<std::chrono::microseconds>&);
+template class KRATOS_API(KRATOS_CORE) Profiler<std::chrono::microseconds>;
+template class KRATOS_API(KRATOS_CORE) ProfilerSingleton<std::chrono::microseconds>;
+template KRATOS_API(KRATOS_CORE) std::ostream& operator<<(std::ostream&, const Profiler<std::chrono::microseconds>&);
 
 
-template class Profiler<std::chrono::nanoseconds>;
-template class ProfilerSingleton<std::chrono::nanoseconds>;
-template std::ostream& operator<<(std::ostream&, const Profiler<std::chrono::nanoseconds>&);
+template class KRATOS_API(KRATOS_CORE) Profiler<std::chrono::nanoseconds>;
+template class KRATOS_API(KRATOS_CORE) ProfilerSingleton<std::chrono::nanoseconds>;
+template KRATOS_API(KRATOS_CORE) std::ostream& operator<<(std::ostream&, const Profiler<std::chrono::nanoseconds>&);
 
 
 } // namespace cie::utils

--- a/kratos/sources/profiler.cpp
+++ b/kratos/sources/profiler.cpp
@@ -207,7 +207,8 @@ void Profiler<T>::Write(std::ostream& rStream) const
         const auto& r_location = p_item->mLocation;
         result.AddString("file", std::string(r_location.GetFileName()));
         result.AddInt("line", int(r_location.GetLineNumber()));
-        result.AddString("function", std::string(r_location.GetFunctionName()));
+        result.AddString("signature", std::string(r_location.GetFunctionName()));
+        result.AddString("function", std::string(r_location.CleanFunctionName()));
         result.AddInt("callCount", p_item->mCallCount);
 
         std::stringstream stream;

--- a/kratos/sources/profiler.cpp
+++ b/kratos/sources/profiler.cpp
@@ -21,13 +21,40 @@
 #include <algorithm>
 #include <thread>
 #include <vector>
-#include <tuple>
 #include <fstream>
 #include <sstream>
 #include <atomic>
 
 
 namespace Kratos::Internals {
+
+
+namespace {
+template <class TTimeUnit>
+std::string GetTimeUnit()
+{
+    KRATOS_ERROR << "Unsupported time unit";
+}
+
+template <>
+std::string GetTimeUnit<std::chrono::milliseconds>()
+{
+    return "ms";
+}
+
+template <>
+std::string GetTimeUnit<std::chrono::microseconds>()
+{
+    return "us";
+}
+
+template <>
+
+std::string GetTimeUnit<std::chrono::nanoseconds>()
+{
+    return "ns";
+}
+} // unnamed namespace
 
 
 template <class T>
@@ -70,7 +97,7 @@ typename Profiler<T>::Item& Profiler<T>::Item::operator+=(const Item& rOther)
 
 template <class T>
 Profiler<T>::Profiler()
-    : Profiler("kratos_profiler_output.json")
+    : Profiler("kratos_profiler_output_" + GetTimeUnit<T>() + ".json")
 {
 }
 
@@ -110,34 +137,6 @@ typename Profiler<T>::Item& Profiler<T>::Create(CodeLocation&& r_item)
     r_list.emplace_back(std::move(r_item));
     return r_list.back();
 }
-
-
-namespace {
-template <class TTimeUnit>
-std::string GetTimeUnit()
-{
-    KRATOS_ERROR << "Unknown time unit";
-}
-
-template <>
-std::string GetTimeUnit<std::chrono::milliseconds>()
-{
-    return "ms";
-}
-
-template <>
-std::string GetTimeUnit<std::chrono::microseconds>()
-{
-    return "us";
-}
-
-template <>
-
-std::string GetTimeUnit<std::chrono::nanoseconds>()
-{
-    return "ns";
-}
-} // unnamed namespace
 
 
 template <class T>

--- a/kratos/utilities/profiler.h
+++ b/kratos/utilities/profiler.h
@@ -29,7 +29,7 @@ namespace Kratos::Internals {
 
 
 template <class TTimeUnit>
-class Profiler
+class KRATOS_API(KRATOS_CORE) Profiler
 {
 private:
     using TimeUnit = TTimeUnit;
@@ -180,11 +180,11 @@ private:
 
 
 template <class T>
-std::ostream& operator<<(std::ostream& rStream, const Profiler<T>& rProfiler);
+KRATOS_API(KRATOS_CORE) std::ostream& operator<<(std::ostream& rStream, const Profiler<T>& rProfiler);
 
 
 template <class TTimeUnit>
-class ProfilerSingleton
+class KRATOS_API(KRATOS_CORE) ProfilerSingleton
 {
 public:
     static Profiler<TTimeUnit>& Get() noexcept;

--- a/kratos/utilities/profiler.h
+++ b/kratos/utilities/profiler.h
@@ -32,10 +32,13 @@ template <class TTimeUnit>
 class KRATOS_API(KRATOS_CORE) Profiler
 {
 private:
+    /// @brief Absolute time type.
     using TimeUnit = TTimeUnit;
 
+    /// @brief Relative time type.
     using Duration = TimeUnit;
 
+    /// @brief  Clock type used for measuring durations.
     using Clock = std::chrono::high_resolution_clock;
 
     /// @brief Class for identifying a profiled scope and aggregating its stats.
@@ -51,21 +54,31 @@ private:
              Duration MaxDuration,
              CodeLocation&& rLocation);
 
+        /// @brief Aggregate profiled data from another @ref Item in the same scope.
         Item& operator+=(const Item& rOther);
 
     private:
         friend class Profiler;
 
+        /// @brief Counter for keeping track of recursive calls.
+        /// @details Recursive function calls are aggregated onto the top
+        ///          level call. To do that, the @ref Item must keep track
+        ///          of its recursion depth.
         unsigned mRecursionLevel;
 
+        /// @brief Counter tracking total number of calls to a function during the program's entire execution time.
         std::size_t mCallCount;
 
+        /// @brief Counter summing the duration of each call to the profiled scope.
         Duration mCumulative;
 
+        /// @brief Minimum time spent in the profiled scope.
         Duration mMin;
 
+        /// @brief Maximum time spent in the profiled scope.
         Duration mMax;
 
+        /// @brief Source information about the profiled scope.
         CodeLocation mLocation;
     }; // class Item
 

--- a/kratos/utilities/profiler.h
+++ b/kratos/utilities/profiler.h
@@ -71,20 +71,19 @@ private:
 
     struct SourceLocationHash
     {
-        std::size_t operator()(const CodeLocation& r_argument) const
+        std::size_t operator()(const CodeLocation& rArgument) const
         {
-            std::string string(r_argument.GetFileName());
-            string.append(std::to_string(r_argument.GetLineNumber()));
-            return std::hash<std::string>()(string);
+            return std::hash<std::string>()(rArgument.GetFileName() + rArgument.GetFunctionName());
         }
     };
 
     struct SourceLocationEquality
     {
-        bool operator()(const CodeLocation& r_lhs,
-                        const CodeLocation& r_rhs) const
+        bool operator()(const CodeLocation& rLhs,
+                        const CodeLocation& rRhs) const
         {
-            return (std::string(r_lhs.GetFileName()) == std::string(r_rhs.GetFileName())) && (r_lhs.GetLineNumber() == r_rhs.GetLineNumber());
+            return (rLhs.GetFileName() == rRhs.GetFileName())
+                   && (rLhs.GetFunctionName() == rRhs.GetFunctionName());
         }
     };
 

--- a/kratos/utilities/profiler.h
+++ b/kratos/utilities/profiler.h
@@ -42,7 +42,7 @@ private:
     class Item
     {
     public:
-        Item(CodeLocation&& rLocation);
+        explicit Item(CodeLocation&& rLocation);
 
     private:
         Item(std::size_t CallCount,

--- a/kratos/utilities/profiler_impl.h
+++ b/kratos/utilities/profiler_impl.h
@@ -16,7 +16,6 @@
 #include "utilities/profiler.h" // <== help the language server
 
 // System includes
-#include <string>
 #include <chrono>
 
 


### PR DESCRIPTION
## Changelog

- fix symbol exports on windows 
    - *`Profiler` is a template with explicit instantiations but its function definitions are split between implementation headers and sources, which requires extra attention when exporting*.
- prevent profilers with different time units of overwriting each others' output files
    - *`Profiler`s with different time units wrote their output when destroyed to the same file  (`kratos_profiler_output.json`). Now the name includes the time unit to prevent this (e.g.: `kratos_profiler_output_us.json`)*.
- fix minimum call durations
    - *profiled scopes keep track of minimum and maximum durations, but the minimum was broken due to buggy initialization.*
