### PR TITLE
[IgaApplication] Create Brep Sbm Utilities

### DIFF
--- a/applications/IgaApplication/custom_utilities/create_breps_sbm_utilities.h
+++ b/applications/IgaApplication/custom_utilities/create_breps_sbm_utilities.h
@@ -1,0 +1,492 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
+//
+//  Main authors:    Nicolo' Antonelli
+//                   Andrea Gorgi
+//
+
+# pragma once
+
+// System includes
+
+// External includes
+
+// Project includes
+#include "includes/io.h"
+#include "includes/kratos_parameters.h"
+#include "includes/model_part.h"
+
+// Geometries
+#include "geometries/nurbs_curve_geometry.h"
+#include "geometries/brep_surface.h"
+#include "geometries/brep_curve.h"
+#include "geometries/brep_curve_on_surface.h"
+
+
+namespace Kratos
+{
+
+///@name Kratos Classes
+///@{
+template<class TNodeType = Node, class TEmbeddedNodeType = Point>
+class CreateBrepsSbmUtilities : public IO
+{
+    public:
+
+    ///@}
+    ///@name Type Definitions
+    ///@{
+
+    /// Pointer definition of CreateBrepsSbmUtilities
+    KRATOS_CLASS_POINTER_DEFINITION(CreateBrepsSbmUtilities);
+
+    using SizeType = std::size_t;
+    using IndexType = std::size_t;
+
+    using GeometryType = Geometry<TNodeType>;
+    using GeometryPointerType = typename GeometryType::Pointer;
+    using GeometrySurrogateArrayType = DenseVector<GeometryPointerType>;
+
+    using ContainerNodeType = PointerVector<TNodeType>;
+    using ContainerEmbeddedNodeType = PointerVector<TEmbeddedNodeType>;
+    
+    using NurbsSurfaceGeometryType = NurbsSurfaceGeometry<3, PointerVector<NodeType>>;
+    using NurbsSurfaceGeometryPointerType = typename NurbsSurfaceGeometryType::Pointer;
+
+    using BrepSurfaceType = BrepSurface<ContainerNodeType, true, ContainerEmbeddedNodeType>;
+    using BrepCurveOnSurfaceType = BrepCurveOnSurface<ContainerNodeType, true, ContainerEmbeddedNodeType>;
+
+    using BrepCurveOnSurfaceLoopType = DenseVector<typename BrepCurveOnSurfaceType::Pointer>;
+    using BrepCurveOnSurfaceLoopArrayType = DenseVector<DenseVector<typename BrepCurveOnSurfaceType::Pointer>>;
+
+    ///@}
+    ///@name Life Cycle
+    ///@{
+
+    /// Constructor with path to input file.
+    CreateBrepsSbmUtilities(
+        SizeType EchoLevel = 0)
+        : mEchoLevel(EchoLevel)
+    {
+    }
+
+    /// Destructor.
+    ~CreateBrepsSbmUtilities() = default;
+
+    ///@}
+    ///@name Python exposed Functions
+    ///@{
+
+    
+    /**
+     * @brief Create a Surrogate Boundary object
+     * 
+     * @param pSurface 
+     * @param rModelPart 
+     * @param rSurrogateModelPartInner 
+     * @param rSurrogateModelPartOuter 
+     * @param A_uvw 
+     * @param B_uvw 
+     * Adds the surface geometry to the herin provided model_part and create the boundary breps for the SBM case.
+     */
+    void CreateSurrogateBoundary(NurbsSurfaceGeometryPointerType& pSurface, 
+                                 ModelPart& rModelPart, 
+                                 ModelPart& rSurrogateModelPartInner, 
+                                 ModelPart& rSurrogateModelPartOuter, 
+                                 const Point& A_uvw, 
+                                 const Point& B_uvw)
+    {
+        CreateBrepSurface(pSurface, rModelPart, rSurrogateModelPartInner, rSurrogateModelPartOuter, mEchoLevel);
+        CreateBrepCurveOnSurfaces(pSurface, rModelPart, rSurrogateModelPartInner, rSurrogateModelPartOuter, A_uvw, B_uvw, mEchoLevel);
+    }
+    
+    /**
+     * @brief Create a Surrogate Boundary object
+     * 
+     * @param pSurface 
+     * @param rModelPart 
+     * @param A_uvw 
+     * @param B_uvw 
+     * Adds the surface geometry to the herin provided model_part and create the boundary breps when SBM is not needed.
+     */
+    void CreateSurrogateBoundary(NurbsSurfaceGeometryPointerType& pSurface, 
+                                 ModelPart& rModelPart, 
+                                 const Point& A_uvw, 
+                                 const Point& B_uvw)
+    {
+        CreateBrepSurface(pSurface, rModelPart, mEchoLevel);
+        IndexType id_brep_curve_on_surface = 2; // because id 1 is the brep surface
+        CreateBrepCurvesOnRectangle(rModelPart, pSurface, A_uvw, B_uvw, id_brep_curve_on_surface);
+    }
+
+
+private:
+
+    /**
+     * @brief Create a Brep Surface object
+     * 
+     * @param pSurface 
+     * @param rModelPart 
+     * @param EchoLevel 
+     */
+    static void CreateBrepSurface(
+        NurbsSurfaceGeometryPointerType pSurface,
+        ModelPart& rModelPart,
+        SizeType EchoLevel = 0)
+    {
+        KRATOS_INFO_IF("ReadBrepSurface", (EchoLevel > 3))
+            << "Creating BrepSurface \""<< std::endl;
+
+        BrepCurveOnSurfaceLoopArrayType outer_loops, inner_loops;
+
+        auto p_brep_surface =
+            Kratos::make_shared<BrepSurfaceType>(
+                pSurface, 
+                outer_loops,
+                inner_loops,
+                false);
+
+        // Sets the brep as geometry parent of the nurbs surface.
+        pSurface->SetGeometryParent(p_brep_surface.get());
+        p_brep_surface->SetId(1);
+        rModelPart.AddGeometry(p_brep_surface);
+    }
+
+    /**
+     * @brief Create a Brep Surface object for the SBM case
+     * 
+     * @param pSurface 
+     * @param rModelPart 
+     * @param rSurrogateModelPartInner 
+     * @param rSurrogateModelPartOuter 
+     * @param EchoLevel 
+     */
+    static void CreateBrepSurface(
+        NurbsSurfaceGeometryPointerType pSurface,
+        ModelPart& rModelPart,
+        ModelPart& rSurrogateModelPartInner, 
+        ModelPart& rSurrogateModelPartOuter,
+        SizeType EchoLevel = 0)
+    {
+        KRATOS_INFO_IF("ReadBrepSurface", (EchoLevel > 3))
+            << "Creating BrepSurface \""<< std::endl;
+
+        BrepCurveOnSurfaceLoopArrayType outer_loops, inner_loops;
+        
+        GeometrySurrogateArrayType surrogate_outer_loop_geometries(rSurrogateModelPartOuter.NumberOfConditions());
+        GeometrySurrogateArrayType surrogate_inner_loop_geometries(rSurrogateModelPartInner.NumberOfConditions());
+        int count = 0;
+        for (auto i_cond : rSurrogateModelPartOuter.Conditions())
+        {
+            surrogate_outer_loop_geometries[count] = i_cond.pGetGeometry();
+            count++;
+        }
+
+        count = 0;
+        for (auto i_cond : rSurrogateModelPartInner.Conditions())
+        {
+            surrogate_inner_loop_geometries[count] = i_cond.pGetGeometry();
+            count++;
+        }
+
+        auto p_brep_surface =
+            Kratos::make_shared<BrepSurfaceType>(
+                pSurface, 
+                outer_loops,
+                inner_loops);
+
+        p_brep_surface->SetSurrogateInnerLoopGeometries(surrogate_inner_loop_geometries);
+        p_brep_surface->SetSurrogateOuterLoopGeometries(surrogate_outer_loop_geometries);
+
+        // Sets the brep as geometry parent of the nurbs surface.
+        pSurface->SetGeometryParent(p_brep_surface.get());
+        p_brep_surface->SetId(1);
+        rModelPart.AddGeometry(p_brep_surface);
+    }
+
+    /**
+     * @brief Create a Brep Curve On Surfaces object
+     * 
+     * @param pSurface 
+     * @param rModelPart 
+     * @param rSurrogateModelPartInner 
+     * @param rSurrogateModelPartOuter 
+     * @param A_uvw 
+     * @param B_uvw 
+     * @param EchoLevel 
+     */
+    static void CreateBrepCurveOnSurfaces(
+        const NurbsSurfaceGeometryPointerType pSurface,
+        ModelPart& rModelPart,
+        const ModelPart& rSurrogateModelPartInner, 
+        const ModelPart& rSurrogateModelPartOuter,
+        const Point& A_uvw, 
+        const Point& B_uvw,
+        const SizeType EchoLevel = 0) {
+    
+        // OUTER 
+        IndexType id_brep_curve_on_surface = 2; // because id 1 is the brep surface
+
+        if (rSurrogateModelPartOuter.Nodes().size() > 0) {
+            SizeType size_surrogate_loop_outer = rSurrogateModelPartOuter.Nodes().size();
+            std::vector<double> surrogate_coords_x_outer(size_surrogate_loop_outer);
+            std::vector<double> surrogate_coords_y_outer(size_surrogate_loop_outer);
+            int count_surrogate_loop_outer = 0;
+            for (auto i_node = rSurrogateModelPartOuter.NodesEnd()-1; i_node != rSurrogateModelPartOuter.NodesBegin()-1; i_node--) {
+                surrogate_coords_x_outer[count_surrogate_loop_outer] = i_node->X();
+                surrogate_coords_y_outer[count_surrogate_loop_outer] = i_node->Y();
+                count_surrogate_loop_outer++;
+            }
+            std::vector<NurbsCurveGeometry<2, PointerVector<Point>>::Pointer> trimming_curves_outer;
+            for (std::size_t i = 0; i < surrogate_coords_x_outer.size(); ++i) {
+                Vector active_range_knot_vector = ZeroVector(2);
+                
+                Point::Pointer firstBrepPoint = Kratos::make_shared<Point>(surrogate_coords_x_outer[i], surrogate_coords_y_outer[i], 0.0);
+                Point::Pointer second_brep_point = Kratos::make_shared<Point>(
+                    surrogate_coords_x_outer[(i + 1) % surrogate_coords_x_outer.size()],  // Wrap around for the last point
+                    surrogate_coords_y_outer[(i + 1) % surrogate_coords_y_outer.size()],  // Wrap around for the last point
+                    0.0);
+                // Compute the knot vector needed
+                if (surrogate_coords_x_outer[(i + 1) % surrogate_coords_x_outer.size()]==surrogate_coords_x_outer[i]) {
+                    active_range_knot_vector[0] = surrogate_coords_y_outer[i];
+                    active_range_knot_vector[1] = surrogate_coords_y_outer[(i + 1) % surrogate_coords_y_outer.size()];
+                }
+                else {
+                    active_range_knot_vector[0] = surrogate_coords_x_outer[i];
+                    active_range_knot_vector[1] = surrogate_coords_x_outer[(i + 1) % surrogate_coords_x_outer.size()];
+                }
+                //// Order the active_range_knot_vector
+                if (active_range_knot_vector[0] > active_range_knot_vector[1]) {
+                    double temp = active_range_knot_vector[1];
+                    active_range_knot_vector[1] = active_range_knot_vector[0] ;
+                    active_range_knot_vector[0] = temp ;
+                }
+                NurbsCurveGeometry<2, PointerVector<Point>>::Pointer p_trimming_curve = CreateSingleBrep(firstBrepPoint, second_brep_point, active_range_knot_vector);
+                trimming_curves_outer.push_back(p_trimming_curve);
+            }
+
+            BrepCurveOnSurfaceLoopType trimming_brep_curve_vector_outer(surrogate_coords_x_outer.size());
+
+            for (std::size_t i = 0; i < trimming_curves_outer.size(); ++i) {
+                Vector active_range_vector = ZeroVector(2);
+                if (surrogate_coords_x_outer[(i + 1) % surrogate_coords_x_outer.size()] == surrogate_coords_x_outer[i]) {
+                    active_range_vector[0] = surrogate_coords_y_outer[i];
+                    active_range_vector[1] = surrogate_coords_y_outer[(i + 1) % surrogate_coords_x_outer.size()];
+                }
+                else {
+                    active_range_vector[0] = surrogate_coords_x_outer[i];
+                    active_range_vector[1] = surrogate_coords_x_outer[(i + 1) % surrogate_coords_x_outer.size()];
+                }
+                bool curve_direction = true;
+
+                // Re-order
+                if (active_range_vector[0] > active_range_vector[1]) {
+                    double temp = active_range_vector[1];
+                    active_range_vector[1] = active_range_vector[0] ;
+                    active_range_vector[0] = temp ;
+                }
+
+                NurbsInterval brep_active_range(active_range_vector[0], active_range_vector[1]);
+
+                auto p_brep_curve_on_surface = Kratos::make_shared<BrepCurveOnSurfaceType>(
+                    pSurface, trimming_curves_outer[i], brep_active_range, curve_direction);
+                p_brep_curve_on_surface->SetId(id_brep_curve_on_surface);
+
+                rModelPart.AddGeometry(p_brep_curve_on_surface);
+                id_brep_curve_on_surface++;
+
+            }
+
+        } else {
+            CreateBrepCurvesOnRectangle(rModelPart, pSurface, A_uvw, B_uvw, id_brep_curve_on_surface);
+        }
+
+        // INNER
+        for (IndexType iel = 1; iel < rSurrogateModelPartInner.Elements().size()+1; iel++) {
+            int first_surrogate_node_id = rSurrogateModelPartInner.pGetElement(iel)->GetGeometry()[0].Id(); // Element 1 because is the only surrogate loop
+            int last_surrogate_node_id = rSurrogateModelPartInner.pGetElement(iel)->GetGeometry()[1].Id();  // Element 1 because is the only surrogate loop
+            int size_surrogate_loop_inner = last_surrogate_node_id - first_surrogate_node_id + 1;
+
+            int count_surrogate_loop_inner = 0;
+            std::vector<double> surrogate_coords_x_inner(size_surrogate_loop_inner);
+            std::vector<double> surrogate_coords_y_inner(size_surrogate_loop_inner);
+            for (int id_node = first_surrogate_node_id; id_node < last_surrogate_node_id+1; id_node++) {
+                surrogate_coords_x_inner[count_surrogate_loop_inner] = rSurrogateModelPartInner.GetNode(id_node).X();
+                surrogate_coords_y_inner[count_surrogate_loop_inner] = rSurrogateModelPartInner.GetNode(id_node).Y();
+                count_surrogate_loop_inner++;
+            }
+            std::vector<NurbsCurveGeometry<2, PointerVector<Point>>::Pointer> trimming_curves_inner;
+
+            for (std::size_t i = 0; i < surrogate_coords_x_inner.size(); ++i) {
+                Vector active_range_knot_vector = ZeroVector(2);
+                
+                Point::Pointer first_brep_point = Kratos::make_shared<Point>(surrogate_coords_x_inner[i], surrogate_coords_y_inner[i], 0.0);
+                Point::Pointer second_brep_point = Kratos::make_shared<Point>(
+                    surrogate_coords_x_inner[(i + 1) % surrogate_coords_x_inner.size()],  // Wrap around for the last point
+                    surrogate_coords_y_inner[(i + 1) % surrogate_coords_y_inner.size()],  // Wrap around for the last point
+                    0.0);
+                // Compute the knot vector needed
+                if (surrogate_coords_x_inner[(i + 1) % surrogate_coords_x_inner.size()]==surrogate_coords_x_inner[i]) {
+                    active_range_knot_vector[0] = surrogate_coords_y_inner[i];
+                    active_range_knot_vector[1] = surrogate_coords_y_inner[(i + 1) % surrogate_coords_y_inner.size()];
+                }
+                else {
+                    active_range_knot_vector[0] = surrogate_coords_x_inner[i];
+                    active_range_knot_vector[1] = surrogate_coords_x_inner[(i + 1) % surrogate_coords_x_inner.size()];
+                }
+                // Order the active_range_knot_vector
+                if (active_range_knot_vector[0] > active_range_knot_vector[1]) {
+                    double temp = active_range_knot_vector[1];
+                    active_range_knot_vector[1] = active_range_knot_vector[0] ;
+                    active_range_knot_vector[0] = temp ;
+                }
+                NurbsCurveGeometry<2, PointerVector<Point>>::Pointer p_trimming_curve = CreateSingleBrep(first_brep_point, second_brep_point, active_range_knot_vector);
+                trimming_curves_inner.push_back(p_trimming_curve);
+            }
+
+            BrepCurveOnSurfaceLoopType trimming_brep_curve_vector(surrogate_coords_x_inner.size());
+
+
+            for (std::size_t i = 0; i < trimming_curves_inner.size(); ++i) {
+                Vector active_range_vector = ZeroVector(2);
+                if (surrogate_coords_x_inner[(i + 1) % surrogate_coords_x_inner.size()]==surrogate_coords_x_inner[i]) {
+                    active_range_vector[0] = surrogate_coords_y_inner[i];
+                    active_range_vector[1] = surrogate_coords_y_inner[(i + 1) % surrogate_coords_x_inner.size()];
+                }
+                else {
+                    active_range_vector[0] = surrogate_coords_x_inner[i];
+                    active_range_vector[1] = surrogate_coords_x_inner[(i + 1) % surrogate_coords_x_inner.size()];
+                }
+                bool curve_direction = true;
+
+                // re-order
+                if (active_range_vector[0] > active_range_vector[1]) {
+                    double temp = active_range_vector[1];
+                    active_range_vector[1] = active_range_vector[0] ;
+                    active_range_vector[0] = temp ;
+                }
+
+                NurbsInterval brep_active_range(active_range_vector[0], active_range_vector[1]);
+
+                auto p_brep_curve_on_surface = Kratos::make_shared<BrepCurveOnSurfaceType>(
+                    pSurface, trimming_curves_inner[i], brep_active_range, curve_direction);
+                p_brep_curve_on_surface->SetId(id_brep_curve_on_surface);
+                rModelPart.AddGeometry(p_brep_curve_on_surface);
+                id_brep_curve_on_surface++;
+                trimming_brep_curve_vector[i] = p_brep_curve_on_surface ;
+
+            }
+
+        }
+    } 
+    
+    /**
+     * @brief Create a Single Brep object
+     * 
+     * @param firstBrepPoint 
+     * @param secondBrepPoint 
+     * @param activeRangeKnotVector 
+     * @return NurbsCurveGeometry<2, PointerVector<Point>>::Pointer 
+     */
+    static typename NurbsCurveGeometry<2, PointerVector<Point>>::Pointer CreateSingleBrep(
+        const Point::Pointer firstBrepPoint,
+        const Point::Pointer secondBrepPoint, 
+        const Vector activeRangeKnotVector)
+        {
+            // Create the data for the trimming curves
+            PointerVector<Point> control_points;
+            control_points.push_back(firstBrepPoint);
+            control_points.push_back(secondBrepPoint);
+            const int polynomial_degree = 1;
+            Vector knot_vector = ZeroVector(4) ;
+            knot_vector[0] = activeRangeKnotVector[0] ;
+            knot_vector[1] = activeRangeKnotVector[0] ;
+            knot_vector[2] = activeRangeKnotVector[1] ;
+            knot_vector[3] = activeRangeKnotVector[1] ;
+            // Create the trimming curves
+            typename NurbsCurveGeometry<2, PointerVector<Point>>::Pointer p_trimming_curve(
+                new NurbsCurveGeometry<2, PointerVector<Point>>(
+                    control_points,
+                    polynomial_degree,
+                    knot_vector));   
+            return p_trimming_curve;
+        }
+    
+    /**
+     * @brief Create a Brep Curves On Rectangle object
+     * 
+     * @param rModelPart 
+     * @param pSurfaceGeometry 
+     * @param A_uvw 
+     * @param B_uvw 
+     * @param lastGeometryId 
+     */
+    static void CreateBrepCurvesOnRectangle(ModelPart& rModelPart, 
+                                            const NurbsSurfaceGeometryPointerType pSurfaceGeometry, 
+                                            const Point& A_uvw, 
+                                            const Point& B_uvw, 
+                                            IndexType &lastGeometryId) {
+        Vector knot_vector = ZeroVector(2);
+        knot_vector[0] = 0.0;
+        knot_vector[1] = std::abs(B_uvw[0] - A_uvw[0]);
+        const int p = 1;
+
+        NurbsCurveGeometry<2, PointerVector<Point>>::PointsArrayType segment1;
+        segment1.push_back(Point::Pointer(new Point(A_uvw[0], A_uvw[1])));
+        segment1.push_back(Point::Pointer(new Point(B_uvw[0], A_uvw[1])));
+
+        NurbsCurveGeometry<2, PointerVector<Point>>::PointsArrayType segment2;
+        segment2.push_back(Point::Pointer(new Point(B_uvw[0], A_uvw[1])));
+        segment2.push_back(Point::Pointer(new Point(B_uvw[0], B_uvw[1])));
+        
+        NurbsCurveGeometry<2, PointerVector<Point>>::PointsArrayType segment3;
+        segment3.push_back(Point::Pointer(new Point(B_uvw[0], B_uvw[1])));
+        segment3.push_back(Point::Pointer(new Point(A_uvw[0], B_uvw[1])));
+        
+        NurbsCurveGeometry<2, PointerVector<Point>>::PointsArrayType segment4;
+        segment4.push_back(Point::Pointer(new Point(A_uvw[0], B_uvw[1])));
+        segment4.push_back(Point::Pointer(new Point(A_uvw[0], A_uvw[1])));
+
+        auto p_curve_1 = Kratos::make_shared<NurbsCurveGeometry<2, PointerVector<Point>>>(segment1, p, knot_vector);
+        auto p_curve_2 = Kratos::make_shared<NurbsCurveGeometry<2, PointerVector<Point>>>(segment2, p, knot_vector);
+        auto p_curve_3 = Kratos::make_shared<NurbsCurveGeometry<2, PointerVector<Point>>>(segment3, p, knot_vector);
+        auto p_curve_4 = Kratos::make_shared<NurbsCurveGeometry<2, PointerVector<Point>>>(segment4, p, knot_vector);
+        
+        auto brep_curve_on_surface = BrepCurveOnSurface< PointerVector<NodeType>, true, PointerVector<Point>>(pSurfaceGeometry, p_curve_1);
+        auto p_brep_curve_on_surface = Kratos::make_shared<BrepCurveOnSurfaceType>(pSurfaceGeometry, p_curve_1);
+        p_brep_curve_on_surface->SetId(lastGeometryId);
+        rModelPart.AddGeometry(p_brep_curve_on_surface);
+        
+        brep_curve_on_surface = BrepCurveOnSurface< PointerVector<NodeType>, true, PointerVector<Point>>(pSurfaceGeometry, p_curve_2);
+        p_brep_curve_on_surface = Kratos::make_shared<BrepCurveOnSurfaceType>(pSurfaceGeometry, p_curve_2);
+        p_brep_curve_on_surface->SetId(++lastGeometryId);
+        rModelPart.AddGeometry(p_brep_curve_on_surface);
+
+        brep_curve_on_surface = BrepCurveOnSurface< PointerVector<NodeType>, true, PointerVector<Point>>(pSurfaceGeometry, p_curve_3);
+        p_brep_curve_on_surface = Kratos::make_shared<BrepCurveOnSurfaceType>(pSurfaceGeometry, p_curve_3);
+        p_brep_curve_on_surface->SetId(++lastGeometryId);
+        rModelPart.AddGeometry(p_brep_curve_on_surface);
+        
+        brep_curve_on_surface = BrepCurveOnSurface< PointerVector<NodeType>, true, PointerVector<Point>>(pSurfaceGeometry, p_curve_4);
+        p_brep_curve_on_surface = Kratos::make_shared<BrepCurveOnSurfaceType>(pSurfaceGeometry, p_curve_4);
+        p_brep_curve_on_surface->SetId(++lastGeometryId);
+        rModelPart.AddGeometry(p_brep_curve_on_surface);
+
+        lastGeometryId++;
+    }
+    
+    ///@}
+    ///@name Utility functions
+    ///@{
+
+    int mEchoLevel;
+
+    ///@}
+}; // Class CreateBrepsSbmUtilities
+}  // namespace Kratos.

