### PR TITLE
Add `AtomicSet` for Atomic Assignment

### DIFF
--- a/kratos/tests/cpp_tests/utilities/test_atomic_utilities.cpp
+++ b/kratos/tests/cpp_tests/utilities/test_atomic_utilities.cpp
@@ -11,6 +11,7 @@
 //
 
 // System includes
+#include <vector>
 
 // External includes
 
@@ -21,6 +22,23 @@
 
 
 namespace Kratos::Testing {
+
+/// @details Loop over an index range larger than an array, overwriting
+///          its components with identical values from all threads.
+KRATOS_TEST_CASE(AtomicSet)
+{
+    constexpr std::size_t array_size = 5;
+    constexpr std::size_t iteration_count = 1e5;
+    std::vector<std::int8_t> array(array_size, 0);
+
+    IndexPartition<std::size_t>(iteration_count).for_each([&array](const std::size_t i){
+        AtomicSet(array[i % array_size], i % array_size);
+    });
+
+    for (unsigned i=0u; i<array_size; ++i) {
+        KRATOS_EXPECT_EQ(array[i], i);
+    } 
+}
 
 KRATOS_TEST_CASE(AtomicAdd)
 {

--- a/kratos/tests/cpp_tests/utilities/test_atomic_utilities.cpp
+++ b/kratos/tests/cpp_tests/utilities/test_atomic_utilities.cpp
@@ -31,7 +31,7 @@ KRATOS_TEST_CASE(AtomicSet)
     constexpr std::size_t iteration_count = 1e5;
     std::vector<std::int8_t> array(array_size, 0);
 
-    IndexPartition<std::size_t>(iteration_count).for_each([&array](const std::size_t i){
+    IndexPartition<std::size_t>(iteration_count).for_each([&array, array_size](const std::size_t i){
         AtomicSet(array[i % array_size], i % array_size);
     });
 

--- a/kratos/utilities/atomic_utilities.h
+++ b/kratos/utilities/atomic_utilities.h
@@ -42,6 +42,23 @@ namespace Kratos {
     #endif //__cpp_lib_atomic_ref
 #endif // KRATOS_SMP_CXX11
 
+/// @brief Set the value of a variable in a threadsafe manner.
+/// @param rTarget Variable to set the value of.
+/// @param rSource Value to overwrite the variable with.
+/// @addtogroup KratosCore
+template <class TTarget, class TSource>
+void AtomicSet(TTarget& rTarget, const TSource& rSource)
+{
+    #ifdef KRATOS_SMP_OPENMP
+        #pragma omp atomic write
+        rTarget = rSource;
+    #elif defined(KRATOS_SMP_CXX11)
+        AtomicRef<TTarget>(rTarget) = rSource;
+    #else
+        rTarget = rSource;
+    #endif
+}
+
 ///@addtogroup KratosCore
 /**
  * collection of utilities for atomic updates of simple types. (essentially mimics the omp atomic)

--- a/kratos/utilities/atomic_utilities.h
+++ b/kratos/utilities/atomic_utilities.h
@@ -42,10 +42,32 @@ namespace Kratos {
     #endif //__cpp_lib_atomic_ref
 #endif // KRATOS_SMP_CXX11
 
-/// @brief Set the value of a variable in a threadsafe manner.
-/// @param rTarget Variable to set the value of.
-/// @param rSource Value to overwrite the variable with.
-/// @addtogroup KratosCore
+/** @brief Set the value of a variable in a threadsafe manner.
+ *  @details Example: find hanging nodes in a model.
+ *           @code
+ *           void FindHangingNodes(const ModelPart& rModelPart,
+ *                                 std::vector<std::uint8_t>& rHangingNodes)
+ *           {
+ *              rHangingNodes = std::vector<std::uint8_t>(rModelPart.Nodes().size(), 1);
+ *              block_for_each(rModelPart.Elements(), [&rHangingNodes, &rModelPart](const Element& r_element){
+ *                  for (const Node& r_node : r_element.GetGeometry()) {
+ *                      const std::size_t i_node = std::distance(
+ *                          rModelPart.Nodes().begin(),
+ *                          std::lower_bound(rModelPart.Nodes().begin(),
+ *                                           rModelPart.Nodes().end(),
+ *                                           r_node,
+ *                                           [](const Node& r_left, const Node& r_right){
+ *                                              return r_left.Id() < r_right.Id();
+ *                                            }));
+ *                      AtomicSet(rHangingNodes[i_node], 0);
+ *                  }
+ *              });
+ *           }
+ *           @endcode
+ *  @param rTarget Variable to set the value of.
+ *  @param rSource Value to overwrite the variable with.
+ *  @addtogroup KratosCore
+ */
 template <class TTarget, class TSource>
 void AtomicSet(TTarget& rTarget, const TSource& rSource)
 {


### PR DESCRIPTION
Atomic utilities included addition, subtraction, multiplication and division. Now it also supports assignment.

##

*The reason for the two template parameters is to help the compiler with template argument deduction. This is useful when assigning literals to integers. For example:*

```cpp
unsigned target = 0u;
AtomicSet(target, 1);
```

*`1` in the example above is a literal that is of type `int` by default while `target` is `unsinged`, so the compiler would start sweating if we didn't have separate template parameters.*