### PR TITLE
set [0,0.5> as limits for Poisson s ratio in Timoshenko beam constitutive laws

### DIFF
--- a/applications/StructuralMechanicsApplication/custom_constitutive/timoshenko_beam_elastic_constitutive_law.cpp
+++ b/applications/StructuralMechanicsApplication/custom_constitutive/timoshenko_beam_elastic_constitutive_law.cpp
@@ -72,8 +72,8 @@ int TimoshenkoBeamElasticConstitutiveLaw::Check(
     KRATOS_ERROR_IF_NOT(rMaterialProperties[CROSS_AREA] > 0.0)       << "The CROSS_AREA value is lower than 0.0" << std::endl;
     KRATOS_ERROR_IF_NOT(rMaterialProperties[I33] > 0.0)              << "The I33 value is lower than 0.0" << std::endl;
     KRATOS_ERROR_IF_NOT(rMaterialProperties[AREA_EFFECTIVE_Y] > 0.0) << "The AREA_EFFECTIVE_Y value is lower than 0.0" << std::endl;
-    KRATOS_ERROR_IF_NOT(rMaterialProperties[POISSON_RATIO] > 0.0)    << "The POISSON_RATIO value is lower than 0.0" << std::endl;
-    KRATOS_ERROR_IF    (rMaterialProperties[POISSON_RATIO] > 0.5)    << "The POISSON_RATIO cannot be greater than 0.5." << std::endl;
+    KRATOS_ERROR_IF    (rMaterialProperties[POISSON_RATIO] < 0.0)    << "The POISSON_RATIO value is lower than 0.0" << std::endl;
+    KRATOS_ERROR_IF_NOT(rMaterialProperties[POISSON_RATIO] < 0.5)    << "The POISSON_RATIO cannot be greater than or equal 0.5." << std::endl;
     return 0;
 }
 

--- a/applications/StructuralMechanicsApplication/custom_constitutive/timoshenko_plane_strain_beam_elastic_constitutive_law.cpp
+++ b/applications/StructuralMechanicsApplication/custom_constitutive/timoshenko_plane_strain_beam_elastic_constitutive_law.cpp
@@ -67,12 +67,11 @@ int TimoshenkoBeamPlaneStrainElasticConstitutiveLaw::Check(
     KRATOS_ERROR_IF_NOT(rMaterialProperties.Has(POISSON_RATIO))         << "POISSON_RATIO is not defined in the properties"    << std::endl;
     KRATOS_ERROR_IF_NOT(rMaterialProperties.Has(THICKNESS))             << "THICKNESS is not defined in the properties"       << std::endl;
     KRATOS_ERROR_IF_NOT(rMaterialProperties.Has(THICKNESS_EFFECTIVE_Y)) << "THICKNESS_EFFECTIVE_Y is not defined in the properties" << std::endl;
-    KRATOS_ERROR_IF_NOT(rMaterialProperties.Has(POISSON_RATIO))         << "POISSON_RATIO is not defined in the properties"    << std::endl;
     KRATOS_ERROR_IF_NOT(rMaterialProperties[YOUNG_MODULUS] > 0.0)       << "The YOUNG_MODULUS value is lower than 0.0" << std::endl;
     KRATOS_ERROR_IF_NOT(rMaterialProperties[THICKNESS] > 0.0)           << "The THICKNESS value is lower than 0.0" << std::endl;
     KRATOS_ERROR_IF_NOT(rMaterialProperties[THICKNESS_EFFECTIVE_Y] > 0.0) << "The THICKNESS_EFFECTIVE_Y value is lower than 0.0" << std::endl;
-    KRATOS_ERROR_IF_NOT(rMaterialProperties[POISSON_RATIO] > 0.0)         << "The POISSON_RATIO value is lower than 0.0" << std::endl;
-    KRATOS_ERROR_IF    (rMaterialProperties[POISSON_RATIO] > 0.5)         << "The POISSON_RATIO cannot be greater than 0.5." << std::endl;
+    KRATOS_ERROR_IF    (rMaterialProperties[POISSON_RATIO] < 0.0)       << "The POISSON_RATIO value is lower than 0.0" << std::endl;
+    KRATOS_ERROR_IF_NOT(rMaterialProperties[POISSON_RATIO] < 0.5)       << "The POISSON_RATIO cannot be greater than or equal 0.5." << std::endl;
     return 0;
 }
 


### PR DESCRIPTION
**📝 Description**
Error checking for the Timoshenko beam constitutive laws used the range <0, 0.5] where [0, 0.5> is more applicable.

This can be understood from the term in the linear elastic constitutive matrix that reads:     nu E / ((1 + nu)(1 - 2 nu))
to end up with a defined positive number the limits to nu are:   -1 < nu < 0.5 
For practical materials  0 <= nu < 0.5 ( so with 0 included in the range).