--- a/applications/IgaApplication/custom_utilities/create_breps_sbm_utilities.h
+++ b/applications/IgaApplication/custom_utilities/create_breps_sbm_utilities.h
@@ -156,12 +156,12 @@ private:
     }
 
     /**
-     * @brief Create a Brep Surface object for the SBM case
+     * @brief Create a Brep Surface object
      * 
      * @param pSurface 
-     * @param rModelPart 
      * @param rSurrogateModelPartInner 
      * @param rSurrogateModelPartOuter 
+     * @param rModelPart 
      * @param EchoLevel 
      */
     static void CreateBrepSurface(
@@ -211,11 +211,11 @@ private:
      * @brief Create a Brep Curve On Surfaces object
      * 
      * @param pSurface 
-     * @param rModelPart 
      * @param rSurrogateModelPartInner 
      * @param rSurrogateModelPartOuter 
      * @param rCoordsA 
      * @param rCoordsB 
+     * @param rModelPart 
      * @param EchoLevel 
      */
     static void CreateBrepCurveOnSurfaces(
@@ -367,11 +367,11 @@ private:
     /**
      * @brief Create a Brep Curves On Rectangle object
      * 
-     * @param rModelPart 
      * @param pSurfaceGeometry 
      * @param rCoordsA 
      * @param rCoordsB 
      * @param rLastGeometryId 
+     * @param rModelPart 
      */
     static void CreateBrepCurvesOnRectangle(const NurbsSurfaceGeometryPointerType pSurfaceGeometry, 
                                             const Point& rCoordsA, 

--- a/applications/IgaApplication/custom_utilities/create_breps_sbm_utilities.h
+++ b/applications/IgaApplication/custom_utilities/create_breps_sbm_utilities.h
@@ -91,19 +91,19 @@ class CreateBrepsSbmUtilities : public IO
      * @param rModelPart 
      * @param rSurrogateModelPartInner 
      * @param rSurrogateModelPartOuter 
-     * @param A_uvw 
-     * @param B_uvw 
+     * @param CoordsA 
+     * @param CoordsB 
      * Adds the surface geometry to the herin provided model_part and create the boundary breps for the SBM case.
      */
     void CreateSurrogateBoundary(NurbsSurfaceGeometryPointerType& pSurface, 
                                  ModelPart& rModelPart, 
                                  ModelPart& rSurrogateModelPartInner, 
                                  ModelPart& rSurrogateModelPartOuter, 
-                                 const Point& A_uvw, 
-                                 const Point& B_uvw)
+                                 const Point& CoordsA, 
+                                 const Point& CoordsB)
     {
         CreateBrepSurface(pSurface, rModelPart, rSurrogateModelPartInner, rSurrogateModelPartOuter, mEchoLevel);
-        CreateBrepCurveOnSurfaces(pSurface, rModelPart, rSurrogateModelPartInner, rSurrogateModelPartOuter, A_uvw, B_uvw, mEchoLevel);
+        CreateBrepCurveOnSurfaces(pSurface, rModelPart, rSurrogateModelPartInner, rSurrogateModelPartOuter, CoordsA, CoordsB, mEchoLevel);
     }
     
     /**
@@ -111,18 +111,18 @@ class CreateBrepsSbmUtilities : public IO
      * 
      * @param pSurface 
      * @param rModelPart 
-     * @param A_uvw 
-     * @param B_uvw 
+     * @param CoordsA 
+     * @param CoordsB 
      * Adds the surface geometry to the herin provided model_part and create the boundary breps when SBM is not needed.
      */
     void CreateSurrogateBoundary(NurbsSurfaceGeometryPointerType& pSurface, 
                                  ModelPart& rModelPart, 
-                                 const Point& A_uvw, 
-                                 const Point& B_uvw)
+                                 const Point& CoordsA, 
+                                 const Point& CoordsB)
     {
         CreateBrepSurface(pSurface, rModelPart, mEchoLevel);
         IndexType id_brep_curve_on_surface = 2; // because id 1 is the brep surface
-        CreateBrepCurvesOnRectangle(rModelPart, pSurface, A_uvw, B_uvw, id_brep_curve_on_surface);
+        CreateBrepCurvesOnRectangle(rModelPart, pSurface, CoordsA, CoordsB, id_brep_curve_on_surface);
     }
 
 
@@ -217,8 +217,8 @@ private:
      * @param rModelPart 
      * @param rSurrogateModelPartInner 
      * @param rSurrogateModelPartOuter 
-     * @param A_uvw 
-     * @param B_uvw 
+     * @param CoordsA 
+     * @param CoordsB 
      * @param EchoLevel 
      */
     static void CreateBrepCurveOnSurfaces(
@@ -226,8 +226,8 @@ private:
         ModelPart& rModelPart,
         const ModelPart& rSurrogateModelPartInner, 
         const ModelPart& rSurrogateModelPartOuter,
-        const Point& A_uvw, 
-        const Point& B_uvw,
+        const Point& CoordsA, 
+        const Point& CoordsB,
         const SizeType EchoLevel = 0) {
     
         // OUTER 
@@ -267,7 +267,7 @@ private:
                     active_range_knot_vector[1] = active_range_knot_vector[0] ;
                     active_range_knot_vector[0] = temp ;
                 }
-                NurbsCurveGeometry<2, PointerVector<Point>>::Pointer p_trimming_curve = CreateSingleBrep(firstBrepPoint, second_brep_point, active_range_knot_vector);
+                NurbsCurveGeometry<2, PointerVector<Point>>::Pointer p_trimming_curve = CreateBrepCurve(firstBrepPoint, second_brep_point, active_range_knot_vector);
                 trimming_curves_outer.push_back(p_trimming_curve);
             }
 
