### PR TITLE
[GeoMechanicsApplication] Fix DGeoFlow logging

### DIFF
--- a/applications/GeoMechanicsApplication/custom_constitutive/incremental_linear_elastic_law.cpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/incremental_linear_elastic_law.cpp
@@ -10,8 +10,8 @@
 //  Main authors:    Wijtze Pieter Kikstra
 //                   Richard Faasse
 
-#include "constitutive_law_dimension.h"
 #include "custom_constitutive/incremental_linear_elastic_law.h"
+#include "constitutive_law_dimension.h"
 #include "geo_mechanics_application_variables.h"
 
 namespace Kratos

--- a/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_element.cpp
@@ -1049,7 +1049,8 @@ std::vector<double> UPwSmallStrainElement<TDim, TNumNodes>::CalculateDegreesOfSa
 
     auto retention_law_params = RetentionLaw::Parameters{this->GetProperties()};
     std::transform(rFluidPressures.begin(), rFluidPressures.end(), mRetentionLawVector.begin(),
-                   std::back_inserter(result), [&retention_law_params](auto fluid_pressure, const auto& pRetentionLaw) {
+                   std::back_inserter(result),
+                   [&retention_law_params](auto fluid_pressure, const auto& pRetentionLaw) {
         retention_law_params.SetFluidPressure(fluid_pressure);
         return pRetentionLaw->CalculateSaturation(retention_law_params);
     });

--- a/applications/GeoMechanicsApplication/custom_elements/filter_compressibility_calculator.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/filter_compressibility_calculator.cpp
@@ -67,7 +67,7 @@ Matrix FilterCompressibilityCalculator::CalculateCompressibilityMatrix() const
 
 double FilterCompressibilityCalculator::CalculateElasticCapacity(double ProjectedGravity) const
 {
-    const auto&  r_properties = mInputProvider.GetElementProperties();
+    const auto& r_properties = mInputProvider.GetElementProperties();
     return 1.0 / (r_properties[DENSITY_WATER] * ProjectedGravity * r_properties[FILTER_LENGTH]) +
            1.0 / r_properties[BULK_MODULUS_FLUID];
 }

--- a/applications/GeoMechanicsApplication/custom_elements/transient_Pw_line_element.h
+++ b/applications/GeoMechanicsApplication/custom_elements/transient_Pw_line_element.h
@@ -299,8 +299,7 @@ private:
                 body_acceleration, rNContainer, volume_acceleration, integration_point_index);
             array_1d<double, TDim> tangent_vector = column(J_container[integration_point_index], 0);
             tangent_vector /= norm_2(tangent_vector);
-            projected_gravity(integration_point_index) =
-                MathUtils<>::Dot(tangent_vector, body_acceleration);
+            projected_gravity(integration_point_index) = MathUtils<>::Dot(tangent_vector, body_acceleration);
         }
         return projected_gravity;
     }

--- a/applications/GeoMechanicsApplication/custom_workflows/dgeoflow.cpp
+++ b/applications/GeoMechanicsApplication/custom_workflows/dgeoflow.cpp
@@ -307,7 +307,7 @@ int KratosExecute::ExecuteFlowAnalysis(std::string_view         WorkingDirectory
         bool has_piping = rCriticalHeadInfo.stepCriticalHead != 0;
 
         if (rCallBackFunctions.ShouldCancel()) {
-            HandleCleanUp(rCallBackFunctions, pOutput);
+            HandleCleanUp(rCallBackFunctions, pOutput, kratos_log_buffer);
 
             return 0;
         }
@@ -317,18 +317,18 @@ int KratosExecute::ExecuteFlowAnalysis(std::string_view         WorkingDirectory
 
         if (has_piping) {
             ExecuteWithPiping(rModelPart, rGidOutputSettings, rCriticalHeadInfo, pOutput,
-                              rCallBackFunctions, pSolvingStrategy);
+                              kratos_log_buffer, rCallBackFunctions, pSolvingStrategy);
         } else {
             ExecuteWithoutPiping(rModelPart, rGidOutputSettings, pSolvingStrategy);
         }
 
-        HandleCleanUp(rCallBackFunctions, pOutput);
+        HandleCleanUp(rCallBackFunctions, pOutput, kratos_log_buffer);
 
         return 0;
     } catch (const std::exception& exc) {
         KRATOS_INFO_IF("GeoFlowKernel", this->GetEchoLevel() > 0) << exc.what();
 
-        HandleCleanUp(rCallBackFunctions, pOutput);
+        HandleCleanUp(rCallBackFunctions, pOutput, kratos_log_buffer);
 
         return 1;
     }
