### PR TITLE
[IgaApplication] Add Nurbs modeler for SBM

### DIFF
--- a/applications/IgaApplication/custom_modelers/nurbs_geometry_modeler.cpp
+++ b/applications/IgaApplication/custom_modelers/nurbs_geometry_modeler.cpp
@@ -106,7 +106,7 @@ namespace Kratos
     ///@name Private Operations
     ///@{
     void NurbsGeometryModeler::CreateAndAddRegularGrid2D( ModelPart& r_model_part, const Point& A_xyz, const Point& B_xyz,
-        const Point& A_uvw, const Point& B_uvw, SizeType OrderU, SizeType OrderV,SizeType NumKnotSpansU, SizeType NumKnotSpansV)
+        const Point& A_uvw, const Point& B_uvw, SizeType OrderU, SizeType OrderV,SizeType NumKnotSpansU, SizeType NumKnotSpansV, bool add_surface_to_model_part)
     {
         KRATOS_ERROR_IF( B_xyz.X() <= A_xyz.X() || B_xyz.Y() <= A_xyz.Y() ) << "NurbsGeometryModeler: "
             << "The two Points A_xyz and B_xyz must meet the following requirement: (B_xyz-A_xyz) > (0,0,0). However, (B_xyz-A_xyz)=" << B_xyz-A_xyz << std::endl;
@@ -175,22 +175,25 @@ namespace Kratos
 
         // Set up weights. Required in case no refinement is performed.
         Vector WeightsRefined(points.size(),1.0);
-
-        // Add geometry to model part
-        if( mParameters.Has("geometry_name") ){
-            p_surface_geometry->SetId(mParameters["geometry_name"].GetString());
-        } else {
-            const SizeType number_of_geometries = r_model_part.NumberOfGeometries();
-            SizeType last_geometry_id = 0;
-            if( number_of_geometries > 0 ){
-                for( auto it = r_model_part.GeometriesBegin(); it!= r_model_part.GeometriesEnd(); ++it){
-                    last_geometry_id = it->Id();
+        
+        // In some cases there is no need of add the surface geometry, add_surface_to_model_part is true by default
+        if (add_surface_to_model_part) {
+            // Add geometry to model part
+            if( mParameters.Has("geometry_name") ){
+                p_surface_geometry->SetId(mParameters["geometry_name"].GetString());
+            } else {
+                const SizeType number_of_geometries = r_model_part.NumberOfGeometries();
+                SizeType last_geometry_id = 0;
+                if( number_of_geometries > 0 ){
+                    for( auto it = r_model_part.GeometriesBegin(); it!= r_model_part.GeometriesEnd(); ++it){
+                        last_geometry_id = it->Id();
+                    }
                 }
+                p_surface_geometry->SetId(last_geometry_id+1);
             }
-            p_surface_geometry->SetId(last_geometry_id+1);
+            r_model_part.AddGeometry(p_surface_geometry);
         }
-        r_model_part.AddGeometry(p_surface_geometry);
-
+    
         // Perform knot refinement.
         PointerVector<NodeType> PointsRefined = p_surface_geometry->Points();
         if( NumKnotSpansU > 1) {
@@ -237,6 +240,13 @@ namespace Kratos
         p_surface_geometry->SetInternals(PointsRefined,
             p_surface_geometry->PolynomialDegreeU(), p_surface_geometry->PolynomialDegreeV(),
             p_surface_geometry->KnotsU(), p_surface_geometry->KnotsV(), WeightsRefined);
+
+        // assign the value p_surface_geometry to the class member mpSurface for derived classes
+        mpSurface = p_surface_geometry;
+        mInsertKnotsU = insert_knots_u;
+        mInsertKnotsV = insert_knots_v;
+        mKnotVectorU = knot_vector_u;
+        mKnotVectorV = knot_vector_v;
     }
 
 

--- a/applications/IgaApplication/custom_modelers/nurbs_geometry_modeler.h
+++ b/applications/IgaApplication/custom_modelers/nurbs_geometry_modeler.h
@@ -66,7 +66,7 @@ public:
     }
 
     /// Destructor.
-    virtual ~NurbsGeometryModeler() = default;
+    ~NurbsGeometryModeler() = default;
 
     /// Creates the Modeler Pointer
     Modeler::Pointer Create(Model& rModel, const Parameters ModelParameters) const override

--- a/applications/IgaApplication/custom_modelers/nurbs_geometry_modeler_sbm.cpp
+++ b/applications/IgaApplication/custom_modelers/nurbs_geometry_modeler_sbm.cpp
@@ -1,0 +1,122 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
+//
+//  Main authors:    Nicolo' Antonelli
+//                   Andrea Gorgi
+//
+
+// Project includes
+#include "includes/define.h"
+#include "nurbs_geometry_modeler_sbm.h"
+#include "geometries/nurbs_shape_function_utilities/nurbs_volume_refinement_utilities.h"
+#include "custom_utilities/create_breps_sbm_utilities.h"
+
+namespace Kratos
+{
+
+    ///@name Stages
+    ///@{
+
+    void NurbsGeometryModelerSbm::SetupGeometryModel(){
+
+        //----------------------------------------------------------------------------------------------------------------
+        KRATOS_INFO_IF("NurbsGeometryModelerSbm", mEchoLevel > 1) << "[NURBS MODELER SBM]:: calling NurbsGeometryModeler" << std::endl;
+        
+        // Call the SetupGeometryModel method of the base class NurbsGeometryModeler
+        NurbsGeometryModeler::SetupGeometryModel();
+    }
+
+    ///@}
+    ///@name Private Operations
+    ///@{
+    void NurbsGeometryModelerSbm::CreateAndAddRegularGrid2D( ModelPart& r_model_part, const Point& A_xyz, const Point& B_xyz,
+        const Point& A_uvw, const Point& B_uvw, SizeType OrderU, SizeType OrderV,SizeType NumKnotSpansU, SizeType NumKnotSpansV, bool add_surface_to_model_part)
+    {   
+
+        // Call the CreateAndAddRegularGrid2D method of the base class NurbsGeometryModeler
+        NurbsGeometryModeler::CreateAndAddRegularGrid2D(r_model_part, A_xyz, B_xyz,
+            A_uvw, B_uvw, OrderU, OrderV, NumKnotSpansU, NumKnotSpansV, false);
+         
+        // Create the Domain/Iga Model Part
+        const std::string iga_model_part_name = mParameters["model_part_name"].GetString();
+        ModelPart& iga_model_part = mpModel->HasModelPart(iga_model_part_name)
+                                    ? mpModel->GetModelPart(iga_model_part_name)
+                                    : mpModel->CreateModelPart(iga_model_part_name);
+
+        // Create the True Model Part -> contains all the true boundary features
+        std::string skin_model_part_inner_initial_name = "skin_model_part_inner_initial_name";
+        std::string skin_model_part_outer_initial_name = "skin_model_part_outer_initial_name";
+        std::string skin_model_part_name;
+        if (mParameters.Has("skin_model_part_inner_initial_name")) {
+            skin_model_part_inner_initial_name = mParameters["skin_model_part_inner_initial_name"].GetString();
+
+            if (!mpModel->HasModelPart(skin_model_part_inner_initial_name)) 
+            KRATOS_ERROR << "The skin_model_part '" << skin_model_part_inner_initial_name << "' was not created in the model.\n" 
+                         << "Check the reading of the mdpa file in the import mdpa modeler."<< std::endl;
+        }
+        if (mParameters.Has("skin_model_part_outer_initial_name")) {
+            skin_model_part_outer_initial_name = mParameters["skin_model_part_outer_initial_name"].GetString();
+
+            if (!mpModel->HasModelPart(skin_model_part_outer_initial_name)) 
+            KRATOS_ERROR << "The skin_model_part '" << skin_model_part_outer_initial_name << "' was not created in the model.\n" 
+                         << "Check the reading of the mdpa file in the import mdpa modeler."<< std::endl;
+        }
+        // If there is not neither skin_inner nor skin_outer throw an error since you are using the sbm modeler
+        if (!(mParameters.Has("skin_model_part_inner_initial_name") || mParameters.Has("skin_model_part_outer_initial_name"))){
+            KRATOS_ERROR << "None of the 'skin_model_part_name' have not been defined " << 
+                            "in the nurbs_geometry_modeler_sbm, define it " << 
+                            "in the project paramer json" << std::endl;
+        }
+        
+        if (mParameters.Has("skin_model_part_name"))
+            skin_model_part_name = mParameters["skin_model_part_name"].GetString();
+        else
+            KRATOS_ERROR << "The skin_model_part name '" << skin_model_part_name << "' was not defined in the project parameters.\n" << std::endl;
+ 
+        // inner
+        ModelPart& skin_model_part_inner_initial = mpModel->HasModelPart(skin_model_part_inner_initial_name)
+            ? mpModel->GetModelPart(skin_model_part_inner_initial_name)
+            : mpModel->CreateModelPart(skin_model_part_inner_initial_name);
+        // outer
+        ModelPart& skin_model_part_outer_initial = mpModel->HasModelPart(skin_model_part_outer_initial_name)
+            ? mpModel->GetModelPart(skin_model_part_outer_initial_name)
+            : mpModel->CreateModelPart(skin_model_part_outer_initial_name);
+
+        // Create the surrogate sub model parts inner and outer
+        ModelPart& surrogate_sub_model_part_inner = iga_model_part.CreateSubModelPart("surrogate_inner");
+        ModelPart& surrogate_sub_model_part_outer = iga_model_part.CreateSubModelPart("surrogate_outer");
+
+        // Skin model part refined after Snake Process
+        ModelPart& skin_model_part = mpModel->CreateModelPart(skin_model_part_name);
+        ModelPart& skin_sub_model_part_in = skin_model_part.CreateSubModelPart("inner");
+        ModelPart& skin_sub_model_part_out = skin_model_part.CreateSubModelPart("outer");
+        
+        
+        // compute unique_knot_vector_u
+        Vector unique_knot_vector_u(2+(NumKnotSpansU-1));
+        unique_knot_vector_u[0] = mKnotVectorU[0]; unique_knot_vector_u[NumKnotSpansU] = mKnotVectorU[mKnotVectorU.size()-1];
+        for (SizeType i_knot_insertion = 0; i_knot_insertion < NumKnotSpansU-1; i_knot_insertion++) {
+            unique_knot_vector_u[i_knot_insertion+1] = mInsertKnotsU[i_knot_insertion];
+        }
+
+        // compute unique_knot_vector_v
+        Vector unique_knot_vector_v(2+(NumKnotSpansV-1));
+        unique_knot_vector_v[0] = mKnotVectorV[0]; unique_knot_vector_v[NumKnotSpansV] = mKnotVectorV[mKnotVectorV.size()-1];
+
+        for (SizeType i_knot_insertion = 0; i_knot_insertion < NumKnotSpansV-1; i_knot_insertion++) {
+            unique_knot_vector_v[i_knot_insertion+1] = mInsertKnotsV[i_knot_insertion];
+        }
+        SnakeSBMUtilities::CreateTheSnakeCoordinates(iga_model_part, skin_model_part_inner_initial, skin_model_part_outer_initial, skin_model_part, mEchoLevel,
+                                                     unique_knot_vector_u, unique_knot_vector_v, mParameters) ;
+        // Create the breps for the outer sbm boundary
+        CreateBrepsSBMUtilities<Node, Point> CreateBrepsSBMUtilities(mEchoLevel);
+        CreateBrepsSBMUtilities.CreateSurrogateBoundary(mpSurface, r_model_part, surrogate_sub_model_part_inner, surrogate_sub_model_part_outer, A_uvw, B_uvw);
+    }
+
+} // end namespace kratos

--- a/applications/IgaApplication/custom_modelers/nurbs_geometry_modeler_sbm.cpp
+++ b/applications/IgaApplication/custom_modelers/nurbs_geometry_modeler_sbm.cpp
@@ -12,10 +12,9 @@
 //
 
 // Project includes
-#include "includes/define.h"
 #include "nurbs_geometry_modeler_sbm.h"
-#include "geometries/nurbs_shape_function_utilities/nurbs_volume_refinement_utilities.h"
 #include "custom_utilities/create_breps_sbm_utilities.h"
+#include "utilities/nurbs_utilities/snake_sbm_utilities.h"
 
 namespace Kratos
 {
@@ -56,15 +55,15 @@ namespace Kratos
         if (mParameters.Has("skin_model_part_inner_initial_name")) {
             skin_model_part_inner_initial_name = mParameters["skin_model_part_inner_initial_name"].GetString();
 
-            if (!mpModel->HasModelPart(skin_model_part_inner_initial_name)) 
-            KRATOS_ERROR << "The skin_model_part '" << skin_model_part_inner_initial_name << "' was not created in the model.\n" 
+            KRATOS_ERROR_IF_NOT(mpModel->HasModelPart(skin_model_part_inner_initial_name)) 
+                         << "The skin_model_part '" << skin_model_part_inner_initial_name << "' was not created in the model.\n" 
                          << "Check the reading of the mdpa file in the import mdpa modeler."<< std::endl;
         }
         if (mParameters.Has("skin_model_part_outer_initial_name")) {
             skin_model_part_outer_initial_name = mParameters["skin_model_part_outer_initial_name"].GetString();
 
-            if (!mpModel->HasModelPart(skin_model_part_outer_initial_name)) 
-            KRATOS_ERROR << "The skin_model_part '" << skin_model_part_outer_initial_name << "' was not created in the model.\n" 
+            KRATOS_ERROR_IF_NOT(mpModel->HasModelPart(skin_model_part_outer_initial_name)) 
+                         << "The skin_model_part '" << skin_model_part_outer_initial_name << "' was not created in the model.\n" 
                          << "Check the reading of the mdpa file in the import mdpa modeler."<< std::endl;
         }
         // If there is not neither skin_inner nor skin_outer throw an error since you are using the sbm modeler

--- a/applications/IgaApplication/custom_modelers/nurbs_geometry_modeler_sbm.cpp
+++ b/applications/IgaApplication/custom_modelers/nurbs_geometry_modeler_sbm.cpp
@@ -69,9 +69,14 @@ namespace Kratos
         }
         // If there is not neither skin_inner nor skin_outer throw an error since you are using the sbm modeler
         if (!(mParameters.Has("skin_model_part_inner_initial_name") || mParameters.Has("skin_model_part_outer_initial_name"))){
-            KRATOS_ERROR << "None of the 'skin_model_part_name' have not been defined " << 
-                            "in the nurbs_geometry_modeler_sbm, define it " << 
-                            "in the project paramer json" << std::endl;
+        
+            // Create the breps for the outer sbm boundary
+            CreateBrepsSBMUtilities<Node, Point> CreateBrepsSBMUtilities(mEchoLevel);
+            CreateBrepsSBMUtilities.CreateSurrogateBoundary(mpSurface, r_model_part, A_uvw, B_uvw);
+            
+            KRATOS_WARNING("None of the 'skin_model_part_name' have not been defined ") << 
+                            "in the nurbs_geometry_modeler_sbm in the project paramer json" << std::endl;
+            return;
         }
         
         if (mParameters.Has("skin_model_part_name"))
@@ -94,8 +99,8 @@ namespace Kratos
 
         // Skin model part refined after Snake Process
         ModelPart& skin_model_part = mpModel->CreateModelPart(skin_model_part_name);
-        ModelPart& skin_sub_model_part_in = skin_model_part.CreateSubModelPart("inner");
-        ModelPart& skin_sub_model_part_out = skin_model_part.CreateSubModelPart("outer");
+        skin_model_part.CreateSubModelPart("inner");
+        skin_model_part.CreateSubModelPart("outer");
         
         
         // compute unique_knot_vector_u

--- a/applications/IgaApplication/custom_modelers/nurbs_geometry_modeler_sbm.h
+++ b/applications/IgaApplication/custom_modelers/nurbs_geometry_modeler_sbm.h
@@ -7,11 +7,12 @@
 //  License:         BSD License
 //                   Kratos default license: kratos/license.txt
 //
-//  Main authors:    Manuel Messmer
+//  Main authors:    Nicolo' Antonelli
+//                   Andrea Gorgi
 //
 
-#if !defined(KRATOS_NURBS_GEOMETRY_MODELER_H_INCLUDED )
-#define  KRATOS_NURBS_GEOMETRY_MODELER_H_INCLUDED
+#if !defined(KRATOS_NURBS_GEOMETRY_MODELER_SBM_H_INCLUDED )
+#define  KRATOS_NURBS_GEOMETRY_MODELER_SBM_H_INCLUDED
 
 // System includes
 
@@ -19,20 +20,22 @@
 
 // Project includes
 #include "includes/model_part.h"
-#include "modeler/modeler.h"
+#include "nurbs_geometry_modeler.h"
 #include "geometries/nurbs_volume_geometry.h"
 #include "geometries/nurbs_surface_geometry.h"
 #include "geometries/nurbs_shape_function_utilities/nurbs_surface_refinement_utilities.h"
+#include "geometries/brep_curve_on_surface.h"
+#include "utilities/nurbs_utilities/snake_sbm_utilities.h"
 
 namespace Kratos {
 
-class KRATOS_API(IGA_APPLICATION) NurbsGeometryModeler
-    : public Modeler
+class KRATOS_API(IGA_APPLICATION) NurbsGeometryModelerSbm
+    : public NurbsGeometryModeler
 {
 public:
     ///@name Type Definitions
     ///@{
-    KRATOS_CLASS_POINTER_DEFINITION( NurbsGeometryModeler );
+    KRATOS_CLASS_POINTER_DEFINITION( NurbsGeometryModelerSbm );
 
     typedef std::size_t IndexType;
     typedef std::size_t SizeType;
@@ -47,31 +50,33 @@ public:
     typedef NurbsVolumeGeometry<PointerVector<NodeType>> NurbsVolumeGeometryType;
     typedef typename NurbsVolumeGeometryType::Pointer NurbsVolumeGeometryPointerType;
 
+    typedef PointerVector<Node> ContainerNodeType;
+    typedef PointerVector<Point> ContainerEmbeddedNodeType;
 
     ///@}
     ///@name Life Cycle
     ///@{
 
     /// Default constructor.
-    NurbsGeometryModeler()
-        : Modeler() {}
+    NurbsGeometryModelerSbm()
+        : NurbsGeometryModeler() {}
 
     /// Constructor.
-    NurbsGeometryModeler(
+    NurbsGeometryModelerSbm(
         Model & rModel,
         const Parameters ModelerParameters = Parameters())
-        : Modeler(rModel, ModelerParameters)
+        : NurbsGeometryModeler(rModel, ModelerParameters)
         , mpModel(&rModel)
     {
     }
 
     /// Destructor.
-    virtual ~NurbsGeometryModeler() = default;
+    virtual ~NurbsGeometryModelerSbm() = default;
 
     /// Creates the Modeler Pointer
     Modeler::Pointer Create(Model& rModel, const Parameters ModelParameters) const override
     {
-        return Kratos::make_shared<NurbsGeometryModeler>(rModel, ModelParameters);
+        return Kratos::make_shared<NurbsGeometryModelerSbm>(rModel, ModelParameters);
     }
 
     ///@}
@@ -83,7 +88,6 @@ public:
     ///@}
 
 protected:
-///@{
 
     /**
      * @brief Creates a regular grid composed out of bivariant B-splines.
@@ -93,18 +97,11 @@ protected:
      * @param NumKnotSpans Number of equidistant elements/knot spans in each direction u,v.
      * @note The CP'S are defined as nodes and added to the rModelPart.
      **/
-    virtual void CreateAndAddRegularGrid2D( ModelPart& r_model_part, const Point& A_xyz, const Point& B_xyz, const Point& A_uvw, const Point& B_uvw,
-        SizeType OrderU, SizeType OrderV, SizeType NumKnotSpansU, SizeType NumKnotSpansV, bool add_surface_to_model_part = true);
-
-    NurbsSurfaceGeometryPointerType mpSurface;
-
-    Vector mKnotVectorU;
-    Vector mKnotVectorV;
-    std::vector<double> mInsertKnotsU;
-    std::vector<double> mInsertKnotsV;
-    
+    void CreateAndAddRegularGrid2D( ModelPart& r_model_part, const Point& A_xyz, const Point& B_xyz, const Point& A_uvw, const Point& B_uvw,
+        SizeType OrderU, SizeType OrderV, SizeType NumKnotSpansU, SizeType NumKnotSpansV, bool add_surface_to_model_part ) override;
 
 private:
+
     ///@name Private Member Variables
     ///@{
 
@@ -112,7 +109,7 @@ private:
 
     ///@}
     ///@name Private Operations
-    
+    ///@{
 
     /**
      * @brief Creates a cartesian grid composed out of trivariant B-spline cubes.
@@ -125,6 +122,7 @@ private:
     void CreateAndAddRegularGrid3D( ModelPart& r_model_part, const Point& A_xyz, const Point& B_xyz, const Point& A_uvw, const Point& B_uvw,
        SizeType OrderU, SizeType OrderV, SizeType OrderW, SizeType NumKnotSpansU, SizeType NumKnotSpansV, SizeType NumKnotSpansW );
 
+    Parameters ReadParamatersFile(const std::string& rDataFileName) const;   
 };
 
 } // End namesapce Kratos

--- a/applications/IgaApplication/custom_modelers/nurbs_geometry_modeler_sbm.h
+++ b/applications/IgaApplication/custom_modelers/nurbs_geometry_modeler_sbm.h
@@ -11,21 +11,14 @@
 //                   Andrea Gorgi
 //
 
-#if !defined(KRATOS_NURBS_GEOMETRY_MODELER_SBM_H_INCLUDED )
-#define  KRATOS_NURBS_GEOMETRY_MODELER_SBM_H_INCLUDED
+# pragma once
 
 // System includes
 
 // External includes
 
 // Project includes
-#include "includes/model_part.h"
 #include "nurbs_geometry_modeler.h"
-#include "geometries/nurbs_volume_geometry.h"
-#include "geometries/nurbs_surface_geometry.h"
-#include "geometries/nurbs_shape_function_utilities/nurbs_surface_refinement_utilities.h"
-#include "geometries/brep_curve_on_surface.h"
-#include "utilities/nurbs_utilities/snake_sbm_utilities.h"
 
 namespace Kratos {
 
@@ -37,21 +30,21 @@ public:
     ///@{
     KRATOS_CLASS_POINTER_DEFINITION( NurbsGeometryModelerSbm );
 
-    typedef std::size_t IndexType;
-    typedef std::size_t SizeType;
-    typedef Node NodeType;
+    using IndexType = std::size_t;
+    using SizeType = std::size_t;
+    using NodeType = Node;
 
-    typedef Geometry<NodeType> GeometryType;
-    typedef typename GeometryType::Pointer GeometryPointerType;
+    using GeometryType = Geometry<NodeType>;
+    using GeometryPointerType = GeometryType::Pointer;
 
-    typedef NurbsSurfaceGeometry<3, PointerVector<NodeType>> NurbsSurfaceGeometryType;
-    typedef typename NurbsSurfaceGeometryType::Pointer NurbsSurfaceGeometryPointerType;
+    using NurbsSurfaceGeometryType = NurbsSurfaceGeometry<3, PointerVector<NodeType>>;
+    using NurbsSurfaceGeometryPointerType = NurbsSurfaceGeometryType::Pointer;
 
-    typedef NurbsVolumeGeometry<PointerVector<NodeType>> NurbsVolumeGeometryType;
-    typedef typename NurbsVolumeGeometryType::Pointer NurbsVolumeGeometryPointerType;
+    using NurbsVolumeGeometryType = NurbsVolumeGeometry<PointerVector<NodeType>>;
+    using NurbsVolumeGeometryPointerType = NurbsVolumeGeometryType::Pointer;
 
-    typedef PointerVector<Node> ContainerNodeType;
-    typedef PointerVector<Point> ContainerEmbeddedNodeType;
+    using ContainerNodeType = PointerVector<Node>;
+    using ContainerEmbeddedNodeType = PointerVector<Point>;
 
     ///@}
     ///@name Life Cycle
@@ -126,4 +119,3 @@ private:
 };
 
 } // End namesapce Kratos
-#endif // KRATOS_NURBS_GEOMETRY_MODELER_H_INCLUDED

--- a/applications/IgaApplication/custom_modelers/nurbs_geometry_modeler_sbm.h
+++ b/applications/IgaApplication/custom_modelers/nurbs_geometry_modeler_sbm.h
@@ -64,7 +64,7 @@ public:
     }
 
     /// Destructor.
-    virtual ~NurbsGeometryModelerSbm() = default;
+    ~NurbsGeometryModelerSbm() = default;
 
     /// Creates the Modeler Pointer
     Modeler::Pointer Create(Model& rModel, const Parameters ModelParameters) const override

--- a/applications/IgaApplication/custom_utilities/create_breps_sbm_utilities.h
+++ b/applications/IgaApplication/custom_utilities/create_breps_sbm_utilities.h
@@ -11,9 +11,7 @@
 //                   Andrea Gorgi
 //
 
-#if !defined(KRATOS_CREATE_BREPS_SBM_UTILITIES_INCLUDED )
-#define  KRATOS_CREATE_BREPS_SBM_UTILITIES_INCLUDED
-
+# pragma once
 
 // System includes
 
@@ -55,36 +53,36 @@ class CreateBrepsSBMUtilities : public IO
     /// Pointer definition of CreateBrepsSBMUtilities
     KRATOS_CLASS_POINTER_DEFINITION(CreateBrepsSBMUtilities);
 
-    typedef std::size_t SizeType;
-    typedef std::size_t IndexType;
+    using SizeType = std::size_t;
+    using IndexType = std::size_t;
 
-    typedef Geometry<TNodeType> GeometryType;
-    typedef typename GeometryType::Pointer GeometryPointerType;
+    using GeometryType = Geometry<TNodeType>;
+    using GeometryPointerType = typename GeometryType::Pointer;
 
-    typedef PointerVector<TNodeType> ContainerNodeType;
-    typedef PointerVector<TEmbeddedNodeType> ContainerEmbeddedNodeType;
+    using ContainerNodeType = PointerVector<TNodeType>;
+    using ContainerEmbeddedNodeType = PointerVector<TEmbeddedNodeType>;
 
-    typedef CouplingGeometry<TNodeType> CouplingGeometryType;
+    using CouplingGeometryType = CouplingGeometry<TNodeType>;
 
-    typedef NurbsSurfaceGeometry<3, ContainerNodeType> NurbsSurfaceType;
-    typedef NurbsCurveGeometry<2, ContainerEmbeddedNodeType> NurbsTrimmingCurveType;
+    using NurbsSurfaceType = NurbsSurfaceGeometry<3, ContainerNodeType>;
+    using NurbsTrimmingCurveType = NurbsCurveGeometry<2, ContainerEmbeddedNodeType>;
 
-    typedef typename NurbsSurfaceType::Pointer NurbsSurfacePointerType;
-    typedef typename NurbsTrimmingCurveType::Pointer NurbsTrimmingCurvePointerType;
+    using NurbsSurfacePointerType = typename NurbsSurfaceType::Pointer;
+    using NurbsTrimmingCurvePointerType = typename NurbsTrimmingCurveType::Pointer;
 
-    typedef NurbsSurfaceGeometry<3, PointerVector<NodeType>> NurbsSurfaceGeometryType;
-    typedef typename NurbsSurfaceGeometryType::Pointer NurbsSurfaceGeometryPointerType;
+    using NurbsSurfaceGeometryType = NurbsSurfaceGeometry<3, PointerVector<NodeType>>;
+    using NurbsSurfaceGeometryPointerType = typename NurbsSurfaceGeometryType::Pointer;
 
-    typedef BrepSurface<ContainerNodeType, true, ContainerEmbeddedNodeType> BrepSurfaceType;
-    typedef BrepCurveOnSurface<ContainerNodeType, true, ContainerEmbeddedNodeType> BrepCurveOnSurfaceType;
-    
-    typedef BrepCurve<ContainerNodeType, ContainerEmbeddedNodeType> BrepCurveType;
-    typedef PointOnGeometry<ContainerNodeType, 3, 2> PointOnGeometryOnSurfaceType;
-    typedef PointOnGeometry<ContainerNodeType, 3, 1> PointOnGeometryOnCurveType;
+    using BrepSurfaceType = BrepSurface<ContainerNodeType, true, ContainerEmbeddedNodeType>;
+    using BrepCurveOnSurfaceType = BrepCurveOnSurface<ContainerNodeType, true, ContainerEmbeddedNodeType>;
 
-    typedef DenseVector<typename BrepCurveOnSurfaceType::Pointer> BrepCurveOnSurfaceArrayType;
-    typedef DenseVector<typename BrepCurveOnSurfaceType::Pointer> BrepCurveOnSurfaceLoopType;
-    typedef DenseVector<DenseVector<typename BrepCurveOnSurfaceType::Pointer>> BrepCurveOnSurfaceLoopArrayType;
+    using BrepCurveType = BrepCurve<ContainerNodeType, ContainerEmbeddedNodeType>;
+    using PointOnGeometryOnSurfaceType = PointOnGeometry<ContainerNodeType, 3, 2>;
+    using PointOnGeometryOnCurveType = PointOnGeometry<ContainerNodeType, 3, 1>;
+
+    using BrepCurveOnSurfaceArrayType = DenseVector<typename BrepCurveOnSurfaceType::Pointer>;
+    using BrepCurveOnSurfaceLoopType = DenseVector<typename BrepCurveOnSurfaceType::Pointer>;
+    using BrepCurveOnSurfaceLoopArrayType = DenseVector<DenseVector<typename BrepCurveOnSurfaceType::Pointer>>;
 
     ///@}
     ///@name Life Cycle
@@ -443,5 +441,3 @@ private:
     ///@}
 }; // Class CreateBrepsSBMUtilities
 }  // namespace Kratos.
-
-#endif

--- a/applications/IgaApplication/custom_utilities/create_breps_sbm_utilities.h
+++ b/applications/IgaApplication/custom_utilities/create_breps_sbm_utilities.h
@@ -103,10 +103,10 @@ class CreateBrepsSBMUtilities : public IO
     ///@{
 
     /// Adds the surface geometry to the herin provided model_part and create the boundary breps for the SBM case.
-    void CreateSurrogateBoundary(NurbsSurfaceGeometryPointerType& p_surface, ModelPart& rModelPart, ModelPart& rSurrogateModelPart_inner, ModelPart& rSurrogateModelPart_outer, const Point& A_uvw, const Point& B_uvw)
+    void CreateSurrogateBoundary(NurbsSurfaceGeometryPointerType& p_surface, ModelPart& rModelPart, ModelPart& rSurrogateModelPartInner, ModelPart& rSurrogateModelPartOuter, const Point& A_uvw, const Point& B_uvw)
     {
-        CreateBrepSurface(p_surface, rModelPart, rSurrogateModelPart_inner, rSurrogateModelPart_outer, mEchoLevel);
-        CreateBrepCurveOnSurfaces(p_surface, rModelPart, rSurrogateModelPart_inner, rSurrogateModelPart_outer, A_uvw, B_uvw, mEchoLevel);
+        CreateBrepSurface(p_surface, rModelPart, rSurrogateModelPartInner, rSurrogateModelPartOuter, mEchoLevel);
+        CreateBrepCurveOnSurfaces(p_surface, rModelPart, rSurrogateModelPartInner, rSurrogateModelPartOuter, A_uvw, B_uvw, mEchoLevel);
     }
 
     /// Adds the surface geometry to the herin provided model_part and create the boundary breps when SBM is not needed.
@@ -155,15 +155,15 @@ private:
      * 
      * @param p_surface 
      * @param rModelPart 
-     * @param rSurrogateModelPart_inner 
-     * @param rSurrogateModelPart_outer 
+     * @param rSurrogateModelPartInner 
+     * @param rSurrogateModelPartOuter 
      * @param EchoLevel 
      */
     static void CreateBrepSurface(
         NurbsSurfaceGeometryPointerType p_surface,
         ModelPart& rModelPart,
-        ModelPart& rSurrogateModelPart_inner, 
-        ModelPart& rSurrogateModelPart_outer,
+        ModelPart& rSurrogateModelPartInner, 
+        ModelPart& rSurrogateModelPartOuter,
         SizeType EchoLevel = 0)
     {
         KRATOS_INFO_IF("ReadBrepSurface", (EchoLevel > 3))
@@ -176,8 +176,8 @@ private:
                 p_surface, 
                 outer_loops,
                 inner_loops,
-                rSurrogateModelPart_inner,
-                rSurrogateModelPart_outer);
+                rSurrogateModelPartInner,
+                rSurrogateModelPartOuter);
 
         // Sets the brep as geometry parent of the nurbs surface.
         p_surface->SetGeometryParent(p_brep_surface.get());
@@ -189,8 +189,8 @@ private:
     static void CreateBrepCurveOnSurfaces(
         NurbsSurfaceGeometryPointerType p_surface,
         ModelPart& rModelPart,
-        ModelPart& rSurrogateModelPart_inner, 
-        ModelPart& rSurrogateModelPart_outer,
+        ModelPart& rSurrogateModelPartInner, 
+        ModelPart& rSurrogateModelPartOuter,
         const Point& A_uvw, const Point& B_uvw,
         SizeType EchoLevel = 0) {
     
@@ -200,12 +200,12 @@ private:
 
         int id_brep_curve_on_surface = 2;
 
-        if (rSurrogateModelPart_outer.Nodes().size() > 0) {
-            int sizeSurrogateLoop_outer = rSurrogateModelPart_outer.Nodes().size();
+        if (rSurrogateModelPartOuter.Nodes().size() > 0) {
+            int sizeSurrogateLoop_outer = rSurrogateModelPartOuter.Nodes().size();
             std::vector<double> surrogatecoord_x_outer(sizeSurrogateLoop_outer);
             std::vector<double> surrogatecoord_y_outer(sizeSurrogateLoop_outer);
             int countSurrogateLoop_outer = 0;
-            for (auto i_node = rSurrogateModelPart_outer.NodesEnd()-1; i_node != rSurrogateModelPart_outer.NodesBegin()-1; i_node--) {
+            for (auto i_node = rSurrogateModelPartOuter.NodesEnd()-1; i_node != rSurrogateModelPartOuter.NodesBegin()-1; i_node--) {
                 surrogatecoord_x_outer[countSurrogateLoop_outer] = i_node->X();
                 surrogatecoord_y_outer[countSurrogateLoop_outer] = i_node->Y();
                 countSurrogateLoop_outer++;
@@ -276,17 +276,17 @@ private:
         }
 
         // INNER
-        for (IndexType iel = 1; iel < rSurrogateModelPart_inner.Elements().size()+1; iel++) {
-            int firstSurrogateNodeId = rSurrogateModelPart_inner.pGetElement(iel)->GetGeometry()[0].Id(); // Element 1 because is the only surrogate loop
-            int lastSurrogateNodeId = rSurrogateModelPart_inner.pGetElement(iel)->GetGeometry()[1].Id();  // Element 1 because is the only surrogate loop
+        for (IndexType iel = 1; iel < rSurrogateModelPartInner.Elements().size()+1; iel++) {
+            int firstSurrogateNodeId = rSurrogateModelPartInner.pGetElement(iel)->GetGeometry()[0].Id(); // Element 1 because is the only surrogate loop
+            int lastSurrogateNodeId = rSurrogateModelPartInner.pGetElement(iel)->GetGeometry()[1].Id();  // Element 1 because is the only surrogate loop
             int sizeSurrogateLoop = lastSurrogateNodeId - firstSurrogateNodeId + 1;
 
             int countSurrogateLoop = 0;
             std::vector<double> surrogatecoord_x(sizeSurrogateLoop);
             std::vector<double> surrogatecoord_y(sizeSurrogateLoop);
             for (int id_node = firstSurrogateNodeId; id_node < lastSurrogateNodeId+1; id_node++) {
-                surrogatecoord_x[countSurrogateLoop] = rSurrogateModelPart_inner.GetNode(id_node).X();
-                surrogatecoord_y[countSurrogateLoop] = rSurrogateModelPart_inner.GetNode(id_node).Y();
+                surrogatecoord_x[countSurrogateLoop] = rSurrogateModelPartInner.GetNode(id_node).X();
+                surrogatecoord_y[countSurrogateLoop] = rSurrogateModelPartInner.GetNode(id_node).Y();
                 countSurrogateLoop++;
             }
             std::vector<NurbsCurveGeometry<2, PointerVector<Point>>::Pointer> trimming_curves_GPT;

--- a/applications/IgaApplication/custom_utilities/create_breps_sbm_utilities.h
+++ b/applications/IgaApplication/custom_utilities/create_breps_sbm_utilities.h
@@ -1,0 +1,406 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
+//
+//  Main authors:    Nicolo' Antonelli
+//                   Andrea Gorgi
+//
+
+#if !defined(KRATOS_CREATE_BREPS_SBM_UTILITIES_INCLUDED )
+#define  KRATOS_CREATE_BREPS_SBM_UTILITIES_INCLUDED
+
+
+// System includes
+
+// External includes
+
+// Project includes
+#include "includes/io.h"
+#include "includes/kratos_parameters.h"
+#include "includes/model_part.h"
+
+// Geometries
+#include "geometries/coupling_geometry.h"
+#include "geometries/point_on_geometry.h"
+
+#include "geometries/nurbs_curve_geometry.h"
+#include "geometries/nurbs_surface_geometry.h"
+
+#include "geometries/brep_surface.h"
+#include "geometries/brep_curve.h"
+
+#include "geometries/nurbs_curve_on_surface_geometry.h"
+#include "geometries/brep_curve_on_surface.h"
+
+
+namespace Kratos
+{
+
+///@name Kratos Classes
+///@{
+template<class TNodeType = Node, class TEmbeddedNodeType = Point>
+class CreateBrepsSBMUtilities : public IO
+{
+    public:
+
+    ///@}
+    ///@name Type Definitions
+    ///@{
+
+    /// Pointer definition of CreateBrepsSBMUtilities
+    KRATOS_CLASS_POINTER_DEFINITION(CreateBrepsSBMUtilities);
+
+    typedef std::size_t SizeType;
+    typedef std::size_t IndexType;
+
+    typedef Geometry<TNodeType> GeometryType;
+    typedef typename GeometryType::Pointer GeometryPointerType;
+
+    typedef PointerVector<TNodeType> ContainerNodeType;
+    typedef PointerVector<TEmbeddedNodeType> ContainerEmbeddedNodeType;
+
+    typedef CouplingGeometry<TNodeType> CouplingGeometryType;
+
+    typedef NurbsSurfaceGeometry<3, ContainerNodeType> NurbsSurfaceType;
+    typedef NurbsCurveGeometry<2, ContainerEmbeddedNodeType> NurbsTrimmingCurveType;
+
+    typedef typename NurbsSurfaceType::Pointer NurbsSurfacePointerType;
+    typedef typename NurbsTrimmingCurveType::Pointer NurbsTrimmingCurvePointerType;
+
+    typedef NurbsSurfaceGeometry<3, PointerVector<NodeType>> NurbsSurfaceGeometryType;
+    typedef typename NurbsSurfaceGeometryType::Pointer NurbsSurfaceGeometryPointerType;
+
+    typedef BrepSurface<ContainerNodeType, true, ContainerEmbeddedNodeType> BrepSurfaceType;
+    typedef BrepCurveOnSurface<ContainerNodeType, true, ContainerEmbeddedNodeType> BrepCurveOnSurfaceType;
+    
+    typedef BrepCurve<ContainerNodeType, ContainerEmbeddedNodeType> BrepCurveType;
+    typedef PointOnGeometry<ContainerNodeType, 3, 2> PointOnGeometryOnSurfaceType;
+    typedef PointOnGeometry<ContainerNodeType, 3, 1> PointOnGeometryOnCurveType;
+
+    typedef DenseVector<typename BrepCurveOnSurfaceType::Pointer> BrepCurveOnSurfaceArrayType;
+    typedef DenseVector<typename BrepCurveOnSurfaceType::Pointer> BrepCurveOnSurfaceLoopType;
+    typedef DenseVector<DenseVector<typename BrepCurveOnSurfaceType::Pointer>> BrepCurveOnSurfaceLoopArrayType;
+
+    ///@}
+    ///@name Life Cycle
+    ///@{
+
+    /// Constructor with path to input file.
+    CreateBrepsSBMUtilities(
+        SizeType EchoLevel = 0)
+        : mEchoLevel(EchoLevel)
+    {
+    }
+
+    /// Destructor.
+    ~CreateBrepsSBMUtilities() = default;
+
+    ///@}
+    ///@name Python exposed Functions
+    ///@{
+
+    /// Adds all CAD geometries to the herin provided model_part.
+    void CreateSurrogateBoundary(NurbsSurfaceGeometryPointerType& p_surface, ModelPart& rModelPart, ModelPart& rSurrogateModelPart_inner, ModelPart& rSurrogateModelPart_outer, const Point& A_uvw, const Point& B_uvw)
+    {
+        CreateBrepSurface(p_surface, rModelPart, rSurrogateModelPart_inner, rSurrogateModelPart_outer, mEchoLevel);
+        CreateBrepCurveOnSurfaces(p_surface, rModelPart, rSurrogateModelPart_inner, rSurrogateModelPart_outer, A_uvw, B_uvw, mEchoLevel);
+    }
+
+
+private:
+
+    // 2D
+    static void CreateBrepSurface(
+        NurbsSurfaceGeometryPointerType p_surface,
+        ModelPart& rModelPart,
+        ModelPart& rSurrogateModelPart_inner, 
+        ModelPart& rSurrogateModelPart_outer,
+        SizeType EchoLevel = 0)
+    {
+        KRATOS_INFO_IF("ReadBrepSurface", (EchoLevel > 3))
+            << "Creating BrepSurface \""<< std::endl;
+
+        bool case1 = rSurrogateModelPart_outer.Nodes().size() > 0;
+        bool case2 = rSurrogateModelPart_inner.Nodes().size() > 0;
+        BrepCurveOnSurfaceLoopArrayType outer_loops, inner_loops;
+
+        auto p_brep_surface =
+            Kratos::make_shared<BrepSurfaceType>(
+                p_surface, 
+                outer_loops,
+                inner_loops,
+                rSurrogateModelPart_inner,
+                rSurrogateModelPart_outer);
+
+        // Sets the brep as geometry parent of the nurbs surface.
+        p_surface->SetGeometryParent(p_brep_surface.get());
+
+        SizeType last_geometry_id = rModelPart.GetParentModelPart().Geometries().size();
+        p_brep_surface->SetId(1);
+        rModelPart.AddGeometry(p_brep_surface);
+
+    }
+
+
+    static void CreateBrepCurveOnSurfaces(
+        NurbsSurfaceGeometryPointerType p_surface,
+        ModelPart& rModelPart,
+        ModelPart& rSurrogateModelPart_inner, 
+        ModelPart& rSurrogateModelPart_outer,
+        const Point& A_uvw, const Point& B_uvw,
+        SizeType EchoLevel = 0) {
+    
+        // OUTER :
+        // Each element in the surrogate_model_part represents a surrogate boundary loop. First "node" is the initial ID of the first surrogate node and
+        // the second "node" is the last surrogate node of that loop. (We have done this in the case we have multiple surrogate boundaries and 1 model part)
+
+        int Id_brep_curve_on_surface = 2;
+
+        if (rSurrogateModelPart_outer.Nodes().size() > 0) {
+            int sizeSurrogateLoop_outer = rSurrogateModelPart_outer.Nodes().size();
+            std::vector<double> surrogatecoord_x_outer(sizeSurrogateLoop_outer);
+            std::vector<double> surrogatecoord_y_outer(sizeSurrogateLoop_outer);
+            int countSurrogateLoop_outer = 0;
+            for (auto i_node = rSurrogateModelPart_outer.NodesEnd()-1; i_node != rSurrogateModelPart_outer.NodesBegin()-1; i_node--) {
+                surrogatecoord_x_outer[countSurrogateLoop_outer] = i_node->X();
+                surrogatecoord_y_outer[countSurrogateLoop_outer] = i_node->Y();
+                countSurrogateLoop_outer++;
+            }
+            // OUTER 
+            std::vector<NurbsCurveGeometry<2, PointerVector<Point>>::Pointer> trimming_curves_GPT_outer;
+            for (std::size_t i = 0; i < surrogatecoord_x_outer.size(); ++i) {
+                Vector active_range_knot_vector = ZeroVector(2);
+                
+                Point::Pointer point1 = Kratos::make_shared<Point>(surrogatecoord_x_outer[i], surrogatecoord_y_outer[i], 0.0);
+                Point::Pointer point2 = Kratos::make_shared<Point>(
+                    surrogatecoord_x_outer[(i + 1) % surrogatecoord_x_outer.size()],  // Wrap around for the last point
+                    surrogatecoord_y_outer[(i + 1) % surrogatecoord_y_outer.size()],  // Wrap around for the last point
+                    0.0);
+                // Compute the knot vector needed
+                if (surrogatecoord_x_outer[(i + 1) % surrogatecoord_x_outer.size()]==surrogatecoord_x_outer[i]) {
+                    active_range_knot_vector[0] = surrogatecoord_y_outer[i];
+                    active_range_knot_vector[1] = surrogatecoord_y_outer[(i + 1) % surrogatecoord_y_outer.size()];
+                }
+                else {
+                    active_range_knot_vector[0] = surrogatecoord_x_outer[i];
+                    active_range_knot_vector[1] = surrogatecoord_x_outer[(i + 1) % surrogatecoord_x_outer.size()];
+                }
+                //// Order the active_range_knot_vector
+                if (active_range_knot_vector[0] > active_range_knot_vector[1]) {
+                    double temp = active_range_knot_vector[1];
+                    active_range_knot_vector[1] = active_range_knot_vector[0] ;
+                    active_range_knot_vector[0] = temp ;
+                }
+                NurbsCurveGeometry<2, PointerVector<Point>>::Pointer p_trimming_curve = CreateSingleBrep(point1, point2, active_range_knot_vector);
+                trimming_curves_GPT_outer.push_back(p_trimming_curve);
+            }
+
+            BrepCurveOnSurfaceLoopType trimming_brep_curve_vector_outer(surrogatecoord_x_outer.size());
+
+            for (std::size_t i = 0; i < trimming_curves_GPT_outer.size(); ++i) {
+                Vector active_range_vector = ZeroVector(2);
+                if (surrogatecoord_x_outer[(i + 1) % surrogatecoord_x_outer.size()]==surrogatecoord_x_outer[i]) {
+                    active_range_vector[0] = surrogatecoord_y_outer[i];
+                    active_range_vector[1] = surrogatecoord_y_outer[(i + 1) % surrogatecoord_x_outer.size()];
+                }
+                else {
+                    active_range_vector[0] = surrogatecoord_x_outer[i];
+                    active_range_vector[1] = surrogatecoord_x_outer[(i + 1) % surrogatecoord_x_outer.size()];
+                }
+                bool curve_direction = true;
+
+                // Re-order
+                if (active_range_vector[0] > active_range_vector[1]) {
+                    double temp = active_range_vector[1];
+                    active_range_vector[1] = active_range_vector[0] ;
+                    active_range_vector[0] = temp ;
+                }
+
+                NurbsInterval brep_active_range(active_range_vector[0], active_range_vector[1]);
+
+                auto p_brep_curve_on_surface = Kratos::make_shared<BrepCurveOnSurfaceType>(
+                    p_surface, trimming_curves_GPT_outer[i], brep_active_range, curve_direction);
+                p_brep_curve_on_surface->SetId(Id_brep_curve_on_surface);
+
+                rModelPart.AddGeometry(p_brep_curve_on_surface);
+                Id_brep_curve_on_surface++;
+
+            }
+
+        } else {
+            CreateBrepCurvesOnRectangle(rModelPart, p_surface, A_uvw, B_uvw, Id_brep_curve_on_surface);
+        }
+
+        // INNER
+        for (int iel = 1; iel < rSurrogateModelPart_inner.Elements().size()+1; iel++) {
+            int firstSurrogateNodeId = rSurrogateModelPart_inner.pGetElement(iel)->GetGeometry()[0].Id(); // Element 1 because is the only surrogate loop
+            int lastSurrogateNodeId = rSurrogateModelPart_inner.pGetElement(iel)->GetGeometry()[1].Id();  // Element 1 because is the only surrogate loop
+            int sizeSurrogateLoop = lastSurrogateNodeId - firstSurrogateNodeId + 1;
+
+            int countSurrogateLoop = 0;
+            std::vector<double> surrogatecoord_x(sizeSurrogateLoop);
+            std::vector<double> surrogatecoord_y(sizeSurrogateLoop);
+            for (int id_node = firstSurrogateNodeId; id_node < lastSurrogateNodeId+1; id_node++) {
+                surrogatecoord_x[countSurrogateLoop] = rSurrogateModelPart_inner.GetNode(id_node).X();
+                surrogatecoord_y[countSurrogateLoop] = rSurrogateModelPart_inner.GetNode(id_node).Y();
+                countSurrogateLoop++;
+            }
+            std::vector<NurbsCurveGeometry<2, PointerVector<Point>>::Pointer> trimming_curves_GPT;
+
+            for (std::size_t i = 0; i < surrogatecoord_x.size(); ++i) {
+                Vector active_range_knot_vector = ZeroVector(2);
+                
+                Point::Pointer point1 = Kratos::make_shared<Point>(surrogatecoord_x[i], surrogatecoord_y[i], 0.0);
+                Point::Pointer point2 = Kratos::make_shared<Point>(
+                    surrogatecoord_x[(i + 1) % surrogatecoord_x.size()],  // Wrap around for the last point
+                    surrogatecoord_y[(i + 1) % surrogatecoord_y.size()],  // Wrap around for the last point
+                    0.0);
+                // Compute the knot vector needed
+                if (surrogatecoord_x[(i + 1) % surrogatecoord_x.size()]==surrogatecoord_x[i]) {
+                    active_range_knot_vector[0] = surrogatecoord_y[i];
+                    active_range_knot_vector[1] = surrogatecoord_y[(i + 1) % surrogatecoord_y.size()];
+                }
+                else {
+                    active_range_knot_vector[0] = surrogatecoord_x[i];
+                    active_range_knot_vector[1] = surrogatecoord_x[(i + 1) % surrogatecoord_x.size()];
+                }
+                // Order the active_range_knot_vector
+                if (active_range_knot_vector[0] > active_range_knot_vector[1]) {
+                    double temp = active_range_knot_vector[1];
+                    active_range_knot_vector[1] = active_range_knot_vector[0] ;
+                    active_range_knot_vector[0] = temp ;
+                }
+                NurbsCurveGeometry<2, PointerVector<Point>>::Pointer p_trimming_curve = CreateSingleBrep(point1, point2, active_range_knot_vector);
+                trimming_curves_GPT.push_back(p_trimming_curve);
+            }
+
+            BrepCurveOnSurfaceLoopType trimming_brep_curve_vector(surrogatecoord_x.size());
+
+
+            for (std::size_t i = 0; i < trimming_curves_GPT.size(); ++i) {
+                Vector active_range_vector = ZeroVector(2);
+                if (surrogatecoord_x[(i + 1) % surrogatecoord_x.size()]==surrogatecoord_x[i]) {
+                    active_range_vector[0] = surrogatecoord_y[i];
+                    active_range_vector[1] = surrogatecoord_y[(i + 1) % surrogatecoord_x.size()];
+                }
+                else {
+                    active_range_vector[0] = surrogatecoord_x[i];
+                    active_range_vector[1] = surrogatecoord_x[(i + 1) % surrogatecoord_x.size()];
+                }
+                bool curve_direction = true;
+
+                // re-order
+                if (active_range_vector[0] > active_range_vector[1]) {
+                    double temp = active_range_vector[1];
+                    active_range_vector[1] = active_range_vector[0] ;
+                    active_range_vector[0] = temp ;
+                }
+
+                NurbsInterval brep_active_range(active_range_vector[0], active_range_vector[1]);
+
+                auto p_brep_curve_on_surface = Kratos::make_shared<BrepCurveOnSurfaceType>(
+                    p_surface, trimming_curves_GPT[i], brep_active_range, curve_direction);
+                p_brep_curve_on_surface->SetId(Id_brep_curve_on_surface);
+                rModelPart.AddGeometry(p_brep_curve_on_surface);
+                Id_brep_curve_on_surface++;
+                trimming_brep_curve_vector[i] = p_brep_curve_on_surface ;
+
+            }
+
+        }
+    } 
+    
+
+
+    ///@}
+    ///@name Utility functions
+    ///@{
+
+    int mEchoLevel;
+
+    static typename NurbsCurveGeometry<2, PointerVector<Point>>::Pointer CreateSingleBrep(
+        Point::Pointer point1, Point::Pointer point2, Vector active_range_knot_vector)
+        {
+            // Create the data for the trimming curves
+            PointerVector<Point> control_points;
+            control_points.push_back(point1);
+            control_points.push_back(point2);
+            int polynomial_degree = 1;
+            Vector knot_vector = ZeroVector(4) ;
+            knot_vector[0] = active_range_knot_vector[0] ;
+            knot_vector[1] = active_range_knot_vector[0] ;
+            knot_vector[2] = active_range_knot_vector[1] ;
+            knot_vector[3] = active_range_knot_vector[1] ;
+            // Create the trimming curves
+            typename NurbsCurveGeometry<2, PointerVector<Point>>::Pointer p_trimming_curve(
+                new NurbsCurveGeometry<2, PointerVector<Point>>(
+                    control_points,
+                    polynomial_degree,
+                    knot_vector));   
+            return p_trimming_curve;
+        }
+    
+
+    
+    static void CreateBrepCurvesOnRectangle(ModelPart& r_model_part, NurbsSurfaceGeometryPointerType p_surface_geometry, const Point& A_uvw, const Point& B_uvw, int &last_geometry_id) {
+        Vector knot_vector = ZeroVector(2);
+        knot_vector[0] = 0.0;
+        knot_vector[1] = std::abs(B_uvw[0] - A_uvw[0]);
+        int p = 1;
+
+        NurbsCurveGeometry<2, PointerVector<Point>>::PointsArrayType segment1;
+        segment1.push_back(Point::Pointer(new Point(A_uvw[0], A_uvw[1])));
+        segment1.push_back(Point::Pointer(new Point(B_uvw[0], A_uvw[1])));
+
+        NurbsCurveGeometry<2, PointerVector<Point>>::PointsArrayType segment2;
+        segment2.push_back(Point::Pointer(new Point(B_uvw[0], A_uvw[1])));
+        segment2.push_back(Point::Pointer(new Point(B_uvw[0], B_uvw[1])));
+        
+        NurbsCurveGeometry<2, PointerVector<Point>>::PointsArrayType segment3;
+        segment3.push_back(Point::Pointer(new Point(B_uvw[0], B_uvw[1])));
+        segment3.push_back(Point::Pointer(new Point(A_uvw[0], B_uvw[1])));
+        
+        NurbsCurveGeometry<2, PointerVector<Point>>::PointsArrayType segment4;
+        segment4.push_back(Point::Pointer(new Point(A_uvw[0], B_uvw[1])));
+        segment4.push_back(Point::Pointer(new Point(A_uvw[0], A_uvw[1])));
+
+        auto p_curve_1 = Kratos::make_shared<NurbsCurveGeometry<2, PointerVector<Point>>>(segment1, p, knot_vector);
+        auto p_curve_2 = Kratos::make_shared<NurbsCurveGeometry<2, PointerVector<Point>>>(segment2, p, knot_vector);
+        auto p_curve_3 = Kratos::make_shared<NurbsCurveGeometry<2, PointerVector<Point>>>(segment3, p, knot_vector);
+        auto p_curve_4 = Kratos::make_shared<NurbsCurveGeometry<2, PointerVector<Point>>>(segment4, p, knot_vector);
+        
+        
+        
+        auto brep_curve_on_surface = BrepCurveOnSurface< PointerVector<NodeType>, true, PointerVector<Point>>(p_surface_geometry, p_curve_1);
+        auto p_brep_curve_on_surface = Kratos::make_shared<BrepCurveOnSurfaceType>(p_surface_geometry, p_curve_1);
+        p_brep_curve_on_surface->SetId(last_geometry_id);
+        r_model_part.AddGeometry(p_brep_curve_on_surface);
+        
+        brep_curve_on_surface = BrepCurveOnSurface< PointerVector<NodeType>, true, PointerVector<Point>>(p_surface_geometry, p_curve_2);
+        p_brep_curve_on_surface = Kratos::make_shared<BrepCurveOnSurfaceType>(p_surface_geometry, p_curve_2);
+        p_brep_curve_on_surface->SetId(++last_geometry_id);
+        r_model_part.AddGeometry(p_brep_curve_on_surface);
+
+        brep_curve_on_surface = BrepCurveOnSurface< PointerVector<NodeType>, true, PointerVector<Point>>(p_surface_geometry, p_curve_3);
+        p_brep_curve_on_surface = Kratos::make_shared<BrepCurveOnSurfaceType>(p_surface_geometry, p_curve_3);
+        p_brep_curve_on_surface->SetId(++last_geometry_id);
+        r_model_part.AddGeometry(p_brep_curve_on_surface);
+        
+        brep_curve_on_surface = BrepCurveOnSurface< PointerVector<NodeType>, true, PointerVector<Point>>(p_surface_geometry, p_curve_4);
+        p_brep_curve_on_surface = Kratos::make_shared<BrepCurveOnSurfaceType>(p_surface_geometry, p_curve_4);
+        p_brep_curve_on_surface->SetId(++last_geometry_id);
+        r_model_part.AddGeometry(p_brep_curve_on_surface);
+
+        last_geometry_id++;
+    }
+
+    ///@}
+}; // Class CreateBrepsSBMUtilities
+}  // namespace Kratos.
+
+#endif

--- a/applications/IgaApplication/iga_application.cpp
+++ b/applications/IgaApplication/iga_application.cpp
@@ -90,6 +90,7 @@ KRATOS_INFO("") << "    KRATOS  _____ _____\n"
     KRATOS_REGISTER_MODELER("IgaModeler", mIgaModeler);
     KRATOS_REGISTER_MODELER("RefinementModeler", mRefinementModeler);
     KRATOS_REGISTER_MODELER("NurbsGeometryModeler", mNurbsGeometryModeler);
+    KRATOS_REGISTER_MODELER("NurbsGeometryModelerSbm", mNurbsGeometryModelerSbm);
 
     // VARIABLES
     KRATOS_REGISTER_VARIABLE(CROSS_AREA)

--- a/applications/IgaApplication/iga_application.h
+++ b/applications/IgaApplication/iga_application.h
@@ -43,6 +43,7 @@
 #include "custom_modelers/iga_modeler.h"
 #include "custom_modelers/refinement_modeler.h"
 #include "custom_modelers/nurbs_geometry_modeler.h"
+#include "custom_modelers/nurbs_geometry_modeler_sbm.h"
 
 namespace Kratos {
 
@@ -141,6 +142,7 @@ private:
     const IgaModeler mIgaModeler;
     const RefinementModeler mRefinementModeler;
     const NurbsGeometryModeler mNurbsGeometryModeler;
+    const NurbsGeometryModelerSbm mNurbsGeometryModelerSbm;
 
     ///@}
     ///@name Private methods

--- a/applications/IgaApplication/tests/test_IgaApplication.py
+++ b/applications/IgaApplication/tests/test_IgaApplication.py
@@ -45,6 +45,7 @@ from iga_test_factory import TwoPatchCantileverRefinedCouplingPenaltyTest as Two
 from test_nurbs_volume_element import TestNurbsVolumeElement as TTestNurbsVolumeElements
 # Modelers tests
 from test_modelers import TestModelers as TTestModelers
+from test_modelers_sbm import TestModelers as TTestModelersSbm
 # Processes tests
 from test_map_nurbs_volume_results_to_embedded_geometry_process import TestMapNurbsVolumeResultsToEmbeddedGeometryProcess as TTestMapNurbsVolumeResultsToEmbeddedGeometryProcess
 
@@ -93,6 +94,7 @@ def AssembleTestSuites():
         TTestNurbsVolumeElements,
         # Modelers
         TTestModelers,
+        TTestModelersSbm,
         TTestMapNurbsVolumeResultsToEmbeddedGeometryProcess
     ]))
 

--- a/applications/IgaApplication/tests/test_IgaApplication.py
+++ b/applications/IgaApplication/tests/test_IgaApplication.py
@@ -45,7 +45,7 @@ from iga_test_factory import TwoPatchCantileverRefinedCouplingPenaltyTest as Two
 from test_nurbs_volume_element import TestNurbsVolumeElement as TTestNurbsVolumeElements
 # Modelers tests
 from test_modelers import TestModelers as TTestModelers
-from test_modelers_sbm import TestModelers as TTestModelersSbm
+from test_modelers_sbm import TestModelersSbm as TTestModelersSbm
 # Processes tests
 from test_map_nurbs_volume_results_to_embedded_geometry_process import TestMapNurbsVolumeResultsToEmbeddedGeometryProcess as TTestMapNurbsVolumeResultsToEmbeddedGeometryProcess
 

--- a/applications/IgaApplication/tests/test_modelers_sbm.py
+++ b/applications/IgaApplication/tests/test_modelers_sbm.py
@@ -1,0 +1,285 @@
+import KratosMultiphysics
+import KratosMultiphysics.IgaApplication
+import KratosMultiphysics.KratosUnittest as KratosUnittest
+
+def run_modelers(current_model, modelers_list):
+    from KratosMultiphysics.modeler_factory import KratosModelerFactory
+    factory = KratosModelerFactory()
+    list_of_modelers = factory.ConstructListOfModelers(current_model, modelers_list)
+
+    for modeler in list_of_modelers:
+        modeler.SetupGeometryModel()
+
+    for modeler in list_of_modelers:
+        modeler.PrepareGeometryModel()
+
+    for modeler in list_of_modelers:
+        modeler.SetupModelPart()
+
+class TestModelersSbm(KratosUnittest.TestCase):
+    
+    # test for SBM
+    def test_nurbs_geometry_2d_modeler_sbm_outer_skin_boundary(self):
+        current_model = KratosMultiphysics.Model()
+        modeler_settings = KratosMultiphysics.Parameters("""
+        [{
+            "modeler_name": "NurbsGeometryModelerSbm",
+            "Parameters": {
+                "model_part_name" : "IgaModelPart",
+                "lower_point_xyz": [0.0,0.0,0.0],
+                "upper_point_xyz": [2.0,2.0,0.0],
+                "lower_point_uvw": [0.0,0.0,0.0],
+                "upper_point_uvw": [2.0,2.0,0.0],
+                "polynomial_order" : [1, 1],
+                "number_of_knot_spans" : [5,5],
+                "sbm_parameters": {
+                    "lambda_outer": 0.5,
+                    "number_of_inner_loops": 0
+                },
+                "skin_model_part_outer_initial_name": "skinModelPart_outer_initial",
+                "skin_model_part_name": "skinModelPart"
+            }
+        }]
+        """)
+       # New model
+        current_model = KratosMultiphysics.Model()
+        skin_model_part_outer_initial = current_model.CreateModelPart("skinModelPart_outer_initial")
+
+        skin_model_part_outer_initial.CreateNewProperties(1)
+
+        skin_model_part_outer_initial.CreateNewNode(1, 0.0, 0.0, 0.0)
+        skin_model_part_outer_initial.CreateNewNode(2, 2.0, 0.0, 0.0)
+        skin_model_part_outer_initial.CreateNewNode(3, 2.0, 2.0, 0.0)
+        skin_model_part_outer_initial.CreateNewNode(4, 0.0, 2.0, 0.0)
+
+        skin_model_part_outer_initial.CreateNewCondition("LineCondition2D2N", 1, [1, 2], skin_model_part_outer_initial.GetProperties()[1])
+        skin_model_part_outer_initial.CreateNewCondition("LineCondition2D2N", 2, [2, 3], skin_model_part_outer_initial.GetProperties()[1])
+        skin_model_part_outer_initial.CreateNewCondition("LineCondition2D2N", 3, [3, 4], skin_model_part_outer_initial.GetProperties()[1])
+        skin_model_part_outer_initial.CreateNewCondition("LineCondition2D2N", 4, [4, 1], skin_model_part_outer_initial.GetProperties()[1])
+
+        run_modelers(current_model, modeler_settings)
+        
+        # test surrogate nodes
+        self.assertEqual(current_model["IgaModelPart.surrogate_outer"].GetNodes()[43].X, 0.4)
+        self.assertEqual(current_model["IgaModelPart.surrogate_outer"].GetNodes()[43].Y, 2.0)
+        self.assertEqual(current_model["IgaModelPart.surrogate_outer"].GetNodes()[43].Z, 0.0)
+
+        self.assertEqual(current_model["IgaModelPart.surrogate_outer"].GetNodes()[51].X, 2.0)
+        self.assertEqual(current_model["IgaModelPart.surrogate_outer"].GetNodes()[51].Y, 0.4)
+        self.assertEqual(current_model["IgaModelPart.surrogate_outer"].GetNodes()[51].Z, 0.0)
+
+        # test the creation of the breps
+        self.assertEqual(current_model["IgaModelPart"].NumberOfGeometries(), 21)
+        self.assertAlmostEqual(current_model["IgaModelPart"].GetGeometry(1).Center().X, 1.0)
+        self.assertAlmostEqual(current_model["IgaModelPart"].GetGeometry(1).Center().Y, 1.0)
+        self.assertAlmostEqual(current_model["IgaModelPart"].GetGeometry(1).Center().Z, 0.0)
+
+    
+    # inner boundary single inner loop
+    def test_nurbs_geometry_2d_modeler_sbm_inner_skin_boundary(self):
+        current_model = KratosMultiphysics.Model()
+        modeler_settings = KratosMultiphysics.Parameters("""
+        [{
+            "modeler_name": "NurbsGeometryModelerSbm",
+            "Parameters": {
+                "model_part_name" : "IgaModelPart",
+                "lower_point_xyz": [0.0,0.0,0.0],
+                "upper_point_xyz": [4.0,6.0,0.0],
+                "lower_point_uvw": [0.0,0.0,0.0],
+                "upper_point_uvw": [4.0,6.0,0.0],
+                "polynomial_order" : [2, 2],
+                "number_of_knot_spans" : [6,9],
+                "sbm_parameters": {
+                    "lambda_inner": 0.5,
+                    "number_of_inner_loops": 1
+                },
+                "skin_model_part_inner_initial_name": "skinModelPart_inner_initial",
+                "skin_model_part_name": "skinModelPart"
+            }
+        }]
+        """)
+       # New model
+        current_model = KratosMultiphysics.Model()
+        skin_model_part_inner_initial = current_model.CreateModelPart("skinModelPart_inner_initial")
+
+        skin_model_part_inner_initial.CreateNewProperties(1)
+
+        skin_model_part_inner_initial.CreateNewNode(1, 0.5, 0.5, 0.0)
+        skin_model_part_inner_initial.CreateNewNode(2, 2.0, 0.5, 0.0)
+        skin_model_part_inner_initial.CreateNewNode(3, 2.0, 3.5, 0.0)
+        skin_model_part_inner_initial.CreateNewNode(4, 0.5, 3.5, 0.0)
+
+        skin_model_part_inner_initial.CreateNewCondition("LineCondition2D2N", 1, [1, 2], skin_model_part_inner_initial.GetProperties()[1])
+        skin_model_part_inner_initial.CreateNewCondition("LineCondition2D2N", 2, [2, 3], skin_model_part_inner_initial.GetProperties()[1])
+        skin_model_part_inner_initial.CreateNewCondition("LineCondition2D2N", 3, [3, 4], skin_model_part_inner_initial.GetProperties()[1])
+        skin_model_part_inner_initial.CreateNewCondition("LineCondition2D2N", 4, [4, 1], skin_model_part_inner_initial.GetProperties()[1])
+
+        run_modelers(current_model, modeler_settings)
+
+        # test surrogate nodes
+        self.assertEqual(current_model["IgaModelPart.surrogate_inner"].GetNodes()[92].X, 2/3)
+        self.assertEqual(current_model["IgaModelPart.surrogate_inner"].GetNodes()[92].Y, 8/3)
+        self.assertEqual(current_model["IgaModelPart.surrogate_inner"].GetNodes()[92].Z, 0.0)
+
+        self.assertEqual(current_model["IgaModelPart.surrogate_inner"].GetNodes()[98].X, 2.0)
+        self.assertEqual(current_model["IgaModelPart.surrogate_inner"].GetNodes()[98].Y, 4/3)
+        self.assertEqual(current_model["IgaModelPart.surrogate_inner"].GetNodes()[98].Z, 0.0)
+
+        # test the creation of the breps
+        self.assertEqual(current_model["IgaModelPart"].NumberOfGeometries(), 17)
+        self.assertAlmostEqual(current_model["IgaModelPart"].GetGeometry(1).Center().X, 2.0)
+        self.assertAlmostEqual(current_model["IgaModelPart"].GetGeometry(1).Center().Y, 3.0)
+        self.assertAlmostEqual(current_model["IgaModelPart"].GetGeometry(1).Center().Z, 0.0)
+
+
+    # inner boundary double inner loops
+    def test_nurbs_geometry_2d_modeler_sbm_two_inner_skin_boundary(self):
+        current_model = KratosMultiphysics.Model()
+        modeler_settings = KratosMultiphysics.Parameters("""
+        [{
+            "modeler_name": "NurbsGeometryModelerSbm",
+            "Parameters": {
+                "model_part_name" : "IgaModelPart",
+                "lower_point_xyz": [0.0,0.0,0.0],
+                "upper_point_xyz": [4.0,6.0,0.0],
+                "lower_point_uvw": [0.0,0.0,0.0],
+                "upper_point_uvw": [4.0,6.0,0.0],
+                "polynomial_order" : [2, 2],
+                "number_of_knot_spans" : [10,15],
+                "sbm_parameters": {
+                    "lambda_inner": 0.5,
+                    "number_of_inner_loops": 2
+                },
+                "skin_model_part_inner_initial_name": "skinModelPart_inner_initial",
+                "skin_model_part_name": "skinModelPart"
+            }
+        }]
+        """)
+
+        current_model = KratosMultiphysics.Model()
+
+        skin_model_part_inner_initial = current_model.CreateModelPart("skinModelPart_inner_initial")
+        skin_model_part_inner_initial.CreateNewProperties(1)
+
+        # object 1
+        skin_model_part_inner_initial.CreateNewNode(1, 0.5, 0.5, 0.0)
+        skin_model_part_inner_initial.CreateNewNode(2, 2.0, 0.5, 0.0)
+        skin_model_part_inner_initial.CreateNewNode(3, 2.0, 3.5, 0.0)
+        skin_model_part_inner_initial.CreateNewNode(4, 0.5, 3.5, 0.0)
+
+        skin_model_part_inner_initial.CreateNewCondition("LineCondition2D2N", 1, [1, 2], skin_model_part_inner_initial.GetProperties()[1])
+        skin_model_part_inner_initial.CreateNewCondition("LineCondition2D2N", 2, [2, 3], skin_model_part_inner_initial.GetProperties()[1])
+        skin_model_part_inner_initial.CreateNewCondition("LineCondition2D2N", 3, [3, 4], skin_model_part_inner_initial.GetProperties()[1])
+        skin_model_part_inner_initial.CreateNewCondition("LineCondition2D2N", 4, [4, 1], skin_model_part_inner_initial.GetProperties()[1])
+
+        # object 2
+        skin_model_part_inner_initial.CreateNewNode(5, 1.5, 4.6, 0.0)
+        skin_model_part_inner_initial.CreateNewNode(6, 3.7, 4.7, 0.0)
+        skin_model_part_inner_initial.CreateNewNode(7, 3.0, 5.5, 0.0)
+
+        skin_model_part_inner_initial.CreateNewCondition("LineCondition2D2N", 5, [5, 6], skin_model_part_inner_initial.GetProperties()[1])
+        skin_model_part_inner_initial.CreateNewCondition("LineCondition2D2N", 6, [6, 7], skin_model_part_inner_initial.GetProperties()[1])
+        skin_model_part_inner_initial.CreateNewCondition("LineCondition2D2N", 7, [7, 5], skin_model_part_inner_initial.GetProperties()[1])
+
+        run_modelers(current_model, modeler_settings)
+
+        # test surrogate nodes
+        self.assertAlmostEqual(current_model["IgaModelPart.surrogate_inner"].GetNodes()[226].X, 1.6)
+        self.assertAlmostEqual(current_model["IgaModelPart.surrogate_inner"].GetNodes()[226].Y, 0.4)
+        self.assertAlmostEqual(current_model["IgaModelPart.surrogate_inner"].GetNodes()[226].Z, 0.0)
+
+        self.assertAlmostEqual(current_model["IgaModelPart.surrogate_inner"].GetNodes()[235].X, 3.2)
+        self.assertAlmostEqual(current_model["IgaModelPart.surrogate_inner"].GetNodes()[235].Y, 5.2)
+        self.assertAlmostEqual(current_model["IgaModelPart.surrogate_inner"].GetNodes()[235].Z, 0.0)
+
+        self.assertAlmostEqual(current_model["IgaModelPart.surrogate_inner"].GetNodes()[213].X, 0.4)
+        self.assertAlmostEqual(current_model["IgaModelPart.surrogate_inner"].GetNodes()[213].Y, 3.6)
+        self.assertAlmostEqual(current_model["IgaModelPart.surrogate_inner"].GetNodes()[213].Z, 0.0)
+
+        # test the creation of the breps
+        self.assertEqual(current_model["IgaModelPart"].NumberOfGeometries(), 41)
+        self.assertAlmostEqual(current_model["IgaModelPart"].GetGeometry(1).Center().X, 2.0)
+        self.assertAlmostEqual(current_model["IgaModelPart"].GetGeometry(1).Center().Y, 3.0)
+        self.assertAlmostEqual(current_model["IgaModelPart"].GetGeometry(1).Center().Z, 0.0)
+
+    
+    # inner boundary single inner loop + outer
+    def test_nurbs_geometry_2d_modeler_sbm_inner_outer_skin_boundary(self):
+        current_model = KratosMultiphysics.Model()
+        modeler_settings = KratosMultiphysics.Parameters("""
+        [{
+            "modeler_name": "NurbsGeometryModelerSbm",
+            "Parameters": {
+                "model_part_name" : "IgaModelPart",
+                "lower_point_xyz": [0.0,0.0,0.0],
+                "upper_point_xyz": [4.0,6.0,0.0],
+                "lower_point_uvw": [0.0,0.0,0.0],
+                "upper_point_uvw": [4.0,6.0,0.0],
+                "polynomial_order" : [2, 2],
+                "number_of_knot_spans" : [20,10],
+                "sbm_parameters": {
+                    "lambda_inner": 1.0,
+                    "lambda_outer": 0.5,
+                    "number_of_inner_loops": 1
+                },
+                "skin_model_part_inner_initial_name": "skinModelPart_inner_initial",
+                "skin_model_part_outer_initial_name": "skinModelPart_outer_initial",
+                "skin_model_part_name": "skinModelPart"
+            }
+        }]
+        """)
+        current_model = KratosMultiphysics.Model()
+
+        # Create Inner skin boundary
+
+        skin_model_part_inner_initial = current_model.CreateModelPart("skinModelPart_inner_initial")
+        skin_model_part_inner_initial.CreateNewProperties(1)
+        skin_model_part_inner_initial.CreateNewNode(1, 1.5, 0.5, 0.0)
+        skin_model_part_inner_initial.CreateNewNode(2, 3.0, 0.5, 0.0)
+        skin_model_part_inner_initial.CreateNewNode(3, 3.0, 3.5, 0.0)
+        skin_model_part_inner_initial.CreateNewNode(4, 1.5, 3.5, 0.0)
+        skin_model_part_inner_initial.CreateNewCondition("LineCondition2D2N", 1, [1, 2], skin_model_part_inner_initial.GetProperties()[1])
+        skin_model_part_inner_initial.CreateNewCondition("LineCondition2D2N", 2, [2, 3], skin_model_part_inner_initial.GetProperties()[1])
+        skin_model_part_inner_initial.CreateNewCondition("LineCondition2D2N", 3, [3, 4], skin_model_part_inner_initial.GetProperties()[1])
+        skin_model_part_inner_initial.CreateNewCondition("LineCondition2D2N", 4, [4, 1], skin_model_part_inner_initial.GetProperties()[1])
+
+        # Create Outer skin boundary
+        skin_model_part_outer_initial = current_model.CreateModelPart("skinModelPart_outer_initial")
+        skin_model_part_outer_initial.CreateNewProperties(1)
+        skin_model_part_outer_initial.CreateNewNode(1, 0.4, 0.0, 0.0)
+        skin_model_part_outer_initial.CreateNewNode(2, 3.5, 0.0, 0.0)
+        skin_model_part_outer_initial.CreateNewNode(3, 3.2, 5.0, 0.0)
+        skin_model_part_outer_initial.CreateNewNode(4, 1.0, 5.5, 0.0)
+        skin_model_part_outer_initial.CreateNewCondition("LineCondition2D2N", 1, [1, 2], skin_model_part_outer_initial.GetProperties()[1])
+        skin_model_part_outer_initial.CreateNewCondition("LineCondition2D2N", 2, [2, 3], skin_model_part_outer_initial.GetProperties()[1])
+        skin_model_part_outer_initial.CreateNewCondition("LineCondition2D2N", 3, [3, 4], skin_model_part_outer_initial.GetProperties()[1])
+        skin_model_part_outer_initial.CreateNewCondition("LineCondition2D2N", 4, [4, 1], skin_model_part_outer_initial.GetProperties()[1])
+
+        run_modelers(current_model, modeler_settings)
+
+        # test surrogate nodes
+        self.assertAlmostEqual(current_model["IgaModelPart.surrogate_inner"].GetNodes()[281].X, 2.8)
+        self.assertAlmostEqual(current_model["IgaModelPart.surrogate_inner"].GetNodes()[281].Y, 0.6)
+        self.assertAlmostEqual(current_model["IgaModelPart.surrogate_inner"].GetNodes()[281].Z, 0.0)
+
+        self.assertAlmostEqual(current_model["IgaModelPart.surrogate_inner"].GetNodes()[269].X, 1.6)
+        self.assertAlmostEqual(current_model["IgaModelPart.surrogate_inner"].GetNodes()[269].Y, 3.0)
+        self.assertAlmostEqual(current_model["IgaModelPart.surrogate_inner"].GetNodes()[269].Z, 0.0)
+
+        self.assertAlmostEqual(current_model["IgaModelPart.surrogate_outer"].GetNodes()[295].X, 0.8)
+        self.assertAlmostEqual(current_model["IgaModelPart.surrogate_outer"].GetNodes()[295].Y, 3.6)
+        self.assertAlmostEqual(current_model["IgaModelPart.surrogate_outer"].GetNodes()[295].Z, 0.0)
+
+        self.assertAlmostEqual(current_model["IgaModelPart.surrogate_outer"].GetNodes()[320].X, 3.6)
+        self.assertAlmostEqual(current_model["IgaModelPart.surrogate_outer"].GetNodes()[320].Y, 0.6)
+        self.assertAlmostEqual(current_model["IgaModelPart.surrogate_outer"].GetNodes()[320].Z, 0.0)
+
+        # test the creation of the breps
+        self.assertEqual(current_model["IgaModelPart"].NumberOfGeometries(), 73)
+        self.assertAlmostEqual(current_model["IgaModelPart"].GetGeometry(1).Center().X, 2.0)
+        self.assertAlmostEqual(current_model["IgaModelPart"].GetGeometry(1).Center().Y, 3.0)
+        self.assertAlmostEqual(current_model["IgaModelPart"].GetGeometry(1).Center().Z, 0.0)
+
+
+if __name__ == '__main__':
+    KratosUnittest.main()

--- a/kratos/geometries/brep_surface.h
+++ b/kratos/geometries/brep_surface.h
@@ -63,6 +63,7 @@ public:
 
     typedef NurbsSurfaceGeometry<3, TContainerPointType> NurbsSurfaceType;
     typedef BrepCurveOnSurface<TContainerPointType, TShiftedBoundary, TContainerPointEmbeddedType> BrepCurveOnSurfaceType;
+    typedef BrepTrimmingUtilities<TShiftedBoundary> BrepTrimmingUtilitiesType;
 
     typedef DenseVector<typename BrepCurveOnSurfaceType::Pointer> BrepCurveOnSurfaceArrayType;
     typedef DenseVector<typename BrepCurveOnSurfaceType::Pointer> BrepCurveOnSurfaceLoopType;
@@ -115,6 +116,22 @@ public:
         , mInnerLoopArray(BrepInnerLoopArray)
         , mIsTrimmed(IsTrimmed)
     {
+    }
+
+    // Constructor for SBM
+    BrepSurface(
+        typename NurbsSurfaceType::Pointer pSurface, 
+        BrepCurveOnSurfaceLoopArrayType& BrepOuterLoopArray,
+        BrepCurveOnSurfaceLoopArrayType& BrepInnerLoopArray,
+        ModelPart& rSurrogateModelPart_inner, ModelPart& rSurrogateModelPart_outer)
+        : BaseType(PointsArrayType(), &msGeometryData)
+        , mpNurbsSurface(pSurface) 
+        , mOuterLoopArray(BrepOuterLoopArray)
+        , mInnerLoopArray(BrepInnerLoopArray)
+        , mpSurrogateModelPart_inner(&rSurrogateModelPart_inner)
+        , mpSurrogateModelPart_outer(&rSurrogateModelPart_outer)
+    {
+        mIsTrimmed = false;
     }
 
     explicit BrepSurface(const PointsArrayType& ThisPoints)
@@ -467,7 +484,7 @@ public:
             mpNurbsSurface->SpansLocalSpace(spans_u, 0);
             mpNurbsSurface->SpansLocalSpace(spans_v, 1);
 
-            BrepTrimmingUtilities::CreateBrepSurfaceTrimmingIntegrationPoints(
+            BrepTrimmingUtilitiesType::CreateBrepSurfaceTrimmingIntegrationPoints(
                 rIntegrationPoints,
                 mOuterLoopArray, mInnerLoopArray,
                 spans_u, spans_v,
@@ -593,6 +610,9 @@ private:
     BrepCurveOnSurfaceLoopArrayType mInnerLoopArray;
 
     BrepCurveOnSurfaceArrayType mEmbeddedEdgesArray;
+
+    ModelPart* mpSurrogateModelPart_inner = nullptr;
+    ModelPart* mpSurrogateModelPart_outer = nullptr;
 
     /** IsTrimmed is used to optimize processes as
     *   e.g. creation of integration domain.

--- a/kratos/geometries/brep_surface.h
+++ b/kratos/geometries/brep_surface.h
@@ -123,13 +123,13 @@ public:
         typename NurbsSurfaceType::Pointer pSurface, 
         BrepCurveOnSurfaceLoopArrayType& BrepOuterLoopArray,
         BrepCurveOnSurfaceLoopArrayType& BrepInnerLoopArray,
-        ModelPart& rSurrogateModelPart_inner, ModelPart& rSurrogateModelPart_outer)
+        ModelPart& rSurrogateModelPartInner, ModelPart& rSurrogateModelPartOuter)
         : BaseType(PointsArrayType(), &msGeometryData)
         , mpNurbsSurface(pSurface) 
         , mOuterLoopArray(BrepOuterLoopArray)
         , mInnerLoopArray(BrepInnerLoopArray)
-        , mpSurrogateModelPart_inner(&rSurrogateModelPart_inner)
-        , mpSurrogateModelPart_outer(&rSurrogateModelPart_outer)
+        , mpSurrogateModelPartInner(&rSurrogateModelPartInner)
+        , mpSurrogateModelPartOuter(&rSurrogateModelPartOuter)
     {
         mIsTrimmed = false;
     }
@@ -611,8 +611,8 @@ private:
 
     BrepCurveOnSurfaceArrayType mEmbeddedEdgesArray;
 
-    ModelPart* mpSurrogateModelPart_inner = nullptr;
-    ModelPart* mpSurrogateModelPart_outer = nullptr;
+    ModelPart* mpSurrogateModelPartInner = nullptr;
+    ModelPart* mpSurrogateModelPartOuter = nullptr;
 
     /** IsTrimmed is used to optimize processes as
     *   e.g. creation of integration domain.

--- a/kratos/geometries/nurbs_shape_function_utilities/nurbs_utilities.h
+++ b/kratos/geometries/nurbs_shape_function_utilities/nurbs_utilities.h
@@ -66,8 +66,17 @@ namespace NurbsUtilities
         const Vector& rKnots,
         const double ParameterT)
     {
+        // Check if the ParameterT (gauss point) is coincident to a knot (laying on an edge of a knot span)
+        double parameter_t_corrected = ParameterT;
+        for (unsigned i = 0; i<rKnots.size(); i++) {
+            if (std::abs(ParameterT-rKnots[i]) < 1e-13) {
+                parameter_t_corrected = rKnots[i];
+                break;
+            }
+        }
+
         const auto span = std::lower_bound(std::begin(rKnots) + PolynomialDegree,
-            std::end(rKnots) - PolynomialDegree, ParameterT) - std::begin(rKnots) - 1;
+            std::end(rKnots) - PolynomialDegree, parameter_t_corrected) - std::begin(rKnots) - 1;
         return span;
     }
 

--- a/kratos/utilities/geometry_utilities/brep_trimming_utilities.cpp
+++ b/kratos/utilities/geometry_utilities/brep_trimming_utilities.cpp
@@ -6,6 +6,9 @@
 //
 //  License:         BSD License
 //                   Kratos default license: kratos/license.txt
+//
+//  Main authors:    Nicolo' Antonelli
+//                   Andrea Gorgi
 
 // header includes
 #include "brep_trimming_utilities.h"
@@ -14,8 +17,8 @@ namespace Kratos
 {
     ///@name Kratos Classes
     ///@{
-
-    void BrepTrimmingUtilities::CreateBrepSurfaceTrimmingIntegrationPoints(
+    template<bool TShiftedBoundary>
+    void BrepTrimmingUtilities<TShiftedBoundary>::CreateBrepSurfaceTrimmingIntegrationPoints(
         IntegrationPointsArrayType& rIntegrationPoints,
         const DenseVector<DenseVector<BrepCurveOnSurfacePointerType>>& rOuterLoops,
         const DenseVector<DenseVector<BrepCurveOnSurfacePointerType>>& rInnerLoops,
@@ -151,5 +154,8 @@ namespace Kratos
     //    const std::vector<double>& rSpansU,
     //    const std::vector<double>& rSpansV,
     //    IntegrationInfo& rIntegrationInfo);
+
+    template class KRATOS_API(KRATOS_CORE) BrepTrimmingUtilities<true>;
+    template class KRATOS_API(KRATOS_CORE) BrepTrimmingUtilities<false>;
 
 } // namespace Kratos.

--- a/kratos/utilities/geometry_utilities/brep_trimming_utilities.cpp
+++ b/kratos/utilities/geometry_utilities/brep_trimming_utilities.cpp
@@ -6,9 +6,6 @@
 //
 //  License:         BSD License
 //                   Kratos default license: kratos/license.txt
-//
-//  Main authors:    Nicolo' Antonelli
-//                   Andrea Gorgi
 
 // header includes
 #include "brep_trimming_utilities.h"

--- a/kratos/utilities/geometry_utilities/brep_trimming_utilities.h
+++ b/kratos/utilities/geometry_utilities/brep_trimming_utilities.h
@@ -6,12 +6,8 @@
 //
 //  License:         BSD License
 //                   Kratos default license: kratos/license.txt
-//
-//  Main authors:    Nicolo' Antonelli
-//                   Andrea Gorgi
 
-#if !defined(KRATOS_BREP_TRIMMING_UTILITIES_H_INCLUDED)
-#define KRATOS_BREP_TRIMMING_UTILITIES_H_INCLUDED
+#pragma once
 
 // Std includes
 #include <list>
@@ -329,4 +325,3 @@ namespace Kratos
     ///@} // Kratos Classes
 } // namespace Kratos.
 
-#endif // KRATOS_BREP_TRIMMING_UTILITIES_H_INCLUDED defined

--- a/kratos/utilities/geometry_utilities/brep_trimming_utilities.h
+++ b/kratos/utilities/geometry_utilities/brep_trimming_utilities.h
@@ -6,6 +6,9 @@
 //
 //  License:         BSD License
 //                   Kratos default license: kratos/license.txt
+//
+//  Main authors:    Nicolo' Antonelli
+//                   Andrea Gorgi
 
 #if !defined(KRATOS_BREP_TRIMMING_UTILITIES_H_INCLUDED)
 #define KRATOS_BREP_TRIMMING_UTILITIES_H_INCLUDED
@@ -32,7 +35,7 @@ namespace Kratos
     ///@{
 
     //using namespace ClipperLib;
-
+    template<bool TShiftedBoundary>
     class KRATOS_API(KRATOS_CORE) BrepTrimmingUtilities
     {
     public:
@@ -52,7 +55,7 @@ namespace Kratos
 
         typedef signed long long cInt;
 
-        using BrepCurveOnSurfacePointerType = typename BrepCurveOnSurface<PointerVector<Node>, false, PointerVector<Point>>::Pointer;
+        using BrepCurveOnSurfacePointerType = typename BrepCurveOnSurface<PointerVector<Node>, TShiftedBoundary, PointerVector<Point>>::Pointer;
 
         //template<class TBrepLoopType, class TPointType>
         static void CreateBrepSurfaceTrimmingIntegrationPoints(

--- a/kratos/utilities/nurbs_utilities/snake_sbm_utilities.cpp
+++ b/kratos/utilities/nurbs_utilities/snake_sbm_utilities.cpp
@@ -257,8 +257,8 @@ namespace Kratos
                 int knot_span_u_point_split = (x_true_boundary_split-starting_pos_uv[0]) / knot_step_uv[0] ;
                 int knot_span_v_point_split = (y_true_boundary_split-starting_pos_uv[1]) / knot_step_uv[1] ;
 
-                if (knot_span_u_point_split == knot_spans_available[idMatrix][0].size()) knot_span_u_point_split--;
-                if (knot_span_v_point_split == knot_spans_available[idMatrix].size()) knot_span_v_point_split--;
+                if (knot_span_u_point_split == int (knot_spans_available[idMatrix][0].size())) knot_span_u_point_split--;
+                if (knot_span_v_point_split == int (knot_spans_available[idMatrix].size())) knot_span_v_point_split--;
 
                 // update xy_coord for the first split segment
                 std::vector<std::vector<double>> xy_coord_i_cond_split(2);

--- a/kratos/utilities/nurbs_utilities/snake_sbm_utilities.cpp
+++ b/kratos/utilities/nurbs_utilities/snake_sbm_utilities.cpp
@@ -1,0 +1,839 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
+//
+
+// System includes
+
+// External includes
+
+// Project includes
+#include "snake_sbm_utilities.h"
+
+namespace Kratos
+{
+
+    void SnakeSBMUtilities::CreateTheSnakeCoordinates(ModelPart& iga_model_part,
+                                                    ModelPart& skin_model_part_inner_initial,
+                                                    ModelPart& skin_model_part_outer_initial, 
+                                                    ModelPart& skin_model_part, 
+                                                    int rEchoLevel, 
+                                                    Vector& knot_vector_u, 
+                                                    Vector& knot_vector_v,
+                                                    const Parameters mParameters) { 
+        
+        // Check
+        KRATOS_ERROR_IF_NOT(mParameters.Has("sbm_parameters")) << "sbm_parameters has not been defined in the nurbs modeler" << std::endl;
+        
+        // Initilize the property of skin_model_part_in and out
+        if (skin_model_part_inner_initial.Nodes().size()>0) {
+        
+            CreateTheSnakeCoordinates(iga_model_part, skin_model_part_inner_initial, skin_model_part, rEchoLevel, knot_vector_u, knot_vector_v, mParameters, true);
+                
+        }
+        if (skin_model_part_outer_initial.Nodes().size()>0) {
+
+            CreateTheSnakeCoordinates(iga_model_part, skin_model_part_outer_initial, skin_model_part, rEchoLevel, knot_vector_u, knot_vector_v, mParameters, false);
+        }
+    }   
+
+    void SnakeSBMUtilities::CreateTheSnakeCoordinates(ModelPart& iga_model_part, 
+                                                      ModelPart& skin_model_part_initial, 
+                                                      ModelPart& skin_model_part,
+                                                      int rEchoLevel, 
+                                                      Vector& knot_vector_u, 
+                                                      Vector& knot_vector_v,
+                                                      const Parameters mParameters,
+                                                      bool is_inner) 
+    { 
+        
+        std::string surrogate_sub_model_part_name; 
+        std::string skin_sub_model_part_name; 
+        // ModelPart skin_sub_model_part; 
+        if (is_inner) {
+            surrogate_sub_model_part_name = "surrogate_inner";
+            skin_sub_model_part_name = "inner";
+        }
+        else {
+            surrogate_sub_model_part_name = "surrogate_outer";
+            skin_sub_model_part_name = "outer";
+        }
+        
+        ModelPart& skin_sub_model_part = skin_model_part.GetSubModelPart(skin_sub_model_part_name);
+        ModelPart& surrogate_sub_model_part = iga_model_part.GetSubModelPart(surrogate_sub_model_part_name);
+
+        if (!skin_model_part_initial.HasProperties(0)) skin_model_part_initial.CreateNewProperties(0);
+        if (!skin_model_part.HasProperties(0)) skin_model_part.CreateNewProperties(0);
+        Properties::Pointer p_cond_prop_in = skin_model_part_initial.pGetProperties(0);
+        skin_model_part_initial.AddProperties(p_cond_prop_in);
+
+        Vector knot_step_uv(2);
+        knot_step_uv[0] = std::abs(knot_vector_u[int(knot_vector_u.size()/2) +1]  - knot_vector_u[int(knot_vector_u.size()/2)] ) ;
+        knot_step_uv[1] = std::abs(knot_vector_v[int(knot_vector_v.size()/2) +1]  - knot_vector_v[int(knot_vector_v.size()/2)] ) ;
+
+        Vector meshSizes_uv(2);
+        meshSizes_uv[0] = knot_step_uv[0]; 
+        meshSizes_uv[1] = knot_step_uv[1];
+        ModelPart& surrogate_model_part = iga_model_part.GetSubModelPart(surrogate_sub_model_part_name);
+        surrogate_model_part.GetProcessInfo().SetValue(MARKER_MESHES, meshSizes_uv);
+
+        Vector starting_pos_uv(2);
+        starting_pos_uv[0] = knot_vector_u[0];
+        starting_pos_uv[1] = knot_vector_v[0];
+
+        Vector parameterExternalCoordinates(4);
+        parameterExternalCoordinates[0] = knot_vector_u[0];
+        parameterExternalCoordinates[1] = knot_vector_v[0];
+        parameterExternalCoordinates[2] = knot_vector_u[knot_vector_u.size()-1];
+        parameterExternalCoordinates[3] = knot_vector_v[knot_vector_v.size()-1];
+        
+        surrogate_model_part.GetProcessInfo().SetValue(LOAD_MESHES, parameterExternalCoordinates);
+
+        // Create the matrix of active/inactive knot spans, one for inner and one for outer loop
+        unsigned int numberOfLoops;
+        if (is_inner)
+            numberOfLoops = mParameters["sbm_parameters"]["number_of_inner_loops"].GetInt();
+        else 
+            numberOfLoops = 1;
+        
+        std::vector<int> n_knot_spans_uv(2);
+        n_knot_spans_uv[0] = knot_vector_u.size()-1; 
+        n_knot_spans_uv[1] = knot_vector_v.size()-1;
+
+        std::vector<std::vector<std::vector<int>>> knot_spans_available;
+        knot_spans_available.reserve(numberOfLoops);
+
+        for (int i = 0; i < numberOfLoops; ++i) {
+            std::vector<std::vector<int>> matrix; 
+            matrix.reserve(n_knot_spans_uv[1]);
+            for (int j = 0; j <= n_knot_spans_uv[1]; ++j) {
+                std::vector<int> row(n_knot_spans_uv[0]); 
+                matrix.push_back(row); 
+            }
+            knot_spans_available.push_back(matrix);
+        }
+        
+        // Optimized Snake -> for inner loops
+        int idMatrixKnotSpansAvailable = 0;
+        int idFirstNode;
+        bool newInnerLoop = true;
+
+        
+        KRATOS_INFO_IF("::[SnakeSBMUtilities]::", rEchoLevel > 0 && is_inner) << "Inner :: Starting SnakeStep" << std::endl;
+        KRATOS_INFO_IF("::[SnakeSBMUtilities]::", rEchoLevel > 0 && !is_inner) << "Outer :: Starting SnakeStep" << std::endl;
+                
+        if (skin_model_part_initial.Conditions().size() > 0) {
+            
+            // CREATE FIRST NODE FOR SKIN SUB MODEL PART
+            auto initial_condition = skin_model_part_initial.GetCondition(1);
+            double x_true_boundary0 = initial_condition.GetGeometry()[0].X();
+            double y_true_boundary0 = initial_condition.GetGeometry()[0].Y();
+
+            const int id_first_node = skin_model_part.GetRootModelPart().Nodes().size()+1;
+            skin_sub_model_part.CreateNewNode(id_first_node, x_true_boundary0, y_true_boundary0, 0.0);
+
+            for (auto &i_cond : skin_model_part_initial.Conditions()) {  
+                if (newInnerLoop) {
+                    idFirstNode = i_cond.GetGeometry()[0].Id();
+                    newInnerLoop = false;
+                }
+                // Collect the coordinates of the points of the i_cond
+                double x_true_boundary1 = i_cond.GetGeometry()[0].X();
+                double y_true_boundary1 = i_cond.GetGeometry()[0].Y();
+                double x_true_boundary2 = i_cond.GetGeometry()[1].X();
+                double y_true_boundary2 = i_cond.GetGeometry()[1].Y();
+
+                std::vector<std::vector<double>> xy_coord_i_cond(2);
+                xy_coord_i_cond[0].resize(2); xy_coord_i_cond[1].resize(2); 
+                
+                xy_coord_i_cond[0][0] = i_cond.GetGeometry()[0].X(); // x_true_boundary1
+                xy_coord_i_cond[1][0] = i_cond.GetGeometry()[0].Y(); // y_true_boundary1
+                xy_coord_i_cond[0][1] = i_cond.GetGeometry()[1].X(); // x_true_boundary2
+                xy_coord_i_cond[1][1] = i_cond.GetGeometry()[1].Y(); // y_true_boundary2
+                
+                // Collect the intersections of the skin boundary with the knot values
+                std::vector<std::vector<int>> knot_span_uv(2);
+                knot_span_uv[0].resize(2); knot_span_uv[1].resize(2);
+
+                knot_span_uv[0][0] = (x_true_boundary1-starting_pos_uv[0]) / knot_step_uv[0]; // knot_span_u_1st_point
+                knot_span_uv[1][0] = (y_true_boundary1-starting_pos_uv[1]) / knot_step_uv[1]; // knot_span_v_1st_point
+                knot_span_uv[0][1] = (x_true_boundary2-starting_pos_uv[0]) / knot_step_uv[0]; // knot_span_u_2nd_point
+                knot_span_uv[1][1] = (y_true_boundary2-starting_pos_uv[1]) / knot_step_uv[1]; // knot_span_v_2nd_point
+
+                // In the inner case, check is the immersed object is inside the rectangular domain
+                if (is_inner &&
+                               (knot_span_uv[0][0] < 0 || knot_span_uv[0][0] >= n_knot_spans_uv[0] ||
+                                knot_span_uv[1][0] < 0 || knot_span_uv[1][0] >= n_knot_spans_uv[1] ||
+                                knot_span_uv[0][1] < 0 || knot_span_uv[0][1] >= n_knot_spans_uv[0] ||
+                                knot_span_uv[1][1] < 0 || knot_span_uv[1][1] >= n_knot_spans_uv[1]) )
+                    KRATOS_ERROR << "[SnakeSbmUtilities]:: The skin boundary provided is bigger than the background geometry in the parameter space." << std::endl;
+
+                // additional check knot_span_uv computation on the domain border [especially for outer boundary]
+                if (knot_span_uv[0][0] == n_knot_spans_uv[0]) knot_span_uv[0][0]--;
+                if (knot_span_uv[1][0] == n_knot_spans_uv[1]) knot_span_uv[1][0]--;
+                if (knot_span_uv[0][1] == n_knot_spans_uv[0]) knot_span_uv[0][1]--;
+                if (knot_span_uv[1][1] == n_knot_spans_uv[1]) knot_span_uv[1][1]--;
+                
+                SnakeStep(skin_sub_model_part, knot_spans_available, idMatrixKnotSpansAvailable, 
+                         knot_span_uv, xy_coord_i_cond, knot_step_uv, starting_pos_uv);
+              
+                if (i_cond.GetGeometry()[1].Id() == idFirstNode) {
+                    idMatrixKnotSpansAvailable++;
+                    newInnerLoop = true;
+                }
+            }
+        }
+
+        PointVector points;
+        for (auto &i_cond : skin_sub_model_part.Conditions()) {
+            points.push_back(PointTypePointer(new PointType(i_cond.Id(), i_cond.GetGeometry()[0].X(), i_cond.GetGeometry()[0].Y(), i_cond.GetGeometry()[0].Z())));
+        }
+        DynamicBins testBins(points.begin(), points.end());
+
+        KRATOS_INFO_IF("::[SnakeSBMUtilities]::", rEchoLevel > 0 && is_inner) << "Inner :: Ending SnakeStep" << std::endl;
+        KRATOS_INFO_IF("::[SnakeSBMUtilities]::", rEchoLevel > 0 && !is_inner) << "Outer :: Ending SnakeStep" << std::endl;
+        
+        // Read lambda parameters: 0.0 -> External,  0.5 -> Optimal
+        double lambda;
+        if (is_inner) 
+            if (mParameters["sbm_parameters"].Has("lambda_inner")) 
+                lambda = mParameters["sbm_parameters"]["lambda_inner"].GetDouble();
+            else 
+                lambda = 0.5;
+        else 
+            if (mParameters["sbm_parameters"].Has("lambda_outer")) 
+                lambda = mParameters["sbm_parameters"]["lambda_outer"].GetDouble();
+            else 
+                lambda = 0.5;
+        
+        KRATOS_INFO_IF("::[SnakeSBMUtilities]::", rEchoLevel > 0 && is_inner) << "Inner :: MarkKnotSpansAvailable" << std::endl;
+        KRATOS_INFO_IF("::[SnakeSBMUtilities]::", rEchoLevel > 0 && !is_inner) << "Outer :: MarkKnotSpansAvailable" << std::endl;
+
+        for (int i = 0; i < numberOfLoops; i++) {
+            int idInnerLoop = i;
+            // Mark the knot_spans_available's for inner and outer loops
+            MarkKnotSpansAvailable(knot_spans_available, idInnerLoop, testBins, skin_sub_model_part, lambda, 
+                                   n_knot_spans_uv, knot_step_uv, starting_pos_uv);  
+            
+            if (is_inner) {
+                CreateSurrogateBuondaryFromSnake_inner (knot_spans_available, idInnerLoop, surrogate_sub_model_part, 
+                                    n_knot_spans_uv, knot_vector_u, knot_vector_v, starting_pos_uv );
+                KRATOS_INFO_IF("::[SnakeSBMUtilities]::", rEchoLevel > 0) << "Inner :: Snake process has finished" << std::endl;
+            }
+            else {
+                CreateSurrogateBuondaryFromSnake_outer (testBins, skin_sub_model_part, knot_spans_available, idInnerLoop, surrogate_sub_model_part, 
+                                    n_knot_spans_uv, knot_vector_u, knot_vector_v, starting_pos_uv);
+                KRATOS_INFO_IF("::[SnakeSBMUtilities]::", rEchoLevel > 0) << "Outer :: Snake process has finished" << std::endl;
+            }
+        }
+
+        KRATOS_INFO_IF("::[SnakeSBMUtilities]::", rEchoLevel > 0 && is_inner) << "Inner :: Loop finished" << std::endl;
+        KRATOS_INFO_IF("::[SnakeSBMUtilities]::", rEchoLevel > 0 && !is_inner) << "Outer :: Loop finished" << std::endl;
+    }
+
+
+    void SnakeSBMUtilities::SnakeStep(ModelPart& skin_model_part, 
+                            std::vector<std::vector<std::vector<int>>> &knot_spans_available, 
+                            int idMatrix, 
+                            std::vector<std::vector<int>> knot_spans_uv, 
+                            std::vector<std::vector<double>> xy_coord_i_cond, 
+                            Vector knot_step_uv, 
+                            Vector starting_pos_uv)
+                            {
+        bool isSplitted = false;
+
+        if (knot_spans_uv[0][0] != knot_spans_uv[0][1] || knot_spans_uv[1][0] != knot_spans_uv[1][1]) { // INTERSECTION BETWEEN TRUE AND SURROGATE BOUNDARY
+            // Check if we are jumping some cut knot spans. If yes we split the true segment
+            if (std::abs(knot_spans_uv[1][0]-knot_spans_uv[1][1]) > 1 || std::abs(knot_spans_uv[0][0]-knot_spans_uv[0][1]) > 1 || 
+                    (knot_spans_uv[0][0] != knot_spans_uv[0][1] && knot_spans_uv[1][0] != knot_spans_uv[1][1]) ) {
+                isSplitted = true;
+
+                // Split the segment and do it recursively
+                double x_true_boundary_split = (xy_coord_i_cond[0][0]+xy_coord_i_cond[0][1]) / 2;
+                double y_true_boundary_split = (xy_coord_i_cond[1][0]+xy_coord_i_cond[1][1]) / 2;
+                int knot_span_u_point_split = (x_true_boundary_split-starting_pos_uv[0]) / knot_step_uv[0] ;
+                int knot_span_v_point_split = (y_true_boundary_split-starting_pos_uv[1]) / knot_step_uv[1] ;
+
+                // update xy_coord for the first split segment
+                std::vector<std::vector<double>> xy_coord_i_cond_split(2);
+                xy_coord_i_cond_split[0].resize(2); xy_coord_i_cond_split[1].resize(2); 
+                xy_coord_i_cond_split[0][0] = xy_coord_i_cond[0][0]; // x_true_boundary1
+                xy_coord_i_cond_split[1][0] = xy_coord_i_cond[1][0]; // y_true_boundary1
+                xy_coord_i_cond_split[0][1] = x_true_boundary_split; // x_true_boundary_split
+                xy_coord_i_cond_split[1][1] = y_true_boundary_split; // y_true_boundary_split
+                // update knot_span_uv for the first split segment
+                std::vector<std::vector<int>> knot_span_uv_split(2);
+                knot_span_uv_split[0].resize(2); knot_span_uv_split[1].resize(2); 
+                knot_span_uv_split[0][0] = knot_spans_uv[0][0]; // knot_span_u_1st_point
+                knot_span_uv_split[1][0] = knot_spans_uv[1][0]; // knot_span_v_1st_point
+                knot_span_uv_split[0][1] = knot_span_u_point_split; // knot_span_u_point_split
+                knot_span_uv_split[1][1] = knot_span_v_point_split; // knot_span_v_point_split
+                
+                // __We do it recursively first split__
+                SnakeStep(skin_model_part, knot_spans_available, idMatrix, knot_span_uv_split, 
+                         xy_coord_i_cond_split, knot_step_uv, starting_pos_uv );
+
+                // update xy_coord for the second split segment
+                xy_coord_i_cond_split[0][0] = x_true_boundary_split; // x_true_boundary_split
+                xy_coord_i_cond_split[1][0] = y_true_boundary_split; // y_true_boundary_split
+                xy_coord_i_cond_split[0][1] = xy_coord_i_cond[0][1]; // x_true_boundary2
+                xy_coord_i_cond_split[1][1] = xy_coord_i_cond[1][1]; // y_true_boundary2
+                // update knot_span_uv for the first split segment
+                knot_span_uv_split[0][0] = knot_span_u_point_split; // knot_span_u_point_split
+                knot_span_uv_split[1][0] = knot_span_v_point_split; // knot_span_v_point_split
+                knot_span_uv_split[0][1] = knot_spans_uv[0][1]; // knot_span_u_2nd_point
+                knot_span_uv_split[1][1] = knot_spans_uv[1][1]; // knot_span_v_2nd_point
+
+                // __We do it recursively second split__
+                SnakeStep(skin_model_part, knot_spans_available, idMatrix, knot_span_uv_split, 
+                         xy_coord_i_cond_split, knot_step_uv, starting_pos_uv);
+            }
+            // Check if the true boundary crosses an u or a v knot value
+            else if (knot_spans_uv[0][0] != knot_spans_uv[0][1]) { // u knot value is crossed
+                // Find the "knot_spans_available" using the intersection
+                knot_spans_available[idMatrix][knot_spans_uv[1][0]][knot_spans_uv[0][0]] = 2;
+                knot_spans_available[idMatrix][knot_spans_uv[1][0]][knot_spans_uv[0][1]] = 2;
+
+            }
+            else if (knot_spans_uv[1][0] != knot_spans_uv[1][1]) { // v knot value is crossed
+                // Find the "knot_spans_available" using the intersection (Snake_coordinate classic -> External Boundary)
+                knot_spans_available[idMatrix][knot_spans_uv[1][0]][knot_spans_uv[0][0]] = 2;
+                knot_spans_available[idMatrix][knot_spans_uv[1][1]][knot_spans_uv[0][0]] = 2;
+            }
+        }
+        if (!isSplitted) {
+            // Call the root model part for the Ids of the node
+            auto idNode1 = skin_model_part.GetRootModelPart().Nodes().size();
+            auto idNode2 = idNode1+1;
+            // Create two nodes and two conditions for each skin condition
+            skin_model_part.CreateNewNode(idNode2, (xy_coord_i_cond[0][0]+xy_coord_i_cond[0][1] ) / 2, (xy_coord_i_cond[1][0]+xy_coord_i_cond[1][1] ) / 2, 0.0);
+            skin_model_part.CreateNewNode(idNode2+1, xy_coord_i_cond[0][1], xy_coord_i_cond[1][1], 0.0);
+            Properties::Pointer p_cond_prop = skin_model_part.pGetProperties(0);
+            Condition::Pointer p_cond1 = skin_model_part.CreateNewCondition("LineCondition2D2N", idNode1, {{idNode1, idNode2}}, p_cond_prop );
+            Condition::Pointer p_cond2 = skin_model_part.CreateNewCondition("LineCondition2D2N", idNode2, {{idNode2, idNode2+1}}, p_cond_prop );
+            skin_model_part.AddCondition(p_cond1);
+            skin_model_part.AddCondition(p_cond2);
+        }
+    }
+
+
+    bool SnakeSBMUtilities::isPointInsideSkinBoundary(Point& point1, DynamicBins& testBins, ModelPart& skin_model_part)
+    {
+        // Get the nearest point of the true boundary
+        PointerType pointToSearch = PointerType(new PointType(1000000, point1.X(), point1.Y(), 0.0));
+        PointerType nearestPoint = testBins.SearchNearestPoint(*pointToSearch);
+        
+        // Get the closest Condition the initial_skin_model_part_in.Conditions
+        int id1 = nearestPoint->Id();
+        auto nearestCondition1 = skin_model_part.GetCondition(id1);
+        // Check if the condition is the first one and therefore the previous one does not exist
+        int id2 = id1 - 1;
+        if (id1 == skin_model_part.ConditionsBegin()->Id()) {
+            int nConditions = skin_model_part.Conditions().size();
+            id2 = id1 + nConditions - 1; 
+        }
+        auto nearestCondition2 = skin_model_part.GetCondition(id2);
+        // The two candidates nodes
+        Point candidatePoint1 = nearestCondition1.GetGeometry()[1];
+        Point candidatePoint2 = nearestCondition2.GetGeometry()[0];
+
+        Point point2 = nearestCondition1.GetGeometry()[0]; // FIRST POINT IN TRUE GEOM
+        Point point3 = candidatePoint1;// SECOND POINT IN TRUE GEOM
+        if (MathUtils<double>::Norm(candidatePoint1-point1) > MathUtils<double>::Norm(candidatePoint2-point1)){
+            // Need to invert the order to preserve the positivity of the area
+            point3 = point2;
+            point2 = candidatePoint2;
+        }
+
+        array_1d<double,3> v_1 = point2 - point1;
+        array_1d<double,3> v_2 = point3 - point1;
+        array_1d<double,3> crossProduct;
+        MathUtils<double>::CrossProduct(crossProduct, v_1, v_2);
+
+        bool isInside = false;
+        if (crossProduct[2] > 0) {isInside = true;}
+
+        return isInside;
+    }
+
+
+
+    void SnakeSBMUtilities::MarkKnotSpansAvailable(std::vector<std::vector<std::vector<int>>> & knot_spans_available, int idMatrix,DynamicBins& testBin, 
+                                                   ModelPart& skin_model_part, double lambda, std::vector<int>& n_knot_spans_uv, 
+                                                   Vector& knot_step_uv, const Vector& starting_pos_uv) {
+        for (int i = 0; i < n_knot_spans_uv[1]; i++) {
+            for (int j = 0; j < n_knot_spans_uv[0]; j++) {
+                if (knot_spans_available[idMatrix][i][j] == 2) {
+                    // Check the 8 neighbor knot spans -> Is there any completely inside? Note that we can just check 1 point.
+                    
+                    // right node
+                    if (i != n_knot_spans_uv[1]-1)
+                        if (knot_spans_available[idMatrix][i+1][j] == 0) { 
+                            Point gaussPoint = Point((j+0.5) * knot_step_uv[0] + starting_pos_uv[0], (i+1+0.5) * knot_step_uv[1] +starting_pos_uv[1], 0);
+                            if (isPointInsideSkinBoundary(gaussPoint, testBin, skin_model_part)) {knot_spans_available[idMatrix][i+1][j] = 1;}
+                        }
+                    // left node    
+                    if (i != 0)
+                        if (knot_spans_available[idMatrix][i-1][j] == 0) { 
+                            Point gaussPoint = Point((j+0.5) * knot_step_uv[0]+starting_pos_uv[0], (i-1+0.5) * knot_step_uv[1] + starting_pos_uv[1], 0);
+                            if (isPointInsideSkinBoundary(gaussPoint, testBin, skin_model_part)) {knot_spans_available[idMatrix][i-1][j] = 1;}
+                        }
+                    // up node
+                    if (j != n_knot_spans_uv[0]-1)
+                        if (knot_spans_available[idMatrix][i][j+1] == 0) { 
+                            Point gaussPoint = Point((j+1+0.5) * knot_step_uv[0]+starting_pos_uv[0], (i+0.5) * knot_step_uv[1]+starting_pos_uv[1], 0);
+                            if (isPointInsideSkinBoundary(gaussPoint, testBin, skin_model_part)) {knot_spans_available[idMatrix][i][j+1] = 1;}
+                        }
+                    //down node
+                    if (j != 0)
+                        if (knot_spans_available[idMatrix][i][j-1] == 0) { 
+                            Point gaussPoint = Point((j-1+0.5) * knot_step_uv[0]+starting_pos_uv[0], (i+0.5) * knot_step_uv[1]+starting_pos_uv[1], 0);
+                            if (isPointInsideSkinBoundary(gaussPoint, testBin, skin_model_part)) {knot_spans_available[idMatrix][i][j-1] = 1;}
+                        } 
+
+                    // corner right-down node
+                    if (j != 0 && i != n_knot_spans_uv[1]-1)
+                        if (knot_spans_available[idMatrix][i+1][j-1] == 0) {
+                            Point gaussPoint = Point((j-1+0.5) * knot_step_uv[0]+starting_pos_uv[0], (i+1+0.5) * knot_step_uv[1]+starting_pos_uv[1], 0);
+                            if (isPointInsideSkinBoundary(gaussPoint, testBin, skin_model_part)) {knot_spans_available[idMatrix][i+1][j-1] = 1;}
+                        }
+                    // corner left-down node
+                    if (j != 0 && i != 0)
+                        if (knot_spans_available[idMatrix][i-1][j-1] == 0) {
+                            Point gaussPoint = Point((j-1+0.5) * knot_step_uv[0]+starting_pos_uv[0], (i-1+0.5) * knot_step_uv[1]+starting_pos_uv[1], 0);
+                            if (isPointInsideSkinBoundary(gaussPoint, testBin, skin_model_part)) {knot_spans_available[idMatrix][i-1][j-1] = 1;}
+                        }
+                    // corner right-up node
+                    if (j != n_knot_spans_uv[0]-1 && i != n_knot_spans_uv[1]-1)
+                        if (knot_spans_available[idMatrix][i+1][j+1] == 0) {
+                            Point gaussPoint = Point((j+1+0.5) * knot_step_uv[0]+starting_pos_uv[0], (i+1+0.5) * knot_step_uv[1]+starting_pos_uv[1], 0);
+                            if (isPointInsideSkinBoundary(gaussPoint, testBin, skin_model_part)) {knot_spans_available[idMatrix][i+1][j+1] = 1;}
+                        }
+                    // corner left-up node
+                    if (j != n_knot_spans_uv[0]-1 && i != 0)
+                        if (knot_spans_available[idMatrix][i-1][j+1] == 0) {
+                            Point gaussPoint = Point((j+1+0.5) * knot_step_uv[0]+starting_pos_uv[0], (i-1+0.5) * knot_step_uv[1]+starting_pos_uv[1], 0);
+                            if (isPointInsideSkinBoundary(gaussPoint, testBin, skin_model_part)) {knot_spans_available[idMatrix][i-1][j+1] = 1;}
+                        }
+
+                    // Create 25 "fake" GaussPoints to check if the majority are inside or outside
+                    const int numFakeGaussPoints = 5;
+                    int numberOfInsideGaussianPoints = 0;
+                    for (int i_GPx = 0; i_GPx < numFakeGaussPoints; i_GPx++){
+                        double x_coord = j*knot_step_uv[0] + knot_step_uv[0]/(numFakeGaussPoints+1)*(i_GPx+1) + starting_pos_uv[0];
+
+                        // NOTE:: The v-knot spans are upside down in the matrix!!
+                        for (int i_GPy = 0; i_GPy < numFakeGaussPoints; i_GPy++) 
+                        {
+                            double y_coord = i*knot_step_uv[1] + knot_step_uv[1]/(numFakeGaussPoints+1)*(i_GPy+1) + starting_pos_uv[1];
+                            Point gaussPoint = Point(x_coord, y_coord, 0);  // GAUSSIAN POINT
+                            if (isPointInsideSkinBoundary(gaussPoint, testBin, skin_model_part)) {
+                                // Sum over the number of numFakeGaussPoints per knot span
+                                numberOfInsideGaussianPoints++;
+                            }
+                        }
+                        
+                    }
+                
+                    // Mark the knot span as available or not depending on the number of Gauss Points Inside/Outside
+                    if (numberOfInsideGaussianPoints < lambda*numFakeGaussPoints*numFakeGaussPoints) {
+                        knot_spans_available[idMatrix][i][j] = -1; // Cut knot spans that have been checked
+                    }
+                    else{
+                        knot_spans_available[idMatrix][i][j] = 1; // The knot span is considered DEACTIVE
+                    }
+
+                    // exit(0);
+                            
+                }
+            }
+        }
+    }
+
+
+    void SnakeSBMUtilities::CreateSurrogateBuondaryFromSnake_inner (std::vector<std::vector<std::vector<int>>> & knot_spans_available, int idMatrix, 
+                            ModelPart& surrogate_model_part_inner, std::vector<int>& n_knot_spans_uv, 
+                            Vector& knot_vector_u, Vector&  knot_vector_v,
+                            const Vector& starting_pos_uv){
+        // Find the start of the Snake
+        int start_i = 0;
+        int start_j = 0;
+        for (int i = 0; i < (n_knot_spans_uv[0]); i++) {
+            for (int j = 0; j < (n_knot_spans_uv[1]); j++ ) {
+                if (knot_spans_available[idMatrix][j][i] == 1 ) {
+                    // Check if one of the neighouring knot span is also == 1,
+                    // otherwise the knot span is isolated I cannot be taken.
+                    if ((knot_spans_available[idMatrix][j+1][i] == 1) || (knot_spans_available[idMatrix][j][i+1] == 1))
+                    {
+                        start_i = i;
+                        start_j = j;
+                        break;
+                    }     
+                }
+            }
+            if (knot_spans_available[idMatrix][start_j][start_i] == 1 ) { break; }
+        }
+        
+        if (!surrogate_model_part_inner.HasProperties(0)) {surrogate_model_part_inner.CreateNewProperties(0);}
+
+        Properties::Pointer p_cond_prop = surrogate_model_part_inner.pGetProperties(0);
+        Node snakeNode(1 , knot_vector_u[start_i], knot_vector_v[start_j], 0.0);
+        
+        const int id_first_node = surrogate_model_part_inner.GetRootModelPart().Nodes().size() + 1;
+        surrogate_model_part_inner.CreateNewNode(id_first_node, snakeNode);
+        IndexType idSnakeNode = id_first_node+1;
+
+        // Follow the clockwise loop
+        int end = 0;
+        // We are going orizontally
+        int direction = 0;
+        // 0 = up_vertical, 1 = right_orizontal, 2 = down_vertical, 3 = left_orizontal
+        int i = start_i; int j = start_j;
+        int I = start_i; int J = start_j;
+        int steps = 0;
+
+        const int max_number_of_steps = 1e5;
+        while (end == 0 && steps < max_number_of_steps) {
+            steps ++ ;
+            int is_special_case = 1; // Variable to check if we are in a super special case and we shouldn't go out of the while loop
+            // Try to go left w.r.t. the current direction
+            if (direction == 0) {I-- ; }
+            if (direction == 1) {J++; }
+            if (direction == 2) {I++ ; }
+            if (direction == 3) {J-- ; }
+            if (knot_spans_available[idMatrix][J][I] == 1) {
+                direction = direction - 1;
+                if (direction == -1) {direction = 3;}
+            }
+            else {
+                // Need to try to go straight or right w.r.t. the current direction; risetto e muovo
+                if (direction == 0) {I++ ; J++ ;}
+                if (direction == 1) {J-- ; I++ ;}
+                if (direction == 2) {I-- ; J-- ;}
+                if (direction == 3) {J++ ; I-- ;}
+                if (knot_spans_available[idMatrix][J][I] == 1) {
+                    // going straight
+                    if (direction == 0) {j++ ; }
+                    if (direction == 1) {i++ ; }
+                    if (direction == 2) {j-- ; }
+                    if (direction == 3) {i-- ; }
+
+                    Node snakeNode(idSnakeNode , knot_vector_u[i], knot_vector_v[j], 0.0);
+                    surrogate_model_part_inner.CreateNewNode(idSnakeNode, snakeNode);
+                    Condition::Pointer pcond1 = surrogate_model_part_inner.CreateNewCondition("LineCondition2D2N", idSnakeNode-1, {{idSnakeNode-1, idSnakeNode}}, p_cond_prop );
+                    idSnakeNode++;
+                }
+                else {
+                    // Need to search to hte right; rese e muovo
+                    if (direction == 0) {J-- ; I++ ;}
+                    if (direction == 1) {I-- ; J-- ;}
+                    if (direction == 2) {J++ ; I-- ;}
+                    if (direction == 3) {I++ ; J++ ;}
+                    if (knot_spans_available[idMatrix][J][I] == 1) {
+                        // We are moving to the right -> First move straight, store, the move to the right (i,j), store again
+                        if (direction == 0) {j++ ; }
+                        if (direction == 1) {i++ ; }
+                        if (direction == 2) {j-- ; }
+                        if (direction == 3) {i-- ; }
+                        Node snakeNode1(idSnakeNode , knot_vector_u[i], knot_vector_v[j], 0.0);
+                        surrogate_model_part_inner.CreateNewNode(idSnakeNode, snakeNode1);
+                        Condition::Pointer pcond1 = surrogate_model_part_inner.CreateNewCondition("LineCondition2D2N", idSnakeNode-1, {{idSnakeNode-1, idSnakeNode}}, p_cond_prop );
+                        idSnakeNode++;
+                        if (direction == 0) {i++ ; }
+                        if (direction == 1) {j-- ; }
+                        if (direction == 2) {i-- ; }
+                        if (direction == 3) {j++ ; }
+                        Node snakeNode2(idSnakeNode , knot_vector_u[i], knot_vector_v[j], 0.0);
+                        surrogate_model_part_inner.CreateNewNode(idSnakeNode, snakeNode2);
+                        Condition::Pointer pcond2 = surrogate_model_part_inner.CreateNewCondition("LineCondition2D2N", idSnakeNode-1, {{idSnakeNode-1, idSnakeNode}}, p_cond_prop );
+                        idSnakeNode++;
+                        direction = direction + 1;
+                        if (direction == 4) {direction = 0;}
+                    }
+                    else { // Special case of "isolated" knot span to be circumnavigated
+                        is_special_case = 0;
+                        // reset and move (I,J) backward
+                        if (direction == 0) {I-- ; J-- ;} 
+                        if (direction == 1) {J++ ; I-- ;}
+                        if (direction == 2) {I++ ; J++ ;}
+                        if (direction == 3) {J-- ; I++ ;}
+                        // Check
+                        if (knot_spans_available[idMatrix][J][I] == 1) {
+                            // First straight, store, then move to the right, store again, then move to the right and store again
+                            if (direction == 0) {j++ ; }
+                            if (direction == 1) {i++ ; }
+                            if (direction == 2) {j-- ; }
+                            if (direction == 3) {i-- ; }
+
+                            Node snakeNode(idSnakeNode , knot_vector_u[i], knot_vector_v[j], 0.0);
+                            surrogate_model_part_inner.CreateNewNode(idSnakeNode, snakeNode);
+                            Condition::Pointer pcond1 = surrogate_model_part_inner.CreateNewCondition("LineCondition2D2N", idSnakeNode-1, {{idSnakeNode-1, idSnakeNode}}, p_cond_prop );
+                            idSnakeNode++;
+
+                            if (direction == 0) {i++ ; }
+                            if (direction == 1) {j-- ; }
+                            if (direction == 2) {i-- ; }
+                            if (direction == 3) {j++ ; }
+
+                            Node snakeNode2(idSnakeNode , knot_vector_u[i], knot_vector_v[j], 0.0);
+                            surrogate_model_part_inner.CreateNewNode(idSnakeNode, snakeNode2);
+                            Condition::Pointer pcond2 = surrogate_model_part_inner.CreateNewCondition("LineCondition2D2N", idSnakeNode-1, {{idSnakeNode-1, idSnakeNode}}, p_cond_prop );
+                            idSnakeNode++;
+
+                            if (direction == 0) {j-- ; }
+                            if (direction == 1) {i-- ; }
+                            if (direction == 2) {j++ ; }
+                            if (direction == 3) {i++ ; }
+
+                            Node snakeNode3(idSnakeNode , knot_vector_u[i], knot_vector_v[j], 0.0);
+                            surrogate_model_part_inner.CreateNewNode(idSnakeNode, snakeNode3);
+                            Condition::Pointer pcond3 = surrogate_model_part_inner.CreateNewCondition("LineCondition2D2N", idSnakeNode-1, {{idSnakeNode-1, idSnakeNode}}, p_cond_prop );
+                            idSnakeNode++;
+
+                            // Finally rotate the direction of 180 degrees
+                            direction = direction + 2;
+                            if (direction == 4) {direction = 0;}
+                            if (direction == 5) {direction = 1;}
+                        }
+                        else
+                            KRATOS_ERROR << "SnakeSBMUtilities:: " <<  "error in the Snakes Coordinates" << std::endl;
+                    }
+                }
+            }
+            // Check if we have close the snake
+            if (I == start_i && J == start_j && is_special_case == 1 ) {
+                // End of the while loop
+                end = 1;
+                KRATOS_INFO("number of steps in the snake step") << steps << std::endl;
+            }
+        }
+        KRATOS_ERROR_IF(steps >= max_number_of_steps-1) << "SnakeSBMUtilities:: " <<  "reached maximum number of steps" << std::endl;
+
+        // Create "fictituos element" to memorize starting and ending node id for each surrogate boundary loop
+        IndexType initialId = id_first_node;
+        if (surrogate_model_part_inner.Elements().size()>0) {
+            // Check if it is not the first inner loop
+            initialId = surrogate_model_part_inner.GetElement(surrogate_model_part_inner.GetRootModelPart().Elements().size()).GetGeometry()[1].Id()+1;
+        }
+        std::vector<ModelPart::IndexType> elem_nodes{initialId, idSnakeNode-1};
+        surrogate_model_part_inner.CreateNewElement("Element2D2N", surrogate_model_part_inner.GetRootModelPart().Elements().size()+1, elem_nodes, p_cond_prop);
+        }
+
+
+    void SnakeSBMUtilities::CreateSurrogateBuondaryFromSnake_outer (DynamicBins& testBin_out, ModelPart& initial_skin_model_part_out, 
+                            std::vector<std::vector<std::vector<int>>> & knot_spans_available, int idMatrix, 
+                            ModelPart& surrogate_model_part_outer, std::vector<int>& n_knot_spans_uv, 
+                            Vector& knot_vector_u, Vector&  knot_vector_v,
+                            const Vector& starting_pos_uv){
+                                             
+        // CHECK ALL THE EXTERNAL KNOT SPANS
+
+        // LEFT BOUNDARY
+        double knot_step_u = knot_vector_u[1]-knot_vector_u[0];
+        double knot_step_v = knot_vector_v[1]-knot_vector_v[0];
+
+        for (int i = 0; i<2; i++) {
+            for (int j = 0; j < (n_knot_spans_uv[1]); j++ ) {
+                Point centroidKnotSpan = Point((j+0.5)*knot_step_u+starting_pos_uv[0], (i+0.5)*knot_step_v+starting_pos_uv[1], 0);
+                if (isPointInsideSkinBoundary(centroidKnotSpan, testBin_out, initial_skin_model_part_out) && knot_spans_available[idMatrix][i][j] != -1) {
+                    knot_spans_available[idMatrix][i][j] = 1;
+                    }
+            }
+        }
+        // TOP BOUNDARY
+        for (int j = knot_spans_available[idMatrix][0].size()-1; j > knot_spans_available[idMatrix][0].size()-3; j--) {
+            for (int i = 0; i < (n_knot_spans_uv[0]); i++) {
+                Point centroidKnotSpan = Point((j+0.5)*knot_step_u+starting_pos_uv[0], (i+0.5)*knot_step_v+starting_pos_uv[1], 0);
+                if (isPointInsideSkinBoundary(centroidKnotSpan, testBin_out, initial_skin_model_part_out) && knot_spans_available[idMatrix][i][j] != -1) {
+                    knot_spans_available[idMatrix][i][j] = 1;
+                    }
+            }
+        }
+        // RIGHT BOUNDARY
+        for (int i = knot_spans_available[idMatrix][0].size()-1; i > knot_spans_available[idMatrix][0].size()-3; i--) {
+            for (int j = n_knot_spans_uv[1]-1; j > -1; j-- ) {
+                Point centroidKnotSpan = Point((j+0.5)*knot_step_u+starting_pos_uv[0], (i+0.5)*knot_step_v+starting_pos_uv[1], 0);
+                if (isPointInsideSkinBoundary(centroidKnotSpan, testBin_out, initial_skin_model_part_out) && knot_spans_available[idMatrix][i][j] != -1) {
+                    knot_spans_available[idMatrix][i][j] = 1;
+                    }
+            }
+        }
+        // BOTTOM BOUNDARY
+        for (int j = 0; j<2; j++) {
+            for (int i = n_knot_spans_uv[0]-1; i > -1 ; i--) {
+                Point centroidKnotSpan = Point((j+0.5)*knot_step_u+starting_pos_uv[0], (i+0.5)*knot_step_v+starting_pos_uv[1], 0);
+                if (isPointInsideSkinBoundary(centroidKnotSpan, testBin_out, initial_skin_model_part_out) && knot_spans_available[idMatrix][i][j] != -1) {
+                    knot_spans_available[idMatrix][i][j] = 1;
+                    }
+            }
+        }
+
+        // Find the start of the Snake
+        int start_i = 0;
+        int start_j = 0;
+        for (int i = 0; i < (n_knot_spans_uv[0]); i++) {
+            for (int j = 0; j < (n_knot_spans_uv[1]); j++ ) {
+                if (knot_spans_available[idMatrix][j][i] == 1 ) {
+                    // Check if one of the neighouring knot span is also == 1,
+                    // otherwise the knot span is isolated I cannot be taken.
+                    if ((knot_spans_available[idMatrix][j+1][i] == 1) || (knot_spans_available[idMatrix][j][i+1] == 1))
+                    {
+                        start_i = i;
+                        start_j = j;
+                        break;
+                    }     
+                }
+            }
+            if (knot_spans_available[idMatrix][start_j][start_i] == 1 ) { break; }
+        }
+        
+        // EXTEND THE MATRIX
+        //-------------------
+        std::vector<std::vector<int>> knot_spans_available_extended(n_knot_spans_uv[1]+2, std::vector<int>(n_knot_spans_uv[0]+2));
+
+        for (int i = 0; i < knot_spans_available[idMatrix].size(); i++){
+            for (int j = 0; j < knot_spans_available[idMatrix][0].size(); j++) {
+                knot_spans_available_extended[i+1][j+1] = knot_spans_available[idMatrix][i][j]; 
+            }
+        }  
+        
+        Properties::Pointer p_cond_prop = surrogate_model_part_outer.CreateNewProperties(1001);
+        Node snakeNode(1 , knot_vector_u[start_i], knot_vector_v[start_j], 0.0);
+
+        const int id_first_node = surrogate_model_part_outer.GetRootModelPart().Nodes().size() + 1;
+        
+        surrogate_model_part_outer.CreateNewNode(id_first_node, snakeNode);
+        IndexType idSnakeNode = id_first_node+1;
+        
+        // Follow the clockwise loop
+        int end = 0;
+        // We are going orizontally
+        int direction = 0 ;      // 0 = up_vertical, 1 = right_orizontal, 2 = down_vertical, 3 = left_orizontal
+        int I = start_i+1;
+        int J = start_j+1; 
+        int i = start_i;
+        int j = start_j;
+        int steps = 0;
+        const int max_number_of_steps = 1e5;
+        while (end == 0 && steps < max_number_of_steps) {
+            steps ++ ;
+            int is_special_case = 1; // Variable to check if we are in a super special case and we shouldn't go out of the while loop
+            // Try to go left w.r.t. the current direction
+            if (direction == 0) {I-- ; }
+            if (direction == 1) {J++; }
+            if (direction == 2) {I++ ; }
+            if (direction == 3) {J-- ; }
+            if (knot_spans_available_extended[J][I] == 1) {
+                direction = direction - 1;
+                if (direction == -1) {direction = 3;}
+            }
+            else {
+                // Need to try to go straight or right w.r.t. the current direction; reset and move
+                if (direction == 0) {I++ ; J++ ;}
+                if (direction == 1) {J-- ; I++ ;}
+                if (direction == 2) {I-- ; J-- ;}
+                if (direction == 3) {J++ ; I-- ;}
+
+                if (knot_spans_available_extended[J][I] == 1) {
+
+                    // Going straight! -> Don't store and move (i,j)
+                    if (direction == 0) {j++ ; }
+                    if (direction == 1) {i++ ; }
+                    if (direction == 2) {j-- ; }
+                    if (direction == 3) {i-- ; }
+
+                    Node snakeNode(idSnakeNode , knot_vector_u[i], knot_vector_v[j], 0.0);
+                    surrogate_model_part_outer.CreateNewNode(idSnakeNode, snakeNode);
+                    Condition::Pointer pcond1 = surrogate_model_part_outer.CreateNewCondition("LineCondition2D2N", idSnakeNode-1, {{idSnakeNode-1, idSnakeNode}}, p_cond_prop );
+                    idSnakeNode++;
+                }
+                else {
+                    // Need to search to the right; Reset and move
+                    if (direction == 0) {J-- ; I++ ;}
+                    if (direction == 1) {I-- ; J-- ;}
+                    if (direction == 2) {J++ ; I-- ;}
+                    if (direction == 3) {I++ ; J++ ;}
+
+                    if (knot_spans_available_extended[J][I] == 1) {
+
+                        // Going to the right! -> first go forward, store, more right (i,j), store again
+                        if (direction == 0) {j++ ; }
+                        if (direction == 1) {i++ ; }
+                        if (direction == 2) {j-- ; }
+                        if (direction == 3) {i-- ; }
+                        Node snakeNode1(idSnakeNode , knot_vector_u[i], knot_vector_v[j], 0.0);
+                        surrogate_model_part_outer.CreateNewNode(idSnakeNode, snakeNode1);
+                        Condition::Pointer pcond1 = surrogate_model_part_outer.CreateNewCondition("LineCondition2D2N", idSnakeNode-1, {{idSnakeNode-1, idSnakeNode}}, p_cond_prop );
+                        idSnakeNode++;
+                        if (direction == 0) {i++ ; }
+                        if (direction == 1) {j-- ; }
+                        if (direction == 2) {i-- ; }
+                        if (direction == 3) {j++ ; }
+                        Node snakeNode2(idSnakeNode , knot_vector_u[i], knot_vector_v[j], 0.0);
+                        surrogate_model_part_outer.CreateNewNode(idSnakeNode, snakeNode2);
+                        Condition::Pointer pcond2 = surrogate_model_part_outer.CreateNewCondition("LineCondition2D2N", idSnakeNode-1, {{idSnakeNode-1, idSnakeNode}}, p_cond_prop );
+                        idSnakeNode++;
+                        direction = direction + 1;
+                        if (direction == 4) {direction = 0;}
+                    }
+                    else { // Special case of "isolated" knot span to be circumnavigated
+                        is_special_case = 0;
+                        // Reset and move (I,J) "backward"
+                        if (direction == 0) {I-- ; J-- ;} 
+                        if (direction == 1) {J++ ; I-- ;}
+                        if (direction == 2) {I++ ; J++ ;}
+                        if (direction == 3) {J-- ; I++ ;}
+                        // Check
+                        if (knot_spans_available_extended[J][I] == 1) {
+                            // First go forward, store, then move to right, then store again, then move to the right and store again
+                            if (direction == 0) {j++ ; }
+                            if (direction == 1) {i++ ; }
+                            if (direction == 2) {j-- ; }
+                            if (direction == 3) {i-- ; }
+                            Node snakeNode(idSnakeNode , knot_vector_u[i], knot_vector_v[j], 0.0);
+                            surrogate_model_part_outer.CreateNewNode(idSnakeNode, snakeNode);
+                            Condition::Pointer pcond1 = surrogate_model_part_outer.CreateNewCondition("LineCondition2D2N", idSnakeNode-1, {{idSnakeNode-1, idSnakeNode}}, p_cond_prop );
+                            idSnakeNode++;
+                            if (direction == 0) {i++ ; }
+                            if (direction == 1) {j-- ; }
+                            if (direction == 2) {i-- ; }
+                            if (direction == 3) {j++ ; }
+                            Node snakeNode2(idSnakeNode , knot_vector_u[i], knot_vector_v[j], 0.0);
+                            surrogate_model_part_outer.CreateNewNode(idSnakeNode, snakeNode2);
+                            Condition::Pointer pcond2 = surrogate_model_part_outer.CreateNewCondition("LineCondition2D2N", idSnakeNode-1, {{idSnakeNode-1, idSnakeNode}}, p_cond_prop );
+                            idSnakeNode++;
+                            if (direction == 0) {j-- ; }
+                            if (direction == 1) {i-- ; }
+                            if (direction == 2) {j++ ; }
+                            if (direction == 3) {i++ ; }
+                            Node snakeNode3(idSnakeNode , knot_vector_u[i], knot_vector_v[j], 0.0);
+                            surrogate_model_part_outer.CreateNewNode(idSnakeNode, snakeNode3);
+                            Condition::Pointer pcond3 = surrogate_model_part_outer.CreateNewCondition("LineCondition2D2N", idSnakeNode-1, {{idSnakeNode-1, idSnakeNode}}, p_cond_prop );
+                            idSnakeNode++;
+                            // Finally rotate the direction of 180 degrees
+                            direction = direction + 2;
+                            if (direction == 4) {direction = 0;}
+                            if (direction == 5) {direction = 1;}
+                        }
+                        else
+                            KRATOS_ERROR << "SnakeSBMUtilities:: " <<  "error in the Snakes Coordinates" << std::endl;
+                    }
+                }
+            }
+            // Check if we have close the snake
+            if (I == start_i+1 && J == start_j+1 && is_special_case == 1 ) {
+                // End of the while loop
+                end = 1;
+                }
+        }
+        // Create "fictituos element" to memorize starting and ending node id for each surrogate boundary loop
+        std::vector<ModelPart::IndexType> elem_nodes{1, idSnakeNode-1};
+        int elem_id = surrogate_model_part_outer.GetRootModelPart().Elements().size()+1;
+        surrogate_model_part_outer.CreateNewElement("Element2D2N", elem_id, elem_nodes, p_cond_prop);
+    }
+}  // namespace Kratos.

--- a/kratos/utilities/nurbs_utilities/snake_sbm_utilities.cpp
+++ b/kratos/utilities/nurbs_utilities/snake_sbm_utilities.cpp
@@ -643,7 +643,7 @@ namespace Kratos
             }
         }
         // TOP BOUNDARY
-        for (int j = knot_spans_available[idMatrix][0].size()-1; j > knot_spans_available[idMatrix][0].size()-3; j--) {
+        for (int j = int (knot_spans_available[idMatrix][0].size()-1); j > int (knot_spans_available[idMatrix][0].size()-3); j--) {
             for (int i = 0; i < (n_knot_spans_uv[1]); i++) {
                 Point centroidKnotSpan = Point((j+0.5)*knot_step_u+starting_pos_uv[0], (i+0.5)*knot_step_v+starting_pos_uv[1], 0);
                 if (IsPointInsideSkinBoundary(centroidKnotSpan, testBin_out, initial_skin_model_part_out) && knot_spans_available[idMatrix][i][j] != -1) {
@@ -652,7 +652,7 @@ namespace Kratos
             }
         }
         // RIGHT BOUNDARY
-        for (int i = knot_spans_available[idMatrix].size()-1; i > knot_spans_available[idMatrix].size()-3; i--) {
+        for (int i = int (knot_spans_available[idMatrix].size()-1); i > int (knot_spans_available[idMatrix].size()-3); i--) {
             for (int j = n_knot_spans_uv[0]-1; j > -1; j-- ) {
                 Point centroidKnotSpan = Point((j+0.5)*knot_step_u+starting_pos_uv[0], (i+0.5)*knot_step_v+starting_pos_uv[1], 0);
                 if (IsPointInsideSkinBoundary(centroidKnotSpan, testBin_out, initial_skin_model_part_out) && knot_spans_available[idMatrix][i][j] != -1) {

--- a/kratos/utilities/nurbs_utilities/snake_sbm_utilities.cpp
+++ b/kratos/utilities/nurbs_utilities/snake_sbm_utilities.cpp
@@ -486,7 +486,7 @@ namespace Kratos
         // Follow the clockwise loop
         bool end = false;
         // We are going orizontally
-        std::size_t direction = 0;
+        int direction = 0;
         // 0 = up_vertical, 1 = right_orizontal, 2 = down_vertical, 3 = left_orizontal
         int i = start_i; int j = start_j;
         int I = start_i; int J = start_j;
@@ -708,7 +708,7 @@ namespace Kratos
         // Follow the clockwise loop
         bool end = false;
         // We are going orizontally
-        std::size_t direction = 0 ;      // 0 = up_vertical, 1 = right_orizontal, 2 = down_vertical, 3 = left_orizontal
+        int direction = 0 ;      // 0 = up_vertical, 1 = right_orizontal, 2 = down_vertical, 3 = left_orizontal
         int I = start_i+1;
         int J = start_j+1; 
         int i = start_i;

--- a/kratos/utilities/nurbs_utilities/snake_sbm_utilities.cpp
+++ b/kratos/utilities/nurbs_utilities/snake_sbm_utilities.cpp
@@ -108,7 +108,7 @@ namespace Kratos
         std::vector<std::vector<std::vector<int>>> knot_spans_available;
         knot_spans_available.reserve(numberOfLoops);
 
-        for (int i = 0; i < numberOfLoops; ++i) {
+        for (IndexType i = 0; i < numberOfLoops; ++i) {
             std::vector<std::vector<int>> matrix; 
             matrix.reserve(n_knot_spans_uv[1]);
             for (int j = 0; j <= n_knot_spans_uv[1]; ++j) {
@@ -120,7 +120,7 @@ namespace Kratos
         
         // Optimized Snake -> for inner loops
         int idMatrixKnotSpansAvailable = 0;
-        int idFirstNode;
+        IndexType idFirstNode;
         bool newInnerLoop = true;
 
         
@@ -214,8 +214,8 @@ namespace Kratos
         KRATOS_INFO_IF("::[SnakeSBMUtilities]::", rEchoLevel > 0 && is_inner) << "Inner :: MarkKnotSpansAvailable" << std::endl;
         KRATOS_INFO_IF("::[SnakeSBMUtilities]::", rEchoLevel > 0 && !is_inner) << "Outer :: MarkKnotSpansAvailable" << std::endl;
 
-        for (int i = 0; i < numberOfLoops; i++) {
-            int idInnerLoop = i;
+        for (IndexType i = 0; i < numberOfLoops; i++) {
+            IndexType idInnerLoop = i;
             // Mark the knot_spans_available's for inner and outer loops
             MarkKnotSpansAvailable(knot_spans_available, idInnerLoop, testBins, skin_sub_model_part, lambda, 
                                    n_knot_spans_uv, knot_step_uv, starting_pos_uv);  
@@ -329,10 +329,10 @@ namespace Kratos
         PointerType nearestPoint = testBins.SearchNearestPoint(*pointToSearch);
         
         // Get the closest Condition the initial_skin_model_part_in.Conditions
-        int id1 = nearestPoint->Id();
+        IndexType id1 = nearestPoint->Id();
         auto nearestCondition1 = skin_model_part.GetCondition(id1);
         // Check if the condition is the first one and therefore the previous one does not exist
-        int id2 = id1 - 1;
+        IndexType id2 = id1 - 1;
         if (id1 == skin_model_part.ConditionsBegin()->Id()) {
             int nConditions = skin_model_part.Conditions().size();
             id2 = id1 + nConditions - 1; 
@@ -424,11 +424,11 @@ namespace Kratos
                     // Create 25 "fake" GaussPoints to check if the majority are inside or outside
                     const int numFakeGaussPoints = 5;
                     int numberOfInsideGaussianPoints = 0;
-                    for (int i_GPx = 0; i_GPx < numFakeGaussPoints; i_GPx++){
+                    for (IndexType i_GPx = 0; i_GPx < numFakeGaussPoints; i_GPx++){
                         double x_coord = j*knot_step_uv[0] + knot_step_uv[0]/(numFakeGaussPoints+1)*(i_GPx+1) + starting_pos_uv[0];
 
                         // NOTE:: The v-knot spans are upside down in the matrix!!
-                        for (int i_GPy = 0; i_GPy < numFakeGaussPoints; i_GPy++) 
+                        for (IndexType i_GPy = 0; i_GPy < numFakeGaussPoints; i_GPy++) 
                         {
                             double y_coord = i*knot_step_uv[1] + knot_step_uv[1]/(numFakeGaussPoints+1)*(i_GPy+1) + starting_pos_uv[1];
                             Point gaussPoint = Point(x_coord, y_coord, 0);  // GAUSSIAN POINT
@@ -646,7 +646,7 @@ namespace Kratos
             }
         }
         // TOP BOUNDARY
-        for (int j = knot_spans_available[idMatrix][0].size()-1; j > knot_spans_available[idMatrix][0].size()-3; j--) {
+        for (int j = int(knot_spans_available[idMatrix][0].size())-1; j > int(knot_spans_available[idMatrix][0].size())-3; j--) {
             for (int i = 0; i < (n_knot_spans_uv[0]); i++) {
                 Point centroidKnotSpan = Point((j+0.5)*knot_step_u+starting_pos_uv[0], (i+0.5)*knot_step_v+starting_pos_uv[1], 0);
                 if (isPointInsideSkinBoundary(centroidKnotSpan, testBin_out, initial_skin_model_part_out) && knot_spans_available[idMatrix][i][j] != -1) {
@@ -655,7 +655,7 @@ namespace Kratos
             }
         }
         // RIGHT BOUNDARY
-        for (int i = knot_spans_available[idMatrix][0].size()-1; i > knot_spans_available[idMatrix][0].size()-3; i--) {
+        for (int i = int(knot_spans_available[idMatrix][0].size())-1; i > int(knot_spans_available[idMatrix][0].size())-3; i--) {
             for (int j = n_knot_spans_uv[1]-1; j > -1; j-- ) {
                 Point centroidKnotSpan = Point((j+0.5)*knot_step_u+starting_pos_uv[0], (i+0.5)*knot_step_v+starting_pos_uv[1], 0);
                 if (isPointInsideSkinBoundary(centroidKnotSpan, testBin_out, initial_skin_model_part_out) && knot_spans_available[idMatrix][i][j] != -1) {
@@ -696,8 +696,8 @@ namespace Kratos
         //-------------------
         std::vector<std::vector<int>> knot_spans_available_extended(n_knot_spans_uv[1]+2, std::vector<int>(n_knot_spans_uv[0]+2));
 
-        for (int i = 0; i < knot_spans_available[idMatrix].size(); i++){
-            for (int j = 0; j < knot_spans_available[idMatrix][0].size(); j++) {
+        for (IndexType i = 0; i < knot_spans_available[idMatrix].size(); i++){
+            for (IndexType j = 0; j < knot_spans_available[idMatrix][0].size(); j++) {
                 knot_spans_available_extended[i+1][j+1] = knot_spans_available[idMatrix][i][j]; 
             }
         }  
@@ -833,7 +833,7 @@ namespace Kratos
         }
         // Create "fictituos element" to memorize starting and ending node id for each surrogate boundary loop
         std::vector<ModelPart::IndexType> elem_nodes{1, idSnakeNode-1};
-        int elem_id = surrogate_model_part_outer.GetRootModelPart().Elements().size()+1;
+        IndexType elem_id = surrogate_model_part_outer.GetRootModelPart().Elements().size()+1;
         surrogate_model_part_outer.CreateNewElement("Element2D2N", elem_id, elem_nodes, p_cond_prop);
     }
 }  // namespace Kratos.

--- a/kratos/utilities/nurbs_utilities/snake_sbm_utilities.h
+++ b/kratos/utilities/nurbs_utilities/snake_sbm_utilities.h
@@ -11,8 +11,7 @@
 //                   Andrea Gorgi
 //
 
-#if !defined(KRATOS_SNAKE_SBM_UTILITIES_H_INCLUDED )
-#define KRATOS_SNAKE_SBM_UTILITIES_H_INCLUDED
+#pragma once
 
 // Project includes
 #include "includes/model_part.h"
@@ -129,7 +128,7 @@ namespace Kratos
                                             ModelPart& skin_model_part, 
                                             double lambda, 
                                             std::vector<int>& n_knot_spans_uv, 
-                                            Vector& knot_step_uv, 
+                                            array_1d<double, 2>& knot_step_uv, 
                                             const Vector& starting_pos_uv);
 
         /**
@@ -175,5 +174,3 @@ namespace Kratos
     }; // Class SnakeSBMUtilities
 
 }  // namespace Kratos.
-
-#endif // KRATOS_DIRECTOR_UTILITIES_H_INCLUDED  defined

--- a/kratos/utilities/nurbs_utilities/snake_sbm_utilities.h
+++ b/kratos/utilities/nurbs_utilities/snake_sbm_utilities.h
@@ -1,0 +1,179 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
+//
+//  Main authors:    Nicolo' Antonelli
+//                   Andrea Gorgi
+//
+
+#if !defined(KRATOS_SNAKE_SBM_UTILITIES_H_INCLUDED )
+#define KRATOS_SNAKE_SBM_UTILITIES_H_INCLUDED
+
+// Project includes
+#include "includes/model_part.h"
+#include "spatial_containers/bins_dynamic.h"
+
+namespace Kratos
+{
+    ///@name Kratos Classes
+    ///@{
+
+    /**
+     * @class SnakeSBMUtilities
+     * @brief Utility class for implementing Snake-based Surrogate Boundary Method (SBM).
+     * This class provides various functions to create and manipulate snake-like surrogate boundaries
+     * for finite element models in Kratos.
+     */
+    class KRATOS_API(IGA_APPLICATION) SnakeSBMUtilities
+    {
+    public:
+        /**
+         * @brief Creates the initial snake coordinates for 2D or 3D skin.
+         * @param iga_model_part Model part containing the IGA geometry.
+         * @param skin_model_part_inner_initial Model part for the initial inner skin boundary.
+         * @param skin_model_part_outer_initial Model part for the initial outer skin boundary.
+         * @param skin_model_part Model part where the snake coordinates will be stored.
+         * @param rEchoLevel Verbosity level for logging.
+         * @param knot_vector_u Knot vector in the U-direction.
+         * @param knot_vector_v Knot vector in the V-direction.
+         * @param mParameters Input parameters for the process.
+         */
+        static void CreateTheSnakeCoordinates(ModelPart& iga_model_part, 
+                                            ModelPart& skin_model_part_inner_initial,
+                                            ModelPart& skin_model_part_outer_initial,
+                                            ModelPart& skin_model_part, 
+                                            int rEchoLevel, 
+                                            Vector& knot_vector_u, 
+                                            Vector& knot_vector_v, 
+                                            const Parameters mParameters);
+        
+        /**
+         * @brief Creates the snake coordinates for a specific loop (inner or outer).
+         * @param iga_model_part Model part containing the IGA geometry.
+         * @param skin_model_part_initial Model part for the initial skin boundary.
+         * @param skin_model_part Model part where the snake coordinates will be stored.
+         * @param rEchoLevel Verbosity level for logging.
+         * @param knot_vector_u Knot vector in the U-direction.
+         * @param knot_vector_v Knot vector in the V-direction.
+         * @param mParameters Input parameters for the process.
+         * @param is_inner_loop Boolean flag to indicate if the loop is inner or outer.
+         */
+        static void CreateTheSnakeCoordinates(ModelPart& iga_model_part, 
+                                            ModelPart& skin_model_part_initial,
+                                            ModelPart& skin_model_part, 
+                                            int rEchoLevel, 
+                                            Vector& knot_vector_u, 
+                                            Vector& knot_vector_v, 
+                                            const Parameters mParameters,
+                                            bool is_inner_loop);
+
+        /**
+         * @brief Performs a single step in the snake algorithm for 2D models.
+         * @param skin_model_part The skin model part to be updated.
+         * @param knot_spans_available Knot spans available for the snake.
+         * @param idMatrixKnotSpansAvailable ID of the matrix tracking available knot spans.
+         * @param knot_spans_uv Knot spans in UV coordinates.
+         * @param xy_coord_i_cond XY coordinates of control points.
+         * @param knot_step_uv Step size in UV space.
+         * @param starting_pos_uv Starting position in UV space.
+         */
+        static void SnakeStep(ModelPart& skin_model_part, 
+                            std::vector<std::vector<std::vector<int>>> &knot_spans_available, 
+                            int idMatrixKnotSpansAvailable, 
+                            std::vector<std::vector<int>> knot_spans_uv, 
+                            std::vector<std::vector<double>> xy_coord_i_cond, 
+                            Vector knot_step_uv, 
+                            Vector starting_pos_uv);
+
+    private:
+        ///@name IGA functionalities
+        ///@{
+        using PointType = Node;
+        using PointTypePointer = Node::Pointer;
+        using PointVector = std::vector<PointType::Pointer>;
+        using PointIterator = std::vector<PointType::Pointer>::iterator;
+        using DistanceVector = std::vector<double>;
+        using DistanceIterator = std::vector<double>::iterator;
+        using DynamicBins = BinsDynamic<3, PointType, PointVector, PointTypePointer, PointIterator, DistanceIterator>;
+        using PointerType = DynamicBins::PointerType;
+
+        /**
+         * @brief Checks if a point is inside the given skin boundary.
+         * @param pointToSearch The point to be checked.
+         * @param testBins Spatial bins to search for nearby points.
+         * @param skin_model_part_in Input skin model part.
+         * @return True if the point is inside the boundary, false otherwise.
+         */
+        static bool isPointInsideSkinBoundary(Point& pointToSearch, 
+                                                DynamicBins& testBins,
+                                                ModelPart& skin_model_part_in);
+
+        /**
+         * @brief Marks the knot spans as available for the snake algorithm.
+         * @param knot_spans_available Reference to the knot spans availability matrix.
+         * @param idMatrix ID of the matrix being updated.
+         * @param testBin Spatial bins to search for nearby points.
+         * @param skin_model_part Skin model part being analyzed.
+         * @param lambda Relaxation parameter.
+         * @param n_knot_spans_uv Number of knot spans in UV directions.
+         * @param knot_step_uv Step size in UV space.
+         * @param starting_pos_uv Starting position in UV space.
+         */
+        static void MarkKnotSpansAvailable(std::vector<std::vector<std::vector<int>>> & knot_spans_available, 
+                                            int idMatrix,DynamicBins& testBin, 
+                                            ModelPart& skin_model_part, 
+                                            double lambda, 
+                                            std::vector<int>& n_knot_spans_uv, 
+                                            Vector& knot_step_uv, 
+                                            const Vector& starting_pos_uv);
+
+        /**
+         * @brief Creates the inner surrogate boundary from the snake algorithm.
+         * @param knot_spans_available Reference to the knot spans availability matrix.
+         * @param idMatrix ID of the matrix being updated.
+         * @param surrogate_model_part_inner Model part representing the inner boundary.
+         * @param n_knot_spans_uv Number of knot spans in UV directions.
+         * @param knot_vector_u Knot vector in the U-direction.
+         * @param knot_vector_v Knot vector in the V-direction.
+         * @param starting_pos_uv Starting position in UV space.
+         */
+        static void CreateSurrogateBuondaryFromSnake_inner (std::vector<std::vector<std::vector<int>>> & knot_spans_available, 
+                                                            int idMatrix, 
+                                                            ModelPart& surrogate_model_part_inner, 
+                                                            std::vector<int>& n_knot_spans_uv, 
+                                                            Vector& knot_vector_u,
+                                                            Vector& knot_vector_v,
+                                                            const Vector& starting_pos_uv);
+
+        /**
+         * @brief Creates the outer surrogate boundary from the snake algorithm.
+         * @param testBin_out Spatial bins for testing.
+         * @param initial_skin_model_part_out Initial outer skin model part.
+         * @param knot_spans_available Reference to the knot spans availability matrix.
+         * @param idMatrix ID of the matrix being updated.
+         * @param surrogate_model_part_outer Model part representing the outer boundary.
+         * @param n_knot_spans_uv Number of knot spans in UV directions.
+         * @param knot_vector_u Knot vector in the U-direction.
+         * @param knot_vector_v Knot vector in the V-direction.
+         * @param starting_pos_uv Starting position in UV space.
+         */
+        static void CreateSurrogateBuondaryFromSnake_outer (DynamicBins& testBin_out, 
+                                                            ModelPart& initial_skin_model_part_out, 
+                                                            std::vector<std::vector<std::vector<int>>> & knot_spans_available, 
+                                                            int idMatrix, 
+                                                            ModelPart& surrogate_model_part_outer, 
+                                                            std::vector<int>& n_knot_spans_uv, 
+                                                            Vector& knot_vector_u, 
+                                                            Vector&  knot_vector_v,
+                                                            const Vector& starting_pos_uv);
+
+    }; // Class SnakeSBMUtilities
+
+}  // namespace Kratos.
+
+#endif // KRATOS_DIRECTOR_UTILITIES_H_INCLUDED  defined

--- a/kratos/utilities/nurbs_utilities/snake_sbm_utilities.h
+++ b/kratos/utilities/nurbs_utilities/snake_sbm_utilities.h
@@ -108,7 +108,7 @@ namespace Kratos
          * @param skin_model_part_in Input skin model part.
          * @return True if the point is inside the boundary, false otherwise.
          */
-        static bool isPointInsideSkinBoundary(Point& pointToSearch, 
+        static bool IsPointInsideSkinBoundary(Point& pointToSearch, 
                                                 DynamicBins& testBins,
                                                 ModelPart& skin_model_part_in);
 
@@ -141,7 +141,7 @@ namespace Kratos
          * @param knot_vector_v Knot vector in the V-direction.
          * @param starting_pos_uv Starting position in UV space.
          */
-        static void CreateSurrogateBuondaryFromSnake_inner (std::vector<std::vector<std::vector<int>>> & knot_spans_available, 
+        static void CreateSurrogateBuondaryFromSnakeInner (std::vector<std::vector<std::vector<int>>> & knot_spans_available, 
                                                             int idMatrix, 
                                                             ModelPart& surrogate_model_part_inner, 
                                                             std::vector<int>& n_knot_spans_uv, 
@@ -161,7 +161,7 @@ namespace Kratos
          * @param knot_vector_v Knot vector in the V-direction.
          * @param starting_pos_uv Starting position in UV space.
          */
-        static void CreateSurrogateBuondaryFromSnake_outer (DynamicBins& testBin_out, 
+        static void CreateSurrogateBuondaryFromSnakeOuter (DynamicBins& testBin_out, 
                                                             ModelPart& initial_skin_model_part_out, 
                                                             std::vector<std::vector<std::vector<int>>> & knot_spans_available, 
                                                             int idMatrix, 


### PR DESCRIPTION
**📝 Description**
We have added the NURBS Modeler SBM:

1.  It is a derived class from the existing NURBS modeler, which creates a rectangular domain. 
2. The first addition is the identification of surrogate boundaries for the inner and outer loops.
3. The second addition is the creation of the surface and BREP curves from the surrogate boundaries.

In particular, we have developed two utilities: one to identify the surrogate boundaries and another to create the BREP entities. These utilities were created to enhance clarity and because they might be used separately in other applications.

Please mark the PR with appropriate tags: 
- IgaApplication