### PR TITLE
[Core][MPI] Missing `SHALLOW_GLOBAL_POINTERS_SERIALIZATION` flag in `GatherModelPartUtility`

### DIFF
--- a/kratos/mpi/utilities/gather_modelpart_utility.cpp
+++ b/kratos/mpi/utilities/gather_modelpart_utility.cpp
@@ -395,6 +395,7 @@ void GatherModelPartUtility::GatherEntityFromOtherPartitions(
                     std::string recv_buffer;
                     r_data_communicator.Recv(recv_buffer, origin_rank, static_cast<int>(index));
                     StreamSerializer serializer;
+                    serializer.Set(Serializer::SHALLOW_GLOBAL_POINTERS_SERIALIZATION);
                     const auto p_serializer_buffer = dynamic_cast<std::stringstream*>(serializer.pGetBuffer());
                     p_serializer_buffer->write(recv_buffer.data(), recv_buffer.size());
                     if constexpr (std::is_same<TObjectType, Node>::value) {
@@ -422,6 +423,7 @@ void GatherModelPartUtility::GatherEntityFromOtherPartitions(
             if (it_find != send_entities.end()) {
                 for (auto index : it_find->second) {
                     StreamSerializer serializer;
+                    serializer.Set(Serializer::SHALLOW_GLOBAL_POINTERS_SERIALIZATION);
                     if constexpr (std::is_same<TObjectType, Node>::value) {
                         KRATOS_DEBUG_ERROR_IF_NOT(rModelPart.HasNode(index)) << "Node with index " << index << " not found in model part" << std::endl;
                         auto p_send_node = rModelPart.pGetNode(index);

--- a/kratos/mpi/utilities/gather_modelpart_utility.cpp
+++ b/kratos/mpi/utilities/gather_modelpart_utility.cpp
@@ -386,6 +386,7 @@ void GatherModelPartUtility::GatherEntityFromOtherPartitions(
     }
 
     // Use serializer
+    auto& r_root_model_part = rModelPart.GetRootModelPart();
     for (int i_rank = 0; i_rank < world_size; ++i_rank) {
         // Receiving
         if (i_rank == rank) {
@@ -401,17 +402,17 @@ void GatherModelPartUtility::GatherEntityFromOtherPartitions(
                     if constexpr (std::is_same<TObjectType, Node>::value) {
                         Node::Pointer p_new_node;
                         serializer.load("bring_node_" + std::to_string(index), p_new_node);
-                        KRATOS_DEBUG_ERROR_IF(rModelPart.HasNode(p_new_node->Id())) << "The node " << p_new_node->Id() << " from rank: " << origin_rank << " already exists in rank: " << rank << std::endl;
+                        KRATOS_DEBUG_ERROR_IF(r_root_model_part.HasNode(p_new_node->Id())) << "The node " << p_new_node->Id() << " from rank: " << origin_rank << " already exists in rank: " << rank << std::endl;
                         entities_to_bring.push_back(p_new_node);
                     } else if constexpr (std::is_same<TObjectType, Element>::value) {
                         Element::Pointer p_new_element;
                         serializer.load("bring_element_" + std::to_string(index), p_new_element);
-                        KRATOS_DEBUG_ERROR_IF(rModelPart.HasElement(p_new_element->Id())) << "The element " << p_new_element->Id() << " from rank: " << origin_rank << " already exists in rank: " << rank << std::endl;
+                        KRATOS_DEBUG_ERROR_IF(r_root_model_part.HasElement(p_new_element->Id())) << "The element " << p_new_element->Id() << " from rank: " << origin_rank << " already exists in rank: " << rank << std::endl;
                         entities_to_bring.push_back(p_new_element);
                     } else if constexpr (std::is_same<TObjectType, Condition>::value) {
                         Condition::Pointer p_new_condition;
                         serializer.load("bring_condition_" + std::to_string(index), p_new_condition);
-                        KRATOS_DEBUG_ERROR_IF(rModelPart.HasCondition(p_new_condition->Id())) << "The condition " << p_new_condition->Id() << " from rank: " << origin_rank << " already exists in rank: " << rank << std::endl;
+                        KRATOS_DEBUG_ERROR_IF(r_root_model_part.HasCondition(p_new_condition->Id())) << "The condition " << p_new_condition->Id() << " from rank: " << origin_rank << " already exists in rank: " << rank << std::endl;
                         entities_to_bring.push_back(p_new_condition);
                     } else {
                         KRATOS_ERROR << "Entity type not supported" << std::endl;


### PR DESCRIPTION
**📝 Description**

Fix serialization issue by setting `SHALLOW_GLOBAL_POINTERS_SERIALIZATION` in `GatherEntityFromOtherPartitions`. The fix is partial, still having issues but this reduces consderably the number of problems. Maybe more changes coming soon.

The PR modifies the `GatherEntityFromOtherPartitions` function in the `gather_modelpart_utility.cpp` file by adding the `serializer.Set(Serializer::SHALLOW_GLOBAL_POINTERS_SERIALIZATION)` call before serializing data in two places: once for receiving data (`recv_buffer`) and once for sending entities (`send_entities`). This change ensures that global pointers are serialized shallowly during the communication process between partitions, which is important to avoid potential data communications in MPI.

**🆕 Changelog**

- [Missing `SHALLOW_GLOBAL_POINTERS_SERIALIZATION` flag in `GatherModelPartUtility`](https://github.com/KratosMultiphysics/Kratos/commit/a6a087fed3df77d33874288dbe3b2f9b5422cf4b)