@@ -304,7 +304,7 @@ private:
             }
 
         } else {
-            CreateBrepCurvesOnRectangle(rModelPart, pSurface, A_uvw, B_uvw, id_brep_curve_on_surface);
+            CreateBrepCurvesOnRectangle(rModelPart, pSurface, CoordsA, CoordsB, id_brep_curve_on_surface);
         }
 
         // INNER
@@ -346,7 +346,7 @@ private:
                     active_range_knot_vector[1] = active_range_knot_vector[0] ;
                     active_range_knot_vector[0] = temp ;
                 }
-                NurbsCurveGeometry<2, PointerVector<Point>>::Pointer p_trimming_curve = CreateSingleBrep(first_brep_point, second_brep_point, active_range_knot_vector);
+                NurbsCurveGeometry<2, PointerVector<Point>>::Pointer p_trimming_curve = CreateBrepCurve(first_brep_point, second_brep_point, active_range_knot_vector);
                 trimming_curves_inner.push_back(p_trimming_curve);
             }
 
@@ -394,7 +394,7 @@ private:
      * @param activeRangeKnotVector 
      * @return NurbsCurveGeometry<2, PointerVector<Point>>::Pointer 
      */
-    static typename NurbsCurveGeometry<2, PointerVector<Point>>::Pointer CreateSingleBrep(
+    static typename NurbsCurveGeometry<2, PointerVector<Point>>::Pointer CreateBrepCurve(
         const Point::Pointer firstBrepPoint,
         const Point::Pointer secondBrepPoint, 
         const Vector activeRangeKnotVector)
@@ -423,35 +423,35 @@ private:
      * 
      * @param rModelPart 
      * @param pSurfaceGeometry 
-     * @param A_uvw 
-     * @param B_uvw 
+     * @param CoordsA 
+     * @param CoordsB 
      * @param lastGeometryId 
      */
     static void CreateBrepCurvesOnRectangle(ModelPart& rModelPart, 
                                             const NurbsSurfaceGeometryPointerType pSurfaceGeometry, 
-                                            const Point& A_uvw, 
-                                            const Point& B_uvw, 
+                                            const Point& CoordsA, 
+                                            const Point& CoordsB, 
                                             IndexType &lastGeometryId) {
         Vector knot_vector = ZeroVector(2);
         knot_vector[0] = 0.0;
-        knot_vector[1] = std::abs(B_uvw[0] - A_uvw[0]);
+        knot_vector[1] = std::abs(CoordsB[0] - CoordsA[0]);
         const int p = 1;
 
         NurbsCurveGeometry<2, PointerVector<Point>>::PointsArrayType segment1;
-        segment1.push_back(Point::Pointer(new Point(A_uvw[0], A_uvw[1])));
-        segment1.push_back(Point::Pointer(new Point(B_uvw[0], A_uvw[1])));
+        segment1.push_back(Point::Pointer(new Point(CoordsA[0], CoordsA[1])));
+        segment1.push_back(Point::Pointer(new Point(CoordsB[0], CoordsA[1])));
 
         NurbsCurveGeometry<2, PointerVector<Point>>::PointsArrayType segment2;
-        segment2.push_back(Point::Pointer(new Point(B_uvw[0], A_uvw[1])));
-        segment2.push_back(Point::Pointer(new Point(B_uvw[0], B_uvw[1])));
+        segment2.push_back(Point::Pointer(new Point(CoordsB[0], CoordsA[1])));
+        segment2.push_back(Point::Pointer(new Point(CoordsB[0], CoordsB[1])));
         
         NurbsCurveGeometry<2, PointerVector<Point>>::PointsArrayType segment3;
-        segment3.push_back(Point::Pointer(new Point(B_uvw[0], B_uvw[1])));
-        segment3.push_back(Point::Pointer(new Point(A_uvw[0], B_uvw[1])));
+        segment3.push_back(Point::Pointer(new Point(CoordsB[0], CoordsB[1])));
+        segment3.push_back(Point::Pointer(new Point(CoordsA[0], CoordsB[1])));
         
         NurbsCurveGeometry<2, PointerVector<Point>>::PointsArrayType segment4;
-        segment4.push_back(Point::Pointer(new Point(A_uvw[0], B_uvw[1])));
-        segment4.push_back(Point::Pointer(new Point(A_uvw[0], A_uvw[1])));
+        segment4.push_back(Point::Pointer(new Point(CoordsA[0], CoordsB[1])));
+        segment4.push_back(Point::Pointer(new Point(CoordsA[0], CoordsA[1])));
 
         auto p_curve_1 = Kratos::make_shared<NurbsCurveGeometry<2, PointerVector<Point>>>(segment1, p, knot_vector);
         auto p_curve_2 = Kratos::make_shared<NurbsCurveGeometry<2, PointerVector<Point>>>(segment2, p, knot_vector);

--- a/applications/IgaApplication/tests/cpp_tests/test_sbm_create_brep_utilities.cpp
+++ b/applications/IgaApplication/tests/cpp_tests/test_sbm_create_brep_utilities.cpp
@@ -93,7 +93,7 @@ KRATOS_TEST_CASE_IN_SUITE(TestCreateBrepsSbmUtilitiesOuter, KratosIgaFastSuite)
     
     // Create the breps for the outer sbm boundary
     CreateBrepsSbmUtilities<Node, Point> CreateBrepsSbmUtilities(EchoLevel);
-    CreateBrepsSbmUtilities.CreateSurrogateBoundary(surface, iga_model_part, surrogate_sub_model_part_inner, surrogate_sub_model_part_outer, A_uvw, B_uvw);
+    CreateBrepsSbmUtilities.CreateSurrogateBoundary(surface, surrogate_sub_model_part_inner, surrogate_sub_model_part_outer, A_uvw, B_uvw, iga_model_part);
     
     const double tolerance = 1e-12;
 
@@ -195,7 +195,7 @@ KRATOS_TEST_CASE_IN_SUITE(TestCreateBrepsSbmUtilitiesInner, KratosIgaFastSuite)
     
     // Create the breps for the outer sbm boundary
     CreateBrepsSbmUtilities<Node, Point> CreateBrepsSbmUtilities(EchoLevel);
-    CreateBrepsSbmUtilities.CreateSurrogateBoundary(surface, iga_model_part, surrogate_sub_model_part_inner, surrogate_sub_model_part_outer, A_uvw, B_uvw);
+    CreateBrepsSbmUtilities.CreateSurrogateBoundary(surface, surrogate_sub_model_part_inner, surrogate_sub_model_part_outer, A_uvw, B_uvw, iga_model_part);
     
     const double tolerance = 1e-12;
 

--- a/applications/IgaApplication/tests/cpp_tests/test_sbm_create_brep_utilities.cpp
+++ b/applications/IgaApplication/tests/cpp_tests/test_sbm_create_brep_utilities.cpp
@@ -1,0 +1,214 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
+//
+//  Main authors:    Nicolo' Antonelli
+//  Main authors:    Andrea Gorgi
+
+// Project includes
+#include "containers/model.h"
+#include "testing/testing.h"
+#include "custom_utilities/create_breps_sbm_utilities.h"
+#include "includes/kratos_parameters.h"
+#include "custom_modelers/nurbs_geometry_modeler.h"
+
+namespace Kratos::Testing
+{
+    using NurbsSurfaceGeometryType = NurbsSurfaceGeometry<3, PointerVector<Node>>;
+    using NurbsSurfaceGeometryPointerType = typename NurbsSurfaceGeometryType::Pointer;
+
+// Tests the SnakeSbmUtilities with a square outer geometry
+KRATOS_TEST_CASE_IN_SUITE(TestCreateBrepsSbmUtilitiesOuter, KratosIgaFastSuite)
+{
+    using IndexType = std::size_t;
+    using GeometryType = Geometry<Node>;
+    using ContainerNodeType = PointerVector<Node>;
+    using ContainerEmbeddedNodeType = PointerVector<Point>;
+    using BrepCurveOnSurfaceType = BrepCurveOnSurface<ContainerNodeType, true, ContainerEmbeddedNodeType>;
+    using CoordinatesArrayType = GeometryType::CoordinatesArrayType;
+    
+    // Initialization
+    std::size_t EchoLevel = 0;
+    Model model;
+    ModelPart& iga_model_part = model.CreateModelPart("IgaModelPart");
+    ModelPart& surrogate_sub_model_part_outer = iga_model_part.CreateSubModelPart("surrogate_outer");
+    ModelPart& surrogate_sub_model_part_inner = iga_model_part.CreateSubModelPart("surrogate_inner");
+    
+    surrogate_sub_model_part_outer.CreateNewProperties(0);
+    
+    surrogate_sub_model_part_outer.CreateNewNode(1, -1.0, -1.0, 0.0);
+    surrogate_sub_model_part_outer.CreateNewNode(2, -1.0, -0.9, 0.0);
+    surrogate_sub_model_part_outer.CreateNewNode(3, -1.0, -0.8, 0.0);
+
+    surrogate_sub_model_part_outer.CreateNewNode(4, -0.9, -0.8, 0.0);
+    surrogate_sub_model_part_outer.CreateNewNode(5, -0.8, -0.8, 0.0);
+    
+    surrogate_sub_model_part_outer.CreateNewNode(6, -0.8, -0.9, 0.0);
+    surrogate_sub_model_part_outer.CreateNewNode(7, -0.8, -1.0, 0.0);
+
+    surrogate_sub_model_part_outer.CreateNewNode(8, -0.9, -1.0, 0.0);
+    
+    
+    Properties::Pointer p_prop = surrogate_sub_model_part_outer.pGetProperties(0);
+    surrogate_sub_model_part_outer.CreateNewCondition("LineCondition2D2N", 1, {{1, 2}}, p_prop);
+    surrogate_sub_model_part_outer.CreateNewCondition("LineCondition2D2N", 2, {{2, 3}}, p_prop);
+    surrogate_sub_model_part_outer.CreateNewCondition("LineCondition2D2N", 3, {{3, 4}}, p_prop);
+    surrogate_sub_model_part_outer.CreateNewCondition("LineCondition2D2N", 4, {{4, 5}}, p_prop);
+    surrogate_sub_model_part_outer.CreateNewCondition("LineCondition2D2N", 5, {{5, 6}}, p_prop);
+    surrogate_sub_model_part_outer.CreateNewCondition("LineCondition2D2N", 6, {{6, 7}}, p_prop);
+    surrogate_sub_model_part_outer.CreateNewCondition("LineCondition2D2N", 7, {{7, 8}}, p_prop);
+
+    Kratos::Parameters parameters(R"(
+        {
+            "echo_level": 0,
+            "model_part_name": "IgaModelPart",
+            "geometry_name"  : "nurbs_surface",
+            "lower_point_xyz": [-1, -1, 0],
+            "upper_point_xyz": [1, 1, 0],
+            "lower_point_uvw": [-1, -1, 0],
+            "upper_point_uvw": [1, 1, 0],
+            "polynomial_order":     [2, 2],
+            "number_of_knot_spans": [20, 20]
+        }
+    )");
+
+    const Point& A_uvw = Point(-1, -1, 0);
+    const Point& B_uvw = Point(1, 1, 0);
+
+    NurbsGeometryModeler nurbs_modeler(model, parameters);
+    nurbs_modeler.SetupGeometryModel();
+    
+    NurbsSurfaceGeometryPointerType surface = std::dynamic_pointer_cast<NurbsSurfaceGeometryType>(iga_model_part.pGetGeometry("nurbs_surface"));
+    
+    // Create the breps for the outer sbm boundary
+    CreateBrepsSbmUtilities<Node, Point> CreateBrepsSbmUtilities(EchoLevel);
+    CreateBrepsSbmUtilities.CreateSurrogateBoundary(surface, iga_model_part, surrogate_sub_model_part_inner, surrogate_sub_model_part_outer, A_uvw, B_uvw);
+    
+    const double tolerance = 1e-12;
+
+    for (IndexType current_id = 2; current_id < iga_model_part.NumberOfGeometries(); current_id++) {
+
+        BrepCurveOnSurfaceType::Pointer brep_curve = std::dynamic_pointer_cast<BrepCurveOnSurfaceType>(iga_model_part.pGetGeometry(current_id));
+        auto ppp = brep_curve->DomainInterval();
+        CoordinatesArrayType vertex_1_on_physical;
+        CoordinatesArrayType vertex_2_on_physical;
+        CoordinatesArrayType local_coord_vertex_1 = ZeroVector(3); 
+        CoordinatesArrayType local_coord_vertex_2 = ZeroVector(3);
+
+        local_coord_vertex_1[0] = ppp.GetT0(); local_coord_vertex_2[0] = ppp.GetT1();
+
+        brep_curve->GlobalCoordinates(vertex_1_on_physical, local_coord_vertex_1);
+        brep_curve->GlobalCoordinates(vertex_2_on_physical, local_coord_vertex_2);
+
+        KRATOS_EXPECT_NEAR(vertex_1_on_physical[0], surrogate_sub_model_part_outer.GetNode(iga_model_part.NumberOfGeometries()-current_id).X() , tolerance);
+        KRATOS_EXPECT_NEAR(vertex_1_on_physical[1], surrogate_sub_model_part_outer.GetNode(iga_model_part.NumberOfGeometries()-current_id).Y() , tolerance);
+    }
+
+    // Ensure the number of nodes matches expectation
+    KRATOS_EXPECT_EQ(iga_model_part.Geometries().size(), 10);
+
+}
+
+
+KRATOS_TEST_CASE_IN_SUITE(TestCreateBrepsSbmUtilitiesInner, KratosIgaFastSuite)
+{
+    using IndexType = std::size_t;
+    using GeometryType = Geometry<Node>;
+    using ContainerNodeType = PointerVector<Node>;
+    using ContainerEmbeddedNodeType = PointerVector<Point>;
+    using BrepCurveOnSurfaceType = BrepCurveOnSurface<ContainerNodeType, true, ContainerEmbeddedNodeType>;
+    using CoordinatesArrayType = GeometryType::CoordinatesArrayType;
+    
+    // Initialization
+    std::size_t EchoLevel = 0;
+    Model model;
+    ModelPart& iga_model_part = model.CreateModelPart("IgaModelPart");
+    ModelPart& surrogate_sub_model_part_outer = iga_model_part.CreateSubModelPart("surrogate_outer");
+    ModelPart& surrogate_sub_model_part_inner = iga_model_part.CreateSubModelPart("surrogate_inner");
+    
+    surrogate_sub_model_part_inner.CreateNewProperties(0);
+    
+    surrogate_sub_model_part_inner.CreateNewNode(1, -1.0, -1.0, 0.0);
+    surrogate_sub_model_part_inner.CreateNewNode(2, -1.0, -0.9, 0.0);
+    surrogate_sub_model_part_inner.CreateNewNode(3, -1.0, -0.8, 0.0);
+
+    surrogate_sub_model_part_inner.CreateNewNode(4, -0.9, -0.8, 0.0);
+    surrogate_sub_model_part_inner.CreateNewNode(5, -0.8, -0.8, 0.0);
+    
+    surrogate_sub_model_part_inner.CreateNewNode(6, -0.8, -0.9, 0.0);
+    surrogate_sub_model_part_inner.CreateNewNode(7, -0.8, -1.0, 0.0);
+
+    surrogate_sub_model_part_inner.CreateNewNode(8, -0.9, -1.0, 0.0);
+    
+    
+    Properties::Pointer p_prop = surrogate_sub_model_part_inner.pGetProperties(0);
+    surrogate_sub_model_part_inner.CreateNewCondition("LineCondition2D2N", 1, {{1, 2}}, p_prop);
+    surrogate_sub_model_part_inner.CreateNewCondition("LineCondition2D2N", 2, {{2, 3}}, p_prop);
+    surrogate_sub_model_part_inner.CreateNewCondition("LineCondition2D2N", 3, {{3, 4}}, p_prop);
+    surrogate_sub_model_part_inner.CreateNewCondition("LineCondition2D2N", 4, {{4, 5}}, p_prop);
+    surrogate_sub_model_part_inner.CreateNewCondition("LineCondition2D2N", 5, {{5, 6}}, p_prop);
+    surrogate_sub_model_part_inner.CreateNewCondition("LineCondition2D2N", 6, {{6, 7}}, p_prop);
+    surrogate_sub_model_part_inner.CreateNewCondition("LineCondition2D2N", 7, {{7, 8}}, p_prop);
+
+
+    // Create "fictituos element" to memorize starting and ending node id for each surrogate boundary loop
+    std::vector<ModelPart::IndexType> elem_nodes{1, 8};
+    surrogate_sub_model_part_inner.CreateNewElement("Element2D2N", 1, elem_nodes, p_prop);
+
+    Kratos::Parameters parameters(R"(
+        {
+            "echo_level": 0,
+            "model_part_name": "IgaModelPart",
+            "geometry_name"  : "nurbs_surface",
+            "lower_point_xyz": [-2, -2, 0],
+            "upper_point_xyz": [0, 0, 0],
+            "lower_point_uvw": [-2, -2, 0],
+            "upper_point_uvw": [0, 0, 0],
+            "polynomial_order":     [2, 2],
+            "number_of_knot_spans": [20, 20]
+        }
+    )");
+
+    const Point& A_uvw = Point(-2, -2, 0);
+    const Point& B_uvw = Point(0, 0, 0);
+
+    NurbsGeometryModeler nurbs_modeler(model, parameters);
+    nurbs_modeler.SetupGeometryModel();
+    
+    NurbsSurfaceGeometryPointerType surface = std::dynamic_pointer_cast<NurbsSurfaceGeometryType>(iga_model_part.pGetGeometry("nurbs_surface"));
+    
+    // Create the breps for the outer sbm boundary
+    CreateBrepsSbmUtilities<Node, Point> CreateBrepsSbmUtilities(EchoLevel);
+    CreateBrepsSbmUtilities.CreateSurrogateBoundary(surface, iga_model_part, surrogate_sub_model_part_inner, surrogate_sub_model_part_outer, A_uvw, B_uvw);
+    
+    const double tolerance = 1e-12;
+
+    for (IndexType current_id = 6; current_id < iga_model_part.NumberOfGeometries(); current_id++) {
+
+        BrepCurveOnSurfaceType::Pointer brep_curve = std::dynamic_pointer_cast<BrepCurveOnSurfaceType>(iga_model_part.pGetGeometry(current_id));
+        auto ppp = brep_curve->DomainInterval();
+        CoordinatesArrayType vertex_1_on_physical;
+        CoordinatesArrayType vertex_2_on_physical;
+        CoordinatesArrayType local_coord_vertex_1 = ZeroVector(3); 
+        CoordinatesArrayType local_coord_vertex_2 = ZeroVector(3);
+
+        local_coord_vertex_1[0] = ppp.GetT0(); local_coord_vertex_2[0] = ppp.GetT1();
+
+        brep_curve->GlobalCoordinates(vertex_1_on_physical, local_coord_vertex_1);
+        brep_curve->GlobalCoordinates(vertex_2_on_physical, local_coord_vertex_2);
+
+        KRATOS_EXPECT_NEAR(vertex_1_on_physical[0], surrogate_sub_model_part_inner.GetNode(current_id-5).X() , tolerance);
+        KRATOS_EXPECT_NEAR(vertex_1_on_physical[1], surrogate_sub_model_part_inner.GetNode(current_id-5).Y() , tolerance);
+    }
+
+    // Ensure the number of nodes matches expectation
+    KRATOS_EXPECT_EQ(iga_model_part.Geometries().size(), 14);
+
+}
+
+}

--- a/applications/IgaApplication/tests/cpp_tests/test_sbm_create_brep_utilities.cpp
+++ b/applications/IgaApplication/tests/cpp_tests/test_sbm_create_brep_utilities.cpp
@@ -62,6 +62,12 @@ KRATOS_TEST_CASE_IN_SUITE(TestCreateBrepsSbmUtilitiesOuter, KratosIgaFastSuite)
     surrogate_sub_model_part_outer.CreateNewCondition("LineCondition2D2N", 5, {{5, 6}}, p_prop);
     surrogate_sub_model_part_outer.CreateNewCondition("LineCondition2D2N", 6, {{6, 7}}, p_prop);
     surrogate_sub_model_part_outer.CreateNewCondition("LineCondition2D2N", 7, {{7, 8}}, p_prop);
+    surrogate_sub_model_part_outer.CreateNewCondition("LineCondition2D2N", 8, {{8, 1}}, p_prop);
+
+    for (auto &cond : surrogate_sub_model_part_outer.Conditions())
+    {
+        cond.Set(BOUNDARY, true);
+    }
 
     Kratos::Parameters parameters(R"(
         {
@@ -105,8 +111,8 @@ KRATOS_TEST_CASE_IN_SUITE(TestCreateBrepsSbmUtilitiesOuter, KratosIgaFastSuite)
         brep_curve->GlobalCoordinates(vertex_1_on_physical, local_coord_vertex_1);
         brep_curve->GlobalCoordinates(vertex_2_on_physical, local_coord_vertex_2);
 
-        KRATOS_EXPECT_NEAR(vertex_1_on_physical[0], surrogate_sub_model_part_outer.GetNode(iga_model_part.NumberOfGeometries()-current_id).X() , tolerance);
-        KRATOS_EXPECT_NEAR(vertex_1_on_physical[1], surrogate_sub_model_part_outer.GetNode(iga_model_part.NumberOfGeometries()-current_id).Y() , tolerance);
+        KRATOS_EXPECT_NEAR(vertex_2_on_physical[0], surrogate_sub_model_part_outer.GetNode(current_id-1).X() , tolerance);
+        KRATOS_EXPECT_NEAR(vertex_2_on_physical[1], surrogate_sub_model_part_outer.GetNode(current_id-1).Y() , tolerance);
     }
 
     // Ensure the number of nodes matches expectation
@@ -154,7 +160,12 @@ KRATOS_TEST_CASE_IN_SUITE(TestCreateBrepsSbmUtilitiesInner, KratosIgaFastSuite)
     surrogate_sub_model_part_inner.CreateNewCondition("LineCondition2D2N", 5, {{5, 6}}, p_prop);
     surrogate_sub_model_part_inner.CreateNewCondition("LineCondition2D2N", 6, {{6, 7}}, p_prop);
     surrogate_sub_model_part_inner.CreateNewCondition("LineCondition2D2N", 7, {{7, 8}}, p_prop);
+    surrogate_sub_model_part_inner.CreateNewCondition("LineCondition2D2N", 8, {{8,1}}, p_prop);
 
+    for (auto &cond : surrogate_sub_model_part_inner.Conditions())
+    {
+        cond.Set(BOUNDARY, false);
+    }
 
     // Create "fictituos element" to memorize starting and ending node id for each surrogate boundary loop
     std::vector<ModelPart::IndexType> elem_nodes{1, 8};

--- a/kratos/geometries/brep_surface.h
+++ b/kratos/geometries/brep_surface.h
@@ -58,6 +58,7 @@ public:
     typedef Geometry<typename TContainerPointType::value_type> BaseType;
     typedef Geometry<typename TContainerPointType::value_type> GeometryType;
     typedef typename GeometryType::Pointer GeometryPointer;
+    using GeometrySurrogateArrayType = DenseVector<GeometryPointer>;
 
     typedef GeometryData::IntegrationMethod IntegrationMethod;
 
@@ -163,6 +164,8 @@ public:
         mInnerLoopArray = rOther.mInnerLoopArray;
         mEmbeddedEdgesArray = rOther.mEmbeddedEdgesArray;
         mIsTrimmed = rOther.mIsTrimmed;
+        mpSurrogateInnerLoopGeometries = rOther.GetSurrogateInnerLoopGeometries();
+        mpSurrogateOuterLoopGeometries = rOther.GetSurrogateOuterLoopGeometries();
         return *this;
     }
 
@@ -176,6 +179,8 @@ public:
         mInnerLoopArray = rOther.mInnerLoopArray;
         mEmbeddedEdgesArray = rOther.mEmbeddedEdgesArray;
         mIsTrimmed = rOther.mIsTrimmed;
+        mpSurrogateInnerLoopGeometries = rOther.GetSurrogateInnerLoopGeometries();
+        mpSurrogateOuterLoopGeometries = rOther.GetSurrogateOuterLoopGeometries();
         return *this;
     }
 
@@ -550,6 +555,42 @@ public:
         return GeometryData::KratosGeometryType::Kratos_Brep_Surface;
     }
 
