### PR TITLE
Remove unused damage from geo continuum element and dgeoflow

### DIFF
--- a/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_FIC_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_FIC_element.cpp
@@ -118,7 +118,7 @@ void UPwSmallStrainFICElement<TDim, TNumNodes>::InitializeNonLinearIteration(con
     ConstitutiveLaw::Parameters ConstitutiveParameters(Geom, this->GetProperties(), rCurrentProcessInfo);
     ConstitutiveParameters.Set(ConstitutiveLaw::COMPUTE_CONSTITUTIVE_TENSOR);
     ConstitutiveParameters.Set(ConstitutiveLaw::USE_ELEMENT_PROVIDED_STRAIN);
-    ConstitutiveParameters.Set(ConstitutiveLaw::INITIALIZE_MATERIAL_RESPONSE); // Note: this is for nonlocal damage
+    ConstitutiveParameters.Set(ConstitutiveLaw::INITIALIZE_MATERIAL_RESPONSE);
 
     // Element variables
     ElementVariables Variables;
@@ -177,7 +177,7 @@ void UPwSmallStrainFICElement<TDim, TNumNodes>::FinalizeNonLinearIteration(const
     ConstitutiveLaw::Parameters ConstitutiveParameters(Geom, this->GetProperties(), rCurrentProcessInfo);
     ConstitutiveParameters.Set(ConstitutiveLaw::COMPUTE_CONSTITUTIVE_TENSOR);
     ConstitutiveParameters.Set(ConstitutiveLaw::USE_ELEMENT_PROVIDED_STRAIN);
-    ConstitutiveParameters.Set(ConstitutiveLaw::INITIALIZE_MATERIAL_RESPONSE); // Note: this is for nonlocal damage
+    ConstitutiveParameters.Set(ConstitutiveLaw::INITIALIZE_MATERIAL_RESPONSE);
 
     // Element variables
     ElementVariables Variables;

--- a/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_element.cpp
@@ -253,7 +253,7 @@ void UPwSmallStrainElement<TDim, TNumNodes>::InitializeSolutionStep(const Proces
     ConstitutiveLaw::Parameters ConstitutiveParameters(this->GetGeometry(), this->GetProperties(),
                                                        rCurrentProcessInfo);
     ConstitutiveParameters.Set(ConstitutiveLaw::USE_ELEMENT_PROVIDED_STRAIN);
-    ConstitutiveParameters.Set(ConstitutiveLaw::INITIALIZE_MATERIAL_RESPONSE); // Note: this is for nonlocal damage
+    ConstitutiveParameters.Set(ConstitutiveLaw::INITIALIZE_MATERIAL_RESPONSE);
 
     ElementVariables Variables;
     this->InitializeElementVariables(Variables, rCurrentProcessInfo);
@@ -356,7 +356,7 @@ void UPwSmallStrainElement<TDim, TNumNodes>::InitializeNonLinearIteration(const 
                                                        rCurrentProcessInfo);
     ConstitutiveParameters.Set(ConstitutiveLaw::COMPUTE_STRESS);
     ConstitutiveParameters.Set(ConstitutiveLaw::USE_ELEMENT_PROVIDED_STRAIN);
-    ConstitutiveParameters.Set(ConstitutiveLaw::INITIALIZE_MATERIAL_RESPONSE); // Note: this is for nonlocal damage
+    ConstitutiveParameters.Set(ConstitutiveLaw::INITIALIZE_MATERIAL_RESPONSE);
 
     ElementVariables Variables;
     this->InitializeElementVariables(Variables, rCurrentProcessInfo);
@@ -465,14 +465,6 @@ void UPwSmallStrainElement<TDim, TNumNodes>::ExtrapolateGPValues(const Matrix& S
 {
     KRATOS_TRY
 
-    array_1d<double, TNumNodes> DamageContainer;
-
-    for (unsigned int iNode = 0; iNode < TNumNodes; ++iNode) {
-        DamageContainer[iNode] = 0.0;
-        DamageContainer[iNode] =
-            mConstitutiveLawVector[iNode]->GetValue(DAMAGE_VARIABLE, DamageContainer[iNode]);
-    }
-
     GeometryType&               rGeom = this->GetGeometry();
     const double&               Area  = rGeom.Area(); // In 3D this is volume
     array_1d<Vector, TNumNodes> NodalStressVector;    // List with stresses at each node
@@ -500,16 +492,12 @@ void UPwSmallStrainElement<TDim, TNumNodes>::ExtrapolateGPValues(const Matrix& S
      * S1-0 = S[1] at node 0
      */
 
-    array_1d<double, TNumNodes> NodalDamage;
-    noalias(NodalDamage) = prod(ExtrapolationMatrix, DamageContainer);
-
     for (unsigned int i = 0; i < TNumNodes; ++i) {
         noalias(NodalStressVector[i]) = row(AuxNodalStress, i) * Area;
         noalias(NodalStressTensor[i]) = MathUtils<double>::StressVectorToTensor(NodalStressVector[i]);
 
         rGeom[i].SetLock();
         noalias(rGeom[i].FastGetSolutionStepValue(NODAL_CAUCHY_STRESS_TENSOR)) += NodalStressTensor[i];
-        rGeom[i].FastGetSolutionStepValue(NODAL_DAMAGE_VARIABLE) += NodalDamage[i] * Area;
         rGeom[i].FastGetSolutionStepValue(NODAL_AREA) += Area;
         rGeom[i].UnSetLock();
     }

--- a/applications/GeoMechanicsApplication/custom_elements/small_strain_U_Pw_diff_order_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/small_strain_U_Pw_diff_order_element.cpp
@@ -170,7 +170,7 @@ void SmallStrainUPwDiffOrderElement::InitializeSolutionStep(const ProcessInfo& r
 
     ConstitutiveLaw::Parameters ConstitutiveParameters(GetGeometry(), GetProperties(), rCurrentProcessInfo);
     ConstitutiveParameters.Set(ConstitutiveLaw::USE_ELEMENT_PROVIDED_STRAIN);
-    ConstitutiveParameters.Set(ConstitutiveLaw::INITIALIZE_MATERIAL_RESPONSE); // Note: this is for nonlocal damage
+    ConstitutiveParameters.Set(ConstitutiveLaw::INITIALIZE_MATERIAL_RESPONSE);
 
     ElementVariables Variables;
     this->InitializeElementVariables(Variables, rCurrentProcessInfo);

--- a/applications/GeoMechanicsApplication/custom_workflows/dgeoflow.cpp
+++ b/applications/GeoMechanicsApplication/custom_workflows/dgeoflow.cpp
@@ -403,20 +403,6 @@ void KratosExecute::WriteCriticalHeadResultToFile() const
 
 void KratosExecute::AddNodalSolutionStepVariables(ModelPart& rModelPart) const
 {
-    rModelPart.AddNodalSolutionStepVariable(VELOCITY);
-    rModelPart.AddNodalSolutionStepVariable(ACCELERATION);
-
-    // Displacement
-    rModelPart.AddNodalSolutionStepVariable(DISPLACEMENT);
-    rModelPart.AddNodalSolutionStepVariable(TOTAL_DISPLACEMENT);
-    rModelPart.AddNodalSolutionStepVariable(REACTION);
-    rModelPart.AddNodalSolutionStepVariable(POINT_LOAD);
-    rModelPart.AddNodalSolutionStepVariable(LINE_LOAD);
-    rModelPart.AddNodalSolutionStepVariable(SURFACE_LOAD);
-    rModelPart.AddNodalSolutionStepVariable(VOLUME_ACCELERATION);
-    rModelPart.AddNodalSolutionStepVariable(NORMAL_CONTACT_STRESS);
-    rModelPart.AddNodalSolutionStepVariable(TANGENTIAL_CONTACT_STRESS);
-
     // Water
     rModelPart.AddNodalSolutionStepVariable(WATER_PRESSURE);
     rModelPart.AddNodalSolutionStepVariable(REACTION_WATER_PRESSURE);
@@ -424,13 +410,6 @@ void KratosExecute::AddNodalSolutionStepVariables(ModelPart& rModelPart) const
     rModelPart.AddNodalSolutionStepVariable(NORMAL_FLUID_FLUX);
     rModelPart.AddNodalSolutionStepVariable(HYDRAULIC_DISCHARGE);
 
-    // Smoothing
-    rModelPart.AddNodalSolutionStepVariable(NODAL_AREA);
-    rModelPart.AddNodalSolutionStepVariable(NODAL_CAUCHY_STRESS_TENSOR);
-    rModelPart.AddNodalSolutionStepVariable(NODAL_DAMAGE_VARIABLE);
-    rModelPart.AddNodalSolutionStepVariable(NODAL_JOINT_AREA);
-    rModelPart.AddNodalSolutionStepVariable(NODAL_JOINT_WIDTH);
-    rModelPart.AddNodalSolutionStepVariable(NODAL_JOINT_DAMAGE);
 }
 
 int KratosExecute::FindCriticalHead(ModelPart&                 rModelPart,

--- a/applications/GeoMechanicsApplication/custom_workflows/dgeoflow.cpp
+++ b/applications/GeoMechanicsApplication/custom_workflows/dgeoflow.cpp
@@ -403,13 +403,14 @@ void KratosExecute::WriteCriticalHeadResultToFile() const
 
 void KratosExecute::AddNodalSolutionStepVariables(ModelPart& rModelPart) const
 {
+    // Pressure to head conversion
+    rModelPart.AddNodalSolutionStepVariable(VOLUME_ACCELERATION);
     // Water
     rModelPart.AddNodalSolutionStepVariable(WATER_PRESSURE);
     rModelPart.AddNodalSolutionStepVariable(REACTION_WATER_PRESSURE);
     rModelPart.AddNodalSolutionStepVariable(DT_WATER_PRESSURE);
     rModelPart.AddNodalSolutionStepVariable(NORMAL_FLUID_FLUX);
     rModelPart.AddNodalSolutionStepVariable(HYDRAULIC_DISCHARGE);
-
 }
 
 int KratosExecute::FindCriticalHead(ModelPart&                 rModelPart,


### PR DESCRIPTION
**📝 Description**
The extrapolation for the geo UPwSmallStrainElement tries to retrieve a constitutive law Damage variable looping of the number of nodes i.s.o. the number of constitutive laws i.e. number of integration points.
In continuum elements no available constitutive law has damage, therefore I remove the code that tries to do this.

