### PR TITLE
[Core] Add methods to retrieve available sub-items and handle not found errors in `Registry` and `RegistryItem`

### DIFF
--- a/kratos/includes/registry.h
+++ b/kratos/includes/registry.h
@@ -216,6 +216,17 @@ private:
     ///@name Private Operations
     ///@{
 
+    /**
+     * @brief This method throws an error message for a not found item.
+     * @param rFullName The full name of the item.
+     * @param rItemName The name of the item.
+     * @param pCurrentItem The current item.
+     */
+    static void NotFoundError(
+        const std::string& rFullName,
+        const std::string& rItemName,
+        RegistryItem* pCurrentItem
+        );
 
     ///@}
     ///@name Private  Access

--- a/kratos/includes/registry_item.h
+++ b/kratos/includes/registry_item.h
@@ -296,6 +296,16 @@ public:
     }
 
     ///@}
+    ///@name Operations
+    ///@{
+
+    /**
+     * @brief Returns the sub items name list available in the registry item (for error messaged).
+     * @return std::vector<std::string> The sub items name list.
+     */
+    std::vector<std::string> GetSubItemAvailableList() const;
+
+    ///@}
     ///@name Input and output
     ///@{
 
@@ -339,12 +349,6 @@ private:
         buffer << this->GetValue<TItemType>();
         return buffer.str();
     }
-
-    /**
-     * @brief Returns the sub items name list available in the registry item (for error messaged).
-     * @return std::vector<std::string> The sub items name list.
-     */
-    std::vector<std::string> GetSubItemAvailableList() const;
 
     /**
      * @brief This method throws an error message for a not found item.

--- a/kratos/includes/registry_item.h
+++ b/kratos/includes/registry_item.h
@@ -340,6 +340,18 @@ private:
         return buffer.str();
     }
 
+    /**
+     * @brief Returns the sub items name list available in the registry item (for error messaged).
+     * @return std::vector<std::string> The sub items name list.
+     */
+    std::vector<std::string> GetSubItemAvailableList() const;
+
+    /**
+     * @brief This method throws an error message for a not found item.
+     * @param rItemName The name of the item.
+     */
+    void NotFoundError(const std::string& rItemName) const;
+
     ///@}
     ///@name Private classes
     ///@{

--- a/kratos/sources/registry.cpp
+++ b/kratos/sources/registry.cpp
@@ -43,9 +43,8 @@ namespace
             auto& r_item_name = item_path[i];
             if(p_current_item->HasItem(r_item_name)){
                 p_current_item = &p_current_item->GetItem(r_item_name);
-            }
-            else{
-                KRATOS_ERROR << "The item \"" << rItemFullName << "\" is not found in the registry. The item \"" << p_current_item->Name() << "\" does not have \"" << r_item_name << "\"" << std::endl;
+            } else {
+                NotFoundError(rItemFullName, r_item_name, p_current_item);
             }
         }
 
@@ -65,18 +64,16 @@ namespace
             auto& r_item_name = item_path[i];
             if(p_current_item->HasItem(r_item_name)){
                 p_current_item = &p_current_item->GetItem(r_item_name);
-            }
-            else{
-                KRATOS_ERROR << "The item \"" << rItemFullName << "\" is not found in the registry. The item \"" << p_current_item->Name() << "\" does not have \"" << r_item_name << "\"" << std::endl;
+            } else {
+                NotFoundError(rItemFullName, r_item_name, p_current_item);
             }
         }
 
         auto& r_item_name = item_path.back();
         if(p_current_item->HasItem(r_item_name)){
             p_current_item->RemoveItem(r_item_name);
-        }
-        else{
-            KRATOS_ERROR << "The item \"" << rItemFullName << "\" is not found in the registry. The item \"" << p_current_item->Name() << "\" does not have \"" << r_item_name << "\"" << std::endl;
+        } else {
+            NotFoundError(rItemFullName, r_item_name, p_current_item);
         }
     }
 
@@ -156,6 +153,21 @@ namespace
     std::string Registry::ToJson(std::string const& Indentation) const
     {
         return GetRootRegistryItem().ToJson(Indentation);
+    }
+
+    void Registry::NotFoundError(
+        const std::string& rFullName,
+        const std::string& rItemName,
+        RegistryItem* pCurrentItem
+        )
+    {
+        const std::vector<std::string> available_list = pCurrentItem->GetSubItemAvailableList();
+        std::stringstream error_message_buffer;
+        error_message_buffer << "The item \"" << rFullName << "\" is not found in the registry. The item \"" << pCurrentItem->Name() << "\" does not have \"" << rItemName << "\". The available objects are: \n";
+        for (std::string const& item : available_list) {
+            error_message_buffer << "\t\t" << item << "\n";
+        }
+        KRATOS_ERROR << error_message_buffer.str() << std::endl;
     }
 
     RegistryItem& Registry::GetRootRegistryItem()

--- a/kratos/sources/registry_item.cpp
+++ b/kratos/sources/registry_item.cpp
@@ -91,6 +91,29 @@ namespace Kratos
         }
     }
 