+    /**
+     * @brief Set the Surrogate Outer Loop Geometries object
+     * @param pSurrogateOuterLoopArray 
+     */
+    void SetSurrogateOuterLoopGeometries(GeometrySurrogateArrayType &rSurrogateOuterLoopArray)
+    {
+        mpSurrogateOuterLoopGeometries = &rSurrogateOuterLoopArray;
+    }
+    
+    /**
+     * @brief Set the Surrogate Inner Loop Geometries object
+     * @param pSurrogateInnerLoopArray 
+     */
+    void SetSurrogateInnerLoopGeometries(GeometrySurrogateArrayType &rSurrogateInnerLoopArray)
+    {
+        mpSurrogateInnerLoopGeometries = &rSurrogateInnerLoopArray;
+    }
+
+    /**
+     * @brief Get the Surrogate Inner Loop Geometries object
+     * @return GeometrySurrogateArrayType 
+     */
+    GeometrySurrogateArrayType& GetSurrogateInnerLoopGeometries()
+    {
+        return *mpSurrogateInnerLoopGeometries;
+    }
+
+    /**
+     * @brief Get the Surrogate Outer Loop Geometries object
+     * @return GeometrySurrogateArrayType 
+     */
+    GeometrySurrogateArrayType& GetSurrogateOuterLoopGeometries()
+    {
+        return *mpSurrogateOuterLoopGeometries;
+    }
+
     ///@}
     ///@name Information
     ///@{
