### PR TITLE
[CoSim] Extra options for ComputeNormalsOperation

### DIFF
--- a/kratos/python/add_geometrical_utilities_to_python.cpp
+++ b/kratos/python/add_geometrical_utilities_to_python.cpp
@@ -222,6 +222,14 @@ void AddGeometricalUtilitiesToPython(pybind11::module &m)
             rNormalCalculationUtils.CalculateNormals<ModelPart::ConditionsContainerType,true>(rModelPart, EnforceGenericAlgorithm);})
         .def("CalculateNormals", [](NormalCalculationUtils& rNormalCalculationUtils, ModelPart& rModelPart){
             rNormalCalculationUtils.CalculateNormals<ModelPart::ConditionsContainerType,true>(rModelPart);})
+        .def("CalculateElementNormals", [](NormalCalculationUtils& rNormalCalculationUtils,
+                                           ModelPart& rModelPart,
+                                           const bool UnitNormals){
+                rNormalCalculationUtils.CalculateNormals<ModelPart::ElementsContainerType,true>(rModelPart,
+                                                                                                false,
+                                                                                                UnitNormals);},
+            pybind11::arg("model_part"),
+            pybind11::arg("unit_normals") = false)
         .def("CalculateNormalsNonHistorical", [](NormalCalculationUtils& rNormalCalculationUtils, ModelPart& rModelPart, const bool EnforceGenericAlgorithm, const NormalCalculationUtils::NormalVariableType& rNormalVariable){
             rNormalCalculationUtils.CalculateNormals<ModelPart::ConditionsContainerType,false>(rModelPart, EnforceGenericAlgorithm, rNormalVariable);})
         .def("CalculateNormalsNonHistorical", [](NormalCalculationUtils& rNormalCalculationUtils, ModelPart& rModelPart, const bool EnforceGenericAlgorithm){


### PR DESCRIPTION
This PR is related to coupling the `CableNetApplication` with the `MPMApplication`.

- add option for computing normals on `Element`s instead of `Condition`s
- add option for selecting between unit normals / area scaled normals

@matekelemen @philbucher 