### PR TITLE
[Core][Hotfix] Revert flag removed in #12700, the DoF set was calculated always because of this

### DIFF
--- a/kratos/solving_strategies/builder_and_solvers/residualbased_block_builder_and_solver.h
+++ b/kratos/solving_strategies/builder_and_solvers/residualbased_block_builder_and_solver.h
@@ -714,7 +714,11 @@ public:
     {
         KRATOS_TRY;
 
+        // Call the external utility
         BlockBuildDofArrayUtility::SetUpDofArray(rModelPart, BaseType::mDofSet, this->GetEchoLevel(), BaseType::GetCalculateReactionsFlag());
+
+        // Set the flag as añready initialized
+        BaseType::mDofSetIsInitialized = true;
 
         KRATOS_CATCH("");
     }

--- a/kratos/solving_strategies/builder_and_solvers/residualbased_block_builder_and_solver.h
+++ b/kratos/solving_strategies/builder_and_solvers/residualbased_block_builder_and_solver.h
@@ -718,7 +718,6 @@ public:
         BlockBuildDofArrayUtility::SetUpDofArray(rModelPart, BaseType::mDofSet, this->GetEchoLevel(), BaseType::GetCalculateReactionsFlag());
 
         // Set the flag as already initialized
-
         BaseType::mDofSetIsInitialized = true;
 
         KRATOS_CATCH("");

--- a/kratos/solving_strategies/builder_and_solvers/residualbased_block_builder_and_solver.h
+++ b/kratos/solving_strategies/builder_and_solvers/residualbased_block_builder_and_solver.h
@@ -717,7 +717,8 @@ public:
         // Call the external utility
         BlockBuildDofArrayUtility::SetUpDofArray(rModelPart, BaseType::mDofSet, this->GetEchoLevel(), BaseType::GetCalculateReactionsFlag());
 
-        // Set the flag as añready initialized
+        // Set the flag as already initialized
+
         BaseType::mDofSetIsInitialized = true;
 
         KRATOS_CATCH("");


### PR DESCRIPTION
**📝 Description**

In #12700 `BaseType::mDofSetIsInitialized = true;` was accidentally removed and therefore the DoF set was always computed (not wrong result , but computation time was increassed).

![image](https://github.com/user-attachments/assets/4733b6fd-1ec6-411e-8707-440dc9c02d49)

Detected by @jrubiogonzalez 

**🆕 Changelog**

- [Revert flag removed in #12700](https://github.com/KratosMultiphysics/Kratos/commit/075473ead8abbe9f78ee7963b8676848393c4e6f) https://github.com/KratosMultiphysics/Kratos/pull/12700
