### PR TITLE
[Core] Efficient NURBS Surface Checking

### DIFF
--- a/kratos/geometries/nurbs_surface_geometry.h
+++ b/kratos/geometries/nurbs_surface_geometry.h
@@ -78,6 +78,7 @@ public:
         , mKnotsV(rKnotsV)
     {
         CheckAndFitKnotVectors();
+        CheckIsRationalOnlyOnce();
     }
 
     /// Conctructor for NURBS surfaces
@@ -99,6 +100,8 @@ public:
 
         KRATOS_ERROR_IF(rWeights.size() != rThisPoints.size())
             << "Number of control points and weights do not match!" << std::endl;
+
+        CheckIsRationalOnlyOnce();
     }
 
     explicit NurbsSurfaceGeometry(const PointsArrayType& ThisPoints)
@@ -116,6 +119,7 @@ public:
         , mWeights(rOther.mWeights)
         , mpGeometryParent(rOther.mpGeometryParent)
     {
+        CheckIsRationalOnlyOnce();
     }
 
     /// Copy constructor from a geometry with different point type.
@@ -306,6 +310,22 @@ public:
     SizeType NumberOfKnotsV() const
     {
         return mKnotsV.size();
+    }
+
+    /* Checks if shape functions are rational or not.
+     * @mRational is true if NURBS, false if B-Splines only (all weights are considered as 1) */
+    void CheckIsRationalOnlyOnce()
+    {
+        if (mWeights.size() == 0)
+            mIsRational = false;
+        else {
+            for (IndexType i = 0; i < mWeights.size(); ++i) {
+                if (std::abs(mWeights[i] - 1.0) > 1e-10) {
+                    mIsRational = true;
+                }
+            }
+            mIsRational = false;
+        }
     }
 
     /* Checks if shape functions are rational or not.
@@ -603,7 +623,7 @@ public:
 
         for (IndexType i = 0; i < rIntegrationPoints.size(); ++i)
         {
-            if (IsRational()) {
+            if (mIsRational) {
                 shape_function_container.ComputeNurbsShapeFunctionValues(
                     mKnotsU, mKnotsV, mWeights, rIntegrationPoints[i][0], rIntegrationPoints[i][1]);
             }
@@ -707,7 +727,7 @@ public:
     {
         NurbsSurfaceShapeFunction shape_function_container(mPolynomialDegreeU, mPolynomialDegreeV, 0);
 
-        if (IsRational()) {
+        if (mIsRational) {
             shape_function_container.ComputeNurbsShapeFunctionValues(
                 mKnotsU, mKnotsV, mWeights, rLocalCoordinates[0], rLocalCoordinates[1]);
         }
@@ -746,7 +766,7 @@ public:
     {
         NurbsSurfaceShapeFunction shape_function_container(mPolynomialDegreeU, mPolynomialDegreeV, DerivativeOrder);
 
-        if (IsRational()) {
+        if (mIsRational) {
             shape_function_container.ComputeNurbsShapeFunctionValues(
                 mKnotsU, mKnotsV, mWeights, rLocalCoordinates[0], rLocalCoordinates[1]);
         }
@@ -791,7 +811,7 @@ public:
     {
         NurbsSurfaceShapeFunction shape_function_container(mPolynomialDegreeU, mPolynomialDegreeV, 0);
 
-        if (IsRational()) {
+        if (mIsRational) {
             shape_function_container.ComputeNurbsShapeFunctionValues(mKnotsU, mKnotsV, mWeights, rCoordinates[0], rCoordinates[1]);
         }
         else {
@@ -814,7 +834,7 @@ public:
     {
         NurbsSurfaceShapeFunction shape_function_container(mPolynomialDegreeU, mPolynomialDegreeV, 0);
 
-        if (IsRational()) {
+        if (mIsRational) {
             shape_function_container.ComputeNurbsShapeFunctionValues(mKnotsU, mKnotsV, mWeights, rCoordinates[0], rCoordinates[1]);
         }
         else {
@@ -892,6 +912,7 @@ private:
     Vector mKnotsU;
     Vector mKnotsV;
     Vector mWeights;
+    bool mIsRational;
 
     /// A NurbsSurface may refer to the BrepSurface as geometry parent.
     BaseType* mpGeometryParent = nullptr;

--- a/kratos/geometries/nurbs_surface_geometry.h
+++ b/kratos/geometries/nurbs_surface_geometry.h
@@ -319,12 +319,13 @@ public:
         if (mWeights.size() == 0)
             mIsRational = false;
         else {
+            mIsRational = false;
             for (IndexType i = 0; i < mWeights.size(); ++i) {
-                if (std::abs(mWeights[i] - 1.0) > 1e-10) {
+                if (std::abs(mWeights[i] - 1.0) > 1e-8) {
                     mIsRational = true;
+                    break;
                 }
             }
-            mIsRational = false;
         }
     }
 


### PR DESCRIPTION
**📝 Description**
This PR adds a `mRational` member variable to store whether the surface is a NURBS. Initialize it in the constructor to avoid repeatedly checking for each element, improving efficiency.

Kudos to @NickNick9 
