### PR TITLE
[Core] Some minor headers clean up

### DIFF
--- a/kratos/mpi/utilities/amgcl_distributed_csr_spmm_utilities.h
+++ b/kratos/mpi/utilities/amgcl_distributed_csr_spmm_utilities.h
@@ -5,15 +5,13 @@
 //   _|\_\_|  \__,_|\__|\___/ ____/
 //                   Multi-Physics
 //
-//  License:		 BSD License
-//					 Kratos default license: kratos/license.txt
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
 //
 //  Main authors:    Riccardo Rossi
 //
-//
 
-#if !defined(KRATOS_CSR_SPMM_UTILITIES_H_INCLUDED)
-#define  KRATOS_CSR_SPMM_UTILITIES_H_INCLUDED
+#pragma once
 
 // System includes
 
@@ -68,5 +66,3 @@ public:
 };
 
 }
-
-#endif // KRATOS_CSR_SPMM_UTILITIES_H_INCLUDED

--- a/kratos/mpi/utilities/data_communicator_factory.h
+++ b/kratos/mpi/utilities/data_communicator_factory.h
@@ -10,11 +10,14 @@
 //  Main author:     Jordi Cotela
 //
 
-#ifndef KRATOS_DATA_COMMUNICATOR_FACTORY_INCLUDED
-#define KRATOS_DATA_COMMUNICATOR_FACTORY_INCLUDED
+#pragma once
 
+// System includes
 #include <string>
 
+// External includes
+
+// Project includes
 #include "includes/data_communicator.h"
 
 namespace Kratos
@@ -146,5 +149,3 @@ const DataCommunicator& CreateIntersectionAndRegister(
 }
 
 }
-
-#endif // KRATOS_DATA_COMMUNICATOR_FACTORY_INCLUDED

--- a/kratos/mpi/utilities/distributed_model_part_initializer.h
+++ b/kratos/mpi/utilities/distributed_model_part_initializer.h
@@ -4,27 +4,20 @@
 //   _|\_\_|  \__,_|\__|\___/ ____/
 //                   Multi-Physics
 //
-//  License:		 BSD License
-//					 Kratos default license: kratos/license.txt
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
 //
 //  Main authors:    Philipp Bucher (https://github.com/philbucher)
 //
 
-
-#if !defined(KRATOS_DISTRIBUTED_MODEL_PART_INITIALIZER_H_INCLUDED )
-#define  KRATOS_DISTRIBUTED_MODEL_PART_INITIALIZER_H_INCLUDED
-
+#pragma once
 
 // System includes
 
-
 // External includes
 
-
 // Project includes
-#include "includes/define.h"
 #include "includes/model_part.h"
-
 
 namespace Kratos
 {
@@ -95,5 +88,3 @@ private:
 ///@} addtogroup block
 
 }  // namespace Kratos.
-
-#endif // KRATOS_DISTRIBUTED_MODEL_PART_INITIALIZER_H_INCLUDED defined

--- a/kratos/mpi/utilities/model_part_communicator_utilities.h
+++ b/kratos/mpi/utilities/model_part_communicator_utilities.h
@@ -10,15 +10,13 @@
 //  Main author:     Jordi Cotela
 //
 
-#ifndef KRATOS_MODEL_PART_COMMUNICATOR_UTILITIES_H_INCLUDED
-#define	KRATOS_MODEL_PART_COMMUNICATOR_UTILITIES_H_INCLUDED
+#pragma once
 
 // System includes
 
 // External includes
 
 // Project includes
-#include "includes/define.h"
 #include "includes/model_part.h"
 #include "mpi/includes/mpi_communicator.h"
 
@@ -97,6 +95,4 @@ public:
 ///@}
 
 }  // namespace Kratos.
-
-#endif	/* KRATOS_MODEL_PART_COMMUNICATOR_UTILITIES_H_INCLUDED */
 

--- a/kratos/mpi/utilities/mpi_normal_calculation_utilities.h
+++ b/kratos/mpi/utilities/mpi_normal_calculation_utilities.h
@@ -10,13 +10,11 @@
 //  Main author:     Jordi Cotela
 //
 
-#ifndef KRATOS_MPI_NORMAL_CALCULATION_UTILITIES_H
-#define KRATOS_MPI_NORMAL_CALCULATION_UTILITIES_H
+#pragma once
 
 // System includes
 
 // External includes
-
 
 // Project includes
 #include "includes/model_part.h"
@@ -269,5 +267,3 @@ inline std::ostream& operator << (std::ostream& rOStream,
 ///@} addtogroup block
 
 }  // namespace Kratos.
-
-#endif // KRATOS_MPI_NORMAL_CALCULATION_UTILITIES_H


### PR DESCRIPTION
# **📝 Description**

## Refactor header guards and improve code structure

- Replaced traditional header guards (`#ifndef`, `#define`, `#endif`) with `#pragma once` in multiple header files for better portability and ease of maintenance.
- Cleaned up redundant preprocessor directives and ensured consistent header formatting across files.
- Removed unnecessary comments and empty lines.

## Files affected:
```
- amgcl_distributed_csr_spmm_utilities.h
- data_communicator_factory.h
- distributed_model_part_initializer.h
- model_part_communicator_utilities.h
- mpi_normal_calculation_utilities.h
```

# **🆕 Changelog**

- [Some minor headers clean up](https://github.com/KratosMultiphysics/Kratos/commit/e9ac7803f75834e604701b0732d2c1963dc6ab2a)