+    std::vector<std::string> RegistryItem::GetSubItemAvailableList() const
+    {
+        std::vector<std::string> available_list;
+        auto it_item_begin = this->cbegin();
+        auto it_item_end = this->cend();
+        available_list.reserve(std::distance(it_item_begin, it_item_end));
+        for (auto it_item = it_item_begin; it_item != it_item_end; ++it_item) {
+            available_list.push_back((it_item->second)->Name());
+        }
+        return available_list;
+    }
+
+    void RegistryItem::NotFoundError(const std::string& rItemName) const
+    {
+        const std::vector<std::string> available_list = GetSubItemAvailableList();
+        std::stringstream available_list_str;
+        available_list_str << "The RegistryItem " << this->Name() << " does not have an item with name " << rItemName << ". The available objects are: \n";
+        for (std::string const& item : available_list) {
+            available_list_str << "\t\t" << item << "\n";
+        }
+        KRATOS_ERROR << available_list_str.str() << std::endl;
+    }
+
     std::string RegistryItem::GetValueString() const
     {
         return (this->*(this->mGetValueStringMethod))();
@@ -163,7 +186,9 @@ namespace Kratos
     {
         SubRegistryItemType& r_map = GetSubRegistryItemMap();
         auto iterator = r_map.find(rItemName);
-        KRATOS_ERROR_IF(iterator == r_map.end()) << "The RegistryItem " << this->Name() << " does not have an item with name " << rItemName << std::endl;
+        if (iterator == r_map.end()) {
+            NotFoundError(rItemName);
+        }
         return *(iterator->second);
     }
 
@@ -171,7 +196,9 @@ namespace Kratos
     {
         SubRegistryItemType& r_map = GetSubRegistryItemMap();
         auto iterator = r_map.find(rItemName);
-        KRATOS_ERROR_IF(iterator == r_map.end()) << "The RegistryItem " << this->Name() << " does not have an item with name " << rItemName << std::endl;
+        if (iterator == r_map.end()) {
+            NotFoundError(rItemName);
+        }
         return *(iterator->second);
     }
 
@@ -179,7 +206,9 @@ namespace Kratos
     {
         SubRegistryItemType& r_map = GetSubRegistryItemMap();
         auto iterator = r_map.find(rItemName);
-        KRATOS_ERROR_IF(iterator == r_map.end()) << "The RegistryItem " << this->Name() << " does not have an item with name " << rItemName << std::endl;
+        if (iterator == r_map.end()) {
+            NotFoundError(rItemName);
+        }
         r_map.erase(iterator);
     }
 

--- a/kratos/sources/registry_item.cpp
+++ b/kratos/sources/registry_item.cpp
@@ -106,12 +106,12 @@ namespace Kratos
     void RegistryItem::NotFoundError(const std::string& rItemName) const
     {
         const std::vector<std::string> available_list = GetSubItemAvailableList();
-        std::stringstream available_list_str;
-        available_list_str << "The RegistryItem " << this->Name() << " does not have an item with name " << rItemName << ". The available objects are: \n";
+        std::stringstream error_message_buffer;
+        error_message_buffer << "The RegistryItem " << this->Name() << " does not have an item with name " << rItemName << ". The available objects are: \n";
         for (std::string const& item : available_list) {
-            available_list_str << "\t\t" << item << "\n";
+            error_message_buffer << "\t\t" << item << "\n";
         }
-        KRATOS_ERROR << available_list_str.str() << std::endl;
+        KRATOS_ERROR << error_message_buffer.str() << std::endl;
     }
 
     std::string RegistryItem::GetValueString() const

--- a/kratos/tests/cpp_tests/sources/test_registry.cpp
+++ b/kratos/tests/cpp_tests/sources/test_registry.cpp
@@ -21,9 +21,7 @@
 #include "includes/expect.h"
 #include "includes/registry.h"
 
-namespace Kratos {
-
-namespace Testing {
+namespace Kratos::Testing {
 
 namespace
 {
@@ -141,6 +139,7 @@ KRATOS_TEST_CASE_IN_SUITE(RegistrySubValue, KratosCoreFastSuite)
 
     registry_item.AddItem<double>("sub_value_item", value);
     auto& sub_item = registry_item.GetItem("sub_value_item");
+    KRATOS_EXPECT_EXCEPTION_IS_THROWN(registry_item.GetItem("sub_value_item_2"), "");
 
     KRATOS_EXPECT_EQ(sub_item.Name(),"sub_value_item");
     KRATOS_EXPECT_TRUE(sub_item.HasValue());
@@ -315,5 +314,4 @@ KRATOS_TEST_CASE_IN_SUITE(RegistryIsSameType, KratosCoreFastSuite) {
     KRATOS_EXPECT_FALSE(Registry::GetItem("variables.all.VELOCITY").IsSameType(test_double));
 }
 
-}
-}  // namespace Kratos.
+}  // namespace Kratos::Testing.

--- a/kratos/tests/cpp_tests/sources/test_registry_access.cpp
+++ b/kratos/tests/cpp_tests/sources/test_registry_access.cpp
@@ -37,6 +37,8 @@ KRATOS_TEST_CASE_IN_SUITE(RegistryItemGetValueDerivedAsBase, KratosCoreFastSuite
     auto pProcess = Registry::GetValue<Process>("Processes.KratosMultiphysics.OutputProcess.Prototype");
 
     KRATOS_EXPECT_TRUE((std::is_same<Process,decltype(pProcess)>::value))
+
+    KRATOS_EXPECT_EXCEPTION_IS_THROWN(Registry::GetValue<Process>("Processes.KratosMultiphysics.output_process.Prototype"), "");
 }
 
 

--- a/kratos/tests/test_python_registry.py
+++ b/kratos/tests/test_python_registry.py
@@ -12,6 +12,18 @@ class TestPythonRegistry(KratosUnittest.TestCase):
         # Check that base Process is registered in its corresponding module as well as in the All block
         self.assertTrue(KratosMultiphysics.Registry.HasItem("Processes.All.Process"))
         self.assertTrue(KratosMultiphysics.Registry.HasItem("Processes.KratosMultiphysics.Process"))
+        self.assertFalse(KratosMultiphysics.Registry.HasItem("Processes.KratosMultiphysics.ProcessPikachu"))
+
+    def testGetItemCpp(self):
+        # Check that base Process is registered in its corresponding module as well as in the All block
+        base_process = KratosMultiphysics.Registry["Processes.All.Process.Prototype"]
+        self.assertTrue(isinstance(base_process, KratosMultiphysics.Process))
+        base_process = KratosMultiphysics.Registry["Processes.KratosMultiphysics.Process.Prototype"]
+        self.assertTrue(isinstance(base_process, KratosMultiphysics.Process))
+
+    @KratosUnittest.expectedFailure
+    def testHasItemCppFail(self):
+        KratosMultiphysics.Registry["Processes.All.ProcessPikachu.Prototype"]
 
     def testHasItemPython(self):
         # Add a fake entity to the Python registry
@@ -38,7 +50,6 @@ class TestPythonRegistry(KratosUnittest.TestCase):
 
         # Remove the auxiliary testing tentities from the Python registry
         KratosMultiphysics.Registry.RemoveItem("FakeEntities")
-
 
     def testAddItem(self):
         # Add some fake entities to the Python registry
@@ -217,4 +228,5 @@ class TestPythonRegistry(KratosUnittest.TestCase):
         KratosMultiphysics.Registry.RemoveItem("Processes")
 
 if __name__ == "__main__":
+    KratosMultiphysics.Logger.GetDefaultOutput().SetSeverity(KratosMultiphysics.Logger.Severity.WARNING)
     KratosUnittest.main()


### PR DESCRIPTION
**📝 Description**

Add methods to retrieve available sub-items and handle not found errors in `RegistryItem`. Until now the error message when trying to retrieve an item were not meaningful, were just displating that the given name was not available, not displaying the list of potential candidates (as done in "legacy" `KratosComponents`). This message would be very helpful, because sometimes the problem may come from some typo of case sensitivity.

For example:

~~~c++
Registry::GetValue<Process>("Processes.KratosMultiphysics.output_process.Prototype"); // Instead of OutputProcess
~~~

Then:

~~~sh
C++ exception with description "Error: The item "Processes.KratosMultiphysics.output_process.Prototype" is not found in the registry. The item "KratosMultiphysics" does not have "output_process". The available objects are: 
                OutputProcess
                ApplyRayCastingProcess<3>
                ApplyRayCastingInterfaceRecognitionProcess<3>
                ApplyRayCastingInterfaceRecognitionProcess<2>
                ApplyRayCastingProcess<2>
                Process
~~~

Adding new tests.

**🆕 Changelog**

- [Add methods to retrieve available sub-items and handle not found errors in `RegistryItem`](https://github.com/KratosMultiphysics/Kratos/commit/392eff9422b96f4f632c50025a03d95d68faed88)
- [Refactor test_registry.cpp to use nested namespace Kratos::Testing and add exception expectation for missing sub-item retrieval](https://github.com/KratosMultiphysics/Kratos/commit/44ad0a23783da6422690bd0f73e7a16c07a3f19b)
- [Add tests for registry item retrieval and expected failures in Python registry](https://github.com/KratosMultiphysics/Kratos/commit/7cef84e939541a5f1d6a05c21c44cb41ffd8e88f)
- [Implement NotFoundError method for improved error handling in `Registry` and `RegistryItem`](https://github.com/KratosMultiphysics/Kratos/pull/12943/commits/44df6de06878c36dcc70d62b0df49c98fbcb9df3)
[44df6de](https://github.com/KratosMultiphysics/Kratos/pull/12943/commits/44df6de06878c36dcc70d62b0df49c98fbcb9df3)
[Add exception expectation for invalid registry item retrieval in tests](https://github.com/KratosMultiphysics/Kratos/pull/12943/commits/6339c0fee9014e2a09830688121967add4767019)
