### PR TITLE
[Mapping] Fix UpdateFunctionNonHist to use SetValue for setting node value

### DIFF
--- a/applications/MappingApplication/custom_utilities/mapper_utilities.h
+++ b/applications/MappingApplication/custom_utilities/mapper_utilities.h
@@ -91,7 +91,7 @@ static void UpdateFunctionNonHist(NodeType& rNode,
                             const double Value,
                             const double Factor)
 {
-    rNode.GetValue(rVariable) = Value * Factor;
+    rNode.SetValue(rVariable, Value * Factor);
 }
 
 static void UpdateFunctionNonHistWithAdd(NodeType& rNode,


### PR DESCRIPTION
This is throwing an error in OMP if the node value was not initialized. This is solved by just using SetValue instead.