### PR TITLE
[Core][Benchmark] Adding benchmark for `parallel_utilities`

### DIFF
--- a/kratos/benchmarks/parallel_utilities_benchmark.cpp
+++ b/kratos/benchmarks/parallel_utilities_benchmark.cpp
@@ -1,0 +1,103 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
+//
+//  Main authors:    Vicente Mataix Ferrandiz
+//
+
+// System includes
+#include <utility>
+#include <numeric>
+#include <iostream>
+#include <unordered_map>
+
+// External includes
+#include <benchmark/benchmark.h>
+
+// Project includes
+#include "utilities/parallel_utilities.h"
+#include "utilities/reduction_utilities.h"
+
+namespace Kratos
+{
+// Template class for testing
+template<std::size_t TSize>
+class RHSElement {
+public:
+    explicit RHSElement(const double Val) : mRHSVal(Val) {}
+    void CalculateRHS(std::vector<double>& rVector) {
+        if (rVector.size() != TSize) { rVector.resize(TSize); }
+        std::fill(rVector.begin(), rVector.end(), mRHSVal);
+    }
+    double GetAccumRHSValue() { return mAccumRHSValue; }
+    void SetAccumRHSValue(double Value) { mAccumRHSValue = Value; }
+
+private:
+    double mRHSVal;
+    double mAccumRHSValue = 0.0;
+};
+
+// Benchmark for power operation on a vector
+static void BM_VectorPower(benchmark::State& state) {
+    int nsize = state.range(0);
+    std::vector<double> data_vector(nsize, 5.0);
+
+    for (auto _ : state) {
+        std::for_each(data_vector.begin(), data_vector.end(), [](double& item) {
+            item = std::pow(item, 0.1);
+        });
+    }
+}
+
+// Benchmark for reduction
+static void BM_VectorReduction(benchmark::State& state) {
+    int nsize = state.range(0);
+    const std::vector<double> data_vector(nsize, 5.0);
+
+    for (auto _ : state) {
+        double final_sum = std::accumulate(data_vector.begin(), data_vector.end(), 0.0);
+        benchmark::DoNotOptimize(final_sum);
+    }
+}
+
+// Benchmark for element-wise operations with thread-local storage
+static void BM_ThreadLocalStorage(benchmark::State& state) {
+    constexpr std::size_t vec_size = 6;
+    std::size_t n_elems = state.range(0);
+
+    using RHSElementType = RHSElement<vec_size>;
+
+    std::vector<double> rhs_vals(n_elems);
+    for (std::size_t i = 0; i < n_elems; ++i) {
+        rhs_vals[i] = (i % 12) * 1.889;
+    }
+
+    std::vector<RHSElementType> elements;
+    for (std::size_t i = 0; i < rhs_vals.size(); ++i) {
+        elements.push_back(RHSElementType(rhs_vals[i]));
+    }
+
+    std::vector<double> tls(vec_size);
+
+    for (auto _ : state) {
+        for (auto& elem : elements) {
+            elem.CalculateRHS(tls);
+            double sum = std::accumulate(tls.begin(), tls.end(), 0.0);
+            elem.SetAccumRHSValue(sum);
+        }
+    }
+}
+
+// Register benchmarks and provide input size as a command-line option
+BENCHMARK(BM_VectorPower)->Arg(1e3)->Arg(1e5)->Arg(1e6);
+BENCHMARK(BM_VectorReduction)->Arg(1e3)->Arg(1e5)->Arg(1e6);
+BENCHMARK(BM_ThreadLocalStorage)->Arg(1e3)->Arg(1e5)->Arg(1e6);
+
+}  // namespace Kratos
+
+BENCHMARK_MAIN();

--- a/kratos/tests/cpp_tests/utilities/test_parallel_utilities.cpp
+++ b/kratos/tests/cpp_tests/utilities/test_parallel_utilities.cpp
@@ -4,11 +4,12 @@
 //   _|\_\_|  \__,_|\__|\___/ ____/
 //                   Multi-Physics
 //
-//  License:		 BSD License
-//					 Kratos default license: kratos/license.txt
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
 //
 //  Main authors:    Riccardo Rossi
 //                   Philipp Bucher (https://github.com/philbucher)
+//
 
 // System includes
 #include <utility>


### PR DESCRIPTION
**📝 Description**

Adding benchmark for `parallel_utilities`.

Part of https://github.com/KratosMultiphysics/Kratos/pull/12923

**🆕 Changelog**

- [Fix formatting of license comment in `test_parallel_utilities.cpp`](https://github.com/KratosMultiphysics/Kratos/commit/9ee0dc14fe4b41a687e51fedb08d58193336a759)
- [Add benchmarks for  `parallel_utilities` in `parallel_utilities_benchmark.cpp`](https://github.com/KratosMultiphysics/Kratos/commit/34cf34331a8d5175545ac3db272b60ea64b301db)
