### PR TITLE
[Core] Fix Clang warning when `discard-qualifier` on line 133 of `registry.h`

### DIFF
--- a/kratos/includes/registry.h
+++ b/kratos/includes/registry.h
@@ -130,7 +130,7 @@ public:
         return mspRootRegistryItem->end();
     }
 
-    static auto const cend()
+    static auto cend()
     {
         return mspRootRegistryItem->cend();
     }


### PR DESCRIPTION
**📝 Description**

Fix Clang warning when `discard-qualifier` on line 133 of `registry.h`. `const` is not needed for the `cend` iterator. 

**🆕 Changelog**

- [Fix Clang warning when `discard-qualifier` on line 133 of `registry.h`](https://github.com/KratosMultiphysics/Kratos/commit/8f9c45fd32aa5b49b8c08084687be446527f4dd7)
