### PR TITLE
Allow the Atomic Sum of Different Types

### DIFF
--- a/kratos/utilities/atomic_utilities.h
+++ b/kratos/utilities/atomic_utilities.h
@@ -58,7 +58,7 @@ inline void AtomicAdd(TLeftData& target, const TRightData& value)
     #pragma omp atomic
     target += value;
 #elif defined(KRATOS_SMP_CXX11)
-    AtomicRef<TDataType>{target} += value;
+    AtomicRef<TLeftData>{target} += value;
 #else
     target += value;
 #endif

--- a/kratos/utilities/atomic_utilities.h
+++ b/kratos/utilities/atomic_utilities.h
@@ -51,8 +51,8 @@ namespace Kratos {
  * @param target variable being atomically updated by doing target += value
  * @param value value being added
  */
-template<class TDataType>
-inline void AtomicAdd(TDataType& target, const TDataType& value)
+template<class TLeftData, class TRightData>
+inline void AtomicAdd(TLeftData& target, const TRightData& value)
 {
 #ifdef KRATOS_SMP_OPENMP
     #pragma omp atomic


### PR DESCRIPTION
`AtomicAdd` used the same template parameter for both the left and right hand side operands. This PR templates the two operands separately, allowing the left hand side operand's update with a different type.

```cpp
float target = 0;
double update = 1;
AtomicAdd(target, update);
```

A use case would be assembly when the local space uses double precision floats while the global space is in single precision.

@reviewers can you please take a close look? I don't think this would be an issue, but I've been wrong about OpenMP before ...