### PR TITLE
[Core] Brep Surface - trimmed integration (Part 1 - Outer loop)

### DIFF
--- a/kratos/utilities/geometry_utilities/brep_trimming_utilities.cpp
+++ b/kratos/utilities/geometry_utilities/brep_trimming_utilities.cpp
@@ -80,7 +80,7 @@ namespace Kratos
                     solution = Clipper2Lib::RectClip(rectangle, all_loops);
 
                     const double span_area = std::abs(Clipper2Lib::Area(rectangle.AsPath()));
-                    double clip_area = std::abs(Clipper2Lib::Area(solution[0]));
+                    double clip_area = 0.0;
                     if (solution.size() > 0)
                     {
                         clip_area = std::abs(Clipper2Lib::Area(solution[0]));

--- a/kratos/utilities/geometry_utilities/brep_trimming_utilities.h
+++ b/kratos/utilities/geometry_utilities/brep_trimming_utilities.h
@@ -84,7 +84,7 @@ namespace Kratos
             double minweight = std::numeric_limits<double>::max();
             Diagonal diagonal, newdiagonal;
 
-            std::list<Diagonal> diagonals;
+            std::queue<Diagonal> diagonals;
 
             IndexType n = polygon.size();
             std::vector< Clipper2Lib::Point64 > const& points = polygon;
@@ -195,11 +195,11 @@ namespace Kratos
 
             newdiagonal.index1 = 0;
             newdiagonal.index2 = n - 1;
-            diagonals.push_back(newdiagonal);
+            diagonals.push(newdiagonal);
 
             while (!diagonals.empty()) {
-                diagonal = *(diagonals.begin());
-                diagonals.pop_front();
+                diagonal = diagonals.front();
+                diagonals.pop();
 
                 bestvertex = dpstates(diagonal.index2, diagonal.index1).bestvertex;
                 if (bestvertex == -1) {
@@ -222,12 +222,12 @@ namespace Kratos
                 if (bestvertex > (diagonal.index1 + 1)) {
                     newdiagonal.index1 = diagonal.index1;
                     newdiagonal.index2 = bestvertex;
-                    diagonals.push_back(newdiagonal);
+                    diagonals.push(newdiagonal);
                 }
                 if (diagonal.index2 > (bestvertex + 1)) {
                     newdiagonal.index1 = bestvertex;
                     newdiagonal.index2 = diagonal.index2;
-                    diagonals.push_back(newdiagonal);
+                    diagonals.push(newdiagonal);
                 }
             }
         }

--- a/kratos/utilities/geometry_utilities/brep_trimming_utilities.h
+++ b/kratos/utilities/geometry_utilities/brep_trimming_utilities.h
@@ -77,7 +77,32 @@ namespace Kratos
         //Triangulation 
         static void Triangulate_OPT(const Clipper2Lib::Path64& polygon, std::vector<Matrix>& triangles, const double factor)
         {
-            if (polygon.size() == 4)
+            array_1d<double, 2> p1, p2, p3, p4;
+            int bestvertex;
+            double weight = 0;
+            double d1, d2 = 0.0;
+            double minweight = std::numeric_limits<double>::max();
+            Diagonal diagonal, newdiagonal;
+
+            std::list<Diagonal> diagonals;
+
+            IndexType n = polygon.size();
+            std::vector< Clipper2Lib::Point64 > const& points = polygon;
+
+            //if first and last point are coincide, neglect the last point
+            double p0_x, p0_y, pn_x, pn_y, dpx, dpy;
+            p0_x = BrepTrimmingUtilities::IntPointToDoublePoint(points[0], factor)[0];
+            p0_y = BrepTrimmingUtilities::IntPointToDoublePoint(points[0], factor)[1];
+            pn_x = BrepTrimmingUtilities::IntPointToDoublePoint(points[n - 1], factor)[0];
+            pn_y = BrepTrimmingUtilities::IntPointToDoublePoint(points[n - 1], factor)[1];
+            dpx = pn_x - p0_x;
+            dpy = pn_y - p0_y;
+
+            if(sqrt((dpx*dpx+dpy*dpy)) < 1e-9){
+                n = n - 1;
+            }
+
+            if (n == 3) //special case with only one triangle
             {
                 Matrix triangle(3, 2);
                 triangle(0, 0) = BrepTrimmingUtilities::IntPointToDoublePoint(polygon[0], factor)[0];
@@ -90,17 +115,6 @@ namespace Kratos
                 return;
             }
 
-            array_1d<double, 2> p1, p2, p3, p4;
-            int bestvertex;
-            double weight = 0;
-            double d1, d2 = 0.0;
-            double minweight = std::numeric_limits<double>::max();
-            Diagonal diagonal, newdiagonal;
-
-            std::list<Diagonal> diagonals;
-
-            IndexType n = polygon.size();
-            std::vector< Clipper2Lib::Point64 > const& points = polygon;
             matrix<DPState> dpstates(n, n);
 
             //init states and visibility

--- a/kratos/utilities/geometry_utilities/brep_trimming_utilities.h
+++ b/kratos/utilities/geometry_utilities/brep_trimming_utilities.h
@@ -80,7 +80,7 @@ namespace Kratos
             array_1d<double, 2> p1, p2, p3, p4;
             int bestvertex;
             double weight = 0;
-            double d1, d2 = 0.0;
+            double d1 = 0.0, d2 = 0.0;
             double minweight = std::numeric_limits<double>::max();
             Diagonal diagonal, newdiagonal;
 


### PR DESCRIPTION
**📝 Description**
This is the first part of the PR series to fix the problem related to the trimmed integration in the IGA application.
This PR corrects some issues for the outer loop trimming. 

**🆕 Changelog**
- Check whether the initial and final points coincide before starting  triangulation
- Initialize the `clip_area` (to avoid a case where `solution.size() == 0`)

The inner trimming and test cases will be elaborated on in the next PRs.