### PR TITLE
[Core] Adding additional SMP information into header information

### DIFF
--- a/kratos/sources/kernel.cpp
+++ b/kratos/sources/kernel.cpp
@@ -4,8 +4,8 @@
 //   _|\_\_|  \__,_|\__|\___/ ____/
 //                   Multi-Physics
 //
-//  License:		 BSD License
-//					 Kratos default license: kratos/license.txt
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
 //
 //  Main authors:    Pooyan Dadvand
 //
@@ -204,33 +204,39 @@ void Kernel::SetPythonVersion(std::string pyVersion) {
 
 void Kernel::PrintParallelismSupportInfo() const
 {
-    #ifdef KRATOS_SMP_NONE
+#ifdef KRATOS_SMP_NONE
     constexpr bool threading_support = false;
-    #else
+    constexpr auto smp = "None";
+#else
     constexpr bool threading_support = true;
-    #endif
-
-    #ifdef KRATOS_USING_MPI
-    constexpr bool mpi_support = true;
+    std::string scheduling_str;
+    #if defined(KRATOS_SMP_OPENMP)
+        const auto smp = "OpenMP";
+    #elif defined(KRATOS_SMP_CXX11)
+        constexpr auto smp = "C++11";
     #else
-    constexpr bool mpi_support = false;
+        constexpr auto smp = "Unknown";
     #endif
+#endif
+
+#ifdef KRATOS_USING_MPI
+    constexpr bool mpi_support = true;
+#else
+    constexpr bool mpi_support = false;
+#endif
 
     Logger logger("");
     logger << LoggerMessage::Severity::INFO;
 
     if (threading_support) {
         if (mpi_support) {
-            logger << "Compiled with threading and MPI support." << std::endl;
+            logger << "Compiled with threading and MPI support. Threading support with " << smp << "." << std::endl;
+        } else {
+            logger << "Compiled with threading support. Threading support with " << smp << "." << std::endl;
         }
-        else {
-            logger << "Compiled with threading support." << std::endl;
-        }
-    }
-    else if (mpi_support) {
+    } else if (mpi_support) {
         logger << "Compiled with MPI support." << std::endl;
-    }
-    else {
+    } else {
         logger << "Serial compilation." << std::endl;
     }
 
@@ -242,8 +248,7 @@ void Kernel::PrintParallelismSupportInfo() const
         if (mIsDistributedRun) {
             const DataCommunicator& r_world = ParallelEnvironment::GetDataCommunicator("World");
             logger << "MPI world size:         " << r_world.Size() << "." << std::endl;
-        }
-        else {
+        } else {
             logger << "Running without MPI." << std::endl;
         }
     }


### PR DESCRIPTION
**📝 Description**

Adding additional SMP information into header information. 

~~~sh
 |  /           |                  
 ' /   __| _` | __|  _ \   __|    
 . \  |   (   | |   (   |\__ \  
_|\_\_|  \__,_|\__|\___/ ____/
           Multi-Physics 10.1."0"-core/explicit-schedule-parallel-utili-d7754dadfa-Release-x86_64
           Compiled for GNU/Linux and Python3.10 with Clang-14.0
Compiled with threading and MPI support. Threading support with OpenMP
Maximum number of threads: 20.
Running without MPI.
~~~

Part of https://github.com/KratosMultiphysics/Kratos/pull/12923

**🆕 Changelog**

- [Adding additional SMP information into header information](https://github.com/KratosMultiphysics/Kratos/commit/384fe0e9c40e36435d7dfc1b9cff83a2303aec1e)
