### PR TITLE
Coorection to GetLowerSpan method in nurbs_utilitites

### DIFF
--- a/kratos/geometries/nurbs_shape_function_utilities/nurbs_utilities.h
+++ b/kratos/geometries/nurbs_shape_function_utilities/nurbs_utilities.h
@@ -12,8 +12,7 @@
 //  Ported from the ANurbs library (https://github.com/oberbichler/ANurbs)
 //
 
-#if !defined(KRATOS_NURBS_UTILITY_H_INCLUDED )
-#define  KRATOS_NURBS_UTILITY_H_INCLUDED
+#pragma once
 
 // System includes
 
@@ -64,10 +63,20 @@ namespace NurbsUtilities
     inline IndexType GetLowerSpan(
         const SizeType PolynomialDegree,
         const Vector& rKnots,
-        const double ParameterT)
+        const double ParameterT,
+        const double tolerance = 1e-12)
     {
+        // Check if the ParameterT (gauss point) is coincident to a knot (laying on an edge of a knot span)
+        double parameter_t_corrected = ParameterT;
+        for (unsigned i = PolynomialDegree; i < rKnots.size(); i++) {
+            if (std::abs(ParameterT-rKnots[i]) < tolerance) {
+                parameter_t_corrected = rKnots[i];
+                break;
+            }
+        }
         const auto span = std::lower_bound(std::begin(rKnots) + PolynomialDegree,
-            std::end(rKnots) - PolynomialDegree, ParameterT) - std::begin(rKnots) - 1;
+            std::end(rKnots) - PolynomialDegree, parameter_t_corrected) - std::begin(rKnots) - 1;
+        
         return span;
     }
 
@@ -187,5 +196,3 @@ namespace NurbsUtilities
 }; // class NurbsUtility
 ///@}
 } // namespace Kratos
-
-#endif // KRATOS_NURBS_UTILITY_H_INCLUDED defined

