### PR TITLE
[StructuralMechanicsApplication] Only check constitutive laws when an element is active

### DIFF
--- a/applications/StructuralMechanicsApplication/custom_elements/beam_elements/timoshenko_beam_element_2D2N.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/beam_elements/timoshenko_beam_element_2D2N.cpp
@@ -1012,7 +1012,11 @@ int LinearTimoshenkoBeamElement2D2N::Check(const ProcessInfo& rCurrentProcessInf
 {
     KRATOS_TRY;
 
-    return mConstitutiveLawVector[0]->Check(GetProperties(), GetGeometry(), rCurrentProcessInfo);
+    if (this->IsActive())
+    {
+        return mConstitutiveLawVector[0]->Check(GetProperties(), GetGeometry(), rCurrentProcessInfo);
+    }
+    return 0;
 
     KRATOS_CATCH( "" );
 }

--- a/applications/StructuralMechanicsApplication/custom_elements/beam_elements/timoshenko_curved_beam_element_2D3N.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/beam_elements/timoshenko_curved_beam_element_2D3N.cpp
@@ -805,8 +805,11 @@ void LinearTimoshenkoCurvedBeamElement2D3N::CalculateOnIntegrationPoints(
 int LinearTimoshenkoCurvedBeamElement2D3N::Check(const ProcessInfo& rCurrentProcessInfo) const
 {
     KRATOS_TRY;
-
-    return mConstitutiveLawVector[0]->Check(GetProperties(), GetGeometry(), rCurrentProcessInfo);
+    if (this->IsActive())
+    {
+        return mConstitutiveLawVector[0]->Check(GetProperties(), GetGeometry(), rCurrentProcessInfo);
+    }
+    return 0;
 
     KRATOS_CATCH( "" );
 }

--- a/applications/StructuralMechanicsApplication/custom_elements/truss_elements/linear_truss_element.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/truss_elements/linear_truss_element.cpp
@@ -839,8 +839,12 @@ int LinearTrussElement<TDimension, TNNodes>::Check(const ProcessInfo& rCurrentPr
 {
     KRATOS_TRY;
 
-    return mConstitutiveLawVector[0]->Check(GetProperties(), GetGeometry(), rCurrentProcessInfo);
     KRATOS_ERROR_IF_NOT(GetProperties().Has(CROSS_AREA)) << "CROSS_AREA not defined in the properties" << std::endl;
+    if (this->IsActive())
+    {
+        return mConstitutiveLawVector[0]->Check(GetProperties(), GetGeometry(), rCurrentProcessInfo);
+    }
+    return 0;
 
     KRATOS_CATCH("");
 }

--- a/applications/StructuralMechanicsApplication/tests/cpp_tests/test_timoshenko_beams.cpp
+++ b/applications/StructuralMechanicsApplication/tests/cpp_tests/test_timoshenko_beams.cpp
@@ -113,4 +113,39 @@ void Create2DBeamModel_and_CheckPK2Stress(const std::string & TimoshenkoBeamElem
         const std::vector expected_bending_moment {70710.7, 70710.7};
         Create2DBeamModel_and_CheckPK2Stress<3>("LinearTimoshenkoCurvedBeamElement2D3N", expected_shear_stress, expected_bending_moment);
     }
+
+    Element::Pointer CreateInactiveElementOfType(const std::string& rElementType, Model& rModel) {
+        auto& r_model_part = rModel.CreateModelPart("ModelPart",1);
+
+        // Set the element properties
+        auto p_elem_prop = r_model_part.CreateNewProperties(0);
+
+        // Create the test element
+        r_model_part.CreateNewNode(1, 0.0, 0.0, 0.0);
+        r_model_part.CreateNewNode(2, 1.0, 0.0, 0.0);
+        r_model_part.CreateNewNode(3, 2.0, 0.0, 0.0);
+        const std::vector<ModelPart::IndexType> element_nodes{1,2,3};
+
+        auto p_element = r_model_part.CreateNewElement(rElementType, 1, element_nodes, p_elem_prop);
+        p_element->Set(ACTIVE, false);
+
+        return p_element;
+    }
+
+
+    KRATOS_TEST_CASE_IN_SUITE(LinearTimoshenkoBeamElement2D3N_CheckWithoutInitializeDoesNotCrashForInactiveElement,
+        KratosStructuralMechanicsFastSuite)
+    {
+        Model model;
+        const auto p_element = CreateInactiveElementOfType("LinearTimoshenkoBeamElement2D3N", model);
+        KRATOS_EXPECT_EQ(0, p_element->Check(ProcessInfo{}));
+    }
+
+    KRATOS_TEST_CASE_IN_SUITE(LinearTimoshenkoCurvedBeamElement2D3N_CheckWithoutInitializeDoesNotCrashForInactiveElement,
+        KratosStructuralMechanicsFastSuite)
+    {
+        Model model;
+        const auto p_element = CreateInactiveElementOfType("LinearTimoshenkoCurvedBeamElement2D3N", model);
+        KRATOS_EXPECT_EQ(0, p_element->Check(ProcessInfo{}));
+    }
 }

--- a/applications/StructuralMechanicsApplication/tests/cpp_tests/test_truss.cpp
+++ b/applications/StructuralMechanicsApplication/tests/cpp_tests/test_truss.cpp
@@ -385,6 +385,26 @@ void CreateTrussModel2N_and_CheckPK2Stress(std::string TrussElementName)
         KRATOS_EXPECT_TRUE(p_constitutive_law->IsInitialized())
     }
 
+    KRATOS_TEST_CASE_IN_SUITE(TrussElementLinearCheckWithoutInitializeDoesNotCrash, KratosStructuralMechanicsFastSuite)
+    {
+        Model current_model;
+        auto& r_model_part = CreateTestModelPart(current_model);
+        constexpr auto length = 2.0;
+        auto [p_bottom_node, p_top_node] = CreateEndNodes(r_model_part, length);
+        AddDisplacementDofsElement(r_model_part);
+        auto p_elem_prop = r_model_part.CreateNewProperties(0);
+        p_elem_prop->SetValue(CONSTITUTIVE_LAW, std::make_shared<StubBilinearLaw>());
+        p_elem_prop->SetValue(CROSS_AREA, 1.0);
+
+        const std::vector<ModelPart::IndexType> element_nodes {p_bottom_node->Id(), p_top_node->Id()};
+        auto p_element = r_model_part.CreateNewElement("LinearTrussElement2D2N", 1, element_nodes, p_elem_prop);
+
+        p_element->Set(ACTIVE, false);
+
+        std::vector<ConstitutiveLaw::Pointer> constitutive_laws;
+        KRATOS_EXPECT_EQ(0, p_element->Check(r_model_part.GetProcessInfo()));
+    }
+
     KRATOS_TEST_CASE_IN_SUITE(TrussElementLinear3D2N_CalculatesPK2Stress, KratosStructuralMechanicsFastSuite)
     {
         CreateTrussModel2N_and_CheckPK2Stress("TrussLinearElement3D2N");


### PR DESCRIPTION
**📝 Description**
During testing with the structural elements, we found that inactive elements lead to issues in the workflow. The reason is that all on all elements, the `Check` function is called (see the [check](https://github.com/KratosMultiphysics/Kratos/blob/master/kratos/sources/model_part.cpp#L2299-L2324) in ModelPart), while only the active elements are initialized (see the [EntitiesUtilities](https://github.com/KratosMultiphysics/Kratos/blob/master/kratos/utilities/entities_utilities.h#L254-L276)). Since the constitutive law vector is only created when an element is Initialized (meaning, when it's active), the check on the constitutive law should only been done when the element is active.

This PR adds that check, including unit tests to describe + test this behavior.
