### PR TITLE
[GeoMechanicsApplication] Removed two redundant default values for "reset_displacements"

### DIFF
--- a/applications/GeoMechanicsApplication/python_scripts/geomechanics_Pw_solver.py
+++ b/applications/GeoMechanicsApplication/python_scripts/geomechanics_Pw_solver.py
@@ -41,7 +41,6 @@ class PwSolver(GeoSolver):
             "compute_reactions": false,
             "move_mesh_flag": false,
             "nodal_smoothing": false,
-            "reset_displacements":  false,
             "solution_type": "quasi_static",
             "scheme_type": "Newmark",
             "newmark_beta": 0.25,

--- a/applications/GeoMechanicsApplication/python_scripts/geomechanics_U_Pw_solver.py
+++ b/applications/GeoMechanicsApplication/python_scripts/geomechanics_U_Pw_solver.py
@@ -43,7 +43,6 @@ class UPwSolver(GeoSolver):
             "compute_reactions": false,
             "move_mesh_flag": false,
             "nodal_smoothing": false,
-            "reset_displacements":  false,
             "solution_type": "quasi_static",
             "scheme_type": "Newmark",
             "newmark_beta": 0.25,


### PR DESCRIPTION
**📝 Description**

Two Python solvers (`PwSolver` and `UPwSolver`) defined default values for "reset_displacements" that was already defined by their base class (`GeoMechanicalSolver`). These repeated default values have been removed now.
