### PR TITLE
[SMApp] Minor hotfixes in the Base solid element

### DIFF
--- a/applications/StructuralMechanicsApplication/custom_elements/solid_elements/base_solid_element.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/solid_elements/base_solid_element.cpp
@@ -684,8 +684,7 @@ void BaseSolidElement::CalculateOnIntegrationPoints(
     const GeometryType::IntegrationPointsArrayType &integration_points = this->IntegrationPoints(this->GetIntegrationMethod());
 
     const SizeType number_of_integration_points = integration_points.size();
-    if (rOutput.size() != number_of_integration_points)
-        rOutput.resize(number_of_integration_points, false);
+    rOutput.assign(number_of_integration_points, false);
 
     if (mConstitutiveLawVector[0]->Has( rVariable)) {
         for ( IndexType point_number = 0; point_number <number_of_integration_points; ++point_number ) {
@@ -717,8 +716,7 @@ void BaseSolidElement::CalculateOnIntegrationPoints(
     const GeometryType::IntegrationPointsArrayType &integration_points = this->IntegrationPoints(this->GetIntegrationMethod());
 
     const SizeType number_of_integration_points = integration_points.size();
-    if (rOutput.size() != number_of_integration_points)
-        rOutput.resize(number_of_integration_points, false);
+    rOutput.assign(number_of_integration_points, 0);
 
     if (mConstitutiveLawVector[0]->Has( rVariable)) {
         GetValueOnConstitutiveLaw(rVariable, rOutput);
@@ -745,8 +743,6 @@ void BaseSolidElement::CalculateOnIntegrationPoints(
     const SizeType strain_size = mConstitutiveLawVector[0]->GetStrainSize();
     const SizeType number_of_nodes = r_geometry.size();
 
-    if ( rOutput.size() != number_of_integration_points )
-        rOutput.resize( number_of_integration_points, false );
     rOutput.assign(number_of_integration_points, 0.0);
 
     if (mConstitutiveLawVector[0]->Has( rVariable)) {
@@ -936,8 +932,6 @@ void BaseSolidElement::CalculateOnIntegrationPoints(
     const GeometryType::IntegrationPointsArrayType &integration_points = this->IntegrationPoints(this->GetIntegrationMethod());
 
     const SizeType number_of_integration_points = integration_points.size();
-    if ( rOutput.size() != number_of_integration_points )
-        rOutput.resize( number_of_integration_points );
     rOutput.assign(number_of_integration_points, array_1d<double, 3>(3, 0.0));
 
     const auto& r_geom = GetGeometry();
@@ -986,8 +980,6 @@ void BaseSolidElement::CalculateOnIntegrationPoints(
     const GeometryType::IntegrationPointsArrayType &integration_points = this->IntegrationPoints(this->GetIntegrationMethod());
 
     const SizeType number_of_integration_points = integration_points.size();
-    if (rOutput.size() != number_of_integration_points)
-        rOutput.resize(number_of_integration_points);
     rOutput.assign(number_of_integration_points, array_1d<double, 6>(6, 0.0));
 
     if (mConstitutiveLawVector[0]->Has( rVariable)) {
@@ -1013,8 +1005,6 @@ void BaseSolidElement::CalculateOnIntegrationPoints(
     const SizeType strain_size = mConstitutiveLawVector[0]->GetStrainSize();
 
     const SizeType number_of_integration_points = integration_points.size();
-    if ( rOutput.size() != number_of_integration_points )
-        rOutput.resize( number_of_integration_points );
     rOutput.assign(number_of_integration_points, ZeroVector(strain_size));
 
     if (mConstitutiveLawVector[0]->Has( rVariable)) {

--- a/applications/StructuralMechanicsApplication/custom_elements/solid_elements/base_solid_element.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/solid_elements/base_solid_element.cpp
@@ -828,7 +828,7 @@ void BaseSolidElement::CalculateOnIntegrationPoints(
                 detJ = r_geometry.DeterminantOfJacobian(detJ);
             } else {
                 for (IndexType point_number = 0; point_number < number_of_integration_points; ++point_number) {
-                   detJ[point_number] = r_geometry.DeterminantOfJacobian(integration_points[point_number]);
+                    detJ[point_number] = r_geometry.DeterminantOfJacobian(integration_points[point_number]);
                 }
             }
 
@@ -938,6 +938,7 @@ void BaseSolidElement::CalculateOnIntegrationPoints(
     const SizeType number_of_integration_points = integration_points.size();
     if ( rOutput.size() != number_of_integration_points )
         rOutput.resize( number_of_integration_points );
+    rOutput.assign(number_of_integration_points, array_1d<double, 3>(3, 0.0));
 
     const auto& r_geom = GetGeometry();
     const SizeType number_of_nodes = r_geom.size();
@@ -987,6 +988,7 @@ void BaseSolidElement::CalculateOnIntegrationPoints(
     const SizeType number_of_integration_points = integration_points.size();
     if (rOutput.size() != number_of_integration_points)
         rOutput.resize(number_of_integration_points);
+    rOutput.assign(number_of_integration_points, array_1d<double, 6>(6, 0.0));
 
     if (mConstitutiveLawVector[0]->Has( rVariable)) {
         GetValueOnConstitutiveLaw(rVariable, rOutput);
@@ -1013,6 +1015,7 @@ void BaseSolidElement::CalculateOnIntegrationPoints(
     const SizeType number_of_integration_points = integration_points.size();
     if ( rOutput.size() != number_of_integration_points )
         rOutput.resize( number_of_integration_points );
+    rOutput.assign(number_of_integration_points, ZeroVector(strain_size));
 
     if (mConstitutiveLawVector[0]->Has( rVariable)) {
         GetValueOnConstitutiveLaw(rVariable, rOutput);

--- a/applications/StructuralMechanicsApplication/custom_elements/solid_elements/base_solid_element.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/solid_elements/base_solid_element.cpp
@@ -747,6 +747,7 @@ void BaseSolidElement::CalculateOnIntegrationPoints(
 
     if ( rOutput.size() != number_of_integration_points )
         rOutput.resize( number_of_integration_points, false );
+    rOutput.assign(number_of_integration_points, 0.0);
 
     if (mConstitutiveLawVector[0]->Has( rVariable)) {
         GetValueOnConstitutiveLaw(rVariable, rOutput);


### PR DESCRIPTION
Basically defaulting to null the components of the output in the CalculateOnIntgerationPoints. Currently, if the CL does not return the value, the output are random values, not 0.