### PR TITLE
[Core] Move Semantics for `NodalData`

### DIFF
--- a/kratos/containers/nodal_data.cpp
+++ b/kratos/containers/nodal_data.cpp
@@ -44,14 +44,6 @@ namespace Kratos
 
     }
 
-    /// Assignment operator.
-    NodalData& NodalData::operator=(NodalData const& rOther){
-        mId = rOther.mId;
-        mSolutionStepsNodalData = rOther.mSolutionStepsNodalData;
-
-        return *this;
-    }
-
     /// Turn back information as a string.
     std::string NodalData::Info() const
     {

--- a/kratos/containers/nodal_data.h
+++ b/kratos/containers/nodal_data.h
@@ -33,7 +33,7 @@ namespace Kratos
 /** This class is the container for nodal data storing:
  *  Id : The Id of the node
 */
-class KRATOS_API(KRATOS_CORE) NodalData
+class KRATOS_API(KRATOS_CORE) NodalData final
 {
 public:
     ///@name Type Definitions
@@ -60,39 +60,36 @@ public:
 
     NodalData(IndexType TheId, VariablesList::Pointer pVariablesList, BlockType const * ThisData, SizeType NewQueueSize = 1);
 
-    /// Destructor.
-    ~NodalData(){}
+    NodalData(NodalData&&) noexcept = default;
 
     ///@}
     ///@name Operators
     ///@{
 
-    /// Assignment operator.
-    NodalData& operator=(NodalData const& rOther);
+    NodalData& operator=(NodalData const& rOther) = default;
+
+    NodalData& operator=(NodalData&&) noexcept = default;
 
     ///@}
-    ///@name Operations
-    ///@{
-
 
     ///@}
     ///@name Access
     ///@{
 
     /// Returns the Id of the Node. Same as GetId to ensure backward compatibility
-    IndexType Id() const
+    IndexType Id() const noexcept
     {
         return mId;
     }
 
-    /// Returns the Id of the Node. 
-    IndexType GetId() const
+    /// Returns the Id of the Node.
+    IndexType GetId() const noexcept
     {
         return mId;
     }
 
     /// Sets the Id of the Node.
-    void SetId(IndexType NewId)
+    void SetId(IndexType NewId) noexcept
     {
         mId = NewId;
     }
@@ -103,12 +100,12 @@ public:
         mSolutionStepsNodalData = TheData;
     }
 
-    VariablesListDataValueContainer& GetSolutionStepData()
+    VariablesListDataValueContainer& GetSolutionStepData() noexcept
     {
         return mSolutionStepsNodalData;
     }
 
-    const VariablesListDataValueContainer& GetSolutionStepData() const
+    const VariablesListDataValueContainer& GetSolutionStepData() const noexcept
     {
         return mSolutionStepsNodalData;
     }
@@ -190,7 +187,6 @@ private:
 
     /// Copy constructor.
     NodalData(NodalData const& rOther);
-
 
     ///@}
 

--- a/kratos/includes/dof.h
+++ b/kratos/includes/dof.h
@@ -174,7 +174,7 @@ public:
     }
 
     //This default constructor is needed for serializer
-    Dof()
+    Dof() noexcept
         : mIsFixed(false),
           mVariableType(DofTrait<TDataType, Variable<TDataType> >::Id),
           mReactionType(DofTrait<TDataType, Variable<TDataType> >::Id),
@@ -184,38 +184,9 @@ public:
     {
     }
 
-    /// Copy constructor.
-    Dof(Dof const& rOther)
-        : mIsFixed(rOther.mIsFixed),
-          mVariableType(rOther.mVariableType),
-          mReactionType(rOther.mReactionType),
-          mIndex(rOther.mIndex),
-          mEquationId(rOther.mEquationId),
-          mpNodalData(rOther.mpNodalData)
-    {
-    }
-
-
-    /// Destructor.
-    ~Dof() {}
-
-
     ///@}
     ///@name Operators
     ///@{
-
-    /// Assignment operator.
-    Dof& operator=(Dof const& rOther)
-    {
-        mIsFixed = rOther.mIsFixed;
-        mEquationId = rOther.mEquationId;
-        mpNodalData = rOther.mpNodalData;
-        mIndex = rOther.mIndex;
-        mVariableType = rOther.mVariableType;
-        mReactionType = rOther.mReactionType;
-
-        return *this;
-    }
 
     template<class TVariableType>
     typename TVariableType::Type& operator()(const TVariableType& rThisVariable, IndexType SolutionStepIndex = 0)
@@ -289,12 +260,12 @@ public:
     ///@name Access
     ///@{
 
-    IndexType Id() const
+    IndexType Id() const noexcept
     {
         return mpNodalData->GetId();
     }
 
-    IndexType GetId() const
+    IndexType GetId() const noexcept
     {
         return mpNodalData->GetId();
     }
@@ -321,28 +292,28 @@ public:
 
     /** Return the Equation Id related to this degree eof freedom.
      */
-    EquationIdType EquationId() const
+    EquationIdType EquationId() const noexcept
     {
         return mEquationId;
     }
 
     /** Sets the Equation Id to the desired value
      */
-    void SetEquationId(EquationIdType NewEquationId)
+    void SetEquationId(EquationIdType NewEquationId) noexcept
     {
         mEquationId = NewEquationId;
     }
 
     /** Fixes the Dof
      */
-    void FixDof()
+    void FixDof() noexcept
     {
         mIsFixed=true;
     }
 
     /** Frees the degree of freedom
      */
-    void FreeDof()
+    void FreeDof() noexcept
     {
         mIsFixed=false;
     }
@@ -373,13 +344,13 @@ public:
     ///@name Inquiry
     ///@{
 
-    bool IsFixed() const
+    bool IsFixed() const noexcept
     {
         return mIsFixed;
     }
 
 
-    bool IsFree() const
+    bool IsFree() const noexcept
     {
         return !IsFixed();
     }


### PR DESCRIPTION
## Changelog

- define move constructor and move assignment operator for `NodalData`
- replace custom constructors, destructors and assignment operators with default-generated ones in `NodalData` and `Dof`
- make `NodalData` `final` because it does not have a virtual destructor
