### PR TITLE
Fix Some Ublas Space Const Correctness Issues

### DIFF
--- a/kratos/spaces/ublas_space.h
+++ b/kratos/spaces/ublas_space.h
@@ -341,12 +341,12 @@ public:
         return aux_sum;
     }
 
-    static void Mult(const Matrix& rA, VectorType& rX, VectorType& rY)
+    static void Mult(const Matrix& rA, const VectorType& rX, VectorType& rY)
     {
         axpy_prod(rA, rX, rY, true);
     }
 
-    static void Mult(const compressed_matrix<TDataType>& rA, VectorType& rX, VectorType& rY)
+    static void Mult(const compressed_matrix<TDataType>& rA, const VectorType& rX, VectorType& rY)
     {
 #ifndef _OPENMP
         axpy_prod(rA, rX, rY, true);
@@ -356,9 +356,9 @@ public:
     }
 
     template< class TOtherMatrixType >
-    static void TransposeMult(TOtherMatrixType& rA, VectorType& rX, VectorType& rY)
+    static void TransposeMult(const TOtherMatrixType& rA, const VectorType& rX, VectorType& rY)
     {
-		boost::numeric::ublas::axpy_prod(rX, rA, rY, true);
+        boost::numeric::ublas::axpy_prod(rX, rA, rY, true);
     } // rY = rAT * rX
 
     static inline SizeType GraphDegree(IndexType i, TMatrixType& A)


### PR DESCRIPTION
Argument ordering (which one is the input, which one the output) in the UBLAS space can be inconsistent and a bit confusing. It doesn't help that `const` correctness is all over the place too.

This PR turns the input arguments of some functions `const` to promote compile-time errors and readability. 