### PR TITLE
Missing Addition of Template Argument TShiftedBoundary

### DIFF
--- a/kratos/geometries/brep_surface.h
+++ b/kratos/geometries/brep_surface.h
@@ -63,6 +63,7 @@ public:
 
     typedef NurbsSurfaceGeometry<3, TContainerPointType> NurbsSurfaceType;
     typedef BrepCurveOnSurface<TContainerPointType, TShiftedBoundary, TContainerPointEmbeddedType> BrepCurveOnSurfaceType;
+    typedef BrepTrimmingUtilities<TShiftedBoundary> BrepTrimmingUtilitiesType;
 
     typedef DenseVector<typename BrepCurveOnSurfaceType::Pointer> BrepCurveOnSurfaceArrayType;
     typedef DenseVector<typename BrepCurveOnSurfaceType::Pointer> BrepCurveOnSurfaceLoopType;
@@ -467,7 +468,7 @@ public:
             mpNurbsSurface->SpansLocalSpace(spans_u, 0);
             mpNurbsSurface->SpansLocalSpace(spans_v, 1);
 
-            BrepTrimmingUtilities::CreateBrepSurfaceTrimmingIntegrationPoints(
+            BrepTrimmingUtilitiesType::CreateBrepSurfaceTrimmingIntegrationPoints(
                 rIntegrationPoints,
                 mOuterLoopArray, mInnerLoopArray,
                 spans_u, spans_v,

--- a/kratos/utilities/geometry_utilities/brep_trimming_utilities.cpp
+++ b/kratos/utilities/geometry_utilities/brep_trimming_utilities.cpp
@@ -14,8 +14,8 @@ namespace Kratos
 {
     ///@name Kratos Classes
     ///@{
-
-    void BrepTrimmingUtilities::CreateBrepSurfaceTrimmingIntegrationPoints(
+    template<bool TShiftedBoundary>
+    void BrepTrimmingUtilities<TShiftedBoundary>::CreateBrepSurfaceTrimmingIntegrationPoints(
         IntegrationPointsArrayType& rIntegrationPoints,
         const DenseVector<DenseVector<BrepCurveOnSurfacePointerType>>& rOuterLoops,
         const DenseVector<DenseVector<BrepCurveOnSurfacePointerType>>& rInnerLoops,
@@ -152,4 +152,6 @@ namespace Kratos
     //    const std::vector<double>& rSpansV,
     //    IntegrationInfo& rIntegrationInfo);
 
+    template class KRATOS_API(KRATOS_CORE) BrepTrimmingUtilities<true>;
+    template class KRATOS_API(KRATOS_CORE) BrepTrimmingUtilities<false>;
 } // namespace Kratos.

--- a/kratos/utilities/geometry_utilities/brep_trimming_utilities.h
+++ b/kratos/utilities/geometry_utilities/brep_trimming_utilities.h
@@ -7,8 +7,7 @@
 //  License:         BSD License
 //                   Kratos default license: kratos/license.txt
 
-#if !defined(KRATOS_BREP_TRIMMING_UTILITIES_H_INCLUDED)
-#define KRATOS_BREP_TRIMMING_UTILITIES_H_INCLUDED
+#pragma once
 
 // Std includes
 #include <list>
@@ -33,6 +32,7 @@ namespace Kratos
 
     //using namespace ClipperLib;
 
+    template<bool TShiftedBoundary>
     class KRATOS_API(KRATOS_CORE) BrepTrimmingUtilities
     {
     public:
@@ -52,7 +52,7 @@ namespace Kratos
 
         typedef signed long long cInt;
 
-        using BrepCurveOnSurfacePointerType = typename BrepCurveOnSurface<PointerVector<Node>, false, PointerVector<Point>>::Pointer;
+        using BrepCurveOnSurfacePointerType = typename BrepCurveOnSurface<PointerVector<Node>, TShiftedBoundary, PointerVector<Point>>::Pointer;
 
         //template<class TBrepLoopType, class TPointType>
         static void CreateBrepSurfaceTrimmingIntegrationPoints(
@@ -339,5 +339,3 @@ namespace Kratos
     };
     ///@} // Kratos Classes
 } // namespace Kratos.
-
-#endif // KRATOS_BREP_TRIMMING_UTILITIES_H_INCLUDED defined


### PR DESCRIPTION
**📝 Description**

This PR introduces the template argument TShiftedBoundary to BrepTrimmingUtilities.

By default, this template is set to false and is only set to true in the SBM case. It will be enabled from the SBM_Nurbs_Modeler soon.