@@ -595,6 +636,10 @@ private:
 
     BrepCurveOnSurfaceArrayType mEmbeddedEdgesArray;
 
+    GeometrySurrogateArrayType* mpSurrogateInnerLoopGeometries;
+    GeometrySurrogateArrayType* mpSurrogateOuterLoopGeometries;
+    
+
     /** IsTrimmed is used to optimize processes as
     *   e.g. creation of integration domain.
     */
@@ -614,6 +659,8 @@ private:
         rSerializer.save("InnerLoopArray", mInnerLoopArray);
         rSerializer.save("EmbeddedEdgesArray", mEmbeddedEdgesArray);
         rSerializer.save("IsTrimmed", mIsTrimmed);
+        rSerializer.save("SurrogateInnerLoopGeometries", mpSurrogateInnerLoopGeometries);
+        rSerializer.save("SurrogateOuterLoopGeometries", mpSurrogateOuterLoopGeometries);
     }
 
     void load( Serializer& rSerializer ) override
@@ -624,6 +671,8 @@ private:
         rSerializer.load("InnerLoopArray", mInnerLoopArray);
         rSerializer.load("EmbeddedEdgesArray", mEmbeddedEdgesArray);
         rSerializer.load("IsTrimmed", mIsTrimmed);
+        rSerializer.save("SurrogateInnerLoopGeometries", mpSurrogateInnerLoopGeometries);
+        rSerializer.save("SurrogateOuterLoopGeometries", mpSurrogateOuterLoopGeometries);
     }
 
     BrepSurface()


### PR DESCRIPTION
**📝 Description**
This PR introduces a utility for the creation of Surrogate Boundary BReps geometries. The new functionality allows defining BRep surfaces and curves to define the "trimmed" domain.

Specifically, this utility will be called from the SBM modeler (in the next PR) after identifying the surrogate boundary location. And this will be the last stage of the nurbs_sbm_modeler.