### PR TITLE
[Core] Bugfix - Initialize DOF set flag in residual-based block builder and solver

### DIFF
--- a/kratos/solving_strategies/builder_and_solvers/residualbased_block_builder_and_solver.h
+++ b/kratos/solving_strategies/builder_and_solvers/residualbased_block_builder_and_solver.h
@@ -715,6 +715,7 @@ public:
         KRATOS_TRY;
 
         BlockBuildDofArrayUtility::SetUpDofArray(rModelPart, BaseType::mDofSet, this->GetEchoLevel(), BaseType::GetCalculateReactionsFlag());
+        SetDofSetIsInitializedFlag(true);
 
         KRATOS_CATCH("");
     }

--- a/kratos/solving_strategies/builder_and_solvers/residualbased_block_builder_and_solver.h
+++ b/kratos/solving_strategies/builder_and_solvers/residualbased_block_builder_and_solver.h
@@ -716,7 +716,6 @@ public:
 
         // Call the external utility
         BlockBuildDofArrayUtility::SetUpDofArray(rModelPart, BaseType::mDofSet, this->GetEchoLevel(), BaseType::GetCalculateReactionsFlag());
-        SetDofSetIsInitializedFlag(true);
 
         // Set the flag as already initialized
         BaseType::mDofSetIsInitialized = true;

--- a/kratos/tests/cpp_tests/strategies/builder_and_solvers/test_builder_and_solver.cpp
+++ b/kratos/tests/cpp_tests/strategies/builder_and_solvers/test_builder_and_solver.cpp
@@ -403,6 +403,7 @@ namespace Kratos::Testing
         SparseSpaceType::MatrixPointerType pA; /// The LHS matrix of the system of equations
 
         pBuilderAndSolver->SetUpDofSet(pScheme, rModelPart);
+        KRATOS_EXPECT_TRUE(pBuilderAndSolver->GetDofSetIsInitializedFlag())
         pBuilderAndSolver->SetUpSystem(rModelPart);
         pBuilderAndSolver->ResizeAndInitializeVectors(pScheme, pA, pDx, pb, rModelPart);
 


### PR DESCRIPTION
It seems this was removed by mistake on the latest PR (https://github.com/KratosMultiphysics/Kratos/pull/12700) , so now the dof set is being rebuilt at every time step! 

ping @jrubiogonzalez as he was the one that found the error. 