### PR TITLE
Fix `block_for_each` Template Requirements

### DIFF
--- a/kratos/tests/cpp_tests/utilities/test_parallel_utilities.cpp
+++ b/kratos/tests/cpp_tests/utilities/test_parallel_utilities.cpp
@@ -121,6 +121,31 @@ KRATOS_TEST_CASE_IN_SUITE(BlockPartitionerConstContainer, KratosCoreFastSuite)
     KRATOS_EXPECT_DOUBLE_EQ(final_sum_short, expected_value);
 }
 
+// Pass a container whose iterator is a raw pointer.
+KRATOS_TEST_CASE_IN_SUITE(BlockPartitionerContiguousContainer, KratosCoreFastSuite)
+{
+    struct TestView
+    {
+        using iterator = int*;
+        using size_type = std::size_t;
+        iterator begin() const noexcept {return mBegin;}
+        iterator end() const noexcept {return mEnd;}
+        size_type size() const noexcept {return std::distance(mBegin, mEnd);}
+        iterator mBegin;
+        iterator mEnd;
+    }; // struct TestView
+
+    std::vector<int> array(1e3);
+    std::iota(array.begin(), array.end(), 0);
+
+    TestView view {array.data(), array.data() + array.size()};
+    block_for_each(view, [](int& r_entry){r_entry += r_entry;});
+
+    for (int i_entry=0; i_entry<static_cast<int>(array.size()); ++i_entry) {
+        KRATOS_EXPECT_EQ(array[i_entry], i_entry + i_entry);
+    }
+}
+
 // Basic Type
 KRATOS_TEST_CASE_IN_SUITE(IndexPartitioner, KratosCoreFastSuite)
 {

--- a/kratos/utilities/parallel_utilities.h
+++ b/kratos/utilities/parallel_utilities.h
@@ -369,7 +369,7 @@ template <class TReduction,
 template <class TContainerType,
           class TFunctionType,
           std::enable_if_t<!std::is_same_v<
-            std::iterator_traits<typename decltype(std::declval<std::remove_cv_t<TContainerType>>().begin())::value_type>,
+            typename std::iterator_traits<decltype(std::declval<std::remove_cv_t<TContainerType>>().begin())>::value_type,
             void
           >, bool> = true
          >


### PR DESCRIPTION
`block_for_each` has quite a few overloads even though all of them are templates. To distinguish between them, some need a bit of `enable_if` magic to make the compiler choose the correct one.

I had a template bracketing error in one of these `enable_if`s that manifested when the deduced template parameter was a container whose `iterator` is a raw pointer.

oopsies.
