### PR TITLE
[GeoMechanicsApplication] Use the pressure geometry where needed

### DIFF
--- a/applications/GeoMechanicsApplication/custom_elements/small_strain_U_Pw_diff_order_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/small_strain_U_Pw_diff_order_element.cpp
@@ -1003,11 +1003,12 @@ void SmallStrainUPwDiffOrderElement::InitializeNodalVariables(ElementVariables& 
     rVariables.PressureVector.resize(num_p_nodes, false);
     rVariables.PressureDtVector.resize(num_p_nodes, false);
     rVariables.DeltaPressureVector.resize(num_p_nodes, false);
+    const auto& r_p_geometry = *mpPressureGeometry;
     for (SizeType i = 0; i < num_p_nodes; ++i) {
-        rVariables.PressureVector[i]      = r_geom[i].FastGetSolutionStepValue(WATER_PRESSURE);
-        rVariables.PressureDtVector[i]    = r_geom[i].FastGetSolutionStepValue(DT_WATER_PRESSURE);
-        rVariables.DeltaPressureVector[i] = r_geom[i].FastGetSolutionStepValue(WATER_PRESSURE) -
-                                            r_geom[i].FastGetSolutionStepValue(WATER_PRESSURE, 1);
+        rVariables.PressureVector[i] = r_p_geometry[i].FastGetSolutionStepValue(WATER_PRESSURE);
+        rVariables.PressureDtVector[i] = r_p_geometry[i].FastGetSolutionStepValue(DT_WATER_PRESSURE);
+        rVariables.DeltaPressureVector[i] = r_p_geometry[i].FastGetSolutionStepValue(WATER_PRESSURE) -
+                                            r_p_geometry[i].FastGetSolutionStepValue(WATER_PRESSURE, 1);
     }
 
     KRATOS_CATCH("")
@@ -1430,11 +1431,10 @@ void SmallStrainUPwDiffOrderElement::SetUpPressureGeometryPointer()
     }
 }
 
-Vector SmallStrainUPwDiffOrderElement::GetPressureSolutionVector()
+Vector SmallStrainUPwDiffOrderElement::GetPressureSolutionVector() const
 {
     Vector result(mpPressureGeometry->PointsNumber());
-    std::transform(this->GetGeometry().begin(),
-                   this->GetGeometry().begin() + mpPressureGeometry->PointsNumber(), result.begin(),
+    std::transform(mpPressureGeometry->begin(), mpPressureGeometry->end(), result.begin(),
                    [](const auto& node) { return node.FastGetSolutionStepValue(WATER_PRESSURE); });
     return result;
 }

--- a/applications/GeoMechanicsApplication/custom_elements/small_strain_U_Pw_diff_order_element.hpp
+++ b/applications/GeoMechanicsApplication/custom_elements/small_strain_U_Pw_diff_order_element.hpp
@@ -243,7 +243,7 @@ protected:
                                         std::vector<Vector>& rStressVectors,
                                         std::vector<Matrix>& rConstitutiveMatrices);
 
-    Vector GetPressureSolutionVector();
+    [[nodiscard]] Vector GetPressureSolutionVector() const;
 
     [[nodiscard]] std::vector<double> CalculateDegreesOfSaturation(const std::vector<double>& rFluidPressures);
     [[nodiscard]] std::vector<double> CalculateDerivativesOfSaturation(const std::vector<double>& rFluidPressures);


### PR DESCRIPTION
**📝 Description**

In two instances, the displacement geometry was used, where the pressure geometry was intended. No failures occurred due to limiting the number of nodes visited. It gave, however, rise to confusion. That has been addressed now.

Furthermore, a member function was made `const` and marked `[[nodiscard]]`.
