### PR TITLE
Fix u Dirichtlet condition in GeoMechanicsApplication by earlier initialization of the constitutive law

### DIFF
--- a/applications/GeoMechanicsApplication/custom_elements/U_Pw_base_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/U_Pw_base_element.cpp
@@ -146,14 +146,24 @@ void UPwBaseElement::Initialize(const ProcessInfo& rCurrentProcessInfo)
             std::fill(r_stress_vector.begin(), r_stress_vector.end(), 0.0);
         }
     }
-
-    mStateVariablesFinalized.resize(number_of_integration_points);
-    if (r_properties[CONSTITUTIVE_LAW]->Has(STATE_VARIABLES)) {
-        for (unsigned int i = 0; i < mConstitutiveLawVector.size(); ++i) {
-            mConstitutiveLawVector[i]->SetValue(STATE_VARIABLES, mStateVariablesFinalized[i], rCurrentProcessInfo);
-        }
+    std::vector<Vector> strain_vectors;
+    strain_vectors.resize(number_of_integration_points);
+    for (auto& r_strain_vector : strain_vectors) {
+        r_strain_vector.resize(GetStressStatePolicy().GetVoigtSize());
+        std::fill(r_strain_vector.begin(), r_strain_vector.end(), 0.0);
     }
 
+    mStateVariablesFinalized.resize(number_of_integration_points);
+    ConstitutiveLaw::Parameters cl_values;
+    cl_values.SetProcessInfo(rCurrentProcessInfo);
+    cl_values.SetMaterialProperties(r_properties);
+    for (unsigned int i = 0; i < mConstitutiveLawVector.size(); ++i) {
+        cl_values.SetStrainVector(strain_vectors[i]);
+        cl_values.SetStressVector(mStressVector[i]);
+        if (r_properties[CONSTITUTIVE_LAW]->Has(STATE_VARIABLES))
+            mConstitutiveLawVector[i]->SetValue(STATE_VARIABLES, mStateVariablesFinalized[i], rCurrentProcessInfo);
+        mConstitutiveLawVector[i]->InitializeMaterialResponseCauchy(cl_values);
+    }
     mIsInitialised = true;
 
     KRATOS_CATCH("")

--- a/applications/GeoMechanicsApplication/custom_elements/U_Pw_base_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/U_Pw_base_element.cpp
@@ -146,12 +146,8 @@ void UPwBaseElement::Initialize(const ProcessInfo& rCurrentProcessInfo)
             std::fill(r_stress_vector.begin(), r_stress_vector.end(), 0.0);
         }
     }
-    std::vector<Vector> strain_vectors;
-    strain_vectors.resize(number_of_integration_points);
-    for (auto& r_strain_vector : strain_vectors) {
-        r_strain_vector.resize(GetStressStatePolicy().GetVoigtSize());
-        std::fill(r_strain_vector.begin(), r_strain_vector.end(), 0.0);
-    }
+    std::vector<Vector> strain_vectors(number_of_integration_points,
+                                       ZeroVector(GetStressStatePolicy().GetVoigtSize()));
 
     mStateVariablesFinalized.resize(number_of_integration_points);
     ConstitutiveLaw::Parameters cl_values;

--- a/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_element.cpp
@@ -248,8 +248,6 @@ void UPwSmallStrainElement<TDim, TNumNodes>::InitializeSolutionStep(const Proces
 {
     KRATOS_TRY
 
-    if (!mIsInitialised) this->Initialize(rCurrentProcessInfo);
-
     ConstitutiveLaw::Parameters ConstitutiveParameters(this->GetGeometry(), this->GetProperties(),
                                                        rCurrentProcessInfo);
     ConstitutiveParameters.Set(ConstitutiveLaw::USE_ELEMENT_PROVIDED_STRAIN);

--- a/applications/GeoMechanicsApplication/custom_elements/small_strain_U_Pw_diff_order_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/small_strain_U_Pw_diff_order_element.cpp
@@ -166,8 +166,6 @@ void SmallStrainUPwDiffOrderElement::InitializeSolutionStep(const ProcessInfo& r
 {
     KRATOS_TRY
 
-    if (!mIsInitialised) this->Initialize(rCurrentProcessInfo);
-
     ConstitutiveLaw::Parameters ConstitutiveParameters(GetGeometry(), GetProperties(), rCurrentProcessInfo);
     ConstitutiveParameters.Set(ConstitutiveLaw::USE_ELEMENT_PROVIDED_STRAIN);
     ConstitutiveParameters.Set(ConstitutiveLaw::INITIALIZE_MATERIAL_RESPONSE);

--- a/applications/GeoMechanicsApplication/tests/test_dirichlet_u.py
+++ b/applications/GeoMechanicsApplication/tests/test_dirichlet_u.py
@@ -16,7 +16,6 @@ class KratosGeoMechanicsDirichletUTests(KratosUnittest.TestCase):
         # Code here will be placed AFTER every test in this TestCase.
         pass
 
-    @KratosUnittest.skip("Test test_dirichlet skipped temporary until u Dirichlet condition is fixed.")
     def test_dirichlet_u(self):
         """
         4 element elongation test in 2 stages. The incremental elastic material should show 


### PR DESCRIPTION
u Dirchlet conditions in GeoMechanics application were not working, because the constitutive law strain members were initialized after application of the condition. That is too late and leads to zero unbalance from this load.

**🆕 Changelog**
Call the strain and stress initialization for the constitutive law in Initialize of the UPW base class already.
