### PR TITLE
[Core] Adding Future and Legacy namespaces

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,11 @@ if(POLICY CMP0135)
   cmake_policy(SET CMP0135 NEW)
 endif(POLICY CMP0135)
 
+# Path Normalization
+if(POLICY CMP0177)
+  cmake_policy(SET CMP0177 NEW)
+endif(POLICY CMP0177)
+
 # Set here the version number **** only update upon tagging a release!
 set (KratosMultiphysics_MAJOR_VERSION 10)
 set (KratosMultiphysics_MINOR_VERSION 2)
@@ -294,6 +299,7 @@ SET(INSTALL_PYTHON_FILES ON)        # To be removed when all applications are po
 include(install_function)
 include(KratosDependencies)
 include(KratosGTest)
+include(KratosAddSources)
 include(KratosGBenchmark)
 include(FetchContent)
 

--- a/cmake_modules/KratosAddSources.cmake
+++ b/cmake_modules/KratosAddSources.cmake
@@ -1,0 +1,31 @@
+# This function automatically configures a given application to build its tests
+macro(kratos_add_sources)
+    set(multiValueArgs SOURCE_DIRS)
+
+    cmake_parse_arguments(KRATOS_ADD_SOURCES "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+
+    if(KRATOS_ADD_SOURCES_SOURCE_DIRS)
+
+        FOREACH(subFolder ${KRATOS_ADD_SOURCES_SOURCE_DIRS})
+            FILE(GLOB_RECURSE ${subFolder}Sources "${subFolder}/*.cpp" "${subFolder}/*.c") #all .cpp and .c
+
+            # Auxiliar list
+            SET(AUXILIAR_CORE_SOURCES "")
+            FOREACH(file ${${subFolder}Sources})
+                SET(EXCEPTION_CHECK 0)
+                FOREACH(exception ${LIST_OF_SOURCE_EXCEPTIONS})
+                    IF(${file} STREQUAL ${exception})
+                        SET(EXCEPTION_CHECK 1)
+                    ENDIF(${file} STREQUAL ${exception})
+                ENDFOREACH(exception ${LIST_OF_SOURCE_EXCEPTIONS})
+                IF (${EXCEPTION_CHECK} EQUAL 0)
+                    LIST(APPEND AUXILIAR_CORE_SOURCES ${file})
+                ENDIF(${EXCEPTION_CHECK} EQUAL 0)
+            ENDFOREACH(file ${${subFolder}Sources})
+
+            # Append to final list
+            LIST(APPEND ${ARGV0} ${AUXILIAR_CORE_SOURCES})
+        ENDFOREACH(subFolder ${ListFolders})
+    endif()
+
+endmacro(kratos_add_sources)

--- a/cmake_modules/KratosAddSources.cmake
+++ b/cmake_modules/KratosAddSources.cmake
@@ -1,6 +1,6 @@
 # This function automatically configures a given application to build its tests
 macro(kratos_add_sources)
-    set(multiValueArgs SOURCE_DIRS)
+    set(multiValueArgs SOURCE_DIRS EXCEPTIONS)
 
     cmake_parse_arguments(KRATOS_ADD_SOURCES "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
 
@@ -13,11 +13,11 @@ macro(kratos_add_sources)
             SET(AUXILIAR_CORE_SOURCES "")
             FOREACH(file ${${subFolder}Sources})
                 SET(EXCEPTION_CHECK 0)
-                FOREACH(exception ${LIST_OF_SOURCE_EXCEPTIONS})
+                FOREACH(exception ${KRATOS_ADD_SOURCES_EXCEPTIONS})
                     IF(${file} STREQUAL ${exception})
                         SET(EXCEPTION_CHECK 1)
                     ENDIF(${file} STREQUAL ${exception})
-                ENDFOREACH(exception ${LIST_OF_SOURCE_EXCEPTIONS})
+                ENDFOREACH(exception ${KRATOS_ADD_SOURCES_EXCEPTIONS})
                 IF (${EXCEPTION_CHECK} EQUAL 0)
                     LIST(APPEND AUXILIAR_CORE_SOURCES ${file})
                 ENDIF(${EXCEPTION_CHECK} EQUAL 0)

--- a/kratos/CMakeLists.txt
+++ b/kratos/CMakeLists.txt
@@ -20,16 +20,23 @@ SET(LIST_OF_SOURCE_EXCEPTIONS
     ${CMAKE_CURRENT_SOURCE_DIR}/modeler/cad_tessellation_modeler.cpp
 )
 
-kratos_add_sources(KRATOS_CORE_SOURCES SOURCE_DIRS "${LIST_FOLDER}")
+## Kratos python interface code
+FILE(GLOB_RECURSE KRATOS_PYTHON_SOURCES "python/*.cpp")
+
+kratos_add_sources(KRATOS_CORE_SOURCES SOURCE_DIRS "${LIST_FOLDER}" EXCEPTIONS "${LIST_OF_SOURCE_EXCEPTIONS}")
 if(${KRATOS_USE_FUTURE} MATCHES ON)
     add_definitions( -DKRATOS_USE_FUTURE )
     message(WARNING "You are using sources from Kratos::Future. This is not recommended for stability.")
-    kratos_add_sources(KRATOS_CORE_SOURCES SOURCE_DIRS "${LIST_FUTURE}")
+    ## TODO: Change this in the future (no pun intended) and make it part of the interface target in a different folder.
+    FILE(GLOB_RECURSE KRATOS_FUTURE_PYTHON_SOURCES "future/python/*.cpp") 
+    kratos_add_sources(KRATOS_CORE_SOURCES SOURCE_DIRS "${LIST_FUTURE}" EXCEPTIONS "${KRATOS_FUTURE_PYTHON_SOURCES}")
 endif(${KRATOS_USE_FUTURE} MATCHES ON)
 if(${KRATOS_USE_LEGACY} MATCHES ON)
     add_definitions( -DKRATOS_USE_LEGACY )
     message(WARNING "You are using sources from Kratos::Legacy. This will be removed soon.")
-    kratos_add_sources(KRATOS_CORE_SOURCES SOURCE_DIRS "${LIST_LEGACY}")
+    ## TODO: Change this in the future and make it part of the interface target in a different folder.
+    FILE(GLOB_RECURSE KRATOS_LEGACY_PYTHON_SOURCES "legacy/python/*.cpp")
+    kratos_add_sources(KRATOS_CORE_SOURCES SOURCE_DIRS "${LIST_LEGACY}" EXCEPTIONS "${KRATOS_LEGACY_PYTHON_SOURCES}")
 endif(${KRATOS_USE_LEGACY} MATCHES ON)
 
 if(${USE_TRIANGLE_NONFREE_TPL} MATCHES ON )
@@ -37,9 +44,6 @@ if(${USE_TRIANGLE_NONFREE_TPL} MATCHES ON )
         ${CMAKE_CURRENT_SOURCE_DIR}/modeler/cad_tessellation_modeler.cpp
     )
 endif(${USE_TRIANGLE_NONFREE_TPL} MATCHES ON )
-
-## Kratos python interface code
-FILE(GLOB_RECURSE KRATOS_PYTHON_SOURCES "python/*.cpp")
 
 ## Kratos Version
 set( KRATOS_VERSION_SOURCES
@@ -157,7 +161,7 @@ if (${AMGCL_GPGPU} MATCHES ON)
 endif()
 
 ## Define library Kratos which defines the basic python interface
-pybind11_add_module(Kratos MODULE THIN_LTO ${KRATOS_PYTHON_SOURCES})
+pybind11_add_module(Kratos MODULE THIN_LTO ${KRATOS_PYTHON_SOURCES} ${KRATOS_FUTURE_PYTHON_SOURCES} ${KRATOS_LEGACY_PYTHON_SOURCES})
 target_link_libraries(Kratos PRIVATE KratosCore)
 
 # Precompile most demanding / widely included headers

--- a/kratos/CMakeLists.txt
+++ b/kratos/CMakeLists.txt
@@ -7,7 +7,9 @@ else(${USE_TRIANGLE_NONFREE_TPL} MATCHES ON )
 endif(${USE_TRIANGLE_NONFREE_TPL} MATCHES ON )
 include_directories( ${KRATOS_SOURCE_DIR}/external_libraries/tinyexpr )
 
-SET(ListFolders sources conditions constraints containers elements factories geometries includes integration linear_solvers mappers modeler modified_shape_functions operations processes controllers response_functions solving_strategies spaces spatial_containers utilities)
+SET(LIST_FOLDER sources conditions constraints containers elements factories geometries includes integration linear_solvers mappers modeler modified_shape_functions operations processes controllers response_functions solving_strategies spaces spatial_containers utilities)
+SET(LIST_FUTURE future)
+SET(LIST_LEGACY legacy)
 
 ## Kratos main source code
 SET(LIST_OF_SOURCE_EXCEPTIONS
@@ -18,26 +20,19 @@ SET(LIST_OF_SOURCE_EXCEPTIONS
     ${CMAKE_CURRENT_SOURCE_DIR}/modeler/cad_tessellation_modeler.cpp
 )
 
-FOREACH(subFolder ${ListFolders})
-    FILE(GLOB_RECURSE ${subFolder}Sources "${subFolder}/*.cpp" "${subFolder}/*.c") #all .cpp and .c
+kratos_add_sources(KRATOS_CORE_SOURCES SOURCE_DIRS "${LIST_FOLDER}")
+if(${KRATOS_USE_FUTURE} MATCHES ON)
+    add_definitions( -DKRATOS_USE_FUTURE )
+    message(WARNING "You are using sources from Kratos::Future. This is not recommended for stability.")
+    kratos_add_sources(KRATOS_CORE_SOURCES SOURCE_DIRS "${LIST_FUTURE}")
+endif(${KRATOS_USE_FUTURE} MATCHES ON)
+if(${KRATOS_USE_LEGACY} MATCHES ON)
+    add_definitions( -DKRATOS_USE_LEGACY )
+    message(WARNING "You are using sources from Kratos::Legacy. This will be removed soon.")
+    kratos_add_sources(KRATOS_CORE_SOURCES SOURCE_DIRS "${LIST_LEGACY}")
+endif(${KRATOS_USE_LEGACY} MATCHES ON)
 
-    # Auxiliar list
-    SET(AUXILIAR_CORE_SOURCES "")
-    FOREACH(file ${${subFolder}Sources})
-        SET(EXCEPTION_CHECK 0)
-        FOREACH(exception ${LIST_OF_SOURCE_EXCEPTIONS})
-            IF(${file} STREQUAL ${exception})
-                SET(EXCEPTION_CHECK 1)
-            ENDIF(${file} STREQUAL ${exception})
-        ENDFOREACH(exception ${LIST_OF_SOURCE_EXCEPTIONS})
-        IF (${EXCEPTION_CHECK} EQUAL 0)
-            LIST(APPEND AUXILIAR_CORE_SOURCES ${file})
-        ENDIF(${EXCEPTION_CHECK} EQUAL 0)
-    ENDFOREACH(file ${${subFolder}Sources})
-
-    # Append to final list
-    LIST(APPEND KRATOS_CORE_SOURCES ${AUXILIAR_CORE_SOURCES})
-ENDFOREACH(subFolder ${ListFolders})
+message("Files: ${KRATOS_CORE_SOURCES}")
 
 if(${USE_TRIANGLE_NONFREE_TPL} MATCHES ON )
     SET(KRATOS_TPL_SOURCES
@@ -188,7 +183,7 @@ if(CMAKE_UNITY_BUILD MATCHES ON)
     set_source_files_properties (${CMAKE_CURRENT_SOURCE_DIR}/testing/distributed_test_case.cpp PROPERTIES SKIP_UNITY_BUILD_INCLUSION TRUE)
 
     ## this cannot be compiled with unity build because calculate_discontinuous_distance_to_skin_process.cpp does implicit instantiation before specialization
-    set_source_files_properties (${CMAKE_CURRENT_SOURCE_DIR}/processes/find_global_nodal_entity_neighbours_process.cpp PROPERTIES SKIP_UNITY_BUILD_INCLUSION TRUE)
+    # set_source_files_properties (${CMAKE_CURRENT_SOURCE_DIR}/processes/find_global_nodal_entity_neighbours_process.cpp PROPERTIES SKIP_UNITY_BUILD_INCLUSION TRUE)
 
     ## The following are conflicting due to KratosComponents
     file(GLOB_RECURSE KRATOS_STRATEGIES_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/solving_strategies/*.cpp)

--- a/kratos/CMakeLists.txt
+++ b/kratos/CMakeLists.txt
@@ -181,7 +181,7 @@ if(CMAKE_UNITY_BUILD MATCHES ON)
     set_source_files_properties (${CMAKE_CURRENT_SOURCE_DIR}/testing/distributed_test_case.cpp PROPERTIES SKIP_UNITY_BUILD_INCLUSION TRUE)
 
     ## this cannot be compiled with unity build because calculate_discontinuous_distance_to_skin_process.cpp does implicit instantiation before specialization
-    # set_source_files_properties (${CMAKE_CURRENT_SOURCE_DIR}/processes/find_global_nodal_entity_neighbours_process.cpp PROPERTIES SKIP_UNITY_BUILD_INCLUSION TRUE)
+    set_source_files_properties (${CMAKE_CURRENT_SOURCE_DIR}/processes/find_global_nodal_entity_neighbours_process.cpp PROPERTIES SKIP_UNITY_BUILD_INCLUSION TRUE)
 
     ## The following are conflicting due to KratosComponents
     file(GLOB_RECURSE KRATOS_STRATEGIES_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/solving_strategies/*.cpp)

--- a/kratos/CMakeLists.txt
+++ b/kratos/CMakeLists.txt
@@ -32,8 +32,6 @@ if(${KRATOS_USE_LEGACY} MATCHES ON)
     kratos_add_sources(KRATOS_CORE_SOURCES SOURCE_DIRS "${LIST_LEGACY}")
 endif(${KRATOS_USE_LEGACY} MATCHES ON)
 
-message("Files: ${KRATOS_CORE_SOURCES}")
-
 if(${USE_TRIANGLE_NONFREE_TPL} MATCHES ON )
     SET(KRATOS_TPL_SOURCES
         ${CMAKE_CURRENT_SOURCE_DIR}/modeler/cad_tessellation_modeler.cpp

--- a/kratos/future/processes/future_process.cpp
+++ b/kratos/future/processes/future_process.cpp
@@ -1,0 +1,32 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
+//
+//  Main authors:    Carlos A. Roig
+//
+//
+
+// System includes
+
+// External includes
+
+// Project includes
+#include "future/processes/future_process.h"
+
+namespace Kratos::Future
+{
+
+/***********************************************************************************/
+/***********************************************************************************/
+
+void Process::Execute()
+{
+    KRATOS_ERROR << "I come from the future :)" << std::endl;
+}
+
+} //

--- a/kratos/future/processes/future_process.h
+++ b/kratos/future/processes/future_process.h
@@ -1,0 +1,128 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
+//
+//  Main authors:    Carlos A. Roig
+//
+
+#pragma once
+
+// System includes
+
+// External includes
+
+// Project includes
+#include "processes/process.h"
+
+namespace Kratos::Future
+{
+
+/**
+ * @class Process
+ * @ingroup KratosCore
+ * @brief The base class for all processes in Kratos.
+ * @details This is a dummy class to test the future namespace and should never be used. Please do not remove this class.
+*/
+class Process : public Flags
+{
+public:
+    ///@name Type Definitions
+    ///@{
+
+    /// Pointer definition of Process
+    KRATOS_CLASS_POINTER_DEFINITION(Process);
+
+    ///@}
+    ///@name Life Cycle
+    ///@{
+
+    /// Default constructor.
+    Process() : Flags() {}
+    explicit Process(const Flags options) : Flags( options ) {}
+
+    /// Destructor.
+    ~Process() override {}
+
+    ///@}
+    ///@name Operators
+    ///@{
+
+    void operator()()
+    {
+        Execute();
+    }
+
+    virtual void Execute();
+
+    ///@}
+    ///@name Access
+    ///@{
+
+    ///@}
+    ///@name Inquiry
+    ///@{
+
+    ///@}
+    ///@name Input and output
+    ///@{
+
+    /// Turn back information as a string.
+    std::string Info() const override
+    {
+        return "Process";
+    }
+
+    ///@}
+    ///@name Friends
+    ///@{
+
+    ///@}
+private:
+    ///@name Static Member Variables
+    ///@{
+
+    KRATOS_REGISTRY_ADD_PROTOTYPE("Processes.KratosMultiphysics.Future", Process, Process)
+    KRATOS_REGISTRY_ADD_PROTOTYPE("Processes.All.Future", Process, Process)
+
+    ///@}
+    ///@name Un accessible methods
+    ///@{
+
+    /// Assignment operator.
+    Process& operator=(Process const& rOther);
+
+    ///@}
+
+}; // Class Process
+
+///@}
+
+///@name Type Definitions
+///@{
+
+///@}
+///@name Input and output
+///@{
+
+/// input stream function
+inline std::istream& operator >> (std::istream& rIStream,
+                                  Process& rThis);
+
+/// output stream function
+inline std::ostream& operator << (std::ostream& rOStream,
+                                  const Process& rThis)
+{
+    rThis.PrintInfo(rOStream);
+    rOStream << std::endl;
+    rThis.PrintData(rOStream);
+
+    return rOStream;
+}
+///@}
+
+}  // namespace Kratos::Future.

--- a/kratos/future/python/add_processes_to_python.cpp
+++ b/kratos/future/python/add_processes_to_python.cpp
@@ -1,0 +1,43 @@
+
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
+//
+//  Main authors:    Carlos A. Roig
+//
+//
+
+// System includes
+
+// External includes
+
+// Project includes
+#include "includes/define_python.h"
+
+// Future Extensions
+#include "future/python/add_processes_to_python.h"
+#include "future/processes/future_process.h"
+
+namespace Kratos::Future::Python
+{
+
+namespace py = pybind11;
+
+void AddProcessesToPython(py::module& m)
+{
+    // Pack everything under the "Future" submodule
+    py::class_<Future::Process, Future::Process::Pointer, Flags>(m,"Process")
+        .def(py::init<>())
+        .def("Execute",&Future::Process::Execute)
+        .def("Info",&Future::Process::Info)
+        .def("__str__", PrintObject<Future::Process>)
+    ;
+}
+
+}  // namespace Kratos::Python.
+

--- a/kratos/future/python/add_processes_to_python.h
+++ b/kratos/future/python/add_processes_to_python.h
@@ -1,0 +1,27 @@
+
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
+//
+//  Main authors:    Carlos A. Roig
+//
+//
+
+#pragma once
+
+// System includes
+
+// External includes
+#include <pybind11/pybind11.h>
+
+// Project includes
+
+namespace Kratos::Future::Python
+{
+    void AddProcessesToPython(pybind11::module &m);
+}  // namespace Kratos::Python.

--- a/kratos/future/python/kratos_python.cpp
+++ b/kratos/future/python/kratos_python.cpp
@@ -1,0 +1,36 @@
+
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
+//
+//  Main authors:    Carlos A. Roig
+//
+//
+
+// System includes
+
+// External includes
+
+// Project includes
+#include "includes/define_python.h"
+
+// Future Extensions
+#include "future/python/add_processes_to_python.h"
+
+namespace Kratos::Future::Python
+{
+
+namespace py = pybind11;
+
+void AddFutureToPython(py::module& m)
+{
+    AddProcessesToPython(m);
+}
+
+}  // namespace Kratos::Future::Python.
+

--- a/kratos/future/python/kratos_python.h
+++ b/kratos/future/python/kratos_python.h
@@ -1,0 +1,27 @@
+
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
+//
+//  Main authors:    Carlos A. Roig
+//
+//
+
+#pragma once
+
+// System includes
+
+// External includes
+#include <pybind11/pybind11.h>
+
+// Project includes
+
+namespace Kratos::Future::Python
+{
+    void AddFutureToPython(pybind11::module &m);
+}  // namespace Kratos::Future::Python.

--- a/kratos/legacy/processes/legacy_process.cpp
+++ b/kratos/legacy/processes/legacy_process.cpp
@@ -1,0 +1,32 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
+//
+//  Main authors:    Carlos A. Roig
+//
+//
+
+// System includes
+
+// External includes
+
+// Project includes
+#include "legacy/processes/legacy_process.h"
+
+namespace Kratos::Legacy
+{
+
+/***********************************************************************************/
+/***********************************************************************************/
+
+void Process::Execute()
+{
+    KRATOS_ERROR << "I... I don't feel well... My time has come, soon I will be unmade. Thank you for all the segmentation faults we lived together. :_)" << std::endl;
+}
+
+} //

--- a/kratos/legacy/processes/legacy_process.h
+++ b/kratos/legacy/processes/legacy_process.h
@@ -1,0 +1,128 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
+//
+//  Main authors:    Carlos A. Roig
+//
+
+#pragma once
+
+// System includes
+
+// External includes
+
+// Project includes
+#include "processes/process.h"
+
+namespace Kratos::Legacy
+{
+
+/**
+ * @class Process
+ * @ingroup KratosCore
+ * @brief The base class for all processes in Kratos.
+ * @details This is a dummy class to test the legacy namespace and should never be used. Please do not remove this class.
+*/
+class Process : public Flags
+{
+public:
+    ///@name Type Definitions
+    ///@{
+
+    /// Pointer definition of Process
+    KRATOS_CLASS_POINTER_DEFINITION(Process);
+
+    ///@}
+    ///@name Life Cycle
+    ///@{
+
+    /// Default constructor.
+    Process() : Flags() {}
+    explicit Process(const Flags options) : Flags( options ) {}
+
+    /// Destructor.
+    ~Process() override {}
+
+    ///@}
+    ///@name Operators
+    ///@{
+
+    void operator()()
+    {
+        Execute();
+    }
+
+    virtual void Execute();
+
+    ///@}
+    ///@name Access
+    ///@{
+
+    ///@}
+    ///@name Inquiry
+    ///@{
+
+    ///@}
+    ///@name Input and output
+    ///@{
+
+    /// Turn back information as a string.
+    std::string Info() const override
+    {
+        return "Process";
+    }
+
+    ///@}
+    ///@name Friends
+    ///@{
+
+    ///@}
+private:
+    ///@name Static Member Variables
+    ///@{
+
+    KRATOS_REGISTRY_ADD_PROTOTYPE("Processes.KratosMultiphysics.Legacy", Process, Process)
+    KRATOS_REGISTRY_ADD_PROTOTYPE("Processes.All.Legacy", Process, Process)
+
+    ///@}
+    ///@name Un accessible methods
+    ///@{
+
+    /// Assignment operator.
+    Process& operator=(Process const& rOther);
+
+    ///@}
+
+}; // Class Process
+
+///@}
+
+///@name Type Definitions
+///@{
+
+///@}
+///@name Input and output
+///@{
+
+/// input stream function
+inline std::istream& operator >> (std::istream& rIStream,
+                                  Process& rThis);
+
+/// output stream function
+inline std::ostream& operator << (std::ostream& rOStream,
+                                  const Process& rThis)
+{
+    rThis.PrintInfo(rOStream);
+    rOStream << std::endl;
+    rThis.PrintData(rOStream);
+
+    return rOStream;
+}
+///@}
+
+}  // namespace Kratos::Legacy.

--- a/kratos/legacy/python/add_processes_to_python.cpp
+++ b/kratos/legacy/python/add_processes_to_python.cpp
@@ -1,0 +1,43 @@
+
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
+//
+//  Main authors:    Carlos A. Roig
+//
+//
+
+// System includes
+
+// External includes
+
+// Project includes
+#include "includes/define_python.h"
+
+// Legacy Extensions
+#include "legacy/python/add_processes_to_python.h"
+#include "legacy/processes/legacy_process.h"
+
+namespace Kratos::Legacy::Python
+{
+
+namespace py = pybind11;
+
+void AddProcessesToPython(py::module& m)
+{
+    // Pack everything under the "Legacy" submodule
+    py::class_<Legacy::Process, Legacy::Process::Pointer, Flags>(m,"Process")
+        .def(py::init<>())
+        .def("Execute",&Legacy::Process::Execute)
+        .def("Info",&Legacy::Process::Info)
+        .def("__str__", PrintObject<Legacy::Process>)
+    ;
+}
+
+}  // namespace Kratos::Python.
+

--- a/kratos/legacy/python/add_processes_to_python.h
+++ b/kratos/legacy/python/add_processes_to_python.h
@@ -1,0 +1,27 @@
+
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
+//
+//  Main authors:    Carlos A. Roig
+//
+//
+
+#pragma once
+
+// System includes
+
+// External includes
+#include <pybind11/pybind11.h>
+
+// Project includes
+
+namespace Kratos::Legacy::Python
+{
+    void AddProcessesToPython(pybind11::module &m);
+}  // namespace Kratos::Python.

--- a/kratos/legacy/python/kratos_python.cpp
+++ b/kratos/legacy/python/kratos_python.cpp
@@ -1,0 +1,36 @@
+
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
+//
+//  Main authors:    Carlos A. Roig
+//
+//
+
+// System includes
+
+// External includes
+
+// Project includes
+#include "includes/define_python.h"
+
+// Legacy Extensions
+#include "legacy/python/add_processes_to_python.h"
+
+namespace Kratos::Legacy::Python
+{
+
+namespace py = pybind11;
+
+void AddLegacyToPython(py::module& m)
+{
+    AddProcessesToPython(m);
+}
+
+}  // namespace Kratos::Legacy::Python.
+

--- a/kratos/legacy/python/kratos_python.h
+++ b/kratos/legacy/python/kratos_python.h
@@ -1,0 +1,27 @@
+
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
+//
+//  Main authors:    Carlos A. Roig
+//
+//
+
+#pragma once
+
+// System includes
+
+// External includes
+#include <pybind11/pybind11.h>
+
+// Project includes
+
+namespace Kratos::Legacy::Python
+{
+    void AddLegacyToPython(pybind11::module &m);
+}  // namespace Kratos::Legacy::Python.

--- a/kratos/python/kratos_python.cpp
+++ b/kratos/python/kratos_python.cpp
@@ -78,6 +78,14 @@
 #include "add_globals_to_python.h"
 #include "add_geometry_data_to_python.h"
 
+#ifdef KRATOS_USE_FUTURE
+    #include "future/python/kratos_python.h"
+#endif
+
+#ifdef KRATOS_USE_LEGACY
+    #include "legacy/python/kratos_python.h"
+#endif
+
 namespace Kratos::Python
 {
 
@@ -156,6 +164,16 @@ PYBIND11_MODULE(Kratos, m)
     AddRegistryToPython(m);
     AddContainerExpressionToPython(m);
     AddGlobalsToPython(m);
+
+#ifdef KRATOS_USE_FUTURE
+    auto future = m.def_submodule("Future", "Kratos Future submodule containing experimental features");
+    Future::Python::AddFutureToPython(future);
+#endif
+
+#ifdef KRATOS_USE_FUTURE
+    auto legacy = m.def_submodule("Legacy", "Kratos Legacy submodule containing legacy features");
+    Legacy::Python::AddLegacyToPython(legacy);
+#endif
 
     m.def("Hello", Hello);
 }

--- a/kratos/tests/cpp_tests/sources/test_namespaces.cpp
+++ b/kratos/tests/cpp_tests/sources/test_namespaces.cpp
@@ -1,0 +1,132 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
+//
+//  Main authors:    Vicente Mataix Ferrandiz
+//
+
+// System includes
+
+// External includes
+
+// Project includes
+#include "testing/testing.h"
+
+#ifdef KRATOS_USE_FUTURE
+    #include "future/processes/future_process.h"
+#endif
+#ifdef KRATOS_USE_FUTURE
+    #include "legacy/processes/legacy_process.h"
+#endif
+
+namespace Kratos::Testing
+{
+
+/* Test if the class exists in the namespace if the namespace has been compiled */
+KRATOS_TEST_CASE_IN_SUITE(FutureProcess, KratosCoreFastSuite)
+{
+    #ifdef KRATOS_USE_FUTURE
+        Future::Process process;
+
+        KRATOS_EXPECT_EXCEPTION_IS_THROWN(
+            process.Execute(),
+            "I come from the future :)"
+        );
+    #else 
+        KRATOS_SUCCEED();
+    #endif
+}
+
+/* Test if the class exists in the registry if the namespace has been compiled */
+KRATOS_TEST_CASE_IN_SUITE(FutureProcessFromRegistry, KratosCoreFastSuite)
+{
+    #ifdef KRATOS_USE_FUTURE
+        KRATOS_EXPECT_TRUE(Registry::HasItem("Processes.KratosMultiphysics.Future.Process"))
+
+        if (Registry::HasItem("Processes.KratosMultiphysics.Future")) {
+            auto process = Registry::GetValue<Future::Process>("Processes.KratosMultiphysics.Future.Process.Prototype");
+
+            KRATOS_EXPECT_EXCEPTION_IS_THROWN(
+                process.Execute(),
+                "I come from the future :)"
+            );
+        }
+    #else 
+        KRATOS_EXPECT_FALSE(Registry::HasItem("Processes.KratosMultiphysics.Future.Process"))
+    #endif
+}
+
+/* Test that the class in the registry is not the same class as its legacy / production counterpart */
+KRATOS_TEST_CASE_IN_SUITE(FutureProcessFromRegistryIsNotProcess, KratosCoreFastSuite)
+{
+    #ifdef KRATOS_USE_FUTURE
+        KRATOS_EXPECT_TRUE(Registry::HasItem("Processes.KratosMultiphysics.Future.Process"))
+
+        if (Registry::HasItem("Processes.KratosMultiphysics.Future")) {
+            KRATOS_EXPECT_EXCEPTION_IS_THROWN(
+                auto process = Registry::GetValue<Process>("Processes.KratosMultiphysics.Future.Process.Prototype");,
+                "Error: bad any_cast"
+            );
+        }
+    #else 
+        KRATOS_EXPECT_FALSE(Registry::HasItem("Processes.KratosMultiphysics.Future.Process"))
+    #endif
+}
+
+/* Test if the class exists in the namespace if the namespace has been compiled */
+KRATOS_TEST_CASE_IN_SUITE(LegacyProcess, KratosCoreFastSuite)
+{
+    #ifdef KRATOS_USE_LEGACY
+        Legacy::Process process;
+
+        KRATOS_EXPECT_EXCEPTION_IS_THROWN(
+            process.Execute(),
+            "I... I don't feel well... My time has come, soon I will be unmade. Thank you for all the segmentation faults we lived together. :_)"
+        );
+    #else 
+        KRATOS_SUCCEED();
+    #endif
+}
+
+/* Test if the class exists in the registry if the namespace has been compiled */
+KRATOS_TEST_CASE_IN_SUITE(LegacyProcessFromRegistry, KratosCoreFastSuite)
+{
+    #ifdef KRATOS_USE_LEGACY
+        KRATOS_EXPECT_TRUE(Registry::HasItem("Processes.KratosMultiphysics.Legacy.Process"))
+
+        if (Registry::HasItem("Processes.KratosMultiphysics.Legacy.Process")) {
+            auto process = Registry::GetValue<Legacy::Process>("Processes.KratosMultiphysics.Legacy.Process.Prototype");
+
+            KRATOS_EXPECT_EXCEPTION_IS_THROWN(
+                process.Execute(),
+                "I... I don't feel well... My time has come, soon I will be unmade. Thank you for all the segmentation faults we lived together. :_)"
+            );
+        }
+    #else 
+        KRATOS_EXPECT_FALSE(Registry::HasItem("Processes.KratosMultiphysics.Legacy.Process"))
+    #endif
+}
+
+/* Test that the class in the registry is not the same class as its future / production counterpart */
+KRATOS_TEST_CASE_IN_SUITE(LegacyProcessFromRegistryIsNotProcess, KratosCoreFastSuite)
+{
+    #ifdef KRATOS_USE_FUTURE
+        KRATOS_EXPECT_TRUE(Registry::HasItem("Processes.KratosMultiphysics.Legacy.Process"))
+
+        if (Registry::HasItem("Processes.KratosMultiphysics.Legacy")) {
+            KRATOS_EXPECT_EXCEPTION_IS_THROWN(
+                auto process = Registry::GetValue<Process>("Processes.KratosMultiphysics.Legacy.Process.Prototype");,
+                "Error: bad any_cast"
+            );
+        }
+    #else 
+        KRATOS_EXPECT_FALSE(Registry::HasItem("Processes.KratosMultiphysics.Legacy.Process"))
+    #endif
+}
+
+} // Kratos::Testing namespace


### PR DESCRIPTION
**📝 Description**
Draft for the future / legacy namespaces. I went for being able to completly strip those from a normal compilation so all code is located in `kratos/future` and `kratos/legacy` folders following the core structure.

I've added a couple of classes and tests to check (because we need them to test something otherwise the PR would be mostly empty...):
- That it works
- That you cannot mix classes from one namespace to another via the registry
- That you can compile without, with one, or with all namespaces enabled

This does not have to be the final implementation so if you want changes / suggestions I am all ears. 

Ping @rubenzorrilla 

Edit: Btw, you need to use:

```
-DKRATOS_USE_FUTURE=ON/OFF
-DKRATOS_USE_LEGACY=ON/OF
```

To enable or disable them.

**🆕 Changelog**
- Added Future and Legacy namespaces