@@ -348,6 +348,7 @@ int KratosExecute::ExecuteWithPiping(ModelPart&                rModelPart,
                                      const Kratos::Parameters& rGidOutputSettings,
                                      const CriticalHeadInfo&   rCriticalHeadInfo,
                                      LoggerOutput::Pointer     pOutput,
+                                     const std::stringstream&  rKratosLogBuffer,
                                      const CallBackFunctions&  rCallBackFunctions,
                                      const GeoMechanicsNewtonRaphsonErosionProcessStrategyType::Pointer pSolvingStrategy)
 {
@@ -370,8 +371,8 @@ int KratosExecute::ExecuteWithPiping(ModelPart&                rModelPart,
         KRATOS_ERROR << "No river boundary found.";
     }
 
-    FindCriticalHead(rModelPart, rGidOutputSettings, rCriticalHeadInfo, pOutput, p_river_boundary,
-                     pSolvingStrategy, rCallBackFunctions);
+    FindCriticalHead(rModelPart, rGidOutputSettings, rCriticalHeadInfo, pOutput, rKratosLogBuffer,
+                     p_river_boundary, pSolvingStrategy, rCallBackFunctions);
 
     WriteCriticalHeadResultToFile();
 
@@ -417,6 +418,7 @@ int KratosExecute::FindCriticalHead(ModelPart&                 rModelPart,
                                     const Kratos::Parameters&  rGidOutputSettings,
                                     const CriticalHeadInfo&    rCriticalHeadInfo,
                                     LoggerOutput::Pointer      pOutput,
+                                    const std::stringstream&   rKratosLogBuffer,
                                     const shared_ptr<Process>& pRiverBoundary,
                                     const GeoMechanicsNewtonRaphsonErosionProcessStrategyType::Pointer pSolvingStrategy,
                                     const CallBackFunctions& rCallBackFunctions)
@@ -485,7 +487,7 @@ int KratosExecute::FindCriticalHead(ModelPart&                 rModelPart,
         }
 
         if (rCallBackFunctions.ShouldCancel()) {
-            HandleCleanUp(rCallBackFunctions, pOutput);
+            HandleCleanUp(rCallBackFunctions, pOutput, rKratosLogBuffer);
 
             return 0;
         }
@@ -506,11 +508,11 @@ void KratosExecute::HandleCriticalHeadFound(const CriticalHeadInfo& rCriticalHea
     }
 }
 
-void KratosExecute::HandleCleanUp(const CallBackFunctions& rCallBackFunctions, LoggerOutput::Pointer pOutput)
+void KratosExecute::HandleCleanUp(const CallBackFunctions& rCallBackFunctions,
+                                  LoggerOutput::Pointer    pOutput,
+                                  const std::stringstream& rKratosLogBuffer)
 {
-    std::stringstream kratos_log_buffer;
-
-    rCallBackFunctions.LogCallback(kratos_log_buffer.str().c_str());
+    rCallBackFunctions.LogCallback(rKratosLogBuffer.str().c_str());
     Logger::RemoveOutput(pOutput);
     ResetModelParts();
 }

--- a/applications/GeoMechanicsApplication/custom_workflows/dgeoflow.h
+++ b/applications/GeoMechanicsApplication/custom_workflows/dgeoflow.h
@@ -115,6 +115,7 @@ public:
                           const Kratos::Parameters& rGidOutputSettings,
                           const CriticalHeadInfo&   rCriticalHeadInfo,
                           LoggerOutput::Pointer     pOutput,
+                          const std::stringstream&  rKratosLogBuffer,
                           const CallBackFunctions&  rCallBackFunctions,
                           const GeoMechanicsNewtonRaphsonErosionProcessStrategyType::Pointer pSolvingStrategy);
 
@@ -126,13 +127,16 @@ public:
                          const Kratos::Parameters&  rGidOutputSettings,
                          const CriticalHeadInfo&    rCriticalHeadInfo,
                          LoggerOutput::Pointer      pOutput,
+                         const std::stringstream&   rKratosLogBuffer,
                          const shared_ptr<Process>& pRiverBoundary,
                          const GeoMechanicsNewtonRaphsonErosionProcessStrategyType::Pointer pSolvingStrategy,
                          const CallBackFunctions& rCallBackFunctions);
 
     void HandleCriticalHeadFound(const CriticalHeadInfo& rCriticalHeadInfo);
 
-    void HandleCleanUp(const CallBackFunctions& rCallBackFunctions, LoggerOutput::Pointer pOutput);
+    void HandleCleanUp(const CallBackFunctions& rCallBackFunctions,
+                       LoggerOutput::Pointer    pOutput,
+                       const std::stringstream& rKratosLogBuffer);
 
 private:
     // Initial Setup


### PR DESCRIPTION
**📝 Description**

DGeoFlow did not log anything, since a newly constructed stream object was used when flushing the output. We now use the log buffer that is being filled throughout the analysis run. This required some changes to the signatures of a few member functions (to pass on the intended buffer).