--- a/kratos/tests/cpp_tests/geometries/test_nurbs_curve_shape_functions.cpp
+++ b/kratos/tests/cpp_tests/geometries/test_nurbs_curve_shape_functions.cpp
@@ -30,7 +30,7 @@ namespace Testing {
     typedef std::size_t IndexType;
 
     /// Factory functions
-    NurbsCurveShapeFunction GenerateReferenceNurbsCurveShapeFunction()
+    NurbsCurveShapeFunction GenerateReferenceNurbsCurveShapeFunction(double parameter_t)
     {
         // Assign the polynomial order of the basis
         SizeType polynomial_degree = 4;
@@ -65,9 +65,6 @@ namespace Testing {
         weights[6] = 3.550000000000000;
         weights[7] = 1.000000000000000;
 
-        // Parameter on the curve where to compute the basis functions and their derivatives
-        double parameter_t = 6.5;
-
         // Create the shape function container
         NurbsCurveShapeFunction shape_functions(polynomial_degree, derivative_order);
 
@@ -85,7 +82,9 @@ namespace Testing {
     KRATOS_TEST_CASE_IN_SUITE(NurbsBasisFunctions1d, KratosCoreNurbsGeometriesFastSuite) {
         
         // Get reference Nurbs curve shape functions
-        NurbsCurveShapeFunction shape_functions = GenerateReferenceNurbsCurveShapeFunction();
+        // Parameter on the curve where to compute the basis functions and their derivatives
+        double parameter_t = 6.5;
+        NurbsCurveShapeFunction shape_functions = GenerateReferenceNurbsCurveShapeFunction(parameter_t);
 
         // Check the Nurbs basis functions
         KRATOS_EXPECT_NEAR(shape_functions(0, 0), 0.040341356830719, TOLERANCE);
@@ -135,6 +134,64 @@ namespace Testing {
         KRATOS_EXPECT_NEAR(shape_functions(2, 6), 0.161718941270974, TOLERANCE);
         KRATOS_EXPECT_NEAR(shape_functions(3, 6), -0.295903990157367, TOLERANCE);
         KRATOS_EXPECT_NEAR(shape_functions(4, 6), 0.227141701884515, TOLERANCE);
+    }
+
+
+    KRATOS_TEST_CASE_IN_SUITE(NurbsBasisFunctions1dCloseToKnot, KratosCoreNurbsGeometriesFastSuite) {
+        
+        // Get reference Nurbs curve shape functions
+        // Parameter on the curve where to compute the basis functions and their derivatives
+        double parameter_t = 4.5+1e-13;
+        NurbsCurveShapeFunction shape_functions = GenerateReferenceNurbsCurveShapeFunction(parameter_t);
+        
+        // Check the Nurbs basis functions
+        KRATOS_EXPECT_NEAR(shape_functions(0, 0), 2.16992e-56 , TOLERANCE);
+        KRATOS_EXPECT_NEAR(shape_functions(1, 0), -1.16534e-41 , TOLERANCE);
+        KRATOS_EXPECT_NEAR(shape_functions(2, 0), 1.41472e-27 , TOLERANCE);
+        KRATOS_EXPECT_NEAR(shape_functions(3, 0), 0.396722 , TOLERANCE);
+        KRATOS_EXPECT_NEAR(shape_functions(4, 0), 0.603278 , TOLERANCE);
+
+        // Check the first derivatives of the Nurbs basis functions
+        KRATOS_EXPECT_NEAR(shape_functions(0, 1), 8.64817e-43 , TOLERANCE);
+        KRATOS_EXPECT_NEAR(shape_functions(1, 1), -3.48334e-28 , TOLERANCE);
+        KRATOS_EXPECT_NEAR(shape_functions(2, 1), 2.81918e-14 , TOLERANCE);
+        KRATOS_EXPECT_NEAR(shape_functions(3, 1), -0.386802 , TOLERANCE);
+        KRATOS_EXPECT_NEAR(shape_functions(4, 1), 0.386802 , TOLERANCE);
+
+        // Check the second derivatives of the Nurbs basis functions
+        KRATOS_EXPECT_NEAR(shape_functions(0, 2), 2.58504e-29 , TOLERANCE);
+        KRATOS_EXPECT_NEAR(shape_functions(1, 2), -6.9414e-15 , TOLERANCE);
+        KRATOS_EXPECT_NEAR(shape_functions(2, 2), 0.280895 , TOLERANCE);
+        KRATOS_EXPECT_NEAR(shape_functions(3, 2), -0.466791 , TOLERANCE);
+        KRATOS_EXPECT_NEAR(shape_functions(4, 2), 0.185896 , TOLERANCE);
+
+        // Check the third derivatives of the Nurbs basis functions
+        KRATOS_EXPECT_NEAR(shape_functions(0, 3), 5.15132e-16 , TOLERANCE);
+        KRATOS_EXPECT_NEAR(shape_functions(1, 3), -0.0691621 , TOLERANCE);
+        KRATOS_EXPECT_NEAR(shape_functions(2, 3), 0.233871 , TOLERANCE);
+        KRATOS_EXPECT_NEAR(shape_functions(3, 3), -0.229086 , TOLERANCE);
+        KRATOS_EXPECT_NEAR(shape_functions(4, 3), 0.0643776 , TOLERANCE);
+
+        // Check the fourth derivatives of the Nurbs basis functions
+        KRATOS_EXPECT_NEAR(shape_functions(0, 4), 0.00513263 , TOLERANCE);
+        KRATOS_EXPECT_NEAR(shape_functions(1, 4), -0.0264787 , TOLERANCE);
+        KRATOS_EXPECT_NEAR(shape_functions(2, 4), 0.0677313 , TOLERANCE);
+        KRATOS_EXPECT_NEAR(shape_functions(3, 4), -0.0644236 , TOLERANCE);
+        KRATOS_EXPECT_NEAR(shape_functions(4, 4), 0.0180384 , TOLERANCE);
+
+        // Check the fifth derivatives of the Nurbs basis functions
+        KRATOS_EXPECT_NEAR(shape_functions(0, 5), -0.00220974 , TOLERANCE);
+        KRATOS_EXPECT_NEAR(shape_functions(1, 5), -0.00372319 , TOLERANCE);
+        KRATOS_EXPECT_NEAR(shape_functions(2, 5), 0.0219781 , TOLERANCE);
+        KRATOS_EXPECT_NEAR(shape_functions(3, 5), -0.0223559 , TOLERANCE);
+        KRATOS_EXPECT_NEAR(shape_functions(4, 5), 0.00631078 , TOLERANCE);
+
+        // Check the sixth derivatives of the Nurbs basis functions
+        KRATOS_EXPECT_NEAR(shape_functions(0, 6), 0.00282508 , TOLERANCE);
+        KRATOS_EXPECT_NEAR(shape_functions(1, 6), -0.00676125 , TOLERANCE);
+        KRATOS_EXPECT_NEAR(shape_functions(2, 6), 0.0108606 , TOLERANCE);
+        KRATOS_EXPECT_NEAR(shape_functions(3, 6), -0.00958053 , TOLERANCE);
+        KRATOS_EXPECT_NEAR(shape_functions(4, 6), 0.00265608 , TOLERANCE);
     }
 
 } // namespace Testing.


### PR DESCRIPTION
**📝 Description**

This PR improves the GetLowerSpan function in NurbsUtilities by adding a correction mechanism for ParameterT to ensure numerical robustness. The enhancement helps handle cases where ParameterT is very close to a knot, avoiding potential floating-point precision issues.
