### PR TITLE
[GeoMechanicsApplication] Move C++ unit tests to subdirectories

### DIFF
--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_conditions/test_Pw_normal_flux_condition.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_conditions/test_Pw_normal_flux_condition.cpp
@@ -16,7 +16,7 @@
 #include "containers/model.h"
 #include "custom_conditions/Pw_normal_flux_condition.hpp"
 #include "custom_constitutive/linear_elastic_2D_interface_law.h"
-#include "geo_mechanics_fast_suite.h"
+#include "tests/cpp_tests/geo_mechanics_fast_suite.h"
 
 namespace Kratos::Testing
 {

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_conditions/test_T_micro_climate_flux_condition.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_conditions/test_T_micro_climate_flux_condition.cpp
@@ -12,9 +12,9 @@
 
 #include "containers/model.h"
 #include "custom_conditions/T_microclimate_flux_condition.h"
-#include "geo_mechanics_fast_suite.h"
 #include "geometries/line_2d_4.h"
 #include "geometries/line_2d_5.h"
+#include "tests/cpp_tests/geo_mechanics_fast_suite.h"
 
 #include <boost/numeric/ublas/assignment.hpp>
 

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_conditions/test_U_Pw_condition.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_conditions/test_U_Pw_condition.cpp
@@ -13,7 +13,7 @@
 // Project includes
 #include "custom_conditions/U_Pw_condition.hpp"
 
-#include "geo_mechanics_fast_suite.h"
+#include "tests/cpp_tests/geo_mechanics_fast_suite.h"
 
 using namespace Kratos;
 

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_conditions/test_U_Pw_normal_lysmer_absorbing_condition.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_conditions/test_U_Pw_normal_lysmer_absorbing_condition.cpp
@@ -16,7 +16,7 @@
 #include "custom_elements/U_Pw_small_strain_element.hpp"
 #include "custom_elements/plane_strain_stress_state.h"
 
-#include "geo_mechanics_fast_suite.h"
+#include "tests/cpp_tests/geo_mechanics_fast_suite.h"
 
 namespace Kratos::Testing
 {

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_conditions/test_t_normal_flux_condition.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_conditions/test_t_normal_flux_condition.cpp
@@ -13,10 +13,10 @@
 #include "containers/model.h"
 #include "custom_conditions/T_normal_flux_condition.h"
 #include "geo_mechanics_application_variables.h"
-#include "geo_mechanics_fast_suite.h"
 #include "geometries/line_2d_4.h"
 #include "geometries/line_2d_5.h"
 #include "includes/condition.h"
+#include "tests/cpp_tests/geo_mechanics_fast_suite.h"
 
 using namespace Kratos;
 

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_constitutive/test_thermal_dispersion_law.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_constitutive/test_thermal_dispersion_law.cpp
@@ -12,8 +12,8 @@
 
 #include "custom_constitutive/thermal_dispersion_law.h"
 #include "geo_mechanics_application.h"
-#include "geo_mechanics_fast_suite.h"
 #include "includes/ublas_interface.h"
+#include "tests/cpp_tests/geo_mechanics_fast_suite.h"
 
 namespace Kratos::Testing
 {

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_constitutive/test_thermal_filter_law.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_constitutive/test_thermal_filter_law.cpp
@@ -12,8 +12,8 @@
 
 #include "custom_constitutive/thermal_filter_law.h"
 #include "geo_mechanics_application.h"
-#include "geo_mechanics_fast_suite.h"
 #include "includes/ublas_interface.h"
+#include "tests/cpp_tests/geo_mechanics_fast_suite.h"
 
 namespace Kratos::Testing
 {

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_constitutive/test_truss_backbone_constitutive_law.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_constitutive/test_truss_backbone_constitutive_law.cpp
@@ -14,7 +14,7 @@
 
 #include "custom_constitutive/truss_backbone_constitutive_law.h"
 #include "geo_mechanics_application_variables.h"
-#include "geo_mechanics_fast_suite.h"
+#include "tests/cpp_tests/geo_mechanics_fast_suite.h"
 
 using namespace Kratos;
 

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_elements/test_axisymmetric_stress_state.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_elements/test_axisymmetric_stress_state.cpp
@@ -14,9 +14,9 @@
 #include "containers/model.h"
 #include "custom_elements/axisymmetric_stress_state.h"
 #include "custom_elements/stress_state_policy.h"
-#include "geo_mechanics_fast_suite.h"
 #include "geometries/geometry.h"
 #include "includes/checks.h"
+#include "tests/cpp_tests/geo_mechanics_fast_suite.h"
 #include "tests/cpp_tests/test_utilities/model_setup_utilities.h"
 #include <boost/numeric/ublas/assignment.hpp>
 

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_elements/test_plane_strain_stress_state.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_elements/test_plane_strain_stress_state.cpp
@@ -12,8 +12,8 @@
 
 #include "containers/model.h"
 #include "custom_elements/plane_strain_stress_state.h"
-#include "geo_mechanics_fast_suite.h"
 #include "includes/checks.h"
+#include "tests/cpp_tests/geo_mechanics_fast_suite.h"
 #include "tests/cpp_tests/test_utilities/model_setup_utilities.h"
 #include <boost/numeric/ublas/assignment.hpp>
 

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_elements/test_steady_state_Pw_piping_element.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_elements/test_steady_state_Pw_piping_element.cpp
@@ -17,7 +17,7 @@
 #include "custom_constitutive/linear_elastic_2D_interface_law.h"
 #include "custom_elements/plane_strain_stress_state.h"
 #include "custom_elements/steady_state_Pw_piping_element.hpp"
-#include "geo_mechanics_fast_suite.h"
+#include "tests/cpp_tests/geo_mechanics_fast_suite.h"
 
 namespace Kratos::Testing
 {

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_elements/test_three_dimensional_stress_state.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_elements/test_three_dimensional_stress_state.cpp
@@ -12,8 +12,8 @@
 
 #include "containers/model.h"
 #include "custom_elements/three_dimensional_stress_state.h"
-#include "geo_mechanics_fast_suite.h"
 #include "includes/checks.h"
+#include "tests/cpp_tests/geo_mechanics_fast_suite.h"
 #include "tests/cpp_tests/test_utilities/model_setup_utilities.h"
 #include <boost/numeric/ublas/assignment.hpp>
 

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_elements/test_transient_thermal_element.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_elements/test_transient_thermal_element.cpp
@@ -13,9 +13,9 @@
 #include "containers/model.h"
 #include "custom_elements/transient_thermal_element.h"
 #include "geo_mechanics_application_variables.h"
-#include "geo_mechanics_fast_suite.h"
 #include "geometries/triangle_2d_10.h"
 #include "geometries/triangle_2d_15.h"
+#include "tests/cpp_tests/geo_mechanics_fast_suite.h"
 #include <boost/numeric/ublas/assignment.hpp>
 
 using namespace Kratos;

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_operations/test_activate_model_part_operation.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_operations/test_activate_model_part_operation.cpp
@@ -12,10 +12,10 @@
 
 // Project includes
 #include "containers/model.h"
-#include "tests/cpp_tests/geo_mechanics_fast_suite.h"
 #include "geometries/quadrilateral_2d_4.h"
 #include "includes/expect.h"
 #include "processes/structured_mesh_generator_process.h"
+#include "tests/cpp_tests/geo_mechanics_fast_suite.h"
 
 // Application includes
 #include "custom_operations/activate_model_part_operation.h"

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_operations/test_activate_model_part_operation.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_operations/test_activate_model_part_operation.cpp
@@ -12,18 +12,18 @@
 
 // Project includes
 #include "containers/model.h"
-#include "geo_mechanics_fast_suite.h"
+#include "tests/cpp_tests/geo_mechanics_fast_suite.h"
 #include "geometries/quadrilateral_2d_4.h"
 #include "includes/expect.h"
 #include "processes/structured_mesh_generator_process.h"
 
 // Application includes
-#include "custom_operations/deactivate_model_part_operation.h"
+#include "custom_operations/activate_model_part_operation.h"
 
 namespace Kratos::Testing
 {
 
-KRATOS_TEST_CASE_IN_SUITE(DeactivateModelPartOperation, KratosGeoMechanicsFastSuite)
+KRATOS_TEST_CASE_IN_SUITE(ActivateModelPartOperation, KratosGeoMechanicsFastSuite)
 {
     // Create the test model part
     Model test_model;
@@ -46,31 +46,31 @@ KRATOS_TEST_CASE_IN_SUITE(DeactivateModelPartOperation, KratosGeoMechanicsFastSu
 
     // Deactivate all the model part entities
     for (auto& r_node : r_test_model_part.Nodes()) {
-        r_node.Set(ACTIVE, true);
+        r_node.Set(ACTIVE, false);
     }
     for (auto& r_element : r_test_model_part.Elements()) {
-        r_element.Set(ACTIVE, true);
+        r_element.Set(ACTIVE, false);
     }
     for (auto& r_condition : r_test_model_part.Conditions()) {
-        r_condition.Set(ACTIVE, true);
+        r_condition.Set(ACTIVE, false);
     }
 
     // Create and execute the tested operation
-    Parameters                   operation_settings(R"({
+    Parameters                 operation_settings(R"({
         "model_part_name" : "TestModelPart"
     })");
-    DeactivateModelPartOperation test_operation(test_model, operation_settings);
+    ActivateModelPartOperation test_operation(test_model, operation_settings);
     test_operation.Execute();
 
     // Check that all model part entities are now active
     for (const auto& r_node : r_test_model_part.Nodes()) {
-        KRATOS_EXPECT_FALSE(r_node.Is(ACTIVE))
+        KRATOS_EXPECT_TRUE(r_node.Is(ACTIVE))
     }
     for (const auto& r_element : r_test_model_part.Elements()) {
-        KRATOS_EXPECT_FALSE(r_element.Is(ACTIVE))
+        KRATOS_EXPECT_TRUE(r_element.Is(ACTIVE))
     }
     for (const auto& r_condition : r_test_model_part.Conditions()) {
-        KRATOS_EXPECT_FALSE(r_condition.Is(ACTIVE))
+        KRATOS_EXPECT_TRUE(r_condition.Is(ACTIVE))
     }
 }
 

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_operations/test_deactivate_model_part_operation.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_operations/test_deactivate_model_part_operation.cpp
@@ -12,10 +12,10 @@
 
 // Project includes
 #include "containers/model.h"
-#include "tests/cpp_tests/geo_mechanics_fast_suite.h"
 #include "geometries/quadrilateral_2d_4.h"
 #include "includes/expect.h"
 #include "processes/structured_mesh_generator_process.h"
+#include "tests/cpp_tests/geo_mechanics_fast_suite.h"
 
 // Application includes
 #include "custom_operations/deactivate_model_part_operation.h"

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_operations/test_deactivate_model_part_operation.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_operations/test_deactivate_model_part_operation.cpp
@@ -12,18 +12,18 @@
 
 // Project includes
 #include "containers/model.h"
-#include "geo_mechanics_fast_suite.h"
+#include "tests/cpp_tests/geo_mechanics_fast_suite.h"
 #include "geometries/quadrilateral_2d_4.h"
 #include "includes/expect.h"
 #include "processes/structured_mesh_generator_process.h"
 
 // Application includes
-#include "custom_operations/activate_model_part_operation.h"
+#include "custom_operations/deactivate_model_part_operation.h"
 
 namespace Kratos::Testing
 {
 
-KRATOS_TEST_CASE_IN_SUITE(ActivateModelPartOperation, KratosGeoMechanicsFastSuite)
+KRATOS_TEST_CASE_IN_SUITE(DeactivateModelPartOperation, KratosGeoMechanicsFastSuite)
 {
     // Create the test model part
     Model test_model;
@@ -46,31 +46,31 @@ KRATOS_TEST_CASE_IN_SUITE(ActivateModelPartOperation, KratosGeoMechanicsFastSuit
 
     // Deactivate all the model part entities
     for (auto& r_node : r_test_model_part.Nodes()) {
-        r_node.Set(ACTIVE, false);
+        r_node.Set(ACTIVE, true);
     }
     for (auto& r_element : r_test_model_part.Elements()) {
-        r_element.Set(ACTIVE, false);
+        r_element.Set(ACTIVE, true);
     }
     for (auto& r_condition : r_test_model_part.Conditions()) {
-        r_condition.Set(ACTIVE, false);
+        r_condition.Set(ACTIVE, true);
     }
 
     // Create and execute the tested operation
-    Parameters                 operation_settings(R"({
+    Parameters                   operation_settings(R"({
         "model_part_name" : "TestModelPart"
     })");
-    ActivateModelPartOperation test_operation(test_model, operation_settings);
+    DeactivateModelPartOperation test_operation(test_model, operation_settings);
     test_operation.Execute();
 
     // Check that all model part entities are now active
     for (const auto& r_node : r_test_model_part.Nodes()) {
-        KRATOS_EXPECT_TRUE(r_node.Is(ACTIVE))
+        KRATOS_EXPECT_FALSE(r_node.Is(ACTIVE))
     }
     for (const auto& r_element : r_test_model_part.Elements()) {
-        KRATOS_EXPECT_TRUE(r_element.Is(ACTIVE))
+        KRATOS_EXPECT_FALSE(r_element.Is(ACTIVE))
     }
     for (const auto& r_condition : r_test_model_part.Conditions()) {
-        KRATOS_EXPECT_TRUE(r_condition.Is(ACTIVE))
+        KRATOS_EXPECT_FALSE(r_condition.Is(ACTIVE))
     }
 }
 

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_processes/test_apply_c_phi_reduction_process.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_processes/test_apply_c_phi_reduction_process.cpp
@@ -12,10 +12,10 @@
 //
 #include "containers/model.h"
 #include "custom_processes/apply_c_phi_reduction_process.h"
-#include "geo_mechanics_fast_suite.h"
 #include "geometries/quadrilateral_2d_4.h"
 #include "processes/structured_mesh_generator_process.h"
-#include "stub_linear_elastic_law.h"
+#include "tests/cpp_tests/geo_mechanics_fast_suite.h"
+#include "tests/cpp_tests/stub_linear_elastic_law.h"
 #include <boost/numeric/ublas/assignment.hpp>
 
 using namespace Kratos;

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_processes/test_apply_constant_phreatic_multi_line_pressure_process.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_processes/test_apply_constant_phreatic_multi_line_pressure_process.cpp
@@ -11,10 +11,10 @@
 //
 #include "containers/model.h"
 #include "custom_processes/apply_constant_phreatic_multi_line_pressure_process.h"
-#include "geo_mechanics_fast_suite.h"
 #include "geometries/quadrilateral_2d_4.h"
 #include "includes/checks.h"
 #include "processes/structured_mesh_generator_process.h"
+#include "tests/cpp_tests/geo_mechanics_fast_suite.h"
 
 using namespace Kratos;
 

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_processes/test_apply_k0_procedure_process.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_processes/test_apply_k0_procedure_process.cpp
@@ -32,10 +32,10 @@ public:
     MOCK_METHOD(std::size_t, WorkingSpaceDimension, (), (override));
 };
 
-class StubElement : public Element
+class StubElementForK0ProcedureTest : public Element
 {
 public:
-    KRATOS_CLASS_INTRUSIVE_POINTER_DEFINITION(StubElement);
+    KRATOS_CLASS_INTRUSIVE_POINTER_DEFINITION(StubElementForK0ProcedureTest);
 
     void CalculateOnIntegrationPoints(const Variable<Vector>& rVariable,
                                       std::vector<Vector>&    rOutput,
@@ -63,7 +63,7 @@ Vector ApplyK0ProcedureOnStubElement(const Properties::Pointer& rProperties, con
 {
     Model model;
     auto& r_model_part = model.CreateModelPart("main");
-    auto  p_element    = make_intrusive<StubElement>();
+    auto  p_element    = make_intrusive<StubElementForK0ProcedureTest>();
     p_element->SetProperties(rProperties);
     r_model_part.AddElement(p_element);
 
@@ -98,7 +98,7 @@ ModelPart& PrepareTestModelPart(Model& rModel)
     auto  p_model_part_properties = result.pGetProperties(0);
     p_model_part_properties->SetValue(CONSTITUTIVE_LAW, p_dummy_law);
 
-    auto p_element = make_intrusive<StubElement>();
+    auto p_element = make_intrusive<StubElementForK0ProcedureTest>();
     p_element->SetProperties(p_model_part_properties);
     result.AddElement(p_element);
 
@@ -415,7 +415,7 @@ KRATOS_TEST_CASE_IN_SUITE(K0ProcedureChecksIfProcessHasCorrectMaterialData, Krat
     // Arrange
     Model model;
     auto& r_model_part = model.CreateModelPart("main");
-    auto  p_element    = make_intrusive<StubElement>();
+    auto  p_element    = make_intrusive<StubElementForK0ProcedureTest>();
     p_element->SetId(1);
     p_element->SetProperties(std::make_shared<Properties>());
     r_model_part.AddElement(p_element);

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_processes/test_apply_k0_procedure_process.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_processes/test_apply_k0_procedure_process.cpp
@@ -12,10 +12,10 @@
 #include "containers/model.h"
 #include "custom_processes/apply_k0_procedure_process.h"
 #include "geo_mechanics_application_variables.h"
-#include "geo_mechanics_fast_suite.h"
 #include "includes/element.h"
-#include "stub_linear_elastic_law.h"
-#include "test_utilities.h"
+#include "tests/cpp_tests/geo_mechanics_fast_suite.h"
+#include "tests/cpp_tests/stub_linear_elastic_law.h"
+#include "tests/cpp_tests/test_utilities.h"
 #include <custom_constitutive/incremental_linear_elastic_law.h>
 
 #include <boost/numeric/ublas/assignment.hpp>

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_processes/test_apply_phreatic_multi_line_pressure_table_process.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_processes/test_apply_phreatic_multi_line_pressure_table_process.cpp
@@ -11,8 +11,8 @@
 //
 #include "containers/model.h"
 #include "custom_processes/apply_phreatic_multi_line_pressure_table_process.h"
-#include "geo_mechanics_fast_suite.h"
 #include "includes/checks.h"
+#include "tests/cpp_tests/geo_mechanics_fast_suite.h"
 
 using namespace Kratos;
 

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_processes/test_calculate_incremental_displacement_process.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_processes/test_calculate_incremental_displacement_process.cpp
@@ -12,7 +12,7 @@
 
 #include "custom_processes/calculate_incremental_displacement_process.h"
 #include "geo_mechanics_application_variables.h"
-#include "geo_mechanics_fast_suite.h"
+#include "tests/cpp_tests/geo_mechanics_fast_suite.h"
 
 namespace Kratos::Testing
 {

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_processes/test_geo_extrapolate_integration_point_values_to_nodes_process.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_processes/test_geo_extrapolate_integration_point_values_to_nodes_process.cpp
@@ -13,8 +13,8 @@
 #include "containers/model.h"
 #include "custom_processes/geo_extrapolate_integration_point_values_to_nodes_process.h"
 #include "geo_mechanics_application_variables.h"
-#include "geo_mechanics_fast_suite.h"
 #include "geometries/quadrilateral_2d_4.h"
+#include "tests/cpp_tests/geo_mechanics_fast_suite.h"
 
 namespace Kratos::Testing
 {

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_processes/test_geo_extrapolate_integration_point_values_to_nodes_process.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_processes/test_geo_extrapolate_integration_point_values_to_nodes_process.cpp
@@ -19,12 +19,15 @@
 namespace Kratos::Testing
 {
 
-class StubElement : public Element
+class StubElementForNodalExtrapolationTest : public Element
 {
 public:
-    KRATOS_CLASS_INTRUSIVE_POINTER_DEFINITION(StubElement);
+    KRATOS_CLASS_INTRUSIVE_POINTER_DEFINITION(StubElementForNodalExtrapolationTest);
 
-    StubElement(IndexType NewId, GeometryType::Pointer pGeometry) : Element(NewId, pGeometry) {}
+    StubElementForNodalExtrapolationTest(IndexType NewId, GeometryType::Pointer pGeometry)
+        : Element(NewId, pGeometry)
+    {
+    }
 
     void CalculateOnIntegrationPoints(const Variable<double>& rVariable,
                                       std::vector<double>&    rOutput,
@@ -83,11 +86,11 @@ ModelPart& CreateModelPartWithTwoStubElements(Model& model)
     auto node_6 = model_part.CreateNewNode(6, 2.0, 1.0, 0.0);
 
     auto geometry_1 = std::make_shared<Quadrilateral2D4<Node>>(node_1, node_2, node_3, node_4);
-    auto element_1  = Kratos::make_intrusive<StubElement>(1, geometry_1);
+    auto element_1  = Kratos::make_intrusive<StubElementForNodalExtrapolationTest>(1, geometry_1);
     model_part.AddElement(element_1);
 
     auto geometry_2 = std::make_shared<Quadrilateral2D4<Node>>(node_2, node_5, node_6, node_3);
-    auto element_2  = Kratos::make_intrusive<StubElement>(2, geometry_2);
+    auto element_2  = Kratos::make_intrusive<StubElementForNodalExtrapolationTest>(2, geometry_2);
     model_part.AddElement(element_2);
 
     return model_part;
@@ -134,8 +137,10 @@ KRATOS_TEST_CASE_IN_SUITE(TestExtrapolationProcess_ExtrapolatesCorrectlyForConst
     Model model;
     auto& model_part = CreateModelPartWithTwoStubElements(model);
 
-    dynamic_cast<StubElement&>(model_part.Elements()[1]).mIntegrationDoubleValues = {1.0, 1.0, 1.0, 1.0};
-    dynamic_cast<StubElement&>(model_part.Elements()[2]).mIntegrationDoubleValues = {1.0, 1.0, 1.0, 1.0};
+    dynamic_cast<StubElementForNodalExtrapolationTest&>(model_part.Elements()[1]).mIntegrationDoubleValues = {
+        1.0, 1.0, 1.0, 1.0};
+    dynamic_cast<StubElementForNodalExtrapolationTest&>(model_part.Elements()[2]).mIntegrationDoubleValues = {
+        1.0, 1.0, 1.0, 1.0};
 
     auto parameters = Parameters(R"(
     {
@@ -163,8 +168,10 @@ KRATOS_TEST_CASE_IN_SUITE(TestExtrapolationProcess_ExtrapolatesCorrectlyForTwoCo
     Model model;
     auto& model_part = CreateModelPartWithTwoStubElements(model);
 
-    dynamic_cast<StubElement&>(model_part.Elements()[1]).mIntegrationDoubleValues = {1.0, 1.0, 1.0, 1.0};
-    dynamic_cast<StubElement&>(model_part.Elements()[2]).mIntegrationDoubleValues = {2.0, 2.0, 2.0, 2.0};
+    dynamic_cast<StubElementForNodalExtrapolationTest&>(model_part.Elements()[1]).mIntegrationDoubleValues = {
+        1.0, 1.0, 1.0, 1.0};
+    dynamic_cast<StubElementForNodalExtrapolationTest&>(model_part.Elements()[2]).mIntegrationDoubleValues = {
+        2.0, 2.0, 2.0, 2.0};
 
     auto parameters = Parameters(R"(
     {
@@ -196,11 +203,11 @@ KRATOS_TEST_CASE_IN_SUITE(TestExtrapolationProcess_ExtrapolatesCorrectlyForLinea
     auto& model_part = CreateModelPartWithTwoStubElements(model);
 
     // Linear field in x between -1 and 1
-    dynamic_cast<StubElement&>(model_part.Elements()[1]).mIntegrationDoubleValues = {
+    dynamic_cast<StubElementForNodalExtrapolationTest&>(model_part.Elements()[1]).mIntegrationDoubleValues = {
         -0.57735, 0.57735, 0.57735, -0.57735};
 
     // Linear field in y between -1 and 1
-    dynamic_cast<StubElement&>(model_part.Elements()[2]).mIntegrationDoubleValues = {
+    dynamic_cast<StubElementForNodalExtrapolationTest&>(model_part.Elements()[2]).mIntegrationDoubleValues = {
         -0.57735, -0.57735, 0.57735, 0.57735};
 
     auto                                               parameters = Parameters(R"(
@@ -232,12 +239,12 @@ KRATOS_TEST_CASE_IN_SUITE(TestExtrapolationProcess_ExtrapolatesMatrixCorrectlyFo
     auto& model_part = CreateModelPartWithTwoStubElements(model);
 
     // Linear field in x between -1 and 1
-    dynamic_cast<StubElement&>(model_part.Elements()[1]).mIntegrationMatrixValues = {
+    dynamic_cast<StubElementForNodalExtrapolationTest&>(model_part.Elements()[1]).mIntegrationMatrixValues = {
         ScalarMatrix(3, 3, -0.57735), ScalarMatrix(3, 3, 0.57735), ScalarMatrix(3, 3, 0.57735),
         ScalarMatrix(3, 3, -0.57735)};
 
     // Linear field in y between -1 and 1
-    dynamic_cast<StubElement&>(model_part.Elements()[2]).mIntegrationMatrixValues = {
+    dynamic_cast<StubElementForNodalExtrapolationTest&>(model_part.Elements()[2]).mIntegrationMatrixValues = {
         ScalarMatrix(3, 3, -0.57735), ScalarMatrix(3, 3, -0.57735), ScalarMatrix(3, 3, 0.57735),
         ScalarMatrix(3, 3, 0.57735)};
 
@@ -276,12 +283,12 @@ KRATOS_TEST_CASE_IN_SUITE(TestExtrapolationProcess_ExtrapolatesVectorCorrectlyFo
     auto& model_part = CreateModelPartWithTwoStubElements(model);
 
     // Linear field in x between -1 and 1
-    dynamic_cast<StubElement&>(model_part.Elements()[1]).mIntegrationVectorValues = {
+    dynamic_cast<StubElementForNodalExtrapolationTest&>(model_part.Elements()[1]).mIntegrationVectorValues = {
         ScalarVector(6, -0.57735), ScalarVector(6, 0.57735), ScalarVector(6, 0.57735),
         ScalarVector(6, -0.57735)};
 
     // Linear field in y between -1 and 1
-    dynamic_cast<StubElement&>(model_part.Elements()[2]).mIntegrationVectorValues = {
+    dynamic_cast<StubElementForNodalExtrapolationTest&>(model_part.Elements()[2]).mIntegrationVectorValues = {
         ScalarVector(6, -0.57735), ScalarVector(6, -0.57735), ScalarVector(6, 0.57735), ScalarVector(6, 0.57735)};
 
     auto parameters = Parameters(R"(
@@ -319,12 +326,12 @@ KRATOS_TEST_CASE_IN_SUITE(TestExtrapolationProcess_ExtrapolatesArrayCorrectlyFor
     auto& model_part = CreateModelPartWithTwoStubElements(model);
 
     // Linear field in x between -1 and 1
-    dynamic_cast<StubElement&>(model_part.Elements()[1]).mIntegrationArrayValues = {
+    dynamic_cast<StubElementForNodalExtrapolationTest&>(model_part.Elements()[1]).mIntegrationArrayValues = {
         ScalarVector(3, -0.57735), ScalarVector(3, 0.57735), ScalarVector(3, 0.57735),
         ScalarVector(3, -0.57735)};
 
     // Linear field in y between -1 and 1
-    dynamic_cast<StubElement&>(model_part.Elements()[2]).mIntegrationArrayValues = {
+    dynamic_cast<StubElementForNodalExtrapolationTest&>(model_part.Elements()[2]).mIntegrationArrayValues = {
         ScalarVector(3, -0.57735), ScalarVector(3, -0.57735), ScalarVector(3, 0.57735), ScalarVector(3, 0.57735)};
 
     auto parameters = Parameters(R"(

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_processes/test_reset_displacement_process.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_processes/test_reset_displacement_process.cpp
@@ -37,12 +37,13 @@ public:
     SizeType GetStrainSize() const override { return 4; }
 };
 
-class StubElement : public Element
+class StubElementForResetDisplacementTest : public Element
 {
 public:
-    KRATOS_CLASS_INTRUSIVE_POINTER_DEFINITION(StubElement);
+    KRATOS_CLASS_INTRUSIVE_POINTER_DEFINITION(StubElementForResetDisplacementTest);
 
-    StubElement(IndexType NewId, const GeometryType::Pointer& pGeometry) : Element(NewId, pGeometry)
+    StubElementForResetDisplacementTest(IndexType NewId, const GeometryType::Pointer& pGeometry)
+        : Element(NewId, pGeometry)
     {
         mConstitutiveLaws = std::vector<ConstitutiveLaw::Pointer>(3, make_shared<StubConstitutiveLaw>());
     }
@@ -92,7 +93,7 @@ ModelPart& CreateModelPartWithAStubElement(Model& rModel)
     auto  node_3     = model_part.CreateNewNode(3, 1.0, 1.0, 0.0);
 
     auto geometry = std::make_shared<Triangle2D3<Node>>(node_1, node_2, node_3);
-    model_part.AddElement(make_intrusive<StubElement>(1, geometry));
+    model_part.AddElement(make_intrusive<StubElementForResetDisplacementTest>(1, geometry));
 
     return model_part;
 }

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_strategies/test_backward_euler_Pw_scheme.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_strategies/test_backward_euler_Pw_scheme.cpp
@@ -11,8 +11,8 @@
 //
 
 #include "custom_strategies/schemes/backward_euler_quasistatic_Pw_scheme.hpp"
-#include "geo_mechanics_fast_suite.h"
 #include "spaces/ublas_space.h"
+#include "tests/cpp_tests/geo_mechanics_fast_suite.h"
 
 using namespace Kratos;
 using SparseSpaceType = UblasSpace<double, CompressedMatrix, Vector>;

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_strategies/test_backward_euler_T_scheme.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_strategies/test_backward_euler_T_scheme.cpp
@@ -11,8 +11,8 @@
 //
 
 #include "custom_strategies/schemes/backward_euler_T_scheme.hpp"
-#include "geo_mechanics_fast_suite.h"
 #include "spaces/ublas_space.h"
+#include "tests/cpp_tests/geo_mechanics_fast_suite.h"
 
 namespace Kratos::Testing
 {

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_strategies/test_backward_euler_UPw_scheme.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_strategies/test_backward_euler_UPw_scheme.cpp
@@ -12,8 +12,8 @@
 
 #include "containers/model.h"
 #include "custom_strategies/schemes/backward_euler_quasistatic_U_Pw_scheme.hpp"
-#include "geo_mechanics_fast_suite.h"
 #include "spaces/ublas_space.h"
+#include "tests/cpp_tests/geo_mechanics_fast_suite.h"
 
 namespace Kratos::Testing
 {

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_strategies/test_generalized_newmark_T_scheme.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_strategies/test_generalized_newmark_T_scheme.cpp
@@ -11,8 +11,8 @@
 //
 
 #include "custom_strategies/schemes/generalized_newmark_T_scheme.hpp"
-#include "geo_mechanics_fast_suite.h"
 #include "spaces/ublas_space.h"
+#include "tests/cpp_tests/geo_mechanics_fast_suite.h"
 
 using namespace Kratos;
 using SparseSpaceType = UblasSpace<double, CompressedMatrix, Vector>;

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_strategies/test_generalized_newmark_scheme.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_strategies/test_generalized_newmark_scheme.cpp
@@ -11,8 +11,8 @@
 //
 
 #include "custom_strategies/schemes/generalized_newmark_scheme.hpp"
-#include "geo_mechanics_fast_suite.h"
 #include "spaces/ublas_space.h"
+#include "tests/cpp_tests/geo_mechanics_fast_suite.h"
 
 using namespace Kratos;
 using SparseSpaceType = UblasSpace<double, CompressedMatrix, Vector>;

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_strategies/test_geo_mechanics_newton_rapson_erosion_processs_strategy.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_strategies/test_geo_mechanics_newton_rapson_erosion_processs_strategy.cpp
@@ -12,8 +12,8 @@
 
 // Project includes
 #include "custom_strategies/strategies/geo_mechanics_newton_raphson_erosion_process_strategy.hpp"
-#include "geo_mechanics_fast_suite.h"
-#include "test_utilities.h"
+#include "tests/cpp_tests/geo_mechanics_fast_suite.h"
+#include "tests/cpp_tests/test_utilities.h"
 
 #include <geo_mechanics_application.h>
 #include <linear_solvers/skyline_lu_factorization_solver.h>

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_strategies/test_geomechanics_time_integration_scheme.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_strategies/test_geomechanics_time_integration_scheme.cpp
@@ -10,13 +10,13 @@
 //  Main authors:    Richard Faasse
 //
 
-#include "geo_mechanics_fast_suite.h"
+#include "tests/cpp_tests/geo_mechanics_fast_suite.h"
 
 #include "containers/model.h"
 #include "custom_strategies/schemes/geomechanics_time_integration_scheme.hpp"
 #include "spaces/ublas_space.h"
-#include "test_utilities/spy_condition.h"
-#include "test_utilities/spy_element.h"
+#include "tests/cpp_tests/test_utilities/spy_condition.h"
+#include "tests/cpp_tests/test_utilities/spy_element.h"
 
 using namespace Kratos;
 using SparseSpaceType = UblasSpace<double, CompressedMatrix, Vector>;

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_strategies/test_newmark_Pw_scheme.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_strategies/test_newmark_Pw_scheme.cpp
@@ -11,8 +11,8 @@
 //
 
 #include "custom_strategies/schemes/newmark_quasistatic_Pw_scheme.hpp"
-#include "geo_mechanics_fast_suite.h"
 #include "spaces/ublas_space.h"
+#include "tests/cpp_tests/geo_mechanics_fast_suite.h"
 
 using namespace Kratos;
 using SparseSpaceType = UblasSpace<double, CompressedMatrix, Vector>;

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_strategies/test_newmark_dynamic_U_Pw_scheme.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_strategies/test_newmark_dynamic_U_Pw_scheme.cpp
@@ -11,8 +11,8 @@
 //
 
 #include "custom_strategies/schemes/newmark_dynamic_U_Pw_scheme.hpp"
-#include "geo_mechanics_fast_suite.h"
 #include "spaces/ublas_space.h"
+#include "tests/cpp_tests/geo_mechanics_fast_suite.h"
 
 namespace Kratos::Testing
 {

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_strategies/test_newmark_quasistatic_U_Pw_scheme.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_strategies/test_newmark_quasistatic_U_Pw_scheme.cpp
@@ -10,12 +10,12 @@
 //  Main authors:    Richard Faasse
 //
 
-#include "geo_mechanics_fast_suite.h"
+#include "tests/cpp_tests/geo_mechanics_fast_suite.h"
 
 #include "custom_strategies/schemes/newmark_quasistatic_U_Pw_scheme.hpp"
 #include "spaces/ublas_space.h"
-#include "test_utilities/spy_condition.h"
-#include "test_utilities/spy_element.h"
+#include "tests/cpp_tests/test_utilities/spy_condition.h"
+#include "tests/cpp_tests/test_utilities/spy_element.h"
 
 namespace Kratos::Testing
 {

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_utilities/test_Hencky_strain.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_utilities/test_Hencky_strain.cpp
@@ -12,7 +12,7 @@
 
 #include "custom_utilities/math_utilities.h"
 #include "custom_utilities/stress_strain_utilities.h"
-#include "geo_mechanics_fast_suite.h"
+#include "tests/cpp_tests/geo_mechanics_fast_suite.h"
 
 using namespace Kratos;
 

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_utilities/test_builder_and_solver_factory.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_utilities/test_builder_and_solver_factory.cpp
@@ -11,9 +11,9 @@
 //
 
 #include "custom_utilities/builder_and_solver_factory.hpp"
-#include "geo_mechanics_fast_suite.h"
 #include "linear_solvers/linear_solver.h"
 #include "spaces/ublas_space.h"
+#include "tests/cpp_tests/geo_mechanics_fast_suite.h"
 
 using namespace Kratos;
 using SparseSpaceType  = UblasSpace<double, CompressedMatrix, Vector>;

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_utilities/test_compressibility_matrix.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_utilities/test_compressibility_matrix.cpp
@@ -12,8 +12,8 @@
 
 #include "containers/model.h"
 #include "custom_utilities/transport_equation_utilities.hpp"
-#include "geo_mechanics_fast_suite.h"
 #include "includes/checks.h"
+#include "tests/cpp_tests/geo_mechanics_fast_suite.h"
 #include <boost/numeric/ublas/assignment.hpp>
 
 using namespace Kratos;

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_utilities/test_constitutive_law_utilities.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_utilities/test_constitutive_law_utilities.cpp
@@ -11,8 +11,8 @@
 //
 
 #include "custom_utilities/constitutive_law_utilities.hpp"
-#include "geo_mechanics_fast_suite.h"
 #include "includes/checks.h"
+#include "tests/cpp_tests/geo_mechanics_fast_suite.h"
 #include <boost/numeric/ublas/assignment.hpp>
 
 using namespace Kratos;

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_utilities/test_convergence_criteria_factory.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_utilities/test_convergence_criteria_factory.cpp
@@ -11,8 +11,8 @@
 //
 
 #include "custom_utilities/convergence_criteria_factory.hpp"
-#include "geo_mechanics_fast_suite.h"
 #include "spaces/ublas_space.h"
+#include "tests/cpp_tests/geo_mechanics_fast_suite.h"
 
 using namespace Kratos;
 using SparseSpaceType                = UblasSpace<double, CompressedMatrix, Vector>;

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_utilities/test_coupling_matrix.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_utilities/test_coupling_matrix.cpp
@@ -12,8 +12,8 @@
 
 #include "containers/model.h"
 #include "custom_utilities/transport_equation_utilities.hpp"
-#include "geo_mechanics_fast_suite.h"
 #include "includes/checks.h"
+#include "tests/cpp_tests/geo_mechanics_fast_suite.h"
 #include <boost/numeric/ublas/assignment.hpp>
 
 using namespace Kratos;

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_utilities/test_dof_utilities.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_utilities/test_dof_utilities.cpp
@@ -20,9 +20,9 @@
 #include "custom_utilities/dof_utilities.h"
 #include "geo_aliases.h"
 #include "geo_mechanics_application_variables.h"
-#include "geo_mechanics_fast_suite.h"
 #include "includes/element.h"
-#include "test_utilities/model_setup_utilities.h"
+#include "tests/cpp_tests/geo_mechanics_fast_suite.h"
+#include "tests/cpp_tests/test_utilities/model_setup_utilities.h"
 
 namespace
 {

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_utilities/test_equation_of_motion.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_utilities/test_equation_of_motion.cpp
@@ -13,7 +13,7 @@
 #include "custom_constitutive/linear_elastic_2D_interface_law.h"
 #include "custom_utilities/equation_of_motion_utilities.h"
 #include "geo_mechanics_application_variables.h"
-#include "geo_mechanics_fast_suite.h"
+#include "tests/cpp_tests/geo_mechanics_fast_suite.h"
 #include "tests/cpp_tests/test_utilities.h"
 #include "tests/cpp_tests/test_utilities/model_setup_utilities.h"
 

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_utilities/test_fluid_pressure.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_utilities/test_fluid_pressure.cpp
@@ -12,8 +12,8 @@
 
 #include "boost/numeric/ublas/assignment.hpp"
 #include "custom_utilities/transport_equation_utilities.hpp"
-#include "geo_mechanics_fast_suite.h"
 #include "includes/checks.h"
+#include "tests/cpp_tests/geo_mechanics_fast_suite.h"
 
 using namespace Kratos;
 

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_utilities/test_linear_nodal_extrapolator.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_utilities/test_linear_nodal_extrapolator.cpp
@@ -11,11 +11,11 @@
 //
 
 #include "custom_utilities/linear_nodal_extrapolator.h"
-#include "geo_mechanics_fast_suite.h"
 #include "geometries/quadrilateral_2d_4.h"
 #include "geometries/quadrilateral_2d_8.h"
 #include "geometries/triangle_2d_3.h"
 #include "geometries/triangle_2d_6.h"
+#include "tests/cpp_tests/geo_mechanics_fast_suite.h"
 #include <boost/numeric/ublas/assignment.hpp>
 
 namespace Kratos::Testing

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_utilities/test_node_utilities.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_utilities/test_node_utilities.cpp
@@ -10,9 +10,9 @@
 //  Main authors:    Richard Faasse
 //
 #include "custom_utilities/node_utilities.h"
-#include "geo_mechanics_fast_suite.h"
 #include "includes/node.h"
 #include "includes/variables.h"
+#include "tests/cpp_tests/geo_mechanics_fast_suite.h"
 
 using namespace Kratos;
 

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_utilities/test_permeability_matrix.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_utilities/test_permeability_matrix.cpp
@@ -12,8 +12,8 @@
 
 #include "containers/model.h"
 #include "custom_utilities/transport_equation_utilities.hpp"
-#include "geo_mechanics_fast_suite.h"
 #include "includes/checks.h"
+#include "tests/cpp_tests/geo_mechanics_fast_suite.h"
 #include <boost/numeric/ublas/assignment.hpp>
 
 using namespace Kratos;

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_utilities/test_process_factory.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_utilities/test_process_factory.cpp
@@ -12,7 +12,7 @@
 //
 
 #include "custom_utilities/process_factory.hpp"
-#include "geo_mechanics_fast_suite.h"
+#include "tests/cpp_tests/geo_mechanics_fast_suite.h"
 
 using namespace Kratos;
 

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_utilities/test_process_info_parser.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_utilities/test_process_info_parser.cpp
@@ -11,7 +11,7 @@
 //
 
 #include "custom_utilities/json_process_info_parser.h"
-#include "geo_mechanics_fast_suite.h"
+#include "tests/cpp_tests/geo_mechanics_fast_suite.h"
 
 using namespace Kratos;
 

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_utilities/test_scheme_factory.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_utilities/test_scheme_factory.cpp
@@ -11,8 +11,8 @@
 //
 
 #include "custom_utilities/scheme_factory.hpp"
-#include "geo_mechanics_fast_suite.h"
 #include "spaces/ublas_space.h"
+#include "tests/cpp_tests/geo_mechanics_fast_suite.h"
 
 using namespace Kratos;
 

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_utilities/test_soil_density.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_utilities/test_soil_density.cpp
@@ -11,8 +11,8 @@
 //
 
 #include "custom_utilities/transport_equation_utilities.hpp"
-#include "geo_mechanics_fast_suite.h"
 #include "includes/checks.h"
+#include "tests/cpp_tests/geo_mechanics_fast_suite.h"
 
 using namespace Kratos;
 

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_utilities/test_solving_strategy_factory.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_utilities/test_solving_strategy_factory.cpp
@@ -12,7 +12,7 @@
 
 #include "containers/model.h"
 #include "custom_utilities/solving_strategy_factory.hpp"
-#include "geo_mechanics_fast_suite.h"
+#include "tests/cpp_tests/geo_mechanics_fast_suite.h"
 
 using namespace Kratos;
 

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_utilities/test_stress_strain_utitlities.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_utilities/test_stress_strain_utitlities.cpp
@@ -13,7 +13,7 @@
 
 #include "custom_utilities/math_utilities.h"
 #include "custom_utilities/stress_strain_utilities.h"
-#include "geo_mechanics_fast_suite.h"
+#include "tests/cpp_tests/geo_mechanics_fast_suite.h"
 #include "utilities/math_utils.h"
 #include <boost/numeric/ublas/assignment.hpp>
 

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_utilities/test_transport_equation_utilities.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_utilities/test_transport_equation_utilities.cpp
@@ -11,7 +11,7 @@
 //
 
 #include "custom_utilities/transport_equation_utilities.hpp"
-#include "geo_mechanics_fast_suite.h"
+#include "tests/cpp_tests/geo_mechanics_fast_suite.h"
 #include <boost/numeric/ublas/assignment.hpp>
 
 namespace

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_utilities/test_variables_utilities.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_utilities/test_variables_utilities.cpp
@@ -10,8 +10,8 @@
 //  Main authors:    Richard Faasse
 //
 #include "custom_utilities/variables_utilities.hpp"
-#include "geo_mechanics_fast_suite.h"
 #include "includes/variables.h"
+#include "tests/cpp_tests/geo_mechanics_fast_suite.h"
 
 namespace Kratos::Testing
 {

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_workflows/test_GeoMechanicsNewtonRaphsonErosionProcessStrategy.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_workflows/test_GeoMechanicsNewtonRaphsonErosionProcessStrategy.cpp
@@ -15,8 +15,8 @@
 
 /* Project includes */
 #include "custom_workflows/dgeoflow.h"
-#include "flow_stubs.h"
-#include "geo_mechanics_fast_suite.h"
+#include "tests/cpp_tests/flow_stubs.h"
+#include "tests/cpp_tests/geo_mechanics_fast_suite.h"
 
 namespace Kratos::Testing
 {

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_workflows/test_dgeosettlement.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_workflows/test_dgeosettlement.cpp
@@ -11,10 +11,10 @@
 //
 
 #include "custom_workflows/dgeosettlement.h"
-#include "geo_mechanics_fast_suite.h"
-#include "stub_input_utility.h"
-#include "stub_process_info_parser.h"
-#include "stub_time_loop_executor.h"
+#include "tests/cpp_tests/geo_mechanics_fast_suite.h"
+#include "tests/cpp_tests/stub_input_utility.h"
+#include "tests/cpp_tests/stub_process_info_parser.h"
+#include "tests/cpp_tests/stub_time_loop_executor.h"
 
 using namespace Kratos;
 

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_workflows/test_head_extrapolation_flow_workflow.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_workflows/test_head_extrapolation_flow_workflow.cpp
@@ -15,9 +15,9 @@
 
 // Project includes
 #include "custom_workflows/dgeoflow.h"
-#include "flow_stubs.h"
-#include "geo_mechanics_fast_suite.h"
-#include "test_utilities.h"
+#include "tests/cpp_tests/flow_stubs.h"
+#include "tests/cpp_tests/geo_mechanics_fast_suite.h"
+#include "tests/cpp_tests/test_utilities.h"
 
 namespace
 {

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_workflows/test_prescribed_time_incrementor.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_workflows/test_prescribed_time_incrementor.cpp
@@ -13,7 +13,7 @@
 
 #include "custom_workflows/prescribed_time_incrementor.h"
 #include "custom_workflows/time_step_end_state.hpp"
-#include "geo_mechanics_fast_suite.h"
+#include "tests/cpp_tests/geo_mechanics_fast_suite.h"
 
 using namespace Kratos;
 

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_workflows/test_solving_strategy_wrapper.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_workflows/test_solving_strategy_wrapper.cpp
@@ -14,9 +14,9 @@
 #include "custom_utilities/solving_strategy_factory.hpp"
 #include "custom_workflows/solving_strategy_wrapper.hpp"
 #include "geo_mechanics_application_variables.h"
-#include "geo_mechanics_fast_suite.h"
 #include "linear_solvers/linear_solver.h"
 #include "spaces/ublas_space.h"
+#include "tests/cpp_tests/geo_mechanics_fast_suite.h"
 
 namespace
 {

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_workflows/test_time_incrementor.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_workflows/test_time_incrementor.cpp
@@ -13,7 +13,7 @@
 
 #include "custom_workflows/adaptive_time_incrementor.h"
 #include "custom_workflows/time_step_end_state.hpp"
-#include "geo_mechanics_fast_suite.h"
+#include "tests/cpp_tests/geo_mechanics_fast_suite.h"
 
 using namespace Kratos;
 

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_workflows/test_time_loop_executor.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_workflows/test_time_loop_executor.cpp
@@ -15,7 +15,7 @@
 #include "custom_workflows/prescribed_time_incrementor.h"
 #include "custom_workflows/time_loop_executor.hpp"
 #include "custom_workflows/time_step_end_state.hpp"
-#include "geo_mechanics_fast_suite.h"
+#include "tests/cpp_tests/geo_mechanics_fast_suite.h"
 
 #include <numeric>
 

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_workflows/test_time_stepping.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_workflows/test_time_stepping.cpp
@@ -13,8 +13,8 @@
 
 #include "custom_workflows/strategy_wrapper.hpp"
 #include "custom_workflows/time_step_executor.h"
-#include "geo_mechanics_fast_suite.h"
 #include "solving_strategies/strategies/solving_strategy.h"
+#include "tests/cpp_tests/geo_mechanics_fast_suite.h"
 
 #include <gmock/gmock.h>
 


### PR DESCRIPTION
**📝 Description**

The C++ unit tests that were not yet inside a sub-directory of `cpp_tests` have now moved to appropriate sub-directories.

Furthermore, three classes named `StubElement` have been renamed to fix a name clashes problem with Unity builds.
