### PR TITLE
[GeoMechanicsApplication] GetVariableBasedOnString is now emitting a warning rather than an error in set_parameter_field_process

### DIFF
--- a/applications/GeoMechanicsApplication/python_scripts/set_parameter_field_process.py
+++ b/applications/GeoMechanicsApplication/python_scripts/set_parameter_field_process.py
@@ -50,12 +50,12 @@ class SetParameterFieldProcess(KratosMultiphysics.Process):
             self.params.AddValue("dataset_file_name", settings["dataset_file_name"])
         self.process = KratosGeo.SetParameterFieldProcess(self.model_part, self.params)
 
-    def GetVariableBasedOnString(self) -> Optional[KratosMultiphysics.Variable]:
+    def GetVariableBasedOnString(self) -> Optional[KratosMultiphysics.VariableData]:
         """
         This function returns the variable based on the variable name string.
 
         Returns:
-            - Optional[KratosMultiphysics.Variable]: the kratos variable object
+            - Optional[KratosMultiphysics.VariableData]: the kratos variable object
         """
 
         # Get variable object

--- a/applications/GeoMechanicsApplication/python_scripts/set_parameter_field_process.py
+++ b/applications/GeoMechanicsApplication/python_scripts/set_parameter_field_process.py
@@ -1,5 +1,7 @@
 import json
 import importlib
+import warnings
+from typing import Optional
 
 import KratosMultiphysics
 import KratosMultiphysics.GeoMechanicsApplication as KratosGeo
@@ -48,15 +50,12 @@ class SetParameterFieldProcess(KratosMultiphysics.Process):
             self.params.AddValue("dataset_file_name", settings["dataset_file_name"])
         self.process = KratosGeo.SetParameterFieldProcess(self.model_part, self.params)
 
-    def GetVariableBasedOnString(self):
+    def GetVariableBasedOnString(self) -> Optional[KratosMultiphysics.Variable]:
         """
         This function returns the variable based on the variable name string.
 
-
-        Returns
-        -------
-        variable : KratosMultiphysics.Variable
-
+        Returns:
+            - Optional[KratosMultiphysics.Variable]: the kratos variable object
         """
 
         # Get variable object
@@ -67,8 +66,10 @@ class SetParameterFieldProcess(KratosMultiphysics.Process):
                 variable = getattr(kratos_module, self.params["variable_name"].GetString())
                 return variable
 
-        raise AttributeError(f'The variable: {self.params["variable_name"].GetString()} is not present within '
-                             f'the imported modules')
+        # add warning if variable is not found
+        warnings.warn(f'The variable: {self.params["variable_name"].GetString()} is not present within '
+                      f'the imported modules')
+        return None
 
 
     def ExecuteInitialize(self):
@@ -94,6 +95,9 @@ class SetParameterFieldProcess(KratosMultiphysics.Process):
             all_coordinates = []
 
             variable = self.GetVariableBasedOnString()
+            if variable is None:
+                raise AttributeError(f'The variable: {self.params["variable_name"].GetString()} is not present within '
+                                     f'the imported modules')
 
             for element in self.model_part.Elements:
 

--- a/applications/GeoMechanicsApplication/tests/test_parameter_field.py
+++ b/applications/GeoMechanicsApplication/tests/test_parameter_field.py
@@ -1,10 +1,12 @@
 import os
 import shutil
-import stat
+import warnings
 
 import KratosMultiphysics as Kratos
 import KratosMultiphysics.GeoMechanicsApplication as KratosGeo
 import KratosMultiphysics.KratosUnittest as KratosUnittest
+from KratosMultiphysics.GeoMechanicsApplication.set_parameter_field_process import SetParameterFieldProcess
+
 import test_helper
 
 
@@ -202,6 +204,61 @@ class KratosGeoMechanicsParameterFieldTests(KratosUnittest.TestCase):
 
         self.assertTrue(r'Error: The parameter field does not have the same size as '
                         r'the amount of elements within the model part!' in str(cm.exception))
+
+    def test_GetVariableBasedOnString(self):
+        """
+        Test to check if the variable is correctly retrieved from the imported modules
+        """
+
+        # dummy variables with YOUNG_MODULUS, which is a variable which is exported to the python module
+        settings = Kratos.Parameters("""{
+            "model_part_name": "test",
+            "variable_name": "YOUNG_MODULUS",
+            "dataset": "dummy",
+            "func_type": "json_file",
+            "function": "dummy",
+            "dataset_file_name": "test_file"
+        }""")
+
+        # initialize the set parameter field process
+        model = Kratos.Model()
+        model.CreateModelPart("test")
+        process = SetParameterFieldProcess(model, settings)
+
+        variable = process.GetVariableBasedOnString()
+
+        assert variable == Kratos.YOUNG_MODULUS
+
+    def test_GetVariableBasedOnString_non_existing_variable_in_python(self):
+        """
+        Test to check if a warning is raised when a variable is not present in the imported modules
+        """
+
+        # dummy variables with DENSITY_SOLID_dummy, which is a variable which is not exported to the python module
+        settings = Kratos.Parameters("""{
+            "model_part_name": "test",
+            "variable_name": "DENSITY_SOLID_dummy",
+            "dataset": "dummy",
+            "func_type": "json_file",
+            "function": "dummy",
+            "dataset_file_name": "test_file"
+        }""")
+
+        # initialize the set parameter field process
+        model = Kratos.Model()
+        model.CreateModelPart("test")
+        process = SetParameterFieldProcess(model, settings)
+
+        # catch the warnings for the test
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")  # Ensure warnings are triggered
+
+            assert process.GetVariableBasedOnString() is None
+
+        # Check that a warning was raised
+        assert len(w) == 1
+        assert issubclass(w[-1].category, UserWarning)
+        assert str(w[-1].message) == "The variable: DENSITY_SOLID_dummy is not present within the imported modules"
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
 GetVariableBasedOnString is now emiting a warning rather than an error in set_parameter_field_process
 
Before, an error was emited when a variable like DENSITY_SOLID, which is not exported tot the python api, is requested

 this error is only required when wanting to generate a parameter field with a python function 

But the function which raises the error is still required in the __init__