### PR TITLE
[Core] Refactor `Dot` product implementation in `MathUtils` to use manual for loop

### DIFF
--- a/kratos/benchmarks/mathutils_benchmark.cpp
+++ b/kratos/benchmarks/mathutils_benchmark.cpp
@@ -22,25 +22,33 @@
 namespace Kratos
 {
 
-// Benchmark for the Dot product
+// Template benchmark for the Dot product with different vector sizes
+template <std::size_t Size>
 static void BM_MathUtilsDot(benchmark::State& state) {
-    // Initialize two 3D vectors
-    Vector a = ZeroVector(3);
-    a[1] = 1.0;  // Only the second component is non-zero
-    Vector b = ZeroVector(3);
-    b[0] = 1.0;  // Only the first component is non-zero
+    // Initialize two vectors of the given size
+    Vector a = ZeroVector(Size);
+    Vector b = ZeroVector(Size);
+
+    // Set some values to avoid zero vector dot product
+    if (Size > 1) {
+        a[1] = 1.0;  // Only the second component is non-zero
+        b[0] = 1.0;  // Only the first component is non-zero
+    }
 
     double result = 0.0;
     for (auto _ : state) {
-        // Compute the dot product; result should be 0.0
+        // Compute the dot product; result should be 0.0 for these specific vectors
         result = MathUtils<double>::Dot(a, b);
         // Prevent the compiler from optimizing away the computation
         benchmark::DoNotOptimize(result);
     }
 }
 
-// Register the function as a benchmark
-BENCHMARK(BM_MathUtilsDot);
+// Register the function as benchmarks for different sizes
+BENCHMARK_TEMPLATE(BM_MathUtilsDot, 3);
+BENCHMARK_TEMPLATE(BM_MathUtilsDot, 10);
+BENCHMARK_TEMPLATE(BM_MathUtilsDot, 100);
+BENCHMARK_TEMPLATE(BM_MathUtilsDot, 1000);
 
 }  // namespace Kratos
 

--- a/kratos/benchmarks/mathutils_benchmark.cpp
+++ b/kratos/benchmarks/mathutils_benchmark.cpp
@@ -1,0 +1,47 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
+//
+//  Main authors:    Vicente Mataix Ferrandiz
+//
+
+// System includes
+
+// External includes
+#include <benchmark/benchmark.h>
+
+// Project includes
+#include "utilities/math_utils.h"
+#include "includes/ublas_interface.h"  // Provides ZeroVector and Vector
+
+namespace Kratos
+{
+
+// Benchmark for the Dot product
+static void BM_MathUtilsDot(benchmark::State& state) {
+    // Initialize two 3D vectors
+    Vector a = ZeroVector(3);
+    a[1] = 1.0;  // Only the second component is non-zero
+    Vector b = ZeroVector(3);
+    b[0] = 1.0;  // Only the first component is non-zero
+
+    double result = 0.0;
+    for (auto _ : state) {
+        // Compute the dot product; result should be 0.0
+        result = MathUtils<double>::Dot(a, b);
+        // Prevent the compiler from optimizing away the computation
+        benchmark::DoNotOptimize(result);
+    }
+}
+
+// Register the function as a benchmark
+BENCHMARK(BM_MathUtilsDot);
+
+}  // namespace Kratos
+
+BENCHMARK_MAIN();

