### PR TITLE
Updated test to have an assert to assure list is of length 3 (improve reliability)

### DIFF
--- a/applications/GeoMechanicsApplication/tests/test_set_multiple_moving_load_process.py
+++ b/applications/GeoMechanicsApplication/tests/test_set_multiple_moving_load_process.py
@@ -276,6 +276,8 @@ class KratosGeoMechanicsSetMultipleMovingLoadProcessTests(KratosUnittest.TestCas
             cond.CalculateLocalSystem(lhs, rhs, self.model_part.ProcessInfo)
             all_rhs.append(list(rhs))
 
+        self.assertEqual(len(all_rhs), 3)
+
         self.checkRHS(all_rhs[0], [0.0, 0.0, 0.0, 0.0])
         self.checkRHS(all_rhs[1], [0.0, -2.0, 0.0, 0.0])
         self.checkRHS(all_rhs[2], [0.0, -1.5, 0.0, -0.5])
@@ -291,6 +293,8 @@ class KratosGeoMechanicsSetMultipleMovingLoadProcessTests(KratosUnittest.TestCas
             cond.CalculateLocalSystem(lhs, rhs, self.model_part.ProcessInfo)
             all_rhs.append(list(rhs))
 
+        self.assertEqual(len(all_rhs), 3)
+        
         self.checkRHS(all_rhs[0], [0.0, -2.0, 0.0, 0.0])
         self.checkRHS(all_rhs[1], [0.0, -1.5, 0.0, -0.5])
         self.checkRHS(all_rhs[2], [0.0, -1.0, 0.0, -1.0])
@@ -452,6 +456,8 @@ class KratosGeoMechanicsSetMultipleMovingLoadProcessTests(KratosUnittest.TestCas
             cond.CalculateLocalSystem(lhs, rhs, self.model_part.ProcessInfo)
             all_rhs.append(list(rhs))
 
+        self.assertEqual(len(all_rhs), 3)
+        
         self.checkRHS(all_rhs[0], [0.0, 0.0, 0.0, 0.0])
         self.checkRHS(all_rhs[1], [0.0, 0.0, 0.0, -2.0])
         self.checkRHS(all_rhs[2], [0.0, -0.5, 0.0, -1.5])
@@ -467,6 +473,8 @@ class KratosGeoMechanicsSetMultipleMovingLoadProcessTests(KratosUnittest.TestCas
             cond.CalculateLocalSystem(lhs, rhs, self.model_part.ProcessInfo)
             all_rhs.append(list(rhs))
 
+        self.assertEqual(len(all_rhs), 3)
+        
         self.checkRHS(all_rhs[0], [0.0, 0.0, 0.0, -2.0])
         self.checkRHS(all_rhs[1], [0.0, -0.5, 0.0, -1.5])
         self.checkRHS(all_rhs[2], [0.0, -1.0, 0.0, -1.0])


### PR DESCRIPTION
Improve Reliability of Set_Moving_Loads_tests

**📝 Description**
Sonarcube indicated a reliability rating of D for the test file, linked to the fact that a list is constructed but there was no check that the index checked is created.

**🆕 Changelog**
This was resolved by providing an assertion in the test that the created list is of the correct size before the indexing of the list.
