### PR TITLE
[Core] Some header refactor for consistency and modern C++ standards (`pragma`)

### DIFF
--- a/kratos/includes/table.h
+++ b/kratos/includes/table.h
@@ -5,14 +5,13 @@
 //                   Multi-Physics
 //
 //  License:         BSD License
-//                     Kratos default license: kratos/license.txt
+//                   Kratos default license: kratos/license.txt
 //
 //  Main authors:    Pooyan Dadvand
 //                   Riccardo Rossi
 //
 
-#if !defined(KRATOS_TABLE_H_INCLUDED )
-#define  KRATOS_TABLE_H_INCLUDED
+#pragma once
 
 // System includes
 #include <string>
@@ -865,7 +864,3 @@ inline std::ostream& operator << (std::ostream& rOStream,
 ///@} addtogroup block
 
 }  // namespace Kratos.
-
-#endif // KRATOS_TABLE_H_INCLUDED  defined 
-
-

--- a/kratos/includes/table_stream.h
+++ b/kratos/includes/table_stream.h
@@ -4,16 +4,15 @@
 //   _|\_\_|  \__,_|\__|\___/ ____/
 //                   Multi-Physics
 //
-//  License:		 BSD License
-//					 Kratos default license: kratos/license.txt
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
 //
 //  Main authors:    Vicente Mataix Ferrandiz
 //  Inspired in bprinter, work of Dat Chu: https://github.com/dattanchu/bprinter
 //  Removing all the dependencies of boost::karma and adding bold fonts and additional functionalities needed
 //
 
-#ifndef KRATOS_TABLE_STREAM_H_INCLUDED
-#define KRATOS_TABLE_STREAM_H_INCLUDED
+#pragma once
 
 // System includes
 #include <iostream>
@@ -470,4 +469,3 @@ private:
 }; // Class TableStream
 
 } // namespace Kratos.
-#endif

--- a/kratos/includes/thread_fixed_size_memory_pool.h
+++ b/kratos/includes/thread_fixed_size_memory_pool.h
@@ -4,24 +4,25 @@
 //   _|\_\_|  \__,_|\__|\___/ ____/
 //                   Multi-Physics
 //
-//  License:		 BSD License
-//					 Kratos default license: kratos/license.txt
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
 //
 //  Main authors:    Pooyan Dadvand
 //
 //
 
+#pragma once
 
-#if !defined(KRATOS_THREAD_FIXED_SIZE_MEMORY_POOL_H_INCLUDED )
-#define  KRATOS_THREAD_FIXED_SIZE_MEMORY_POOL_H_INCLUDED
-
+// System includes
 #include <vector>
 #include <list>
 #include <algorithm>
 #include <atomic>
 
+// External includes
 #include "concurrentqueue/concurrentqueue.h"
 
+// Project includes
 #include "includes/chunk.h"
 
 namespace Kratos
@@ -339,5 +340,3 @@ namespace Kratos
   ///@} addtogroup block
 
 }  // namespace Kratos.
-
-#endif // KRATOS_THREAD_FIXED_SIZE_MEMORY_POOL_H_INCLUDED  defined

--- a/kratos/includes/ublas_complex_interface.h
+++ b/kratos/includes/ublas_complex_interface.h
@@ -4,14 +4,13 @@
 //   _|\_\_|  \__,_|\__|\___/ ____/
 //                   Multi-Physics
 //
-//  License:		 BSD License
-//					 Kratos default license: kratos/license.txt
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
 //
 //  Main authors:    Michael Andre
 //
 
-#if !defined(KRATOS_UBLAS_COMPLEX_INTERFACE_H_INCLUDED )
-#define  KRATOS_UBLAS_COMPLEX_INTERFACE_H_INCLUDED
+#pragma once
 
 // System includes
 #include <string>
@@ -76,5 +75,3 @@ typedef matrix_slice<ComplexMatrix> ComplexMatrixSlice;
 ///@}
 
 }  // namespace Kratos.
-
-#endif // KRATOS_UBLAS_COMPLEX_INTERFACE_H_INCLUDED  defined

--- a/kratos/includes/ublas_interface.h
+++ b/kratos/includes/ublas_interface.h
@@ -4,21 +4,17 @@
 //   _|\_\_|  \__,_|\__|\___/ ____/
 //                   Multi-Physics
 //
-//  License:		 BSD License
-//					 Kratos default license: kratos/license.txt
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
 //
 //  Main authors:    Pooyan Dadvand
 //
 
-
-#if !defined(KRATOS_UBLAS_INTERFACE_H_INCLUDED )
-#define  KRATOS_UBLAS_INTERFACE_H_INCLUDED
-
+#pragma once
 
 // System includes
 #include <string>
 #include <iostream>
-
 
 // External includes
 #include <boost/numeric/ublas/matrix.hpp>
@@ -40,7 +36,6 @@
 
 // Project includes
 #include "includes/define.h"
-
 
 namespace Kratos
 {
@@ -115,9 +110,5 @@ namespace Kratos
 ///@name Input and output
 ///@{
 
+///@}
 }  // namespace Kratos.
-
-#endif // KRATOS_UBLAS_INTERFACE_H_INCLUDED  defined
-
-
-

--- a/kratos/includes/variables.h
+++ b/kratos/includes/variables.h
@@ -10,8 +10,7 @@
 //  Main authors:    Pooyan Dadvand
 //
 
-#if !defined(KRATOS_VARIABLES_H_INCLUDED )
-#define  KRATOS_VARIABLES_H_INCLUDED
+#pragma once
 
 // System includes
 #include <string>
@@ -489,5 +488,3 @@ namespace Kratos
 
 #undef  KRATOS_EXPORT_MACRO
 #define KRATOS_EXPORT_MACRO KRATOS_NO_EXPORT
-
-#endif // KRATOS_VARIABLES_H_INCLUDED  defined


### PR DESCRIPTION
# **📝 Description**

## Files Changed:
- `kratos/includes/table.h`
- `kratos/includes/table_stream.h`
- `kratos/includes/thread_fixed_size_memory_pool.h`
- `kratos/includes/ublas_complex_interface.h`
- `kratos/includes/ublas_interface.h`
- `kratos/includes/variables.h`

## Changes:
- **Header Guards**: Replaced `#ifndef` guards with `#pragma once` in all the modified header files.
- **License Formatting**: Standardized license text formatting to ensure it is consistent across different headers.
- **Code Clean-up**: Removed unnecessary closing comments, redundant preprocessor directives (`#endif`), and extra whitespace for a cleaner codebase.

# **🆕 Changelog**

- [Some replacement in headers with `pragma`](https://github.com/KratosMultiphysics/Kratos/commit/98556b0372d6f55b5f5e89cd65accc385a16104c)