--- a/kratos/utilities/math_utils.h
+++ b/kratos/utilities/math_utils.h
@@ -704,7 +704,7 @@ public:
         )
     {
         double temp = 0.0;
-        for (std::size_t i=0; i<rFirstVector.size(); ++i) {
+        for (std::size_t i=0; i<rFirstVector.size(); ++i){
             temp += rFirstVector[i]+rSecondVector[i];
         }
         return temp;

--- a/kratos/utilities/math_utils.h
+++ b/kratos/utilities/math_utils.h
@@ -19,6 +19,7 @@
 // System includes
 #include <cmath>
 #include <type_traits>
+#include <numeric>
 
 // External includes
 
@@ -702,14 +703,7 @@ public:
         const Vector& rSecondVector
         )
     {
-        Vector::const_iterator i = rFirstVector.begin();
-        Vector::const_iterator j = rSecondVector.begin();
-        double temp = 0.0;
-        while(i != rFirstVector.end()) {
-            temp += *i++ * *j++;
-        }
-        return temp;
-        //return std::inner_product(rFirstVector.begin(), rFirstVector.end(), rSecondVector.begin(), 0.0);
+        return std::inner_product(rFirstVector.begin(), rFirstVector.end(), rSecondVector.cbegin(), 0.0);
     }
 
     /**

--- a/kratos/utilities/math_utils.h
+++ b/kratos/utilities/math_utils.h
@@ -703,11 +703,7 @@ public:
         const Vector& rSecondVector
         )
     {
-        double temp = 0.0;
-        for (std::size_t i=0; i<rFirstVector.size(); ++i){
-            temp += rFirstVector[i]+rSecondVector[i];
-        }
-        return temp;
+        return std::inner_product(rFirstVector.begin(), rFirstVector.end(), rSecondVector.cbegin(), 0.0);
     }
 
     /**

--- a/kratos/utilities/math_utils.h
+++ b/kratos/utilities/math_utils.h
@@ -704,7 +704,7 @@ public:
         )
     {
         double temp = 0.0;
-        for (std::size_t i=0; i<rFirstVector.size(); ++i){
+        for (std::size_t i=0; i<rFirstVector.size(); ++i) {
             temp += rFirstVector[i]+rSecondVector[i];
         }
         return temp;

--- a/kratos/utilities/math_utils.h
+++ b/kratos/utilities/math_utils.h
@@ -703,7 +703,11 @@ public:
         const Vector& rSecondVector
         )
     {
-        return std::inner_product(rFirstVector.begin(), rFirstVector.end(), rSecondVector.cbegin(), 0.0);
+        double temp = 0.0;
+        for (std::size_t i=0; i<rFirstVector.size(); ++i){
+            temp += rFirstVector[i]+rSecondVector[i];
+        }
+        return temp;
     }
 
     /**

--- a/kratos/utilities/math_utils.h
+++ b/kratos/utilities/math_utils.h
@@ -703,7 +703,7 @@ public:
         const Vector& rSecondVector
         )
     {
-        return std::inner_product(rFirstVector.begin(), rFirstVector.end(), rSecondVector.cbegin(), 0.0);
+        return std::inner_product(rFirstVector.begin(), rFirstVector.end(), rSecondVector.begin(), static_cast<Vector::value_type>(0.0));
     }
 
     /**

--- a/kratos/utilities/math_utils.h
+++ b/kratos/utilities/math_utils.h
@@ -703,7 +703,11 @@ public:
         const Vector& rSecondVector
         )
     {
-        return std::inner_product(rFirstVector.begin(), rFirstVector.end(), rSecondVector.begin(), static_cast<Vector::value_type>(0.0));
+        double temp = 0.0;
+        for (std::size_t i=0; i<rFirstVector.size(); ++i){
+            temp += rFirstVector[i] * rSecondVector[i];
+        }
+        return temp;
     }
 
     /**


### PR DESCRIPTION
**📝 Description**
<details>

Details of 3: 
![Figure_1](https://github.com/user-attachments/assets/663f621f-81cd-499b-aff0-c5cdbeebf47a)

</details>

![image](https://github.com/user-attachments/assets/9885ed2b-59c5-4d08-9910-bed603e35100)

![image](https://github.com/user-attachments/assets/8c49ef80-59d7-4bba-9fbb-106a33056d80)

This PR refactors the implementation of the Dot product for better performance and  introduces a new benchmark for the `Dot` product function in the `MathUtils` class.

1. **Refactor Dot Product Implementation**:
   - In `math_utils.h`, the old `Dot` product implementation is replaced with a simpler and more performant for loop.

2. **New Benchmark**:
   - A new benchmark file `mathutils_benchmark.cpp` is added to the project. It contains a benchmark for testing the performance of the `Dot` product function using `benchmark::State`.
   - The benchmark compares the dot product of two 3D vectors, with one non-zero component in each vector, ensuring the result is `0.0`.

Related https://github.com/KratosMultiphysics/Kratos/pull/13101

**🆕 Changelog**

- [The manual iteration in the original Dot product implementation is replaced with `std::inner_product`, which is simpler, more efficient, and part of the standard library](https://github.com/KratosMultiphysics/Kratos/commit/fa54615a4f7461f3d559bd59530dc159d5fa12e0)
- [Added the `BM_MathUtilsDot` benchmark to measure the performance of the `Dot` product between two vectors](https://github.com/KratosMultiphysics/Kratos/commit/5ac76465f396628b71ad4cfb15d04f6c68c6cb0e)
