### PR TITLE
[GeoMechanicsApplication] Unit tests for TransientPwElement

### DIFF
--- a/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_element.cpp
@@ -335,6 +335,8 @@ void UPwSmallStrainElement<TDim, TNumNodes>::CalculateHydraulicDischarge(const P
         for (unsigned int node = 0; node < TNumNodes; ++node) {
             double HydraulicDischarge = 0;
             for (unsigned int iDir = 0; iDir < TDim; ++iDir) {
+                auto aa = Variables.GradNpT(node, iDir);
+                auto bb = FluidFlux[GPoint][iDir];
                 HydraulicDischarge += Variables.GradNpT(node, iDir) * FluidFlux[GPoint][iDir];
             }
 

--- a/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_element.cpp
@@ -335,8 +335,6 @@ void UPwSmallStrainElement<TDim, TNumNodes>::CalculateHydraulicDischarge(const P
         for (unsigned int node = 0; node < TNumNodes; ++node) {
             double HydraulicDischarge = 0;
             for (unsigned int iDir = 0; iDir < TDim; ++iDir) {
-                auto aa = Variables.GradNpT(node, iDir);
-                auto bb = FluidFlux[GPoint][iDir];
                 HydraulicDischarge += Variables.GradNpT(node, iDir) * FluidFlux[GPoint][iDir];
             }
 

--- a/applications/GeoMechanicsApplication/custom_elements/transient_Pw_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/transient_Pw_element.cpp
@@ -331,11 +331,9 @@ void TransientPwElement<TDim, TNumNodes>::CalculateOnIntegrationPoints(const Var
             GeoElementUtilities::FillArray1dOutput(rOutput[integration_point], fluid_fluxes[integration_point]);
         }
     } else {
-        if (rOutput.size() != mRetentionLawVector.size())
-            rOutput.resize(mRetentionLawVector.size());
-
-        for (unsigned int i = 0; i < mRetentionLawVector.size(); ++i) {
-            noalias(rOutput[i]) = ZeroVector(3);
+        for (unsigned int integration_point = 0; integration_point < number_of_integration_points;
+             ++integration_point) {
+            noalias(rOutput[integration_point]) = ZeroVector(3);
         }
     }
 

--- a/applications/GeoMechanicsApplication/custom_elements/transient_Pw_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/transient_Pw_element.cpp
@@ -43,11 +43,11 @@ void TransientPwElement<TDim, TNumNodes>::CalculateMassMatrix(MatrixType& rMassM
 {
     KRATOS_TRY
 
-    const unsigned int N_DOF = this->GetNumberOfDOF();
+    const unsigned int n_DoF = this->GetNumberOfDOF();
 
     // Resizing mass matrix
-    if (rMassMatrix.size1() != N_DOF) rMassMatrix.resize(N_DOF, N_DOF, false);
-    noalias(rMassMatrix) = ZeroMatrix(N_DOF, N_DOF);
+    if (rMassMatrix.size1() != n_DoF) rMassMatrix.resize(n_DoF, n_DoF, false);
+    noalias(rMassMatrix) = ZeroMatrix(n_DoF, n_DoF);
 
     KRATOS_CATCH("")
 }
@@ -58,11 +58,11 @@ void TransientPwElement<TDim, TNumNodes>::CalculateDampingMatrix(MatrixType& rDa
 {
     KRATOS_TRY
 
-    const unsigned int N_DOF = this->GetNumberOfDOF();
+    const unsigned int n_DoF = this->GetNumberOfDOF();
 
     // Compute Damping Matrix
-    if (rDampingMatrix.size1() != N_DOF) rDampingMatrix.resize(N_DOF, N_DOF, false);
-    noalias(rDampingMatrix) = ZeroMatrix(N_DOF, N_DOF);
+    if (rDampingMatrix.size1() != n_DoF) rDampingMatrix.resize(n_DoF, n_DoF, false);
+    noalias(rDampingMatrix) = ZeroMatrix(n_DoF, n_DoF);
 
     KRATOS_CATCH("")
 }
@@ -72,9 +72,9 @@ void TransientPwElement<TDim, TNumNodes>::GetValuesVector(Vector& rValues, int S
 {
     KRATOS_TRY
 
-    const unsigned int N_DOF = this->GetNumberOfDOF();
+    const unsigned int n_DoF = this->GetNumberOfDOF();
 
-    if (rValues.size() != N_DOF) rValues.resize(N_DOF, false);
+    if (rValues.size() != n_DoF) rValues.resize(n_DoF, false);
 
     // Why are we constructing a zero vector here?
     for (unsigned int i = 0; i < TNumNodes; ++i) {
@@ -89,9 +89,9 @@ void TransientPwElement<TDim, TNumNodes>::GetFirstDerivativesVector(Vector& rVal
 {
     KRATOS_TRY
 
-    const unsigned int N_DOF = this->GetNumberOfDOF();
+    const unsigned int n_DoF = this->GetNumberOfDOF();
 
-    if (rValues.size() != N_DOF) rValues.resize(N_DOF, false);
+    if (rValues.size() != n_DoF) rValues.resize(n_DoF, false);
 
     // Why are we constructing a zero vector here?
     for (unsigned int i = 0; i < TNumNodes; ++i) {
@@ -106,9 +106,9 @@ void TransientPwElement<TDim, TNumNodes>::GetSecondDerivativesVector(Vector& rVa
 {
     KRATOS_TRY
 
-    const unsigned int N_DOF = this->GetNumberOfDOF();
+    const unsigned int n_DoF = this->GetNumberOfDOF();
 
-    if (rValues.size() != N_DOF) rValues.resize(N_DOF, false);
+    if (rValues.size() != n_DoF) rValues.resize(n_DoF, false);
 
     // Why are we constructing a zero vector here?
     for (unsigned int i = 0; i < TNumNodes; ++i) {
@@ -150,40 +150,40 @@ int TransientPwElement<TDim, TNumNodes>::Check(const ProcessInfo& rCurrentProces
 {
     KRATOS_TRY
 
-    const PropertiesType& Prop = this->GetProperties();
-    const GeometryType&   Geom = this->GetGeometry();
+    const PropertiesType& r_properties = this->GetProperties();
+    const GeometryType&   r_geom       = this->GetGeometry();
 
-    if (Geom.DomainSize() < 1.0e-15)
+    if (r_geom.DomainSize() < 1.0e-15)
         KRATOS_ERROR << "DomainSize < 1.0e-15 for the element " << this->Id() << std::endl;
 
     for (unsigned int i = 0; i < TNumNodes; ++i) {
-        if (Geom[i].SolutionStepsDataHas(WATER_PRESSURE) == false)
-            KRATOS_ERROR << "Missing variable WATER_PRESSURE on node " << Geom[i].Id() << std::endl;
+        if (r_geom[i].SolutionStepsDataHas(WATER_PRESSURE) == false)
+            KRATOS_ERROR << "Missing variable WATER_PRESSURE on node " << r_geom[i].Id() << std::endl;
 
-        if (Geom[i].SolutionStepsDataHas(DT_WATER_PRESSURE) == false)
-            KRATOS_ERROR << "Missing variable DT_WATER_PRESSURE on node " << Geom[i].Id() << std::endl;
+        if (r_geom[i].SolutionStepsDataHas(DT_WATER_PRESSURE) == false)
+            KRATOS_ERROR << "Missing variable DT_WATER_PRESSURE on node " << r_geom[i].Id() << std::endl;
 
-        if (Geom[i].SolutionStepsDataHas(VOLUME_ACCELERATION) == false)
-            KRATOS_ERROR << "Missing variable VOLUME_ACCELERATION on node " << Geom[i].Id() << std::endl;
+        if (r_geom[i].SolutionStepsDataHas(VOLUME_ACCELERATION) == false)
+            KRATOS_ERROR << "Missing variable VOLUME_ACCELERATION on node " << r_geom[i].Id() << std::endl;
 
-        if (Geom[i].HasDofFor(WATER_PRESSURE) == false)
-            KRATOS_ERROR << "Missing variable WATER_PRESSURE on node " << Geom[i].Id() << std::endl;
+        if (r_geom[i].HasDofFor(WATER_PRESSURE) == false)
+            KRATOS_ERROR << "Missing variable WATER_PRESSURE on node " << r_geom[i].Id() << std::endl;
     }
 
     // Verify ProcessInfo variables
 
     // Verify properties
-    if (Prop.Has(DENSITY_WATER) == false || Prop[DENSITY_WATER] < 0.0)
+    if (r_properties.Has(DENSITY_WATER) == false || r_properties[DENSITY_WATER] < 0.0)
         KRATOS_ERROR << "DENSITY_WATER does not exist in the material "
                         "properties or has an invalid value at element "
                      << this->Id() << std::endl;
 
-    if (Prop.Has(BULK_MODULUS_SOLID) == false || Prop[BULK_MODULUS_SOLID] < 0.0)
+    if (r_properties.Has(BULK_MODULUS_SOLID) == false || r_properties[BULK_MODULUS_SOLID] < 0.0)
         KRATOS_ERROR << "BULK_MODULUS_SOLID does not exist in the material "
                         "properties or has an invalid value at element "
                      << this->Id() << std::endl;
 
-    if (Prop.Has(POROSITY) == false || Prop[POROSITY] < 0.0 || Prop[POROSITY] > 1.0)
+    if (r_properties.Has(POROSITY) == false || r_properties[POROSITY] < 0.0 || r_properties[POROSITY] > 1.0)
         KRATOS_ERROR << "POROSITY does not exist in the material properties or "
                         "has an invalid value at element "
                      << this->Id() << std::endl;
@@ -191,64 +191,61 @@ int TransientPwElement<TDim, TNumNodes>::Check(const ProcessInfo& rCurrentProces
     if (TDim == 2) {
         // If this is a 2D problem, nodes must be in XY plane
         for (unsigned int i = 0; i < TNumNodes; ++i) {
-            if (Geom[i].Z() != 0.0)
-                KRATOS_ERROR << " Node with non-zero Z coordinate found. Id: " << Geom[i].Id() << std::endl;
+            if (r_geom[i].Z() != 0.0)
+                KRATOS_ERROR << " Node with non-zero Z coordinate found. Id: " << r_geom[i].Id() << std::endl;
         }
     }
 
     // Verify specific properties
-    if (Prop.Has(BULK_MODULUS_FLUID) == false || Prop[BULK_MODULUS_FLUID] < 0.0)
+    if (r_properties.Has(BULK_MODULUS_FLUID) == false || r_properties[BULK_MODULUS_FLUID] < 0.0)
         KRATOS_ERROR << "BULK_MODULUS_FLUID does not exist in the material "
                         "properties or has an invalid value at element "
                      << this->Id() << std::endl;
 
-    if (Prop.Has(DYNAMIC_VISCOSITY) == false || Prop[DYNAMIC_VISCOSITY] < 0.0)
+    if (r_properties.Has(DYNAMIC_VISCOSITY) == false || r_properties[DYNAMIC_VISCOSITY] < 0.0)
         KRATOS_ERROR << "DYNAMIC_VISCOSITY does not exist in the material "
                         "properties or has an invalid value at element "
                      << this->Id() << std::endl;
 
-    if (Prop.Has(PERMEABILITY_XX) == false || Prop[PERMEABILITY_XX] < 0.0)
+    if (r_properties.Has(PERMEABILITY_XX) == false || r_properties[PERMEABILITY_XX] < 0.0)
         KRATOS_ERROR << "PERMEABILITY_XX does not exist in the material "
                         "properties or has an invalid value at element "
                      << this->Id() << std::endl;
 
-    if (Prop.Has(PERMEABILITY_YY) == false || Prop[PERMEABILITY_YY] < 0.0)
+    if (r_properties.Has(PERMEABILITY_YY) == false || r_properties[PERMEABILITY_YY] < 0.0)
         KRATOS_ERROR << "PERMEABILITY_YY does not exist in the material "
                         "properties or has an invalid value at element "
                      << this->Id() << std::endl;
 
-    if (Prop.Has(PERMEABILITY_XY) == false || Prop[PERMEABILITY_XY] < 0.0)
+    if (r_properties.Has(PERMEABILITY_XY) == false || r_properties[PERMEABILITY_XY] < 0.0)
         KRATOS_ERROR << "PERMEABILITY_XY does not exist in the material "
                         "properties or has an invalid value at element "
                      << this->Id() << std::endl;
 
-    if (!Prop.Has(BIOT_COEFFICIENT))
+    if (!r_properties.Has(BIOT_COEFFICIENT))
         KRATOS_ERROR << "BIOT_COEFFICIENT does not exist in the material "
                         "properties in element "
                      << this->Id() << std::endl;
 
     if constexpr (TDim > 2) {
-        if (Prop.Has(PERMEABILITY_ZZ) == false || Prop[PERMEABILITY_ZZ] < 0.0)
+        if (r_properties.Has(PERMEABILITY_ZZ) == false || r_properties[PERMEABILITY_ZZ] < 0.0)
             KRATOS_ERROR << "PERMEABILITY_ZZ does not exist in the material "
                             "properties or has an invalid value at element "
                          << this->Id() << std::endl;
 
-        if (Prop.Has(PERMEABILITY_YZ) == false || Prop[PERMEABILITY_YZ] < 0.0)
+        if (r_properties.Has(PERMEABILITY_YZ) == false || r_properties[PERMEABILITY_YZ] < 0.0)
             KRATOS_ERROR << "PERMEABILITY_YZ does not exist in the material "
                             "properties or has an invalid value at element "
                          << this->Id() << std::endl;
 
-        if (Prop.Has(PERMEABILITY_ZX) == false || Prop[PERMEABILITY_ZX] < 0.0)
+        if (r_properties.Has(PERMEABILITY_ZX) == false || r_properties[PERMEABILITY_ZX] < 0.0)
             KRATOS_ERROR << "PERMEABILITY_ZX does not exist in the material "
                             "properties or has an invalid value at element "
                          << this->Id() << std::endl;
     }
 
-    // Verify that the constitutive law has the correct dimension
-
-    // Check constitutive law
     if (mRetentionLawVector.size() > 0) {
-        return mRetentionLawVector[0]->Check(Prop, rCurrentProcessInfo);
+        return mRetentionLawVector[0]->Check(r_properties, rCurrentProcessInfo);
     }
 
     return 0;
@@ -319,15 +316,17 @@ void TransientPwElement<TDim, TNumNodes>::CalculateOnIntegrationPoints(const Var
 {
     KRATOS_TRY
 
-    const GeometryType& rGeom      = this->GetGeometry();
-    const IndexType     NumGPoints = rGeom.IntegrationPointsNumber(this->GetIntegrationMethod());
-    if (rOutput.size() != NumGPoints) rOutput.resize(NumGPoints);
+    const GeometryType& r_geom = this->GetGeometry();
+    const IndexType     number_of_integration_points =
+        r_geom.IntegrationPointsNumber(this->GetIntegrationMethod());
+    if (rOutput.size() != number_of_integration_points)
+        rOutput.resize(number_of_integration_points);
 
     if (rVariable == FLUID_FLUX_VECTOR) {
-        std::vector<double> permeability_update_factors(NumGPoints, 1.0);
+        std::vector<double> permeability_update_factors(number_of_integration_points, 1.0);
         const auto fluid_fluxes = this->CalculateFluidFluxes(permeability_update_factors, rCurrentProcessInfo);
 
-        for (unsigned int GPoint = 0; GPoint < NumGPoints; ++GPoint) {
+        for (unsigned int GPoint = 0; GPoint < number_of_integration_points; ++GPoint) {
             GeoElementUtilities::FillArray1dOutput(rOutput[GPoint], fluid_fluxes[GPoint]);
         }
     } else {
@@ -374,11 +373,11 @@ void TransientPwElement<TDim, TNumNodes>::CalculateAll(MatrixType&        rLeftH
     KRATOS_TRY
 
     // Previous definitions
-    const PropertiesType&                           Prop = this->GetProperties();
-    const GeometryType&                             Geom = this->GetGeometry();
+    const PropertiesType&                           r_properties = this->GetProperties();
+    const GeometryType&                             r_geom       = this->GetGeometry();
     const GeometryType::IntegrationPointsArrayType& IntegrationPoints =
-        Geom.IntegrationPoints(this->GetIntegrationMethod());
-    const unsigned int NumGPoints = IntegrationPoints.size();
+        r_geom.IntegrationPoints(this->GetIntegrationMethod());
+    const unsigned int number_of_integration_points = IntegrationPoints.size();
 
     // Element variables
     ElementVariables Variables;
@@ -392,37 +391,37 @@ void TransientPwElement<TDim, TNumNodes>::CalculateAll(MatrixType&        rLeftH
     const auto bishop_coefficients = this->CalculateBishopCoefficients(fluid_pressures);
     const auto integration_coefficients =
         this->CalculateIntegrationCoefficients(IntegrationPoints, Variables.detJContainer);
-    std::vector<double> biot_coefficients(NumGPoints, Prop[BIOT_COEFFICIENT]);
-    const auto          degrees_of_saturation = this->CalculateDegreesOfSaturation(fluid_pressures);
+    std::vector<double> biot_coefficients(number_of_integration_points, r_properties[BIOT_COEFFICIENT]);
+    const auto degrees_of_saturation     = this->CalculateDegreesOfSaturation(fluid_pressures);
     const auto derivatives_of_saturation = this->CalculateDerivativesOfSaturation(fluid_pressures);
     const auto biot_moduli_inverse = GeoTransportEquationUtilities::CalculateInverseBiotModuli(
-        biot_coefficients, degrees_of_saturation, derivatives_of_saturation, Prop);
+        biot_coefficients, degrees_of_saturation, derivatives_of_saturation, r_properties);
 
     // Loop over integration points
-    for (unsigned int GPoint = 0; GPoint < NumGPoints; ++GPoint) {
+    for (unsigned int integration_point = 0; integration_point < number_of_integration_points; ++integration_point) {
         // Compute GradNpT, B and StrainVector
-        this->CalculateKinematics(Variables, GPoint);
+        this->CalculateKinematics(Variables, integration_point);
 
         // Compute Nu and BodyAcceleration
-        GeoElementUtilities::CalculateNuMatrix<TDim, TNumNodes>(Variables.Nu, Variables.NContainer, GPoint);
+        GeoElementUtilities::CalculateNuMatrix<TDim, TNumNodes>(Variables.Nu, Variables.NContainer, integration_point);
         GeoElementUtilities::InterpolateVariableWithComponents<TDim, TNumNodes>(
-            Variables.BodyAcceleration, Variables.NContainer, Variables.VolumeAcceleration, GPoint);
+            Variables.BodyAcceleration, Variables.NContainer, Variables.VolumeAcceleration, integration_point);
 
-        Variables.RelativePermeability = relative_permeability_values[GPoint];
-        Variables.BishopCoefficient    = bishop_coefficients[GPoint];
+        Variables.RelativePermeability = relative_permeability_values[integration_point];
+        Variables.BishopCoefficient    = bishop_coefficients[integration_point];
 
-        Variables.BiotCoefficient    = biot_coefficients[GPoint];
-        Variables.BiotModulusInverse = biot_moduli_inverse[GPoint];
-        Variables.DegreeOfSaturation = degrees_of_saturation[GPoint];
+        Variables.BiotCoefficient    = biot_coefficients[integration_point];
+        Variables.BiotModulusInverse = biot_moduli_inverse[integration_point];
+        Variables.DegreeOfSaturation = degrees_of_saturation[integration_point];
 
-        Variables.IntegrationCoefficient = integration_coefficients[GPoint];
+        Variables.IntegrationCoefficient = integration_coefficients[integration_point];
 
         // Contributions to the left hand side
         if (CalculateStiffnessMatrixFlag) this->CalculateAndAddLHS(rLeftHandSideMatrix, Variables);
 
         // Contributions to the right hand side
         if (CalculateResidualVectorFlag)
-            this->CalculateAndAddRHS(rRightHandSideVector, Variables, GPoint);
+            this->CalculateAndAddRHS(rRightHandSideVector, Variables, integration_point);
     }
 
     KRATOS_CATCH("")
@@ -450,17 +449,18 @@ void TransientPwElement<TDim, TNumNodes>::InitializeElementVariables(ElementVari
     rVariables.GradNpT.resize(TNumNodes, TDim, false);
 
     // General Variables
-    const GeometryType& Geom       = this->GetGeometry();
-    const unsigned int  NumGPoints = Geom.IntegrationPointsNumber(this->GetIntegrationMethod());
+    const GeometryType& r_geom = this->GetGeometry();
+    const unsigned int  number_of_integration_points =
+        r_geom.IntegrationPointsNumber(this->GetIntegrationMethod());
 
     // shape functions
-    (rVariables.NContainer).resize(NumGPoints, TNumNodes, false);
-    rVariables.NContainer = Geom.ShapeFunctionsValues(this->GetIntegrationMethod());
+    (rVariables.NContainer).resize(number_of_integration_points, TNumNodes, false);
+    rVariables.NContainer = r_geom.ShapeFunctionsValues(this->GetIntegrationMethod());
 
     // gradient of shape functions and determinant of Jacobian
-    (rVariables.detJContainer).resize(NumGPoints, false);
+    (rVariables.detJContainer).resize(number_of_integration_points, false);
 
-    Geom.ShapeFunctionsIntegrationPointsGradients(
+    r_geom.ShapeFunctionsIntegrationPointsGradients(
         rVariables.DN_DXContainer, rVariables.detJContainer, this->GetIntegrationMethod());
 
     // Retention law

--- a/applications/GeoMechanicsApplication/custom_elements/transient_Pw_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/transient_Pw_element.cpp
@@ -326,8 +326,9 @@ void TransientPwElement<TDim, TNumNodes>::CalculateOnIntegrationPoints(const Var
         std::vector<double> permeability_update_factors(number_of_integration_points, 1.0);
         const auto fluid_fluxes = this->CalculateFluidFluxes(permeability_update_factors, rCurrentProcessInfo);
 
-        for (unsigned int GPoint = 0; GPoint < number_of_integration_points; ++GPoint) {
-            GeoElementUtilities::FillArray1dOutput(rOutput[GPoint], fluid_fluxes[GPoint]);
+        for (unsigned int integration_point = 0; integration_point < number_of_integration_points;
+             ++integration_point) {
+            GeoElementUtilities::FillArray1dOutput(rOutput[integration_point], fluid_fluxes[integration_point]);
         }
     } else {
         if (rOutput.size() != mRetentionLawVector.size())
@@ -504,7 +505,7 @@ void TransientPwElement<TDim, TNumNodes>::CalculateAndAddCompressibilityMatrix(M
 template <unsigned int TDim, unsigned int TNumNodes>
 void TransientPwElement<TDim, TNumNodes>::CalculateAndAddRHS(VectorType&       rRightHandSideVector,
                                                              ElementVariables& rVariables,
-                                                             unsigned int      GPoint)
+                                                             unsigned int      integration_point)
 {
     KRATOS_TRY
 

--- a/applications/GeoMechanicsApplication/custom_elements/transient_Pw_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/transient_Pw_element.cpp
@@ -33,8 +33,6 @@ Element::Pointer TransientPwElement<TDim, TNumNodes>::Create(IndexType          
                                                              GeometryType::Pointer pGeom,
                                                              PropertiesType::Pointer pProperties) const
 {
-    auto& stressStatePolicy = this->GetStressStatePolicy();
-    auto stressState = stressStatePolicy.Clone();
     return Element::Pointer(
         new TransientPwElement(NewId, pGeom, pProperties, this->GetStressStatePolicy().Clone()));
 }

--- a/applications/GeoMechanicsApplication/custom_elements/transient_Pw_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/transient_Pw_element.cpp
@@ -123,16 +123,19 @@ void TransientPwElement<TDim, TNumNodes>::Initialize(const ProcessInfo& rCurrent
 {
     KRATOS_TRY
 
-    const PropertiesType& r_properties       = this->GetProperties();
+    const PropertiesType& r_properties = this->GetProperties();
     const GeometryType&   r_geom       = this->GetGeometry();
-    const unsigned int    number_of_integration_points = r_geom.IntegrationPointsNumber(this->GetIntegrationMethod());
+    const unsigned int    number_of_integration_points =
+        r_geom.IntegrationPointsNumber(this->GetIntegrationMethod());
 
-    if (mConstitutiveLawVector.size() != number_of_integration_points) mConstitutiveLawVector.resize(number_of_integration_points);
-    for (auto& constitutive_law: mConstitutiveLawVector) {
+    if (mConstitutiveLawVector.size() != number_of_integration_points)
+        mConstitutiveLawVector.resize(number_of_integration_points);
+    for (auto& constitutive_law : mConstitutiveLawVector) {
         constitutive_law = nullptr;
     }
 
-    if (mRetentionLawVector.size() != number_of_integration_points) mRetentionLawVector.resize(number_of_integration_points);
+    if (mRetentionLawVector.size() != number_of_integration_points)
+        mRetentionLawVector.resize(number_of_integration_points);
     for (auto& r_retention_law : mRetentionLawVector) {
         r_retention_law = RetentionLawFactory::Clone(r_properties);
     }

--- a/applications/GeoMechanicsApplication/custom_elements/transient_Pw_element.hpp
+++ b/applications/GeoMechanicsApplication/custom_elements/transient_Pw_element.hpp
@@ -19,7 +19,6 @@
 #include "custom_elements/U_Pw_small_strain_element.hpp"
 #include "custom_utilities/element_utilities.hpp"
 #include "custom_utilities/stress_strain_utilities.h"
-#include "geo_mechanics_application_variables.h"
 
 namespace Kratos
 {

--- a/applications/GeoMechanicsApplication/custom_processes/apply_c_phi_reduction_process.cpp
+++ b/applications/GeoMechanicsApplication/custom_processes/apply_c_phi_reduction_process.cpp
@@ -29,7 +29,9 @@ void ApplyCPhiReductionProcess::ExecuteInitializeSolutionStep()
     KRATOS_ERROR_IF(mReductionFactor <= 0.01)
         << "Reduction factor should not drop below 0.01, calculation stopped." << std::endl;
     KRATOS_ERROR_IF(mReductionIncrement <= 0.001)
-    << "Reduction increment should not drop below 0.001, calculation stopped. Final safety factor = " << 1.0 / mPreviousReductionFactor << std::endl;
+        << "Reduction increment should not drop below 0.001, calculation stopped. Final safety "
+           "factor = "
+        << 1.0 / mPreviousReductionFactor << std::endl;
     KRATOS_INFO("ApplyCPhiReductionProces::ExecuteInitializeSolutionStep")
         << "Try a c-phi reduction factor " << mReductionFactor << " (safety factor "
         << 1. / mReductionFactor << ") Previous reduction = " << mPreviousReductionFactor

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_elements/test_transient_Pw_element.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_elements/test_transient_Pw_element.cpp
@@ -1,0 +1,836 @@
+// KRATOS___
+//     //   ) )
+//    //         ___      ___
+//   //  ____  //___) ) //   ) )
+//  //    / / //       //   / /
+// ((____/ / ((____   ((___/ /  MECHANICS
+//
+//  License:         geo_mechanics_application/license.txt
+//
+//  Main authors:    Wijtze Pieter Kikstra
+//
+
+#include "custom_elements/transient_Pw_element.hpp"
+#include "tests/cpp_tests/geo_mechanics_fast_suite.h"
+#include "tests/cpp_tests/test_utilities.h"
+#include "custom_elements/plane_strain_stress_state.h"
+#include <boost/numeric/ublas/assignment.hpp>
+
+namespace
+{
+using namespace Kratos;
+
+PointerVector<Node> CreateThreeNodes()
+{
+    PointerVector<Node> result;
+    result.push_back(make_intrusive<Node>(1, 0.0, 0.0, 0.0));
+    result.push_back(make_intrusive<Node>(2, 1.0, 0.0, 0.0));
+    result.push_back(make_intrusive<Node>(3, 1.0, 1.0, 0.0));
+    return result;
+}
+
+PointerVector<Node> CreateThreeNodesOnModelPart(ModelPart& rModelPart)
+{
+    PointerVector<Node> result;
+    result.push_back(rModelPart.CreateNewNode(1, 0.0, 0.0, 0.0));
+    result.push_back(rModelPart.CreateNewNode(2, 1.0, 0.0, 0.0));
+    result.push_back(rModelPart.CreateNewNode(3, 1.0, 1.0, 0.0));
+    return result;
+}
+
+PointerVector<Node> CreateThetrahedralOnModelPart(ModelPart& rModelPart)
+{
+    PointerVector<Node> result;
+    result.push_back(rModelPart.CreateNewNode(1, 0.0, 0.0, 0.0));
+    result.push_back(rModelPart.CreateNewNode(2, 1.0, 0.0, 0.0));
+    result.push_back(rModelPart.CreateNewNode(3, 1.0, 1.0, 0.0));
+    result.push_back(rModelPart.CreateNewNode(4, 1.0, 1.0, 1.0));
+    return result;
+}
+
+PointerVector<Node> CreateCoincidentNodes()
+{
+    PointerVector<Node> result;
+    result.push_back(make_intrusive<Node>(1, 0.0, 0.0, 0.0));
+    result.push_back(make_intrusive<Node>(2, 0.0, 0.0, 0.0));
+    result.push_back(make_intrusive<Node>(3, 0.0, 0.0, 0.0));
+    return result;
+}
+
+ModelPart& CreateModelPartWithWaterPressureVariableAndVolumeAcceleration(Model& rModel)
+{
+    auto& r_result = rModel.CreateModelPart("Main");
+    r_result.AddNodalSolutionStepVariable(WATER_PRESSURE);
+    r_result.AddNodalSolutionStepVariable(DT_WATER_PRESSURE);
+    r_result.AddNodalSolutionStepVariable(VOLUME_ACCELERATION);
+
+    return r_result;
+}
+
+void RemoveNodes(ModelPart& rModelPart)
+{
+rModelPart.RemoveNodeFromAllLevels(1);
+rModelPart.RemoveNodeFromAllLevels(2);
+rModelPart.RemoveNodeFromAllLevels(3);
+}
+
+Element::IndexType NextElementNumber(const ModelPart& rModelPart)
+{
+    return rModelPart.NumberOfElements() + 1;
+}
+
+intrusive_ptr<TransientPwElement<2, 3>> CreateTransientPwElementWithPWDofs(
+    const ModelPart& rModelPart, const Properties::Pointer& rProperties, const Geometry<Node>::Pointer& rGeometry)
+{
+    auto p_result = make_intrusive<TransientPwElement<2, 3>>(
+        NextElementNumber(rModelPart), rGeometry, rProperties, std::make_unique<PlaneStrainStressState>());
+    for (auto& node : p_result->GetGeometry()) {
+        node.AddDof(WATER_PRESSURE);
+    }
+
+    return p_result;
+}
+
+intrusive_ptr<TransientPwElement<3, 4>> CreateTransientPwElement3D4NWithPWDofs(
+    const ModelPart& rModelPart, const Properties::Pointer& rProperties, const Geometry<Node>::Pointer& rGeometry)
+{
+    auto p_result = make_intrusive<TransientPwElement<3, 4>>(
+        NextElementNumber(rModelPart), rGeometry, rProperties, std::make_unique<PlaneStrainStressState>());
+    for (auto& node : p_result->GetGeometry()) {
+        node.AddDof(WATER_PRESSURE);
+    }
+
+    return p_result;
+}
+
+intrusive_ptr<TransientPwElement<2, 3>> CreateTriangleTransientPwElementWithPWDofs(
+    ModelPart& rModelPart, const Properties::Pointer& rProperties)
+{
+    const auto p_geometry = std::make_shared<Triangle2D3<Node>>(CreateThreeNodesOnModelPart(rModelPart));
+    auto p_element = CreateTransientPwElementWithPWDofs(rModelPart, rProperties, p_geometry);
+
+    rModelPart.AddElement(p_element);
+    return p_element;
+}
+
+intrusive_ptr<TransientPwElement<3, 4>> CreateThreeDTransientPwElement3D4NWithPWDofs(
+    ModelPart& rModelPart, const Properties::Pointer& rProperties)
+{
+    const auto p_geometry = std::make_shared<Tetrahedra3D4<Node>>(CreateThetrahedralOnModelPart(rModelPart));
+    auto p_element = CreateTransientPwElement3D4NWithPWDofs(rModelPart, rProperties, p_geometry);
+
+    rModelPart.AddElement(p_element);
+    return p_element;
+}
+
+intrusive_ptr<TransientPwElement<2, 3>> CreateTriangleTransientPwElementWithoutPWDofs(
+    ModelPart& rModelPart, const Properties::Pointer& rProperties)
+{
+    const auto p_geometry = std::make_shared<Triangle2D3<Node>>(CreateThreeNodesOnModelPart(rModelPart));
+    auto       p_element  = make_intrusive<TransientPwElement<2, 3>>(
+        NextElementNumber(rModelPart), p_geometry, rProperties, std::make_unique<PlaneStrainStressState>());
+
+    rModelPart.AddElement(p_element);
+    return p_element;
+}
+
+} // namespace
+/*
+namespace Kratos
+{
+
+class MockStressState : public StressStatePolicy
+{
+public:
+    [[nodiscard]] Matrix CalculateBMatrix(const Matrix&         rDN_DX,
+                                                  const Vector&         rN,
+                                                  const Geometry<Node>& rGeometry) {return Matrix();}
+    [[nodiscard]] double CalculateIntegrationCoefficient(const Geometry<Node>::IntegrationPointType& rIntegrationPoint,
+                                                                 double DetJ,
+                                                                 const Geometry<Node>& rGeometry) {return 0.0;}
+    [[nodiscard]] Vector CalculateGreenLagrangeStrain(const Matrix& rDeformationGradient) {return Vector();}
+    [[nodiscard]] const Vector&                      GetVoigtVector() {return Vector();};
+    [[nodiscard]] SizeType                           GetVoigtSize() {return 0;}
+    [[nodiscard]] SizeType                           GetStressTensorSize() {return 0;}
+
+    [[nodiscard]] std::unique_ptr<StressStatePolicy> Clone() const override
+    {
+        return nullptr;
+    }
+};
+
+}*/
+
+namespace Kratos::Testing
+{
+
+using namespace Kratos;
+
+
+KRATOS_TEST_CASE_IN_SUITE(TransientPwElement_CreateInstanceWithGeometryInput,
+                          KratosGeoMechanicsFastSuite)
+{
+    // Arrange
+    const auto p_geometry   = std::make_shared<Triangle2D3<Node>>(CreateThreeNodes());
+    const auto p_properties = std::make_shared<Properties>();
+    const TransientPwElement<2, 3> element(0,p_geometry, p_properties,   std::make_unique<PlaneStrainStressState>());
+
+    // Act
+    const auto p_created_element = element.Create(1, p_geometry, p_properties);
+
+    // Assert
+    EXPECT_NE(p_created_element, nullptr);
+    EXPECT_EQ(p_created_element->Id(), 1);
+    EXPECT_NE(p_created_element->pGetGeometry(), nullptr);
+    EXPECT_NE(p_created_element->pGetProperties(), nullptr);
+}
+
+
+KRATOS_TEST_CASE_IN_SUITE(TransientPwElement_CreateInstanceWithNodeInput, KratosGeoMechanicsFastSuite)
+{
+    // Arrange
+    const auto p_properties = std::make_shared<Properties>();
+
+    // The source element needs to have a geometry, otherwise the version of the
+    // Create method with a node input will fail.
+    const auto p_geometry = std::make_shared<Triangle2D3<Node>>(CreateThreeNodes());
+    const TransientPwElement<2, 3> element(0, p_geometry, p_properties, std::make_unique<PlaneStrainStressState>());
+
+    // Act
+    const auto p_created_element = element.Create(1, CreateThreeNodes(), p_properties);
+
+    // Assert
+    EXPECT_NE(p_created_element, nullptr);
+    EXPECT_EQ(p_created_element->Id(), 1);
+    EXPECT_NE(p_created_element->pGetGeometry(), nullptr);
+    EXPECT_NE(p_created_element->pGetProperties(), nullptr);
+}
+
+KRATOS_TEST_CASE_IN_SUITE(TransientPwElement_DoFList, KratosGeoMechanicsFastSuiteWithoutKernel)
+{
+    // Arrange
+    const auto p_properties = std::make_shared<Properties>();
+
+    Model      model;
+    auto&      r_model_part = CreateModelPartWithWaterPressureVariableAndVolumeAcceleration(model);
+    const auto p_element =
+        CreateTriangleTransientPwElementWithPWDofs(r_model_part, p_properties);
+
+    // Act
+    const auto              dummy_process_info = ProcessInfo{};
+    Element::DofsVectorType degrees_of_freedom;
+    p_element->GetDofList(degrees_of_freedom, dummy_process_info);
+
+    // Assert
+    KRATOS_EXPECT_EQ(degrees_of_freedom.size(), 3);
+    for (auto p_dof : degrees_of_freedom) {
+        KRATOS_EXPECT_EQ(p_dof->GetVariable(), WATER_PRESSURE);
+    }
+}
+
+KRATOS_TEST_CASE_IN_SUITE(TransientPwElement_EquationIdVector,
+                          KratosGeoMechanicsFastSuiteWithoutKernel)
+{
+    // Arrange
+    const auto p_properties = std::make_shared<Properties>();
+
+    Model model;
+    auto& r_model_part = CreateModelPartWithWaterPressureVariableAndVolumeAcceleration(model);
+    auto  p_element =
+        CreateTriangleTransientPwElementWithPWDofs(r_model_part, p_properties);
+
+    unsigned int i = 0;
+    for (const auto& node : p_element->GetGeometry()) {
+        ++i;
+        node.pGetDof(WATER_PRESSURE)->SetEquationId(i);
+    }
+
+    // Act
+    const auto                    dummy_process_info = ProcessInfo{};
+    Element::EquationIdVectorType equation_id_vector;
+    p_element->EquationIdVector(equation_id_vector, dummy_process_info);
+
+    // Assert
+    const Element::EquationIdVectorType expected_ids = {1, 2, 3};
+    KRATOS_EXPECT_VECTOR_EQ(equation_id_vector, expected_ids)
+}
+
+KRATOS_TEST_CASE_IN_SUITE(TransientPwElement_IntegrationMethod,
+                          KratosGeoMechanicsFastSuite)
+{
+    // Arrange
+    const auto p_geometry   = std::make_shared<Triangle2D3<Node>>(CreateCoincidentNodes());
+    const auto p_properties = std::make_shared<Properties>();
+    const TransientPwElement<2, 3> element(0, p_geometry, p_properties, std::make_unique<PlaneStrainStressState>());
+
+    // Act
+    const auto p_integration_method = element.GetIntegrationMethod();
+
+    // Assert
+    const auto expected_integration_method = GeometryData::IntegrationMethod::GI_GAUSS_2;
+    KRATOS_EXPECT_EQ(p_integration_method, expected_integration_method);
+}
+
+KRATOS_TEST_CASE_IN_SUITE(TransientPwElement_CheckThrowsOnFaultyInput, KratosGeoMechanicsFastSuiteWithoutKernel)
+{
+    // Arrange
+    const auto p_geometry   = std::make_shared<Triangle2D3<Node>>(CreateCoincidentNodes());
+    const auto p_properties = std::make_shared<Properties>();
+    const TransientPwElement<2, 3> element(1, p_geometry, p_properties, std::make_unique<PlaneStrainStressState>());
+
+    // Act and Assert
+    const auto dummy_process_info = ProcessInfo{};
+    KRATOS_EXPECT_EXCEPTION_IS_THROWN(element.Check(dummy_process_info),
+                                      "Error: DomainSize < 1.0e-15 for the element 1")
+
+    const auto p_geometry2 = std::make_shared<Triangle2D3<Node>>(CreateThreeNodes());
+    const TransientPwElement<2, 3> element1(1, p_geometry2, p_properties, std::make_unique<PlaneStrainStressState>());
+    KRATOS_EXPECT_EXCEPTION_IS_THROWN(element1.Check(dummy_process_info),
+                                      "Error: Missing variable WATER_PRESSURE on node 1")
+
+    Model model;
+    auto& model_part = model.CreateModelPart("Main");
+    model_part.AddNodalSolutionStepVariable(WATER_PRESSURE);
+    auto  p_new_element =
+            CreateTriangleTransientPwElementWithoutPWDofs(model_part, p_properties);
+    KRATOS_EXPECT_EXCEPTION_IS_THROWN(
+        p_new_element->Check(dummy_process_info),
+        "Error: Missing variable DT_WATER_PRESSURE on node 1")
+
+    RemoveNodes(model_part);
+    model_part.AddNodalSolutionStepVariable(DT_WATER_PRESSURE);
+    p_new_element =
+            CreateTriangleTransientPwElementWithoutPWDofs(model_part, p_properties);
+    KRATOS_EXPECT_EXCEPTION_IS_THROWN(
+        p_new_element->Check(dummy_process_info),
+        "Missing variable VOLUME_ACCELERATION on node 1")
+
+    RemoveNodes(model_part);
+    model_part.AddNodalSolutionStepVariable(VOLUME_ACCELERATION);
+    p_new_element =
+            CreateTriangleTransientPwElementWithoutPWDofs(model_part, p_properties);
+    KRATOS_EXPECT_EXCEPTION_IS_THROWN(
+        p_new_element->Check(dummy_process_info),
+        "Missing variable WATER_PRESSURE on node 1")
+
+    RemoveNodes(model_part);
+    p_new_element =
+                CreateTriangleTransientPwElementWithPWDofs(model_part, p_properties);
+    KRATOS_EXPECT_EXCEPTION_IS_THROWN(
+        p_new_element->Check(dummy_process_info),
+        "DENSITY_WATER does not exist in the material properties or has an invalid value at element 4")
+
+    p_new_element->GetProperties().SetValue(DENSITY_WATER, -1.0E3);
+    KRATOS_EXPECT_EXCEPTION_IS_THROWN(
+        p_new_element->Check(dummy_process_info),
+        "DENSITY_WATER does not exist in the material properties or has an invalid value at element 4")
+
+    p_new_element->GetProperties().SetValue(DENSITY_WATER, 1.0E3);
+    KRATOS_EXPECT_EXCEPTION_IS_THROWN(
+        p_new_element->Check(dummy_process_info),
+        "Error: BULK_MODULUS_SOLID does not exist in the material properties or has an invalid value at element 4")
+
+    p_new_element->GetProperties().SetValue(BULK_MODULUS_SOLID, -1.0E6);
+    KRATOS_EXPECT_EXCEPTION_IS_THROWN(
+        p_new_element->Check(dummy_process_info),
+        "Error: BULK_MODULUS_SOLID does not exist in the material properties or has an invalid value at element 4")
+
+    p_new_element->GetProperties().SetValue(BULK_MODULUS_SOLID, 1.0E6);
+    KRATOS_EXPECT_EXCEPTION_IS_THROWN(
+        p_new_element->Check(dummy_process_info),
+        "Error: POROSITY does not exist in the material properties or has an invalid value at element 4")
+
+    p_new_element->GetProperties().SetValue(POROSITY, -1.0);
+    KRATOS_EXPECT_EXCEPTION_IS_THROWN(
+        p_new_element->Check(dummy_process_info),
+        "Error: POROSITY does not exist in the material properties or has an invalid value at element 4")
+
+    p_new_element->GetProperties().SetValue(POROSITY, 2.0);
+    KRATOS_EXPECT_EXCEPTION_IS_THROWN(
+        p_new_element->Check(dummy_process_info),
+        "Error: POROSITY does not exist in the material properties or has an invalid value at element 4")
+
+    p_new_element->GetProperties().SetValue(POROSITY, 0.5);
+
+    p_new_element->GetGeometry().begin()->Z() += 1;
+    KRATOS_EXPECT_EXCEPTION_IS_THROWN(p_new_element->Check(dummy_process_info),
+                                      "Error:  Node with non-zero Z coordinate found. Id: 1")
+    p_new_element->GetGeometry().begin()->Z() = 0;
+
+    KRATOS_EXPECT_EXCEPTION_IS_THROWN(
+        p_new_element->Check(dummy_process_info),
+        "Error: BULK_MODULUS_FLUID does not exist in the material properties or has an invalid value at element 4")
+
+    p_new_element->GetProperties().SetValue(BULK_MODULUS_FLUID, -1.0e6);
+    KRATOS_EXPECT_EXCEPTION_IS_THROWN(
+        p_new_element->Check(dummy_process_info),
+        "Error: BULK_MODULUS_FLUID does not exist in the material properties or has an invalid value at element 4")
+
+    p_new_element->GetProperties().SetValue(BULK_MODULUS_FLUID, 1.0e6);
+    KRATOS_EXPECT_EXCEPTION_IS_THROWN(
+        p_new_element->Check(dummy_process_info),
+        "Error: DYNAMIC_VISCOSITY does not exist in the material properties or has an invalid value at element 4")
+
+    p_new_element->GetProperties().SetValue(DYNAMIC_VISCOSITY, -1.0E-2);
+    KRATOS_EXPECT_EXCEPTION_IS_THROWN(
+        p_new_element->Check(dummy_process_info),
+        "Error: DYNAMIC_VISCOSITY does not exist in the material properties or has an invalid value at element 4")
+
+    p_new_element->GetProperties().SetValue(DYNAMIC_VISCOSITY, 1.0E-2);
+    KRATOS_EXPECT_EXCEPTION_IS_THROWN(
+        p_new_element->Check(dummy_process_info),
+        "PERMEABILITY_XX does not exist in the material properties or has an invalid value at element 4")
+
+    p_new_element->GetProperties().SetValue(PERMEABILITY_XX, -1.0E-2);
+    KRATOS_EXPECT_EXCEPTION_IS_THROWN(
+        p_new_element->Check(dummy_process_info),
+        "PERMEABILITY_XX does not exist in the material properties or has an invalid value at element 4")
+
+    p_new_element->GetProperties().SetValue(PERMEABILITY_XX, 1.0E-2);
+    KRATOS_EXPECT_EXCEPTION_IS_THROWN(
+        p_new_element->Check(dummy_process_info),
+        "PERMEABILITY_YY does not exist in the material properties or has an invalid value at element 4")
+
+    p_new_element->GetProperties().SetValue(PERMEABILITY_YY, -1.0E-2);
+    KRATOS_EXPECT_EXCEPTION_IS_THROWN(
+        p_new_element->Check(dummy_process_info),
+        "PERMEABILITY_YY does not exist in the material properties or has an invalid value at element 4")
+
+    p_new_element->GetProperties().SetValue(PERMEABILITY_YY, 1.0E-2);
+    KRATOS_EXPECT_EXCEPTION_IS_THROWN(
+        p_new_element->Check(dummy_process_info),
+        "PERMEABILITY_XY does not exist in the material properties or has an invalid value at element 4")
+
+    p_new_element->GetProperties().SetValue(PERMEABILITY_XY, -1.0E-2);
+    KRATOS_EXPECT_EXCEPTION_IS_THROWN(
+        p_new_element->Check(dummy_process_info),
+        "PERMEABILITY_XY does not exist in the material properties or has an invalid value at element 4")
+
+    p_new_element->GetProperties().SetValue(PERMEABILITY_XY, 1.0E-2);
+    KRATOS_EXPECT_EXCEPTION_IS_THROWN(
+        p_new_element->Check(dummy_process_info),
+        "Error: BIOT_COEFFICIENT does not exist in the material properties in element 4")
+
+    p_new_element->GetProperties().SetValue(BIOT_COEFFICIENT, 1.0E-2);
+
+    // No exceptions on correct input for 2D element
+    KRATOS_EXPECT_EQ(p_new_element->Check(dummy_process_info), 0);
+
+    auto p_3D_element =
+           CreateThreeDTransientPwElement3D4NWithPWDofs(model_part, p_properties);
+    KRATOS_EXPECT_EXCEPTION_IS_THROWN(
+        p_3D_element->Check(dummy_process_info),
+        "PERMEABILITY_ZZ does not exist in the material properties or has an invalid value at element 5")
+
+    p_3D_element->GetProperties().SetValue(PERMEABILITY_ZZ, -1.0E-2);
+    KRATOS_EXPECT_EXCEPTION_IS_THROWN(
+        p_3D_element->Check(dummy_process_info),
+        "PERMEABILITY_ZZ does not exist in the material properties or has an invalid value at element 5")
+
+    p_3D_element->GetProperties().SetValue(PERMEABILITY_ZZ, 1.0E-2);
+    KRATOS_EXPECT_EXCEPTION_IS_THROWN(
+        p_3D_element->Check(dummy_process_info),
+        "PERMEABILITY_YZ does not exist in the material properties or has an invalid value at element 5")
+
+    p_3D_element->GetProperties().SetValue(PERMEABILITY_YZ, -1.0E-2);
+    KRATOS_EXPECT_EXCEPTION_IS_THROWN(
+        p_3D_element->Check(dummy_process_info),
+        "PERMEABILITY_YZ does not exist in the material properties or has an invalid value at element 5")
+
+    p_3D_element->GetProperties().SetValue(PERMEABILITY_YZ, 1.0E-2);
+    KRATOS_EXPECT_EXCEPTION_IS_THROWN(
+        p_3D_element->Check(dummy_process_info),
+        "PERMEABILITY_ZX does not exist in the material properties or has an invalid value at element 5")
+
+    p_3D_element->GetProperties().SetValue(PERMEABILITY_ZX, -1.0E-2);
+    KRATOS_EXPECT_EXCEPTION_IS_THROWN(
+        p_3D_element->Check(dummy_process_info),
+        "PERMEABILITY_ZX does not exist in the material properties or has an invalid value at element 5")
+
+    p_3D_element->GetProperties().SetValue(PERMEABILITY_ZX, 1.0E-2);
+
+    // No exceptions on correct input for 3D element
+    KRATOS_EXPECT_EQ(p_3D_element->Check(dummy_process_info), 0);
+}
+
+KRATOS_TEST_CASE_IN_SUITE(TransientPwElement_Initialize,
+                          KratosGeoMechanicsFastSuite)
+{
+    // Arrange
+    const auto p_geometry   = std::make_shared<Triangle2D3<Node>>(CreateCoincidentNodes());
+    const auto p_properties = std::make_shared<Properties>();
+    TransientPwElement<2, 3> element(0, p_geometry, p_properties, std::make_unique<PlaneStrainStressState>());
+    const auto dummy_process_info = ProcessInfo{};
+
+    // Act
+    element.Initialize(dummy_process_info);
+    auto const num_g_points = element.GetGeometry().IntegrationPointsNumber(element.GetIntegrationMethod());
+    auto const constitutive_law_vector = element.mConstitutiveLawVector;
+    auto const retention_law_vector = element.mRetentionLawVector;
+
+    // Assert
+    KRATOS_EXPECT_EQ(constitutive_law_vector.size(), num_g_points);
+    for(const auto constitutive_law: constitutive_law_vector) {
+        KRATOS_EXPECT_EQ(constitutive_law, nullptr);
+    }
+    KRATOS_EXPECT_EQ(retention_law_vector.size(), num_g_points);
+    const auto expected_retention_law = RetentionLawFactory::Clone(element.GetProperties());
+    for(const auto retention_law: retention_law_vector) {
+        KRATOS_EXPECT_EQ(typeid(*retention_law) == typeid(*expected_retention_law), true);
+    }
+}
+
+KRATOS_TEST_CASE_IN_SUITE(TransientPwElement_InitializeSolution,
+                          KratosGeoMechanicsFastSuite)
+{
+    // Arrange
+    const auto p_properties = std::make_shared<Properties>();
+
+    Model      model;
+    auto&      r_model_part = CreateModelPartWithWaterPressureVariableAndVolumeAcceleration(model);
+    r_model_part.AddNodalSolutionStepVariable(HYDRAULIC_DISCHARGE);
+    auto p_element =
+        CreateTriangleTransientPwElementWithPWDofs(r_model_part, p_properties);
+    const auto dummy_process_info = ProcessInfo{};
+
+    // Act
+    p_element->InitializeSolutionStep(dummy_process_info);
+
+    // Assert
+    for (auto& r_node : p_element->GetGeometry()) {
+        KRATOS_EXPECT_EQ(r_node.FastGetSolutionStepValue(HYDRAULIC_DISCHARGE), 0.0);
+    }
+}
+
+KRATOS_TEST_CASE_IN_SUITE(TransientPwElement_FinalizeSolutionStep,
+                          KratosGeoMechanicsFastSuite)
+{
+    // Arrange
+    const auto p_properties = std::make_shared<Properties>();
+
+    Model      model;
+    auto&      r_model_part = CreateModelPartWithWaterPressureVariableAndVolumeAcceleration(model);
+    r_model_part.AddNodalSolutionStepVariable(HYDRAULIC_DISCHARGE);
+    auto p_element =
+        CreateTriangleTransientPwElementWithPWDofs(r_model_part, p_properties);
+    const auto dummy_process_info = ProcessInfo{};
+    p_element->GetProperties().SetValue(DENSITY_WATER, 1.0E3);
+    p_element->GetProperties().SetValue(DYNAMIC_VISCOSITY, 1.0E-2);
+    p_element->GetProperties().SetValue(PERMEABILITY_XX, 1.0);
+    p_element->GetProperties().SetValue(PERMEABILITY_YY, 1.0);
+    p_element->GetProperties().SetValue(PERMEABILITY_XY, 1.0);
+    const auto gravity_acceleration = array_1d<double, 3>{0.0, -10.0, 0.0};
+    p_element->GetGeometry()[0].FastGetSolutionStepValue(VOLUME_ACCELERATION) = gravity_acceleration;
+    p_element->GetGeometry()[1].FastGetSolutionStepValue(VOLUME_ACCELERATION) = gravity_acceleration;
+    p_element->GetGeometry()[2].FastGetSolutionStepValue(VOLUME_ACCELERATION) = gravity_acceleration;
+    p_element->GetGeometry()[0].FastGetSolutionStepValue(WATER_PRESSURE) = 0.0;
+    p_element->GetGeometry()[1].FastGetSolutionStepValue(WATER_PRESSURE) = 0.0;
+    p_element->GetGeometry()[2].FastGetSolutionStepValue(WATER_PRESSURE) = 0.0;
+    p_element->InitializeSolutionStep(dummy_process_info);
+
+    // Act
+    p_element->FinalizeSolutionStep(dummy_process_info);
+
+    // Assert
+    KRATOS_EXPECT_EQ(p_element->GetGeometry()[0].FastGetSolutionStepValue(HYDRAULIC_DISCHARGE), 500000);
+    KRATOS_EXPECT_EQ(p_element->GetGeometry()[1].FastGetSolutionStepValue(HYDRAULIC_DISCHARGE), 0);
+    KRATOS_EXPECT_EQ(p_element->GetGeometry()[2].FastGetSolutionStepValue(HYDRAULIC_DISCHARGE), -500000);
+}
+
+KRATOS_TEST_CASE_IN_SUITE(TransientPwElement_CalculateOnIntegrationPoints_Vector,
+                          KratosGeoMechanicsFastSuite)
+{
+    // Arrange
+    const auto p_properties = std::make_shared<Properties>();
+
+    Model      model;
+    auto&      r_model_part = CreateModelPartWithWaterPressureVariableAndVolumeAcceleration(model);
+    r_model_part.AddNodalSolutionStepVariable(HYDRAULIC_DISCHARGE);
+    auto p_element =
+        CreateTriangleTransientPwElementWithPWDofs(r_model_part, p_properties);
+    const auto dummy_process_info = ProcessInfo{};
+    p_element->GetProperties().SetValue(DENSITY_WATER, 1.0E3);
+    p_element->GetProperties().SetValue(DYNAMIC_VISCOSITY, 1.0E-2);
+    p_element->GetProperties().SetValue(PERMEABILITY_XX, 1.0);
+    p_element->GetProperties().SetValue(PERMEABILITY_YY, 1.0);
+    p_element->GetProperties().SetValue(PERMEABILITY_XY, 1.0);
+    const auto gravity_acceleration = array_1d<double, 3>{0.0, -10.0, 0.0};
+    p_element->GetGeometry()[0].FastGetSolutionStepValue(VOLUME_ACCELERATION) = gravity_acceleration;
+    p_element->GetGeometry()[1].FastGetSolutionStepValue(VOLUME_ACCELERATION) = gravity_acceleration;
+    p_element->GetGeometry()[2].FastGetSolutionStepValue(VOLUME_ACCELERATION) = gravity_acceleration;
+    p_element->GetGeometry()[0].FastGetSolutionStepValue(WATER_PRESSURE) = 0.0;
+    p_element->GetGeometry()[1].FastGetSolutionStepValue(WATER_PRESSURE) = 0.0;
+    p_element->GetGeometry()[2].FastGetSolutionStepValue(WATER_PRESSURE) = 0.0;
+    p_element->InitializeSolutionStep(dummy_process_info);
+
+    // Act
+    std::vector<double> results{};
+    p_element->CalculateOnIntegrationPoints(DEGREE_OF_SATURATION, results, dummy_process_info);
+    auto const num_g_points = p_element->GetGeometry().IntegrationPointsNumber(p_element->GetIntegrationMethod());
+
+    // Assert
+    KRATOS_EXPECT_EQ(results.size(), num_g_points);
+    Vector expected_results(3);
+    expected_results <<= 1.0, 1.0, 1.0;
+    KRATOS_EXPECT_VECTOR_EQ(results, expected_results);
+
+    // Act
+    results.clear();
+    p_element->CalculateOnIntegrationPoints(EFFECTIVE_SATURATION, results, dummy_process_info);
+
+    // Assert
+    KRATOS_EXPECT_EQ(results.size(), num_g_points);
+    expected_results <<= 1.0, 1.0, 1.0;
+    KRATOS_EXPECT_VECTOR_EQ(results, expected_results);
+
+    // Act
+    results.clear();
+    p_element->CalculateOnIntegrationPoints(BISHOP_COEFFICIENT, results, dummy_process_info);
+
+    // Assert
+    KRATOS_EXPECT_EQ(results.size(), num_g_points);
+    expected_results <<= 1.0, 1.0, 1.0;
+    KRATOS_EXPECT_VECTOR_EQ(results, expected_results);
+
+    // Act
+    results.clear();
+    p_element->CalculateOnIntegrationPoints(DERIVATIVE_OF_SATURATION, results, dummy_process_info);
+
+    // Assert
+    KRATOS_EXPECT_EQ(results.size(), num_g_points);
+    expected_results <<= 0.0, 0.0, 0.0;
+    KRATOS_EXPECT_VECTOR_EQ(results, expected_results);
+
+    // Act
+    results.clear();
+    p_element->CalculateOnIntegrationPoints(RELATIVE_PERMEABILITY, results, dummy_process_info);
+
+    // Assert
+    KRATOS_EXPECT_EQ(results.size(), num_g_points);
+    expected_results <<= 1.0, 1.0, 1.0;
+    KRATOS_EXPECT_VECTOR_EQ(results, expected_results);
+
+    // Act
+    results.clear();
+    p_element->CalculateOnIntegrationPoints(HYDRAULIC_HEAD, results, dummy_process_info);
+
+    // Assert
+    KRATOS_EXPECT_EQ(results.size(), num_g_points);
+    expected_results <<= 0.166667, 0.166667, 0.666667;
+    KRATOS_EXPECT_VECTOR_NEAR(results, expected_results, Defaults::relative_tolerance);
+
+    // Act
+    results.clear();
+    p_element->CalculateOnIntegrationPoints(DT_WATER_PRESSURE, results, dummy_process_info);
+
+    // Assert
+    KRATOS_EXPECT_EQ(results.size(), num_g_points);
+    expected_results <<= 0, 0, 0;
+    KRATOS_EXPECT_VECTOR_EQ(results, expected_results);
+}
+
+KRATOS_TEST_CASE_IN_SUITE(TransientPwElement_CalculateOnIntegrationPoints_1DArray,
+                          KratosGeoMechanicsFastSuite)
+{
+    // Arrange
+    const auto p_properties = std::make_shared<Properties>();
+
+    Model      model;
+    auto&      r_model_part = CreateModelPartWithWaterPressureVariableAndVolumeAcceleration(model);
+    r_model_part.AddNodalSolutionStepVariable(HYDRAULIC_DISCHARGE);
+    auto p_element =
+        CreateTriangleTransientPwElementWithPWDofs(r_model_part, p_properties);
+    const auto dummy_process_info = ProcessInfo{};
+    p_element->GetProperties().SetValue(DENSITY_WATER, 1.0E3);
+    p_element->GetProperties().SetValue(DYNAMIC_VISCOSITY, 1.0E-2);
+    p_element->GetProperties().SetValue(PERMEABILITY_XX, 1.0);
+    p_element->GetProperties().SetValue(PERMEABILITY_YY, 1.0);
+    p_element->GetProperties().SetValue(PERMEABILITY_XY, 1.0);
+    const auto gravity_acceleration = array_1d<double, 3>{0.0, -10.0, 0.0};
+    p_element->GetGeometry()[0].FastGetSolutionStepValue(VOLUME_ACCELERATION) = gravity_acceleration;
+    p_element->GetGeometry()[1].FastGetSolutionStepValue(VOLUME_ACCELERATION) = gravity_acceleration;
+    p_element->GetGeometry()[2].FastGetSolutionStepValue(VOLUME_ACCELERATION) = gravity_acceleration;
+    p_element->GetGeometry()[0].FastGetSolutionStepValue(WATER_PRESSURE) = 0.0;
+    p_element->GetGeometry()[1].FastGetSolutionStepValue(WATER_PRESSURE) = 0.0;
+    p_element->GetGeometry()[2].FastGetSolutionStepValue(WATER_PRESSURE) = 0.0;
+    p_element->InitializeSolutionStep(dummy_process_info);
+
+    // Act
+    std::vector<array_1d<double, 3>> results{};
+    p_element->CalculateOnIntegrationPoints(FLUID_FLUX_VECTOR, results, dummy_process_info);
+    auto const num_g_points = p_element->GetGeometry().IntegrationPointsNumber(p_element->GetIntegrationMethod());
+
+    // Assert
+    KRATOS_EXPECT_EQ(results.size(), num_g_points);
+    array_1d<double, 3> expected_nonzero_component{-1e+06, -1e+06, 0};
+    for(const auto & component: results) {
+        KRATOS_EXPECT_VECTOR_EQ(component, expected_nonzero_component);
+    }
+
+    // Act
+    results.clear();
+    p_element->CalculateOnIntegrationPoints(LOCAL_FLUID_FLUX_VECTOR, results, dummy_process_info);
+
+    // Assert
+    KRATOS_EXPECT_EQ(results.size(), num_g_points);
+    array_1d<double, 3> expected_zero_component{0, 0, 0};
+    for(const auto & component: results) {
+        KRATOS_EXPECT_VECTOR_EQ(component, expected_zero_component);
+    }
+}
+
+KRATOS_TEST_CASE_IN_SUITE(TransientPwElement_CalculateOnIntegrationPoints_Matrix,
+                          KratosGeoMechanicsFastSuite)
+{
+    // Arrange
+    const auto p_properties = std::make_shared<Properties>();
+
+    Model      model;
+    auto&      r_model_part = CreateModelPartWithWaterPressureVariableAndVolumeAcceleration(model);
+    r_model_part.AddNodalSolutionStepVariable(HYDRAULIC_DISCHARGE);
+    auto p_element =
+        CreateTriangleTransientPwElementWithPWDofs(r_model_part, p_properties);
+    const auto dummy_process_info = ProcessInfo{};
+    p_element->GetProperties().SetValue(DENSITY_WATER, 1.0E3);
+    p_element->GetProperties().SetValue(DYNAMIC_VISCOSITY, 1.0E-2);
+    p_element->GetProperties().SetValue(PERMEABILITY_XX, 1.0);
+    p_element->GetProperties().SetValue(PERMEABILITY_YY, 1.0);
+    p_element->GetProperties().SetValue(PERMEABILITY_XY, 1.0);
+    const auto gravity_acceleration = array_1d<double, 3>{0.0, -10.0, 0.0};
+    p_element->GetGeometry()[0].FastGetSolutionStepValue(VOLUME_ACCELERATION) = gravity_acceleration;
+    p_element->GetGeometry()[1].FastGetSolutionStepValue(VOLUME_ACCELERATION) = gravity_acceleration;
+    p_element->GetGeometry()[2].FastGetSolutionStepValue(VOLUME_ACCELERATION) = gravity_acceleration;
+    p_element->GetGeometry()[0].FastGetSolutionStepValue(WATER_PRESSURE) = 0.0;
+    p_element->GetGeometry()[1].FastGetSolutionStepValue(WATER_PRESSURE) = 0.0;
+    p_element->GetGeometry()[2].FastGetSolutionStepValue(WATER_PRESSURE) = 0.0;
+    p_element->InitializeSolutionStep(dummy_process_info);
+
+    // Act
+    std::vector<Matrix> results{};
+    p_element->CalculateOnIntegrationPoints(PERMEABILITY_MATRIX, results, dummy_process_info);
+    auto const num_g_points = p_element->GetGeometry().IntegrationPointsNumber(p_element->GetIntegrationMethod());
+
+    // Assert
+    KRATOS_EXPECT_EQ(results.size(), num_g_points);
+    Matrix expected_nonzero_component(2,2);
+    expected_nonzero_component <<= 1, 1, 1, 1;
+    for(const auto & component: results) {
+        KRATOS_EXPECT_MATRIX_EQ(component, expected_nonzero_component);
+    }
+
+    // Act
+    results.clear();
+    p_element->CalculateOnIntegrationPoints(LOCAL_PERMEABILITY_MATRIX, results, dummy_process_info);
+
+    // Assert
+    KRATOS_EXPECT_EQ(results.size(), num_g_points);
+    Matrix expected_zero_component = ZeroMatrix(2,2);
+    for(const auto & component: results) {
+        KRATOS_EXPECT_MATRIX_EQ(component, expected_zero_component);
+    }
+}
+
+KRATOS_TEST_CASE_IN_SUITE(TransientPwElement2D3N_CalculateLocalSystem,
+                          KratosGeoMechanicsFastSuite)
+{
+    // Arrange
+    const auto p_properties = std::make_shared<Properties>();
+
+    Model      model;
+    auto&      r_model_part = CreateModelPartWithWaterPressureVariableAndVolumeAcceleration(model);
+    r_model_part.AddNodalSolutionStepVariable(HYDRAULIC_DISCHARGE);
+    auto p_element =
+        CreateTriangleTransientPwElementWithPWDofs(r_model_part, p_properties);
+    const auto dummy_process_info = ProcessInfo{};
+    p_element->GetProperties().SetValue(BIOT_COEFFICIENT, 0.5);
+    p_element->GetProperties().SetValue(DENSITY_WATER, 1.0E3);
+    p_element->GetProperties().SetValue(DYNAMIC_VISCOSITY, 1.0E-2);
+    p_element->GetProperties().SetValue(BULK_MODULUS_FLUID, 1.0E6);
+    p_element->GetProperties().SetValue(BULK_MODULUS_SOLID, 1.0E6);
+    p_element->GetProperties().SetValue(POROSITY, 0.1);
+    p_element->GetProperties().SetValue(IGNORE_UNDRAINED, false);
+    p_element->GetProperties().SetValue(PERMEABILITY_XX, 1.0);
+    p_element->GetProperties().SetValue(PERMEABILITY_YY, 1.0);
+    p_element->GetProperties().SetValue(PERMEABILITY_XY, 1.0);
+    const auto gravity_acceleration = array_1d<double, 3>{0.0, -10.0, 0.0};
+    p_element->GetGeometry()[0].FastGetSolutionStepValue(VOLUME_ACCELERATION) = gravity_acceleration;
+    p_element->GetGeometry()[1].FastGetSolutionStepValue(VOLUME_ACCELERATION) = gravity_acceleration;
+    p_element->GetGeometry()[2].FastGetSolutionStepValue(VOLUME_ACCELERATION) = gravity_acceleration;
+    p_element->GetGeometry()[0].FastGetSolutionStepValue(WATER_PRESSURE) = 0.0;
+    p_element->GetGeometry()[1].FastGetSolutionStepValue(WATER_PRESSURE) = 0.0;
+    p_element->GetGeometry()[2].FastGetSolutionStepValue(WATER_PRESSURE) = 0.0;
+    p_element->InitializeSolutionStep(dummy_process_info);
+
+    // Act
+    Vector actual_right_hand_side;
+    Matrix actual_left_hand_side;
+    p_element->CalculateLocalSystem(actual_left_hand_side, actual_right_hand_side, dummy_process_info);
+
+    // Assert
+    Matrix expected_left_hand_side(3,3);
+    // clang-format off
+    expected_left_hand_side <<= -49.999999999999993,0,49.999999999999993,
+                                 0,0,0,
+                                 49.999999999999993,0,-49.999999999999993;
+   // clang-format on
+    KRATOS_EXPECT_MATRIX_RELATIVE_NEAR(actual_left_hand_side, expected_left_hand_side, Defaults::relative_tolerance)
+
+    Vector expected_right_hand_side(3);
+    expected_right_hand_side <<= 500000,0,-500000;
+    KRATOS_EXPECT_VECTOR_RELATIVE_NEAR(actual_right_hand_side, expected_right_hand_side, Defaults::relative_tolerance)
+}
+
+KRATOS_TEST_CASE_IN_SUITE(TransientPwElement3D4N_CalculateLocalSystem,
+                          KratosGeoMechanicsFastSuite)
+{
+    // Arrange
+    const auto p_properties = std::make_shared<Properties>();
+
+    Model      model;
+    auto&      r_model_part = CreateModelPartWithWaterPressureVariableAndVolumeAcceleration(model);
+    r_model_part.AddNodalSolutionStepVariable(HYDRAULIC_DISCHARGE);
+    auto p_element =
+           CreateThreeDTransientPwElement3D4NWithPWDofs(r_model_part, p_properties);
+    const auto dummy_process_info = ProcessInfo{};
+    p_element->GetProperties().SetValue(BIOT_COEFFICIENT, 0.5);
+    p_element->GetProperties().SetValue(DENSITY_WATER, 1.0E3);
+    p_element->GetProperties().SetValue(DYNAMIC_VISCOSITY, 1.0E-2);
+    p_element->GetProperties().SetValue(BULK_MODULUS_FLUID, 1.0E6);
+    p_element->GetProperties().SetValue(BULK_MODULUS_SOLID, 1.0E6);
+    p_element->GetProperties().SetValue(POROSITY, 0.1);
+    p_element->GetProperties().SetValue(IGNORE_UNDRAINED, false);
+    p_element->GetProperties().SetValue(PERMEABILITY_XX, 1.0);
+    p_element->GetProperties().SetValue(PERMEABILITY_YY, 1.0);
+    p_element->GetProperties().SetValue(PERMEABILITY_XY, 1.0);
+    const auto gravity_acceleration = array_1d<double, 3>{0.0, -10.0, 0.0};
+    p_element->GetGeometry()[0].FastGetSolutionStepValue(VOLUME_ACCELERATION) = gravity_acceleration;
+    p_element->GetGeometry()[1].FastGetSolutionStepValue(VOLUME_ACCELERATION) = gravity_acceleration;
+    p_element->GetGeometry()[2].FastGetSolutionStepValue(VOLUME_ACCELERATION) = gravity_acceleration;
+    p_element->GetGeometry()[2].FastGetSolutionStepValue(VOLUME_ACCELERATION) = gravity_acceleration;
+    p_element->GetGeometry()[0].FastGetSolutionStepValue(WATER_PRESSURE) = 0.0;
+    p_element->GetGeometry()[1].FastGetSolutionStepValue(WATER_PRESSURE) = 0.0;
+    p_element->GetGeometry()[2].FastGetSolutionStepValue(WATER_PRESSURE) = 0.0;
+    p_element->GetGeometry()[3].FastGetSolutionStepValue(WATER_PRESSURE) = 0.0;
+    p_element->InitializeSolutionStep(dummy_process_info);
+
+    // Act
+    Vector actual_right_hand_side;
+    Matrix actual_left_hand_side;
+    p_element->CalculateLocalSystem(actual_left_hand_side, actual_right_hand_side, dummy_process_info);
+
+    // Assert
+    Matrix expected_left_hand_side(4,4);
+    // clang-format off
+    expected_left_hand_side <<= -16.666666666666664,0,16.666666666666664,0,
+                                 0,0,0,0,
+                                 16.666666666666664,0,-16.666666666666664,0,
+                                 0,0,0,0;
+    // clang-format on
+    KRATOS_EXPECT_MATRIX_RELATIVE_NEAR(actual_left_hand_side, expected_left_hand_side, Defaults::relative_tolerance)
+
+    Vector expected_right_hand_side(4);
+    expected_right_hand_side <<= 125000,0,-125000,0;
+    KRATOS_EXPECT_VECTOR_RELATIVE_NEAR(actual_right_hand_side, expected_right_hand_side, Defaults::relative_tolerance)
+}
+
+} // namespace Kratos::Testing

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_elements/test_transient_Pw_element.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_elements/test_transient_Pw_element.cpp
@@ -188,7 +188,7 @@ KRATOS_TEST_CASE_IN_SUITE(TransientPwElement_DoFList, KratosGeoMechanicsFastSuit
     // Assert
     KRATOS_EXPECT_EQ(degrees_of_freedom.size(), 3);
     KRATOS_EXPECT_TRUE(std::all_of(degrees_of_freedom.begin(), degrees_of_freedom.end(),
-                                   [](auto p_dof) { return p_dof->GetVariable() == WATER_PRESSURE; }));
+                                   [](auto p_dof) { return p_dof->GetVariable() == WATER_PRESSURE; }))
 }
 
 KRATOS_TEST_CASE_IN_SUITE(TransientPwElement_EquationIdVector, KratosGeoMechanicsFastSuiteWithoutKernel)
@@ -432,7 +432,7 @@ KRATOS_TEST_CASE_IN_SUITE(TransientPwElement_Initialize, KratosGeoMechanicsFastS
     KRATOS_EXPECT_EQ(r_retention_law_vector.size(), number_of_integration_points);
     KRATOS_EXPECT_TRUE(std::none_of(r_retention_law_vector.begin(), r_retention_law_vector.end(), [](auto p_retention_law) {
         return dynamic_cast<SaturatedLaw*>(p_retention_law.get()) == nullptr;
-    }));
+    }))
 }
 
 KRATOS_TEST_CASE_IN_SUITE(TransientPwElement_InitializeSolution, KratosGeoMechanicsFastSuiteWithoutKernel)
@@ -450,7 +450,7 @@ KRATOS_TEST_CASE_IN_SUITE(TransientPwElement_InitializeSolution, KratosGeoMechan
     // Assert
     KRATOS_EXPECT_TRUE(std::all_of(
         p_element->GetGeometry().begin(), p_element->GetGeometry().end(),
-        [](auto& r_node) { return r_node.FastGetSolutionStepValue(HYDRAULIC_DISCHARGE) == 0.0; }));
+        [](auto& r_node) { return r_node.FastGetSolutionStepValue(HYDRAULIC_DISCHARGE) == 0.0; }))
 }
 
 KRATOS_TEST_CASE_IN_SUITE(TransientPwElement_FinalizeSolutionStep, KratosGeoMechanicsFastSuiteWithoutKernel)

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_elements/test_transient_Pw_element.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_elements/test_transient_Pw_element.cpp
@@ -68,7 +68,7 @@ ModelPart& CreateModelPartWithWaterPressureVariableAndVolumeAcceleration(Model& 
     return r_result;
 }
 
-void RemoveThreeNOdes(ModelPart& rModelPart)
+void RemoveThreeNodes(ModelPart& rModelPart)
 {
     rModelPart.RemoveNodeFromAllLevels(1);
     rModelPart.RemoveNodeFromAllLevels(2);
@@ -292,19 +292,19 @@ KRATOS_TEST_CASE_IN_SUITE(TransientPwElement_CheckThrowsOnFaultyInput, KratosGeo
     KRATOS_EXPECT_EXCEPTION_IS_THROWN(p_element->Check(dummy_process_info),
                                       "Error: Missing variable DT_WATER_PRESSURE on node 1")
 
-    RemoveThreeNOdes(model_part);
+    RemoveThreeNodes(model_part);
     model_part.AddNodalSolutionStepVariable(DT_WATER_PRESSURE);
     p_element = CreateTriangleTransientPwElementWithoutPWDofs(model_part, p_properties);
     KRATOS_EXPECT_EXCEPTION_IS_THROWN(p_element->Check(dummy_process_info),
                                       "Missing variable VOLUME_ACCELERATION on node 1")
 
-    RemoveThreeNOdes(model_part);
+    RemoveThreeNodes(model_part);
     model_part.AddNodalSolutionStepVariable(VOLUME_ACCELERATION);
     p_element = CreateTriangleTransientPwElementWithoutPWDofs(model_part, p_properties);
     KRATOS_EXPECT_EXCEPTION_IS_THROWN(p_element->Check(dummy_process_info),
                                       "Missing variable WATER_PRESSURE on node 1")
 
-    RemoveThreeNOdes(model_part);
+    RemoveThreeNodes(model_part);
     p_element = CreateTriangleTransientPwElementWithPWDofs(model_part, p_properties);
     KRATOS_EXPECT_EXCEPTION_IS_THROWN(p_element->Check(dummy_process_info),
                                       "DENSITY_WATER does not exist in the material properties or "

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_elements/test_transient_Pw_element.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_elements/test_transient_Pw_element.cpp
@@ -12,6 +12,7 @@
 //
 
 #include "custom_elements/plane_strain_stress_state.h"
+#include "custom_elements/three_dimensional_stress_state.h"
 #include "custom_elements/transient_Pw_element.hpp"
 #include "tests/cpp_tests/geo_mechanics_fast_suite.h"
 #include "tests/cpp_tests/test_utilities.h"
@@ -96,8 +97,9 @@ intrusive_ptr<TransientPwElement<2, 3>> CreateTransientPwElementWithPWDofs(const
 intrusive_ptr<TransientPwElement<3, 4>> CreateTransientPwElement3D4NWithPWDofs(
     const ModelPart& rModelPart, const Properties::Pointer& rProperties, const Geometry<Node>::Pointer& rGeometry)
 {
-    auto p_result = make_intrusive<TransientPwElement<3, 4>>(
-        NextElementNumber(rModelPart), rGeometry, rProperties, std::make_unique<PlaneStrainStressState>());
+    auto p_result =
+        make_intrusive<TransientPwElement<3, 4>>(NextElementNumber(rModelPart), rGeometry, rProperties,
+                                                 std::make_unique<ThreeDimensionalStressState>());
     for (auto& node : p_result->GetGeometry()) {
         node.AddDof(WATER_PRESSURE);
     }

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_elements/test_transient_Pw_element.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_elements/test_transient_Pw_element.cpp
@@ -10,10 +10,10 @@
 //  Main authors:    Wijtze Pieter Kikstra
 //
 
+#include "custom_elements/plane_strain_stress_state.h"
 #include "custom_elements/transient_Pw_element.hpp"
 #include "tests/cpp_tests/geo_mechanics_fast_suite.h"
 #include "tests/cpp_tests/test_utilities.h"
-#include "custom_elements/plane_strain_stress_state.h"
 #include <boost/numeric/ublas/assignment.hpp>
 
 namespace
@@ -69,9 +69,9 @@ ModelPart& CreateModelPartWithWaterPressureVariableAndVolumeAcceleration(Model& 
 
 void RemoveNodes(ModelPart& rModelPart)
 {
-rModelPart.RemoveNodeFromAllLevels(1);
-rModelPart.RemoveNodeFromAllLevels(2);
-rModelPart.RemoveNodeFromAllLevels(3);
+    rModelPart.RemoveNodeFromAllLevels(1);
+    rModelPart.RemoveNodeFromAllLevels(2);
+    rModelPart.RemoveNodeFromAllLevels(3);
 }
 
 Element::IndexType NextElementNumber(const ModelPart& rModelPart)
@@ -79,8 +79,9 @@ Element::IndexType NextElementNumber(const ModelPart& rModelPart)
     return rModelPart.NumberOfElements() + 1;
 }
 
-intrusive_ptr<TransientPwElement<2, 3>> CreateTransientPwElementWithPWDofs(
-    const ModelPart& rModelPart, const Properties::Pointer& rProperties, const Geometry<Node>::Pointer& rGeometry)
+intrusive_ptr<TransientPwElement<2, 3>> CreateTransientPwElementWithPWDofs(const ModelPart& rModelPart,
+                                                                           const Properties::Pointer& rProperties,
+                                                                           const Geometry<Node>::Pointer& rGeometry)
 {
     auto p_result = make_intrusive<TransientPwElement<2, 3>>(
         NextElementNumber(rModelPart), rGeometry, rProperties, std::make_unique<PlaneStrainStressState>());
@@ -103,8 +104,8 @@ intrusive_ptr<TransientPwElement<3, 4>> CreateTransientPwElement3D4NWithPWDofs(
     return p_result;
 }
 
-intrusive_ptr<TransientPwElement<2, 3>> CreateTriangleTransientPwElementWithPWDofs(
-    ModelPart& rModelPart, const Properties::Pointer& rProperties)
+intrusive_ptr<TransientPwElement<2, 3>> CreateTriangleTransientPwElementWithPWDofs(ModelPart& rModelPart,
+                                                                                   const Properties::Pointer& rProperties)
 {
     const auto p_geometry = std::make_shared<Triangle2D3<Node>>(CreateThreeNodesOnModelPart(rModelPart));
     auto p_element = CreateTransientPwElementWithPWDofs(rModelPart, rProperties, p_geometry);
@@ -113,8 +114,8 @@ intrusive_ptr<TransientPwElement<2, 3>> CreateTriangleTransientPwElementWithPWDo
     return p_element;
 }
 
-intrusive_ptr<TransientPwElement<3, 4>> CreateThreeDTransientPwElement3D4NWithPWDofs(
-    ModelPart& rModelPart, const Properties::Pointer& rProperties)
+intrusive_ptr<TransientPwElement<3, 4>> CreateThreeDTransientPwElement3D4NWithPWDofs(ModelPart& rModelPart,
+                                                                                     const Properties::Pointer& rProperties)
 {
     const auto p_geometry = std::make_shared<Tetrahedra3D4<Node>>(CreateThetrahedralOnModelPart(rModelPart));
     auto p_element = CreateTransientPwElement3D4NWithPWDofs(rModelPart, rProperties, p_geometry);
@@ -123,11 +124,11 @@ intrusive_ptr<TransientPwElement<3, 4>> CreateThreeDTransientPwElement3D4NWithPW
     return p_element;
 }
 
-intrusive_ptr<TransientPwElement<2, 3>> CreateTriangleTransientPwElementWithoutPWDofs(
-    ModelPart& rModelPart, const Properties::Pointer& rProperties)
+intrusive_ptr<TransientPwElement<2, 3>> CreateTriangleTransientPwElementWithoutPWDofs(ModelPart& rModelPart,
+                                                                                      const Properties::Pointer& rProperties)
 {
     const auto p_geometry = std::make_shared<Triangle2D3<Node>>(CreateThreeNodesOnModelPart(rModelPart));
-    auto       p_element  = make_intrusive<TransientPwElement<2, 3>>(
+    auto p_element = make_intrusive<TransientPwElement<2, 3>>(
         NextElementNumber(rModelPart), p_geometry, rProperties, std::make_unique<PlaneStrainStressState>());
 
     rModelPart.AddElement(p_element);
@@ -135,6 +136,7 @@ intrusive_ptr<TransientPwElement<2, 3>> CreateTriangleTransientPwElementWithoutP
 }
 
 } // namespace
+
 /*
 namespace Kratos
 {
@@ -166,14 +168,13 @@ namespace Kratos::Testing
 
 using namespace Kratos;
 
-
-KRATOS_TEST_CASE_IN_SUITE(TransientPwElement_CreateInstanceWithGeometryInput,
-                          KratosGeoMechanicsFastSuite)
+KRATOS_TEST_CASE_IN_SUITE(TransientPwElement_CreateInstanceWithGeometryInput, KratosGeoMechanicsFastSuite)
 {
     // Arrange
     const auto p_geometry   = std::make_shared<Triangle2D3<Node>>(CreateThreeNodes());
     const auto p_properties = std::make_shared<Properties>();
-    const TransientPwElement<2, 3> element(0,p_geometry, p_properties,   std::make_unique<PlaneStrainStressState>());
+    const TransientPwElement<2, 3> element(0, p_geometry, p_properties,
+                                           std::make_unique<PlaneStrainStressState>());
 
     // Act
     const auto p_created_element = element.Create(1, p_geometry, p_properties);
@@ -185,7 +186,6 @@ KRATOS_TEST_CASE_IN_SUITE(TransientPwElement_CreateInstanceWithGeometryInput,
     EXPECT_NE(p_created_element->pGetProperties(), nullptr);
 }
 
-
 KRATOS_TEST_CASE_IN_SUITE(TransientPwElement_CreateInstanceWithNodeInput, KratosGeoMechanicsFastSuite)
 {
     // Arrange
@@ -194,7 +194,8 @@ KRATOS_TEST_CASE_IN_SUITE(TransientPwElement_CreateInstanceWithNodeInput, Kratos
     // The source element needs to have a geometry, otherwise the version of the
     // Create method with a node input will fail.
     const auto p_geometry = std::make_shared<Triangle2D3<Node>>(CreateThreeNodes());
-    const TransientPwElement<2, 3> element(0, p_geometry, p_properties, std::make_unique<PlaneStrainStressState>());
+    const TransientPwElement<2, 3> element(0, p_geometry, p_properties,
+                                           std::make_unique<PlaneStrainStressState>());
 
     // Act
     const auto p_created_element = element.Create(1, CreateThreeNodes(), p_properties);
@@ -213,8 +214,7 @@ KRATOS_TEST_CASE_IN_SUITE(TransientPwElement_DoFList, KratosGeoMechanicsFastSuit
 
     Model      model;
     auto&      r_model_part = CreateModelPartWithWaterPressureVariableAndVolumeAcceleration(model);
-    const auto p_element =
-        CreateTriangleTransientPwElementWithPWDofs(r_model_part, p_properties);
+    const auto p_element = CreateTriangleTransientPwElementWithPWDofs(r_model_part, p_properties);
 
     // Act
     const auto              dummy_process_info = ProcessInfo{};
@@ -228,16 +228,14 @@ KRATOS_TEST_CASE_IN_SUITE(TransientPwElement_DoFList, KratosGeoMechanicsFastSuit
     }
 }
 
-KRATOS_TEST_CASE_IN_SUITE(TransientPwElement_EquationIdVector,
-                          KratosGeoMechanicsFastSuiteWithoutKernel)
+KRATOS_TEST_CASE_IN_SUITE(TransientPwElement_EquationIdVector, KratosGeoMechanicsFastSuiteWithoutKernel)
 {
     // Arrange
     const auto p_properties = std::make_shared<Properties>();
 
     Model model;
     auto& r_model_part = CreateModelPartWithWaterPressureVariableAndVolumeAcceleration(model);
-    auto  p_element =
-        CreateTriangleTransientPwElementWithPWDofs(r_model_part, p_properties);
+    auto  p_element    = CreateTriangleTransientPwElementWithPWDofs(r_model_part, p_properties);
 
     unsigned int i = 0;
     for (const auto& node : p_element->GetGeometry()) {
@@ -255,13 +253,13 @@ KRATOS_TEST_CASE_IN_SUITE(TransientPwElement_EquationIdVector,
     KRATOS_EXPECT_VECTOR_EQ(equation_id_vector, expected_ids)
 }
 
-KRATOS_TEST_CASE_IN_SUITE(TransientPwElement_IntegrationMethod,
-                          KratosGeoMechanicsFastSuite)
+KRATOS_TEST_CASE_IN_SUITE(TransientPwElement_IntegrationMethod, KratosGeoMechanicsFastSuite)
 {
     // Arrange
     const auto p_geometry   = std::make_shared<Triangle2D3<Node>>(CreateCoincidentNodes());
     const auto p_properties = std::make_shared<Properties>();
-    const TransientPwElement<2, 3> element(0, p_geometry, p_properties, std::make_unique<PlaneStrainStressState>());
+    const TransientPwElement<2, 3> element(0, p_geometry, p_properties,
+                                           std::make_unique<PlaneStrainStressState>());
 
     // Act
     const auto p_integration_method = element.GetIntegrationMethod();
@@ -276,7 +274,8 @@ KRATOS_TEST_CASE_IN_SUITE(TransientPwElement_CheckThrowsOnFaultyInput, KratosGeo
     // Arrange
     const auto p_geometry   = std::make_shared<Triangle2D3<Node>>(CreateCoincidentNodes());
     const auto p_properties = std::make_shared<Properties>();
-    const TransientPwElement<2, 3> element(1, p_geometry, p_properties, std::make_unique<PlaneStrainStressState>());
+    const TransientPwElement<2, 3> element(1, p_geometry, p_properties,
+                                           std::make_unique<PlaneStrainStressState>());
 
     // Act and Assert
     const auto dummy_process_info = ProcessInfo{};
@@ -284,71 +283,65 @@ KRATOS_TEST_CASE_IN_SUITE(TransientPwElement_CheckThrowsOnFaultyInput, KratosGeo
                                       "Error: DomainSize < 1.0e-15 for the element 1")
 
     const auto p_geometry2 = std::make_shared<Triangle2D3<Node>>(CreateThreeNodes());
-    const TransientPwElement<2, 3> element1(1, p_geometry2, p_properties, std::make_unique<PlaneStrainStressState>());
+    const TransientPwElement<2, 3> element1(1, p_geometry2, p_properties,
+                                            std::make_unique<PlaneStrainStressState>());
     KRATOS_EXPECT_EXCEPTION_IS_THROWN(element1.Check(dummy_process_info),
                                       "Error: Missing variable WATER_PRESSURE on node 1")
 
     Model model;
     auto& model_part = model.CreateModelPart("Main");
     model_part.AddNodalSolutionStepVariable(WATER_PRESSURE);
-    auto  p_new_element =
-            CreateTriangleTransientPwElementWithoutPWDofs(model_part, p_properties);
-    KRATOS_EXPECT_EXCEPTION_IS_THROWN(
-        p_new_element->Check(dummy_process_info),
-        "Error: Missing variable DT_WATER_PRESSURE on node 1")
+    auto p_new_element = CreateTriangleTransientPwElementWithoutPWDofs(model_part, p_properties);
+    KRATOS_EXPECT_EXCEPTION_IS_THROWN(p_new_element->Check(dummy_process_info),
+                                      "Error: Missing variable DT_WATER_PRESSURE on node 1")
 
     RemoveNodes(model_part);
     model_part.AddNodalSolutionStepVariable(DT_WATER_PRESSURE);
-    p_new_element =
-            CreateTriangleTransientPwElementWithoutPWDofs(model_part, p_properties);
-    KRATOS_EXPECT_EXCEPTION_IS_THROWN(
-        p_new_element->Check(dummy_process_info),
-        "Missing variable VOLUME_ACCELERATION on node 1")
+    p_new_element = CreateTriangleTransientPwElementWithoutPWDofs(model_part, p_properties);
+    KRATOS_EXPECT_EXCEPTION_IS_THROWN(p_new_element->Check(dummy_process_info),
+                                      "Missing variable VOLUME_ACCELERATION on node 1")
 
     RemoveNodes(model_part);
     model_part.AddNodalSolutionStepVariable(VOLUME_ACCELERATION);
-    p_new_element =
-            CreateTriangleTransientPwElementWithoutPWDofs(model_part, p_properties);
-    KRATOS_EXPECT_EXCEPTION_IS_THROWN(
-        p_new_element->Check(dummy_process_info),
-        "Missing variable WATER_PRESSURE on node 1")
+    p_new_element = CreateTriangleTransientPwElementWithoutPWDofs(model_part, p_properties);
+    KRATOS_EXPECT_EXCEPTION_IS_THROWN(p_new_element->Check(dummy_process_info),
+                                      "Missing variable WATER_PRESSURE on node 1")
 
     RemoveNodes(model_part);
-    p_new_element =
-                CreateTriangleTransientPwElementWithPWDofs(model_part, p_properties);
-    KRATOS_EXPECT_EXCEPTION_IS_THROWN(
-        p_new_element->Check(dummy_process_info),
-        "DENSITY_WATER does not exist in the material properties or has an invalid value at element 4")
+    p_new_element = CreateTriangleTransientPwElementWithPWDofs(model_part, p_properties);
+    KRATOS_EXPECT_EXCEPTION_IS_THROWN(p_new_element->Check(dummy_process_info),
+                                      "DENSITY_WATER does not exist in the material properties or "
+                                      "has an invalid value at element 4")
 
     p_new_element->GetProperties().SetValue(DENSITY_WATER, -1.0E3);
-    KRATOS_EXPECT_EXCEPTION_IS_THROWN(
-        p_new_element->Check(dummy_process_info),
-        "DENSITY_WATER does not exist in the material properties or has an invalid value at element 4")
+    KRATOS_EXPECT_EXCEPTION_IS_THROWN(p_new_element->Check(dummy_process_info),
+                                      "DENSITY_WATER does not exist in the material properties or "
+                                      "has an invalid value at element 4")
 
     p_new_element->GetProperties().SetValue(DENSITY_WATER, 1.0E3);
-    KRATOS_EXPECT_EXCEPTION_IS_THROWN(
-        p_new_element->Check(dummy_process_info),
-        "Error: BULK_MODULUS_SOLID does not exist in the material properties or has an invalid value at element 4")
+    KRATOS_EXPECT_EXCEPTION_IS_THROWN(p_new_element->Check(dummy_process_info),
+                                      "Error: BULK_MODULUS_SOLID does not exist in the material "
+                                      "properties or has an invalid value at element 4")
 
     p_new_element->GetProperties().SetValue(BULK_MODULUS_SOLID, -1.0E6);
-    KRATOS_EXPECT_EXCEPTION_IS_THROWN(
-        p_new_element->Check(dummy_process_info),
-        "Error: BULK_MODULUS_SOLID does not exist in the material properties or has an invalid value at element 4")
+    KRATOS_EXPECT_EXCEPTION_IS_THROWN(p_new_element->Check(dummy_process_info),
+                                      "Error: BULK_MODULUS_SOLID does not exist in the material "
+                                      "properties or has an invalid value at element 4")
 
     p_new_element->GetProperties().SetValue(BULK_MODULUS_SOLID, 1.0E6);
-    KRATOS_EXPECT_EXCEPTION_IS_THROWN(
-        p_new_element->Check(dummy_process_info),
-        "Error: POROSITY does not exist in the material properties or has an invalid value at element 4")
+    KRATOS_EXPECT_EXCEPTION_IS_THROWN(p_new_element->Check(dummy_process_info),
+                                      "Error: POROSITY does not exist in the material properties "
+                                      "or has an invalid value at element 4")
 
     p_new_element->GetProperties().SetValue(POROSITY, -1.0);
-    KRATOS_EXPECT_EXCEPTION_IS_THROWN(
-        p_new_element->Check(dummy_process_info),
-        "Error: POROSITY does not exist in the material properties or has an invalid value at element 4")
+    KRATOS_EXPECT_EXCEPTION_IS_THROWN(p_new_element->Check(dummy_process_info),
+                                      "Error: POROSITY does not exist in the material properties "
+                                      "or has an invalid value at element 4")
 
     p_new_element->GetProperties().SetValue(POROSITY, 2.0);
-    KRATOS_EXPECT_EXCEPTION_IS_THROWN(
-        p_new_element->Check(dummy_process_info),
-        "Error: POROSITY does not exist in the material properties or has an invalid value at element 4")
+    KRATOS_EXPECT_EXCEPTION_IS_THROWN(p_new_element->Check(dummy_process_info),
+                                      "Error: POROSITY does not exist in the material properties "
+                                      "or has an invalid value at element 4")
 
     p_new_element->GetProperties().SetValue(POROSITY, 0.5);
 
@@ -357,54 +350,54 @@ KRATOS_TEST_CASE_IN_SUITE(TransientPwElement_CheckThrowsOnFaultyInput, KratosGeo
                                       "Error:  Node with non-zero Z coordinate found. Id: 1")
     p_new_element->GetGeometry().begin()->Z() = 0;
 
-    KRATOS_EXPECT_EXCEPTION_IS_THROWN(
-        p_new_element->Check(dummy_process_info),
-        "Error: BULK_MODULUS_FLUID does not exist in the material properties or has an invalid value at element 4")
+    KRATOS_EXPECT_EXCEPTION_IS_THROWN(p_new_element->Check(dummy_process_info),
+                                      "Error: BULK_MODULUS_FLUID does not exist in the material "
+                                      "properties or has an invalid value at element 4")
 
     p_new_element->GetProperties().SetValue(BULK_MODULUS_FLUID, -1.0e6);
-    KRATOS_EXPECT_EXCEPTION_IS_THROWN(
-        p_new_element->Check(dummy_process_info),
-        "Error: BULK_MODULUS_FLUID does not exist in the material properties or has an invalid value at element 4")
+    KRATOS_EXPECT_EXCEPTION_IS_THROWN(p_new_element->Check(dummy_process_info),
+                                      "Error: BULK_MODULUS_FLUID does not exist in the material "
+                                      "properties or has an invalid value at element 4")
 
     p_new_element->GetProperties().SetValue(BULK_MODULUS_FLUID, 1.0e6);
-    KRATOS_EXPECT_EXCEPTION_IS_THROWN(
-        p_new_element->Check(dummy_process_info),
-        "Error: DYNAMIC_VISCOSITY does not exist in the material properties or has an invalid value at element 4")
+    KRATOS_EXPECT_EXCEPTION_IS_THROWN(p_new_element->Check(dummy_process_info),
+                                      "Error: DYNAMIC_VISCOSITY does not exist in the material "
+                                      "properties or has an invalid value at element 4")
 
     p_new_element->GetProperties().SetValue(DYNAMIC_VISCOSITY, -1.0E-2);
-    KRATOS_EXPECT_EXCEPTION_IS_THROWN(
-        p_new_element->Check(dummy_process_info),
-        "Error: DYNAMIC_VISCOSITY does not exist in the material properties or has an invalid value at element 4")
+    KRATOS_EXPECT_EXCEPTION_IS_THROWN(p_new_element->Check(dummy_process_info),
+                                      "Error: DYNAMIC_VISCOSITY does not exist in the material "
+                                      "properties or has an invalid value at element 4")
 
     p_new_element->GetProperties().SetValue(DYNAMIC_VISCOSITY, 1.0E-2);
-    KRATOS_EXPECT_EXCEPTION_IS_THROWN(
-        p_new_element->Check(dummy_process_info),
-        "PERMEABILITY_XX does not exist in the material properties or has an invalid value at element 4")
+    KRATOS_EXPECT_EXCEPTION_IS_THROWN(p_new_element->Check(dummy_process_info),
+                                      "PERMEABILITY_XX does not exist in the material properties "
+                                      "or has an invalid value at element 4")
 
     p_new_element->GetProperties().SetValue(PERMEABILITY_XX, -1.0E-2);
-    KRATOS_EXPECT_EXCEPTION_IS_THROWN(
-        p_new_element->Check(dummy_process_info),
-        "PERMEABILITY_XX does not exist in the material properties or has an invalid value at element 4")
+    KRATOS_EXPECT_EXCEPTION_IS_THROWN(p_new_element->Check(dummy_process_info),
+                                      "PERMEABILITY_XX does not exist in the material properties "
+                                      "or has an invalid value at element 4")
 
     p_new_element->GetProperties().SetValue(PERMEABILITY_XX, 1.0E-2);
-    KRATOS_EXPECT_EXCEPTION_IS_THROWN(
-        p_new_element->Check(dummy_process_info),
-        "PERMEABILITY_YY does not exist in the material properties or has an invalid value at element 4")
+    KRATOS_EXPECT_EXCEPTION_IS_THROWN(p_new_element->Check(dummy_process_info),
+                                      "PERMEABILITY_YY does not exist in the material properties "
+                                      "or has an invalid value at element 4")
 
     p_new_element->GetProperties().SetValue(PERMEABILITY_YY, -1.0E-2);
-    KRATOS_EXPECT_EXCEPTION_IS_THROWN(
-        p_new_element->Check(dummy_process_info),
-        "PERMEABILITY_YY does not exist in the material properties or has an invalid value at element 4")
+    KRATOS_EXPECT_EXCEPTION_IS_THROWN(p_new_element->Check(dummy_process_info),
+                                      "PERMEABILITY_YY does not exist in the material properties "
+                                      "or has an invalid value at element 4")
 
     p_new_element->GetProperties().SetValue(PERMEABILITY_YY, 1.0E-2);
-    KRATOS_EXPECT_EXCEPTION_IS_THROWN(
-        p_new_element->Check(dummy_process_info),
-        "PERMEABILITY_XY does not exist in the material properties or has an invalid value at element 4")
+    KRATOS_EXPECT_EXCEPTION_IS_THROWN(p_new_element->Check(dummy_process_info),
+                                      "PERMEABILITY_XY does not exist in the material properties "
+                                      "or has an invalid value at element 4")
 
     p_new_element->GetProperties().SetValue(PERMEABILITY_XY, -1.0E-2);
-    KRATOS_EXPECT_EXCEPTION_IS_THROWN(
-        p_new_element->Check(dummy_process_info),
-        "PERMEABILITY_XY does not exist in the material properties or has an invalid value at element 4")
+    KRATOS_EXPECT_EXCEPTION_IS_THROWN(p_new_element->Check(dummy_process_info),
+                                      "PERMEABILITY_XY does not exist in the material properties "
+                                      "or has an invalid value at element 4")
 
     p_new_element->GetProperties().SetValue(PERMEABILITY_XY, 1.0E-2);
     KRATOS_EXPECT_EXCEPTION_IS_THROWN(
@@ -416,36 +409,35 @@ KRATOS_TEST_CASE_IN_SUITE(TransientPwElement_CheckThrowsOnFaultyInput, KratosGeo
     // No exceptions on correct input for 2D element
     KRATOS_EXPECT_EQ(p_new_element->Check(dummy_process_info), 0);
 
-    auto p_3D_element =
-           CreateThreeDTransientPwElement3D4NWithPWDofs(model_part, p_properties);
-    KRATOS_EXPECT_EXCEPTION_IS_THROWN(
-        p_3D_element->Check(dummy_process_info),
-        "PERMEABILITY_ZZ does not exist in the material properties or has an invalid value at element 5")
+    auto p_3D_element = CreateThreeDTransientPwElement3D4NWithPWDofs(model_part, p_properties);
+    KRATOS_EXPECT_EXCEPTION_IS_THROWN(p_3D_element->Check(dummy_process_info),
+                                      "PERMEABILITY_ZZ does not exist in the material properties "
+                                      "or has an invalid value at element 5")
 
     p_3D_element->GetProperties().SetValue(PERMEABILITY_ZZ, -1.0E-2);
-    KRATOS_EXPECT_EXCEPTION_IS_THROWN(
-        p_3D_element->Check(dummy_process_info),
-        "PERMEABILITY_ZZ does not exist in the material properties or has an invalid value at element 5")
+    KRATOS_EXPECT_EXCEPTION_IS_THROWN(p_3D_element->Check(dummy_process_info),
+                                      "PERMEABILITY_ZZ does not exist in the material properties "
+                                      "or has an invalid value at element 5")
 
     p_3D_element->GetProperties().SetValue(PERMEABILITY_ZZ, 1.0E-2);
-    KRATOS_EXPECT_EXCEPTION_IS_THROWN(
-        p_3D_element->Check(dummy_process_info),
-        "PERMEABILITY_YZ does not exist in the material properties or has an invalid value at element 5")
+    KRATOS_EXPECT_EXCEPTION_IS_THROWN(p_3D_element->Check(dummy_process_info),
+                                      "PERMEABILITY_YZ does not exist in the material properties "
+                                      "or has an invalid value at element 5")
 
     p_3D_element->GetProperties().SetValue(PERMEABILITY_YZ, -1.0E-2);
-    KRATOS_EXPECT_EXCEPTION_IS_THROWN(
-        p_3D_element->Check(dummy_process_info),
-        "PERMEABILITY_YZ does not exist in the material properties or has an invalid value at element 5")
+    KRATOS_EXPECT_EXCEPTION_IS_THROWN(p_3D_element->Check(dummy_process_info),
+                                      "PERMEABILITY_YZ does not exist in the material properties "
+                                      "or has an invalid value at element 5")
 
     p_3D_element->GetProperties().SetValue(PERMEABILITY_YZ, 1.0E-2);
-    KRATOS_EXPECT_EXCEPTION_IS_THROWN(
-        p_3D_element->Check(dummy_process_info),
-        "PERMEABILITY_ZX does not exist in the material properties or has an invalid value at element 5")
+    KRATOS_EXPECT_EXCEPTION_IS_THROWN(p_3D_element->Check(dummy_process_info),
+                                      "PERMEABILITY_ZX does not exist in the material properties "
+                                      "or has an invalid value at element 5")
 
     p_3D_element->GetProperties().SetValue(PERMEABILITY_ZX, -1.0E-2);
-    KRATOS_EXPECT_EXCEPTION_IS_THROWN(
-        p_3D_element->Check(dummy_process_info),
-        "PERMEABILITY_ZX does not exist in the material properties or has an invalid value at element 5")
+    KRATOS_EXPECT_EXCEPTION_IS_THROWN(p_3D_element->Check(dummy_process_info),
+                                      "PERMEABILITY_ZX does not exist in the material properties "
+                                      "or has an invalid value at element 5")
 
     p_3D_element->GetProperties().SetValue(PERMEABILITY_ZX, 1.0E-2);
 
@@ -453,8 +445,7 @@ KRATOS_TEST_CASE_IN_SUITE(TransientPwElement_CheckThrowsOnFaultyInput, KratosGeo
     KRATOS_EXPECT_EQ(p_3D_element->Check(dummy_process_info), 0);
 }
 
-KRATOS_TEST_CASE_IN_SUITE(TransientPwElement_Initialize,
-                          KratosGeoMechanicsFastSuite)
+KRATOS_TEST_CASE_IN_SUITE(TransientPwElement_Initialize, KratosGeoMechanicsFastSuite)
 {
     // Arrange
     const auto p_geometry   = std::make_shared<Triangle2D3<Node>>(CreateCoincidentNodes());
@@ -466,31 +457,29 @@ KRATOS_TEST_CASE_IN_SUITE(TransientPwElement_Initialize,
     element.Initialize(dummy_process_info);
     auto const num_g_points = element.GetGeometry().IntegrationPointsNumber(element.GetIntegrationMethod());
     auto const constitutive_law_vector = element.mConstitutiveLawVector;
-    auto const retention_law_vector = element.mRetentionLawVector;
+    auto const retention_law_vector    = element.mRetentionLawVector;
 
     // Assert
     KRATOS_EXPECT_EQ(constitutive_law_vector.size(), num_g_points);
-    for(const auto constitutive_law: constitutive_law_vector) {
+    for (const auto constitutive_law : constitutive_law_vector) {
         KRATOS_EXPECT_EQ(constitutive_law, nullptr);
     }
     KRATOS_EXPECT_EQ(retention_law_vector.size(), num_g_points);
     const auto expected_retention_law = RetentionLawFactory::Clone(element.GetProperties());
-    for(const auto retention_law: retention_law_vector) {
+    for (const auto retention_law : retention_law_vector) {
         KRATOS_EXPECT_EQ(typeid(*retention_law) == typeid(*expected_retention_law), true);
     }
 }
 
-KRATOS_TEST_CASE_IN_SUITE(TransientPwElement_InitializeSolution,
-                          KratosGeoMechanicsFastSuite)
+KRATOS_TEST_CASE_IN_SUITE(TransientPwElement_InitializeSolution, KratosGeoMechanicsFastSuite)
 {
     // Arrange
     const auto p_properties = std::make_shared<Properties>();
 
-    Model      model;
-    auto&      r_model_part = CreateModelPartWithWaterPressureVariableAndVolumeAcceleration(model);
+    Model model;
+    auto& r_model_part = CreateModelPartWithWaterPressureVariableAndVolumeAcceleration(model);
     r_model_part.AddNodalSolutionStepVariable(HYDRAULIC_DISCHARGE);
-    auto p_element =
-        CreateTriangleTransientPwElementWithPWDofs(r_model_part, p_properties);
+    auto       p_element = CreateTriangleTransientPwElementWithPWDofs(r_model_part, p_properties);
     const auto dummy_process_info = ProcessInfo{};
 
     // Act
@@ -502,17 +491,15 @@ KRATOS_TEST_CASE_IN_SUITE(TransientPwElement_InitializeSolution,
     }
 }
 
-KRATOS_TEST_CASE_IN_SUITE(TransientPwElement_FinalizeSolutionStep,
-                          KratosGeoMechanicsFastSuite)
+KRATOS_TEST_CASE_IN_SUITE(TransientPwElement_FinalizeSolutionStep, KratosGeoMechanicsFastSuite)
 {
     // Arrange
     const auto p_properties = std::make_shared<Properties>();
 
-    Model      model;
-    auto&      r_model_part = CreateModelPartWithWaterPressureVariableAndVolumeAcceleration(model);
+    Model model;
+    auto& r_model_part = CreateModelPartWithWaterPressureVariableAndVolumeAcceleration(model);
     r_model_part.AddNodalSolutionStepVariable(HYDRAULIC_DISCHARGE);
-    auto p_element =
-        CreateTriangleTransientPwElementWithPWDofs(r_model_part, p_properties);
+    auto       p_element = CreateTriangleTransientPwElementWithPWDofs(r_model_part, p_properties);
     const auto dummy_process_info = ProcessInfo{};
     p_element->GetProperties().SetValue(DENSITY_WATER, 1.0E3);
     p_element->GetProperties().SetValue(DYNAMIC_VISCOSITY, 1.0E-2);
@@ -537,17 +524,15 @@ KRATOS_TEST_CASE_IN_SUITE(TransientPwElement_FinalizeSolutionStep,
     KRATOS_EXPECT_EQ(p_element->GetGeometry()[2].FastGetSolutionStepValue(HYDRAULIC_DISCHARGE), -500000);
 }
 
-KRATOS_TEST_CASE_IN_SUITE(TransientPwElement_CalculateOnIntegrationPoints_Vector,
-                          KratosGeoMechanicsFastSuite)
+KRATOS_TEST_CASE_IN_SUITE(TransientPwElement_CalculateOnIntegrationPoints_Vector, KratosGeoMechanicsFastSuite)
 {
     // Arrange
     const auto p_properties = std::make_shared<Properties>();
 
-    Model      model;
-    auto&      r_model_part = CreateModelPartWithWaterPressureVariableAndVolumeAcceleration(model);
+    Model model;
+    auto& r_model_part = CreateModelPartWithWaterPressureVariableAndVolumeAcceleration(model);
     r_model_part.AddNodalSolutionStepVariable(HYDRAULIC_DISCHARGE);
-    auto p_element =
-        CreateTriangleTransientPwElementWithPWDofs(r_model_part, p_properties);
+    auto       p_element = CreateTriangleTransientPwElementWithPWDofs(r_model_part, p_properties);
     const auto dummy_process_info = ProcessInfo{};
     p_element->GetProperties().SetValue(DENSITY_WATER, 1.0E3);
     p_element->GetProperties().SetValue(DYNAMIC_VISCOSITY, 1.0E-2);
@@ -566,7 +551,8 @@ KRATOS_TEST_CASE_IN_SUITE(TransientPwElement_CalculateOnIntegrationPoints_Vector
     // Act
     std::vector<double> results{};
     p_element->CalculateOnIntegrationPoints(DEGREE_OF_SATURATION, results, dummy_process_info);
-    auto const num_g_points = p_element->GetGeometry().IntegrationPointsNumber(p_element->GetIntegrationMethod());
+    auto const num_g_points =
+        p_element->GetGeometry().IntegrationPointsNumber(p_element->GetIntegrationMethod());
 
     // Assert
     KRATOS_EXPECT_EQ(results.size(), num_g_points);
@@ -629,17 +615,15 @@ KRATOS_TEST_CASE_IN_SUITE(TransientPwElement_CalculateOnIntegrationPoints_Vector
     KRATOS_EXPECT_VECTOR_EQ(results, expected_results);
 }
 
-KRATOS_TEST_CASE_IN_SUITE(TransientPwElement_CalculateOnIntegrationPoints_1DArray,
-                          KratosGeoMechanicsFastSuite)
+KRATOS_TEST_CASE_IN_SUITE(TransientPwElement_CalculateOnIntegrationPoints_1DArray, KratosGeoMechanicsFastSuite)
 {
     // Arrange
     const auto p_properties = std::make_shared<Properties>();
 
-    Model      model;
-    auto&      r_model_part = CreateModelPartWithWaterPressureVariableAndVolumeAcceleration(model);
+    Model model;
+    auto& r_model_part = CreateModelPartWithWaterPressureVariableAndVolumeAcceleration(model);
     r_model_part.AddNodalSolutionStepVariable(HYDRAULIC_DISCHARGE);
-    auto p_element =
-        CreateTriangleTransientPwElementWithPWDofs(r_model_part, p_properties);
+    auto       p_element = CreateTriangleTransientPwElementWithPWDofs(r_model_part, p_properties);
     const auto dummy_process_info = ProcessInfo{};
     p_element->GetProperties().SetValue(DENSITY_WATER, 1.0E3);
     p_element->GetProperties().SetValue(DYNAMIC_VISCOSITY, 1.0E-2);
@@ -658,12 +642,13 @@ KRATOS_TEST_CASE_IN_SUITE(TransientPwElement_CalculateOnIntegrationPoints_1DArra
     // Act
     std::vector<array_1d<double, 3>> results{};
     p_element->CalculateOnIntegrationPoints(FLUID_FLUX_VECTOR, results, dummy_process_info);
-    auto const num_g_points = p_element->GetGeometry().IntegrationPointsNumber(p_element->GetIntegrationMethod());
+    auto const num_g_points =
+        p_element->GetGeometry().IntegrationPointsNumber(p_element->GetIntegrationMethod());
 
     // Assert
     KRATOS_EXPECT_EQ(results.size(), num_g_points);
     array_1d<double, 3> expected_nonzero_component{-1e+06, -1e+06, 0};
-    for(const auto & component: results) {
+    for (const auto& component : results) {
         KRATOS_EXPECT_VECTOR_EQ(component, expected_nonzero_component);
     }
 
@@ -674,22 +659,20 @@ KRATOS_TEST_CASE_IN_SUITE(TransientPwElement_CalculateOnIntegrationPoints_1DArra
     // Assert
     KRATOS_EXPECT_EQ(results.size(), num_g_points);
     array_1d<double, 3> expected_zero_component{0, 0, 0};
-    for(const auto & component: results) {
+    for (const auto& component : results) {
         KRATOS_EXPECT_VECTOR_EQ(component, expected_zero_component);
     }
 }
 
-KRATOS_TEST_CASE_IN_SUITE(TransientPwElement_CalculateOnIntegrationPoints_Matrix,
-                          KratosGeoMechanicsFastSuite)
+KRATOS_TEST_CASE_IN_SUITE(TransientPwElement_CalculateOnIntegrationPoints_Matrix, KratosGeoMechanicsFastSuite)
 {
     // Arrange
     const auto p_properties = std::make_shared<Properties>();
 
-    Model      model;
-    auto&      r_model_part = CreateModelPartWithWaterPressureVariableAndVolumeAcceleration(model);
+    Model model;
+    auto& r_model_part = CreateModelPartWithWaterPressureVariableAndVolumeAcceleration(model);
     r_model_part.AddNodalSolutionStepVariable(HYDRAULIC_DISCHARGE);
-    auto p_element =
-        CreateTriangleTransientPwElementWithPWDofs(r_model_part, p_properties);
+    auto       p_element = CreateTriangleTransientPwElementWithPWDofs(r_model_part, p_properties);
     const auto dummy_process_info = ProcessInfo{};
     p_element->GetProperties().SetValue(DENSITY_WATER, 1.0E3);
     p_element->GetProperties().SetValue(DYNAMIC_VISCOSITY, 1.0E-2);
@@ -708,13 +691,14 @@ KRATOS_TEST_CASE_IN_SUITE(TransientPwElement_CalculateOnIntegrationPoints_Matrix
     // Act
     std::vector<Matrix> results{};
     p_element->CalculateOnIntegrationPoints(PERMEABILITY_MATRIX, results, dummy_process_info);
-    auto const num_g_points = p_element->GetGeometry().IntegrationPointsNumber(p_element->GetIntegrationMethod());
+    auto const num_g_points =
+        p_element->GetGeometry().IntegrationPointsNumber(p_element->GetIntegrationMethod());
 
     // Assert
     KRATOS_EXPECT_EQ(results.size(), num_g_points);
-    Matrix expected_nonzero_component(2,2);
+    Matrix expected_nonzero_component(2, 2);
     expected_nonzero_component <<= 1, 1, 1, 1;
-    for(const auto & component: results) {
+    for (const auto& component : results) {
         KRATOS_EXPECT_MATRIX_EQ(component, expected_nonzero_component);
     }
 
@@ -724,23 +708,21 @@ KRATOS_TEST_CASE_IN_SUITE(TransientPwElement_CalculateOnIntegrationPoints_Matrix
 
     // Assert
     KRATOS_EXPECT_EQ(results.size(), num_g_points);
-    Matrix expected_zero_component = ZeroMatrix(2,2);
-    for(const auto & component: results) {
+    Matrix expected_zero_component = ZeroMatrix(2, 2);
+    for (const auto& component : results) {
         KRATOS_EXPECT_MATRIX_EQ(component, expected_zero_component);
     }
 }
 
-KRATOS_TEST_CASE_IN_SUITE(TransientPwElement2D3N_CalculateLocalSystem,
-                          KratosGeoMechanicsFastSuite)
+KRATOS_TEST_CASE_IN_SUITE(TransientPwElement2D3N_CalculateLocalSystem, KratosGeoMechanicsFastSuite)
 {
     // Arrange
     const auto p_properties = std::make_shared<Properties>();
 
-    Model      model;
-    auto&      r_model_part = CreateModelPartWithWaterPressureVariableAndVolumeAcceleration(model);
+    Model model;
+    auto& r_model_part = CreateModelPartWithWaterPressureVariableAndVolumeAcceleration(model);
     r_model_part.AddNodalSolutionStepVariable(HYDRAULIC_DISCHARGE);
-    auto p_element =
-        CreateTriangleTransientPwElementWithPWDofs(r_model_part, p_properties);
+    auto       p_element = CreateTriangleTransientPwElementWithPWDofs(r_model_part, p_properties);
     const auto dummy_process_info = ProcessInfo{};
     p_element->GetProperties().SetValue(BIOT_COEFFICIENT, 0.5);
     p_element->GetProperties().SetValue(DENSITY_WATER, 1.0E3);
@@ -767,30 +749,28 @@ KRATOS_TEST_CASE_IN_SUITE(TransientPwElement2D3N_CalculateLocalSystem,
     p_element->CalculateLocalSystem(actual_left_hand_side, actual_right_hand_side, dummy_process_info);
 
     // Assert
-    Matrix expected_left_hand_side(3,3);
+    Matrix expected_left_hand_side(3, 3);
     // clang-format off
     expected_left_hand_side <<= -49.999999999999993,0,49.999999999999993,
                                  0,0,0,
                                  49.999999999999993,0,-49.999999999999993;
-   // clang-format on
+    // clang-format on
     KRATOS_EXPECT_MATRIX_RELATIVE_NEAR(actual_left_hand_side, expected_left_hand_side, Defaults::relative_tolerance)
 
     Vector expected_right_hand_side(3);
-    expected_right_hand_side <<= 500000,0,-500000;
+    expected_right_hand_side <<= 500000, 0, -500000;
     KRATOS_EXPECT_VECTOR_RELATIVE_NEAR(actual_right_hand_side, expected_right_hand_side, Defaults::relative_tolerance)
 }
 
-KRATOS_TEST_CASE_IN_SUITE(TransientPwElement3D4N_CalculateLocalSystem,
-                          KratosGeoMechanicsFastSuite)
+KRATOS_TEST_CASE_IN_SUITE(TransientPwElement3D4N_CalculateLocalSystem, KratosGeoMechanicsFastSuite)
 {
     // Arrange
     const auto p_properties = std::make_shared<Properties>();
 
-    Model      model;
-    auto&      r_model_part = CreateModelPartWithWaterPressureVariableAndVolumeAcceleration(model);
+    Model model;
+    auto& r_model_part = CreateModelPartWithWaterPressureVariableAndVolumeAcceleration(model);
     r_model_part.AddNodalSolutionStepVariable(HYDRAULIC_DISCHARGE);
-    auto p_element =
-           CreateThreeDTransientPwElement3D4NWithPWDofs(r_model_part, p_properties);
+    auto       p_element = CreateThreeDTransientPwElement3D4NWithPWDofs(r_model_part, p_properties);
     const auto dummy_process_info = ProcessInfo{};
     p_element->GetProperties().SetValue(BIOT_COEFFICIENT, 0.5);
     p_element->GetProperties().SetValue(DENSITY_WATER, 1.0E3);
@@ -802,6 +782,9 @@ KRATOS_TEST_CASE_IN_SUITE(TransientPwElement3D4N_CalculateLocalSystem,
     p_element->GetProperties().SetValue(PERMEABILITY_XX, 1.0);
     p_element->GetProperties().SetValue(PERMEABILITY_YY, 1.0);
     p_element->GetProperties().SetValue(PERMEABILITY_XY, 1.0);
+    p_element->GetProperties().SetValue(PERMEABILITY_ZZ, 1.0);
+    p_element->GetProperties().SetValue(PERMEABILITY_YZ, 1.0);
+    p_element->GetProperties().SetValue(PERMEABILITY_ZX, 1.0);
     const auto gravity_acceleration = array_1d<double, 3>{0.0, -10.0, 0.0};
     p_element->GetGeometry()[0].FastGetSolutionStepValue(VOLUME_ACCELERATION) = gravity_acceleration;
     p_element->GetGeometry()[1].FastGetSolutionStepValue(VOLUME_ACCELERATION) = gravity_acceleration;
@@ -819,17 +802,17 @@ KRATOS_TEST_CASE_IN_SUITE(TransientPwElement3D4N_CalculateLocalSystem,
     p_element->CalculateLocalSystem(actual_left_hand_side, actual_right_hand_side, dummy_process_info);
 
     // Assert
-    Matrix expected_left_hand_side(4,4);
+    Matrix expected_left_hand_side(4, 4);
     // clang-format off
-    expected_left_hand_side <<= -16.666666666666664,0,16.666666666666664,0,
+    expected_left_hand_side <<= -16.666666666666664,0,0,16.666666666666664,
                                  0,0,0,0,
-                                 16.666666666666664,0,-16.666666666666664,0,
-                                 0,0,0,0;
+                                 0,0,0,0,
+                                 16.666666666666664,0,0,-16.666666666666664;
     // clang-format on
     KRATOS_EXPECT_MATRIX_RELATIVE_NEAR(actual_left_hand_side, expected_left_hand_side, Defaults::relative_tolerance)
 
     Vector expected_right_hand_side(4);
-    expected_right_hand_side <<= 125000,0,-125000,0;
+    expected_right_hand_side <<= 125000, 0, 0, -125000;
     KRATOS_EXPECT_VECTOR_RELATIVE_NEAR(actual_right_hand_side, expected_right_hand_side, Defaults::relative_tolerance)
 }
 

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_elements/test_transient_Pw_element.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_elements/test_transient_Pw_element.cpp
@@ -745,9 +745,6 @@ KRATOS_TEST_CASE_IN_SUITE(TransientPwElement_ZeroReturnFunctions, KratosGeoMecha
     KRATOS_EXPECT_EQ(actual_vector.size(), n_DoF);
     KRATOS_EXPECT_VECTOR_EQ(actual_vector, expected_vector);
 
-    // Act empty functions to increase the coverage
-    element.InitializeNonLinearIteration(dummy_process_info);
-    element.FinalizeNonLinearIteration(dummy_process_info);
 }
 
 } // namespace Kratos::Testing

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_elements/test_transient_Pw_element.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_elements/test_transient_Pw_element.cpp
@@ -187,9 +187,8 @@ KRATOS_TEST_CASE_IN_SUITE(TransientPwElement_DoFList, KratosGeoMechanicsFastSuit
 
     // Assert
     KRATOS_EXPECT_EQ(degrees_of_freedom.size(), 3);
-    for (auto p_dof : degrees_of_freedom) {
-        KRATOS_EXPECT_EQ(p_dof->GetVariable(), WATER_PRESSURE);
-    }
+    KRATOS_EXPECT_TRUE(std::all_of(degrees_of_freedom.begin(), degrees_of_freedom.end(),
+                                   [](auto p_dof) { return p_dof->GetVariable() == WATER_PRESSURE; }));
 }
 
 KRATOS_TEST_CASE_IN_SUITE(TransientPwElement_EquationIdVector, KratosGeoMechanicsFastSuiteWithoutKernel)
@@ -431,9 +430,9 @@ KRATOS_TEST_CASE_IN_SUITE(TransientPwElement_Initialize, KratosGeoMechanicsFastS
 
     const auto& r_retention_law_vector = element.mRetentionLawVector;
     KRATOS_EXPECT_EQ(r_retention_law_vector.size(), number_of_integration_points);
-    for (const auto& retention_law : r_retention_law_vector) {
-        KRATOS_EXPECT_NE(dynamic_cast<SaturatedLaw*>(retention_law.get()), nullptr);
-    }
+    KRATOS_EXPECT_TRUE(std::none_of(r_retention_law_vector.begin(), r_retention_law_vector.end(), [](auto p_retention_law) {
+        return dynamic_cast<SaturatedLaw*>(p_retention_law.get()) == nullptr;
+    }));
 }
 
 KRATOS_TEST_CASE_IN_SUITE(TransientPwElement_InitializeSolution, KratosGeoMechanicsFastSuiteWithoutKernel)
@@ -449,9 +448,9 @@ KRATOS_TEST_CASE_IN_SUITE(TransientPwElement_InitializeSolution, KratosGeoMechan
     p_element->InitializeSolutionStep(dummy_process_info);
 
     // Assert
-    for (auto& r_node : p_element->GetGeometry()) {
-        KRATOS_EXPECT_EQ(r_node.FastGetSolutionStepValue(HYDRAULIC_DISCHARGE), 0.0);
-    }
+    KRATOS_EXPECT_TRUE(std::all_of(
+        p_element->GetGeometry().begin(), p_element->GetGeometry().end(),
+        [](auto& r_node) { return r_node.FastGetSolutionStepValue(HYDRAULIC_DISCHARGE) == 0.0; }));
 }
 
 KRATOS_TEST_CASE_IN_SUITE(TransientPwElement_FinalizeSolutionStep, KratosGeoMechanicsFastSuiteWithoutKernel)

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_elements/test_transient_Pw_element.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_elements/test_transient_Pw_element.cpp
@@ -34,7 +34,7 @@ PointerVector<Node> CreateThreeNodes()
 PointerVector<Node> CreateThreeCoincidentNodes()
 {
     PointerVector<Node> result;
-    for (unsigned int id = 0; id < 3; id++) {
+    for (unsigned int id = 1; id <= 3; id++) {
         result.push_back(make_intrusive<Node>(id, 0.0, 0.0, 0.0));
     }
     return result;
@@ -159,9 +159,8 @@ KRATOS_TEST_CASE_IN_SUITE(TransientPwElement_CreateInstanceWithNodeInput, Kratos
 {
     // Arrange
     const auto p_properties = std::make_shared<Properties>();
-    const auto p_geometry   = std::make_shared<Triangle2D3<Node>>(CreateThreeNodes());
-    const TransientPwElement<2, 3> element(0, p_geometry, p_properties,
-                                           std::make_unique<PlaneStrainStressState>());
+    const TransientPwElement<2, 3> element(0, std::make_shared<Triangle2D3<Node>>(CreateThreeNodes()),
+                                           p_properties, std::make_unique<PlaneStrainStressState>());
 
     // Act
     const auto p_created_element = element.Create(1, CreateThreeNodes(), p_properties);
@@ -553,12 +552,10 @@ KRATOS_TEST_CASE_IN_SUITE(TransientPwElement_CalculateOnIntegrationPoints_Vector
 KRATOS_TEST_CASE_IN_SUITE(TransientPwElement_CalculateOnIntegrationPoints_1DArray, KratosGeoMechanicsFastSuiteWithoutKernel)
 {
     // Arrange
-    const auto p_properties = std::make_shared<Properties>();
-
     Model model;
     auto& r_model_part = CreateModelPartWithWaterPressureVariableAndVolumeAcceleration(model);
     r_model_part.AddNodalSolutionStepVariable(HYDRAULIC_DISCHARGE);
-    auto p_element = CreateTransientPwElementWithPWDofs<2, 3>(r_model_part, p_properties);
+    auto p_element = CreateTransientPwElementWithPWDofs<2, 3>(r_model_part, std::make_shared<Properties>());
     SetBasicPropertiesAndVariables(p_element);
     const auto dummy_process_info = ProcessInfo{};
     p_element->InitializeSolutionStep(dummy_process_info);
@@ -591,12 +588,10 @@ KRATOS_TEST_CASE_IN_SUITE(TransientPwElement_CalculateOnIntegrationPoints_1DArra
 KRATOS_TEST_CASE_IN_SUITE(TransientPwElement_CalculateOnIntegrationPoints_Matrix, KratosGeoMechanicsFastSuiteWithoutKernel)
 {
     // Arrange
-    const auto p_properties = std::make_shared<Properties>();
-
     Model model;
     auto& r_model_part = CreateModelPartWithWaterPressureVariableAndVolumeAcceleration(model);
     r_model_part.AddNodalSolutionStepVariable(HYDRAULIC_DISCHARGE);
-    auto p_element = CreateTransientPwElementWithPWDofs<2, 3>(r_model_part, p_properties);
+    auto p_element = CreateTransientPwElementWithPWDofs<2, 3>(r_model_part, std::make_shared<Properties>());
     SetBasicPropertiesAndVariables(p_element);
     const auto dummy_process_info = ProcessInfo{};
     p_element->InitializeSolutionStep(dummy_process_info);

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_elements/test_transient_Pw_element.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_elements/test_transient_Pw_element.cpp
@@ -438,9 +438,8 @@ KRATOS_TEST_CASE_IN_SUITE(TransientPwElement_Initialize, KratosGeoMechanicsFastS
         KRATOS_EXPECT_EQ(constitutive_law, nullptr);
     }
     KRATOS_EXPECT_EQ(r_retention_law_vector.size(), number_of_integration_points);
-    const auto expected_retention_law = RetentionLawFactory::Clone(element.GetProperties());
     for (const auto & retention_law : r_retention_law_vector) {
-        KRATOS_EXPECT_EQ(typeid(*retention_law).name() == typeid(*expected_retention_law).name(), true);
+        KRATOS_EXPECT_EQ(dynamic_cast<SaturatedLaw*>(retention_law.get()) == nullptr, false);
     }
 }
 

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_elements/test_transient_Pw_element.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_elements/test_transient_Pw_element.cpp
@@ -152,17 +152,9 @@ void SetBasicPropertiesAndVariables(intrusive_ptr<TransientPwElement<TDim, TNumN
         rElement->GetProperties().SetValue(PERMEABILITY_ZX, 1.0);
     }
     const auto gravity_acceleration = array_1d<double, 3>{0.0, -10.0, 0.0};
-    rElement->GetGeometry()[0].FastGetSolutionStepValue(VOLUME_ACCELERATION) = gravity_acceleration;
-    rElement->GetGeometry()[1].FastGetSolutionStepValue(VOLUME_ACCELERATION) = gravity_acceleration;
-    rElement->GetGeometry()[2].FastGetSolutionStepValue(VOLUME_ACCELERATION) = gravity_acceleration;
-    if constexpr (TNumNodes == 4) {
-        rElement->GetGeometry()[2].FastGetSolutionStepValue(VOLUME_ACCELERATION) = gravity_acceleration;
-    }
-    rElement->GetGeometry()[0].FastGetSolutionStepValue(WATER_PRESSURE) = 0.0;
-    rElement->GetGeometry()[1].FastGetSolutionStepValue(WATER_PRESSURE) = 0.0;
-    rElement->GetGeometry()[2].FastGetSolutionStepValue(WATER_PRESSURE) = 0.0;
-    if constexpr (TNumNodes == 4) {
-        rElement->GetGeometry()[3].FastGetSolutionStepValue(WATER_PRESSURE) = 0.0;
+    for (unsigned int node = 0; node < TNumNodes; node++) {
+        rElement->GetGeometry()[node].FastGetSolutionStepValue(VOLUME_ACCELERATION) = gravity_acceleration;
+        rElement->GetGeometry()[node].FastGetSolutionStepValue(WATER_PRESSURE) = 0.0;
     }
 }
 
@@ -736,7 +728,7 @@ KRATOS_TEST_CASE_IN_SUITE(TransientPwElement3D4N_CalculateLocalSystem, KratosGeo
     KRATOS_EXPECT_MATRIX_RELATIVE_NEAR(actual_left_hand_side, expected_left_hand_side, Defaults::relative_tolerance)
 
     Vector expected_right_hand_side(4);
-    expected_right_hand_side <<= 125000, 0, 0, -125000;
+    expected_right_hand_side <<= 166666.666,0,0,-166666.666;
     KRATOS_EXPECT_VECTOR_RELATIVE_NEAR(actual_right_hand_side, expected_right_hand_side, Defaults::relative_tolerance)
 }
 

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_elements/test_transient_Pw_element.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_elements/test_transient_Pw_element.cpp
@@ -137,32 +137,6 @@ intrusive_ptr<TransientPwElement<2, 3>> CreateTriangleTransientPwElementWithoutP
 
 } // namespace
 
-/*
-namespace Kratos
-{
-
-class MockStressState : public StressStatePolicy
-{
-public:
-    [[nodiscard]] Matrix CalculateBMatrix(const Matrix&         rDN_DX,
-                                                  const Vector&         rN,
-                                                  const Geometry<Node>& rGeometry) {return Matrix();}
-    [[nodiscard]] double CalculateIntegrationCoefficient(const Geometry<Node>::IntegrationPointType& rIntegrationPoint,
-                                                                 double DetJ,
-                                                                 const Geometry<Node>& rGeometry) {return 0.0;}
-    [[nodiscard]] Vector CalculateGreenLagrangeStrain(const Matrix& rDeformationGradient) {return Vector();}
-    [[nodiscard]] const Vector&                      GetVoigtVector() {return Vector();};
-    [[nodiscard]] SizeType                           GetVoigtSize() {return 0;}
-    [[nodiscard]] SizeType                           GetStressTensorSize() {return 0;}
-
-    [[nodiscard]] std::unique_ptr<StressStatePolicy> Clone() const override
-    {
-        return nullptr;
-    }
-};
-
-}*/
-
 namespace Kratos::Testing
 {
 

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_elements/test_transient_Pw_element.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_elements/test_transient_Pw_element.cpp
@@ -152,9 +152,9 @@ void SetBasicPropertiesAndVariables(intrusive_ptr<TransientPwElement<TDim, TNumN
         rElement->GetProperties().SetValue(PERMEABILITY_ZX, 1.0);
     }
     const auto gravity_acceleration = array_1d<double, 3>{0.0, -10.0, 0.0};
-    for (unsigned int node = 0; node < TNumNodes; node++) {
-        rElement->GetGeometry()[node].FastGetSolutionStepValue(VOLUME_ACCELERATION) = gravity_acceleration;
-        rElement->GetGeometry()[node].FastGetSolutionStepValue(WATER_PRESSURE) = 0.0;
+    for (auto& r_node : rElement->GetGeometry()) {
+        r_node.FastGetSolutionStepValue(VOLUME_ACCELERATION) = gravity_acceleration;
+        r_node.FastGetSolutionStepValue(WATER_PRESSURE)      = 0.0;
     }
 }
 
@@ -728,7 +728,7 @@ KRATOS_TEST_CASE_IN_SUITE(TransientPwElement3D4N_CalculateLocalSystem, KratosGeo
     KRATOS_EXPECT_MATRIX_RELATIVE_NEAR(actual_left_hand_side, expected_left_hand_side, Defaults::relative_tolerance)
 
     Vector expected_right_hand_side(4);
-    expected_right_hand_side <<= 166666.666,0,0,-166666.666;
+    expected_right_hand_side <<= 166666.666, 0, 0, -166666.666;
     KRATOS_EXPECT_VECTOR_RELATIVE_NEAR(actual_right_hand_side, expected_right_hand_side, Defaults::relative_tolerance)
 }
 

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_elements/test_transient_Pw_element.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_elements/test_transient_Pw_element.cpp
@@ -696,4 +696,59 @@ KRATOS_TEST_CASE_IN_SUITE(TransientPwElement3D4N_CalculateLocalSystem, KratosGeo
     KRATOS_EXPECT_VECTOR_RELATIVE_NEAR(actual_right_hand_side, expected_right_hand_side, Defaults::relative_tolerance)
 }
 
+KRATOS_TEST_CASE_IN_SUITE(TransientPwElement_ZeroReturnFunctions, KratosGeoMechanicsFastSuiteWithoutKernel)
+{
+    // Arrange
+    TransientPwElement<2, 3> element(
+        0, std::make_shared<Triangle2D3<Node>>(CreateThreeCoincidentNodes()),
+        std::make_shared<Properties>(), std::make_unique<PlaneStrainStressState>());
+    const auto   dummy_process_info = ProcessInfo{};
+    const auto   n_DoF              = 3;
+    const Matrix expected_matrix    = ZeroMatrix(n_DoF, n_DoF);
+    const Vector expected_vector    = ZeroVector(n_DoF);
+
+    // Act
+    Matrix actual_matrix;
+    element.CalculateMassMatrix(actual_matrix, dummy_process_info);
+
+    // Assert
+    KRATOS_EXPECT_EQ(actual_matrix.size1(), n_DoF);
+    KRATOS_EXPECT_EQ(actual_matrix.size2(), n_DoF);
+    KRATOS_EXPECT_MATRIX_EQ(actual_matrix, expected_matrix);
+
+    // Act
+    element.CalculateDampingMatrix(actual_matrix, dummy_process_info);
+
+    // Assert
+    KRATOS_EXPECT_EQ(actual_matrix.size1(), n_DoF);
+    KRATOS_EXPECT_EQ(actual_matrix.size2(), n_DoF);
+    KRATOS_EXPECT_MATRIX_EQ(actual_matrix, expected_matrix);
+
+    // Act
+    Vector actual_vector;
+    element.GetValuesVector(actual_vector, dummy_process_info);
+
+    // Assert
+    KRATOS_EXPECT_EQ(actual_vector.size(), n_DoF);
+    KRATOS_EXPECT_VECTOR_EQ(actual_vector, expected_vector);
+
+    // Act
+    element.GetFirstDerivativesVector(actual_vector, dummy_process_info);
+
+    // Assert
+    KRATOS_EXPECT_EQ(actual_vector.size(), n_DoF);
+    KRATOS_EXPECT_VECTOR_EQ(actual_vector, expected_vector);
+
+    // Act
+    element.GetSecondDerivativesVector(actual_vector, dummy_process_info);
+
+    // Assert
+    KRATOS_EXPECT_EQ(actual_vector.size(), n_DoF);
+    KRATOS_EXPECT_VECTOR_EQ(actual_vector, expected_vector);
+
+    // Act empty functions to increase the coverage
+    element.InitializeNonLinearIteration(dummy_process_info);
+    element.FinalizeNonLinearIteration(dummy_process_info);
+}
+
 } // namespace Kratos::Testing

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_elements/test_transient_Pw_element.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_elements/test_transient_Pw_element.cpp
@@ -31,12 +31,12 @@ PointerVector<Node> CreateThreeNodes()
     return result;
 }
 
-PointerVector<Node> CreateCoincidentNodes()
+PointerVector<Node> CreateThreeCoincidentNodes()
 {
     PointerVector<Node> result;
-    result.push_back(make_intrusive<Node>(1, 0.0, 0.0, 0.0));
-    result.push_back(make_intrusive<Node>(2, 0.0, 0.0, 0.0));
-    result.push_back(make_intrusive<Node>(3, 0.0, 0.0, 0.0));
+    for (unsigned int id = 0; id < 3; id++) {
+        result.push_back(make_intrusive<Node>(id, 0.0, 0.0, 0.0));
+    }
     return result;
 }
 
@@ -101,9 +101,10 @@ intrusive_ptr<TransientPwElement<TDim, TNumNodes>> CreateTransientPwElementWithP
 intrusive_ptr<TransientPwElement<2, 3>> CreateTriangleTransientPwElementWithoutPWDofs(ModelPart& rModelPart,
                                                                                       const Properties::Pointer& rProperties)
 {
-    const auto p_geometry = std::make_shared<Triangle2D3<Node>>(CreateNodesOnModelPart<3>(rModelPart));
     auto p_element = make_intrusive<TransientPwElement<2, 3>>(
-        NextElementNumber(rModelPart), p_geometry, rProperties, std::make_unique<PlaneStrainStressState>());
+        NextElementNumber(rModelPart),
+        std::make_shared<Triangle2D3<Node>>(CreateNodesOnModelPart<3>(rModelPart)), rProperties,
+        std::make_unique<PlaneStrainStressState>());
 
     rModelPart.AddElement(p_element);
     return p_element;
@@ -219,7 +220,7 @@ KRATOS_TEST_CASE_IN_SUITE(TransientPwElement_IntegrationMethod, KratosGeoMechani
 {
     // Arrange
     const TransientPwElement<2, 3> element(
-        0, std::make_shared<Triangle2D3<Node>>(CreateCoincidentNodes()),
+        0, std::make_shared<Triangle2D3<Node>>(CreateThreeCoincidentNodes()),
         std::make_shared<Properties>(), std::make_unique<PlaneStrainStressState>());
 
     // Act
@@ -235,7 +236,7 @@ KRATOS_TEST_CASE_IN_SUITE(TransientPwElement_CheckThrowsOnFaultyInput, KratosGeo
     // Arrange
     const auto                     p_properties = std::make_shared<Properties>();
     const TransientPwElement<2, 3> element_with_coincident_nodes(
-        1, std::make_shared<Triangle2D3<Node>>(CreateCoincidentNodes()), p_properties,
+        1, std::make_shared<Triangle2D3<Node>>(CreateThreeCoincidentNodes()), p_properties,
         std::make_unique<PlaneStrainStressState>());
 
     // Act and Assert
@@ -409,9 +410,9 @@ KRATOS_TEST_CASE_IN_SUITE(TransientPwElement_CheckThrowsOnFaultyInput, KratosGeo
 KRATOS_TEST_CASE_IN_SUITE(TransientPwElement_Initialize, KratosGeoMechanicsFastSuiteWithoutKernel)
 {
     // Arrange
-    TransientPwElement<2, 3> element(0, std::make_shared<Triangle2D3<Node>>(CreateCoincidentNodes()),
-                                     std::make_shared<Properties>(),
-                                     std::make_unique<PlaneStrainStressState>());
+    TransientPwElement<2, 3> element(
+        0, std::make_shared<Triangle2D3<Node>>(CreateThreeCoincidentNodes()),
+        std::make_shared<Properties>(), std::make_unique<PlaneStrainStressState>());
     const auto dummy_process_info = ProcessInfo{};
 
     // Act

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_elements/test_transient_Pw_element.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_elements/test_transient_Pw_element.cpp
@@ -91,8 +91,8 @@ intrusive_ptr<TransientPwElement<TDim, TNumNodes>> CreateTransientPwElementWithP
             std::make_shared<Tetrahedra3D4<Node>>(CreateNodesOnModelPart<TNumNodes>(rModelPart)),
             rProperties, std::make_unique<ThreeDimensionalStressState>());
     }
-    for (auto& node : p_element->GetGeometry()) {
-        node.AddDof(WATER_PRESSURE);
+    for (auto& r_node : p_element->GetGeometry()) {
+        r_node.AddDof(WATER_PRESSURE);
     }
     rModelPart.AddElement(p_element);
     return p_element;
@@ -124,9 +124,9 @@ void SetBasicPropertiesAndVariables(intrusive_ptr<TransientPwElement<TDim, TNumN
         rElement->GetProperties().SetValue(PERMEABILITY_ZX, 1.0);
     }
     const auto gravity_acceleration = array_1d<double, 3>{0.0, -10.0, 0.0};
-    for (auto& node : rElement->GetGeometry()) {
-        node.FastGetSolutionStepValue(VOLUME_ACCELERATION) = gravity_acceleration;
-        node.FastGetSolutionStepValue(WATER_PRESSURE)      = 0.0;
+    for (auto& r_node : rElement->GetGeometry()) {
+        r_node.FastGetSolutionStepValue(VOLUME_ACCELERATION) = gravity_acceleration;
+        r_node.FastGetSolutionStepValue(WATER_PRESSURE)      = 0.0;
     }
 }
 
@@ -200,9 +200,9 @@ KRATOS_TEST_CASE_IN_SUITE(TransientPwElement_EquationIdVector, KratosGeoMechanic
     auto p_element = CreateTransientPwElementWithPWDofs<2, 3>(r_model_part, std::make_shared<Properties>());
 
     unsigned int i = 0;
-    for (const auto& node : p_element->GetGeometry()) {
+    for (const auto& r_node : p_element->GetGeometry()) {
         ++i;
-        node.pGetDof(WATER_PRESSURE)->SetEquationId(i);
+        r_node.pGetDof(WATER_PRESSURE)->SetEquationId(i);
     }
 
     // Act
@@ -402,6 +402,9 @@ KRATOS_TEST_CASE_IN_SUITE(TransientPwElement_CheckThrowsOnFaultyInput, KratosGeo
 
     p_3D_element->GetProperties().SetValue(PERMEABILITY_ZX, 1.0E-2);
 
+    // to enable a call of RetentionLaw check
+    p_3D_element->Initialize(dummy_process_info);
+
     // No exceptions on correct input for 3D element
     KRATOS_EXPECT_EQ(p_3D_element->Check(dummy_process_info), 0);
 }
@@ -446,8 +449,8 @@ KRATOS_TEST_CASE_IN_SUITE(TransientPwElement_InitializeSolution, KratosGeoMechan
     p_element->InitializeSolutionStep(dummy_process_info);
 
     // Assert
-    for (auto& node : p_element->GetGeometry()) {
-        KRATOS_EXPECT_EQ(node.FastGetSolutionStepValue(HYDRAULIC_DISCHARGE), 0.0);
+    for (auto& r_node : p_element->GetGeometry()) {
+        KRATOS_EXPECT_EQ(r_node.FastGetSolutionStepValue(HYDRAULIC_DISCHARGE), 0.0);
     }
 }
 

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_processes/test_apply_c_phi_reduction_process.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_processes/test_apply_c_phi_reduction_process.cpp
@@ -187,8 +187,8 @@ KRATOS_TEST_CASE_IN_SUITE(CheckFailureEmptyModelPartApplyCPhiReductionProcess, K
 
 KRATOS_TEST_CASE_IN_SUITE(CheckReturnsZeroForValidModelPartApplyCPhiReductionProcess, KratosGeoMechanicsFastSuite)
 {
-    Model model;
-    auto& r_model_part = PrepareCPhiTestModelPart(model);
+    Model                     model;
+    auto&                     r_model_part = PrepareCPhiTestModelPart(model);
     ApplyCPhiReductionProcess process{r_model_part, {}};
     KRATOS_CHECK_EQUAL(process.Check(), 0);
 }
@@ -224,9 +224,9 @@ KRATOS_TEST_CASE_IN_SUITE(CheckFailureTooSmallReductionIncrementApplyCPhiReducti
     // After halving the initial reduction increment (0.1) for the seventh time, it becomes
     // 0.00078125, so it should throw an exception
     // The final safety factor can be calculated as (1.0 / (1 - 0.1 * 0.5 - 0.1 * 0.5^2 ... + 0.1*0.5^6)) = 1.10919
-    KRATOS_EXPECT_EXCEPTION_IS_THROWN(
-        process.ExecuteInitializeSolutionStep(),
-        "Reduction increment should not drop below 0.001, calculation stopped. Final safety factor = 1.10919");
+    KRATOS_EXPECT_EXCEPTION_IS_THROWN(process.ExecuteInitializeSolutionStep(),
+                                      "Reduction increment should not drop below 0.001, "
+                                      "calculation stopped. Final safety factor = 1.10919");
 }
 
 } // namespace Kratos::Testing


### PR DESCRIPTION
**📝 Description**
A brief description of the PR.

Unit tests have been created for the following TransientPwElement functions
1. Create
2. Initialize
3. Check
4. InitializeSolutionStep
5. InitializeNonLinearIteration
6. FinalizeNonLinearIteration
7. FinalizeSolutionStep
8. three CalculateOnIntegrationPoints
Two unit tests (2D and 3D elements) call CalculateLocalSystem that calls
9. CalculateAll
10. InitializeElementVariables
11. CalculateAndAddLHS
12. CalculateAndAddCompressibilityMatrix
13. CalculateAndAddRHS
14. CalculateAndAddPermeabilityFlow
15. CalculateAndAddFluidBodyFlow
16. CalculateAndAddCompressibilityFlow
17. CalculateKinematics

An extra unit test is created for functions that return zero values:
18. CalculateMassMatrix
19. CalculateDampingMatrix
20. GetValuesVector
21. GetFirstDerivativesVector
22. GetSecondDerivativesVector

The following function have an empty body:
23. InitializeNonLinearIteration
24. FinalizeNonLinearIteration 