### PR TITLE
[Core] Fix Matrix Market Output

### DIFF
--- a/kratos/sources/matrix_market_interface.cpp
+++ b/kratos/sources/matrix_market_interface.cpp
@@ -296,7 +296,7 @@ bool WriteMatrixMarketMatrix(const char *FileName, CompressedMatrixType &M, bool
 
     mm_set_matrix(&mm_code);
     mm_set_coordinate(&mm_code);
-    SetMatrixMarketValueTypeCode(mm_code, *M.begin1().begin());
+    SetMatrixMarketValueTypeCode(mm_code, typename CompressedMatrixType::value_type());
 
     if (Symmetric)
         mm_set_symmetric(&mm_code);


### PR DESCRIPTION
`WriteMatrixMarketMatrix` relied on getting the first row's first entry for the banner, which does not always exist.
