### PR TITLE
[CMake] Move Boost library detection to independent CMake module

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -461,37 +461,8 @@ if( KRATOS_NO_TRY_CATCH MATCHES ON )
   add_definitions( -DKRATOS_NO_TRY_CATCH )
 endif( KRATOS_NO_TRY_CATCH MATCHES ON )
 
-##*****************************
-# Finding and including BOOST library (version should not matter anymore)
-if(DEFINED ENV{BOOST_ROOT})
-  set(BOOST_ROOT $ENV{BOOST_ROOT})
-endif(DEFINED ENV{BOOST_ROOT})
-
-find_package(Boost)
-
-if(NOT Boost_FOUND)
-  # Trying to find in in external libraries
-  set(BOOST_ROOT "${KRATOS_SOURCE_DIR}/external_libraries/boost")
-  find_package(Boost)
-  if(NOT Boost_FOUND)
-    message(FATAL_ERROR "It was not possible to find Boost in your machine, please define properly BOOST_ROOT if you have not")
-  endif(NOT Boost_FOUND)
-endif(NOT Boost_FOUND)
-
-set(Boost_USE_STATIC_LIBS   OFF)
-set(Boost_USE_MULTITHREADED ON)
-set(Boost_REALPATH ON)
-
-include_directories(SYSTEM ${Boost_INCLUDE_DIRS})
-
-message(STATUS "Boost Include: ${Boost_INCLUDE_DIRS}")
-message(STATUS "Boost Linkdir: ${Boost_LIBRARY_DIRS}")
-
-if(Boost_VERSION_STRING VERSION_LESS 1.70)
-  message(WARNING "Kratos requires at least boost version 1.70 to enable boost related performance improvements")
-else()
-  add_definitions( -DBOOST_UBLAS_MOVE_SEMANTICS )
-endif ()
+# Boost
+include(KratosBoost)
 
 # std::atomic_ref is part of C++20, hence using boost::atomic_ref
 # boost::atomic_ref has full support from version 1.74

--- a/cmake_modules/KratosBoost.cmake
+++ b/cmake_modules/KratosBoost.cmake
@@ -1,0 +1,52 @@
+# Finding and including the BOOST library (version should not matter anymore)
+
+# Check if Boost_INCLUDE_DIRS and Boost_LIBRARY_DIRS are already defined
+if(Boost_INCLUDE_DIRS AND Boost_LIBRARY_DIRS)
+  message(STATUS "Using predefined Boost paths for Boost_INCLUDE_DIRS and Boost_LIBRARY_DIRS, instead of searching for Boost")
+else(Boost_INCLUDE_DIRS AND Boost_LIBRARY_DIRS)
+  # Check if the BOOST_ROOT environment variable is defined
+  # If so, use it to set the BOOST_ROOT variable in CMake
+  if(DEFINED ENV{BOOST_ROOT})
+    set(BOOST_ROOT $ENV{BOOST_ROOT})
+  endif(DEFINED ENV{BOOST_ROOT})
+
+  # Attempt to find the Boost library using CMake's find_package
+  find_package(Boost)
+
+  # If Boost is not found, attempt to locate it in the external libraries folder
+  if(NOT Boost_FOUND)
+    # Set BOOST_ROOT to the expected external library directory within the project source
+    set(BOOST_ROOT "${KRATOS_SOURCE_DIR}/external_libraries/boost")
+
+    # Try finding Boost again using the newly set BOOST_ROOT
+    find_package(Boost)
+
+    # If Boost is still not found, terminate with an error message
+    if(NOT Boost_FOUND)
+      message(FATAL_ERROR "It was not possible to find Boost in your machine. Please define BOOST_ROOT correctly if you have it installed.")
+    endif(NOT Boost_FOUND)
+  endif(NOT Boost_FOUND)
+endif()
+
+# Configure Boost usage settings
+set(Boost_USE_STATIC_LIBS   OFF) # Use shared (dynamic) libraries instead of static ones
+set(Boost_USE_MULTITHREADED  ON) # Enable multithreading support in Boost
+set(Boost_REALPATH           ON) # Resolve symbolic links to their real paths
+
+# Ensure Boost include and library directories are properly set
+if(Boost_INCLUDE_DIRS)
+  include_directories(SYSTEM ${Boost_INCLUDE_DIRS})
+endif(Boost_INCLUDE_DIRS)
+
+# Display information about the found Boost installation
+message(STATUS "Boost Include: ${Boost_INCLUDE_DIRS}")
+message(STATUS "Boost Linkdir: ${Boost_LIBRARY_DIRS}")
+
+# Check the Boost version and handle compatibility
+if(Boost_VERSION_STRING VERSION_LESS 1.70)
+  # Warn the user if Boost version is lower than 1.70
+  message(WARNING "Kratos requires at least Boost version 1.70 to enable Boost-related performance improvements")
+else(Boost_VERSION_STRING VERSION_LESS 1.70)
+  # Define BOOST_UBLAS_MOVE_SEMANTICS for improved performance with Boost UBLAS in newer versions
+  add_definitions(-DBOOST_UBLAS_MOVE_SEMANTICS)
+endif(Boost_VERSION_STRING VERSION_LESS 1.70)

--- a/cmake_modules/KratosBoost.cmake
+++ b/cmake_modules/KratosBoost.cmake
@@ -1,5 +1,13 @@
 # Finding and including the BOOST library (version should not matter anymore)
 
+# Check if Boost_INCLUDE_DIRS and Boost_LIBRARY_DIRS are already defined as environment variables
+if(DEFINED ENV{Boost_INCLUDE_DIRS})
+  set(Boost_INCLUDE_DIRS $ENV{Boost_INCLUDE_DIRS})
+endif(DEFINED ENV{Boost_INCLUDE_DIRS})
+if(DEFINED ENV{Boost_LIBRARY_DIRS})
+  set(Boost_LIBRARY_DIRS $ENV{Boost_LIBRARY_DIRS})
+endif(DEFINED ENV{Boost_LIBRARY_DIRS})
+
 # Check if Boost_INCLUDE_DIRS and Boost_LIBRARY_DIRS are already defined
 if(Boost_INCLUDE_DIRS AND Boost_LIBRARY_DIRS)
   message(STATUS "Using predefined Boost paths for Boost_INCLUDE_DIRS and Boost_LIBRARY_DIRS, instead of searching for Boost")


### PR DESCRIPTION
# **📝 Description**

Refactor Boost library configuration to a separate module (KratosBoost.cmake)

## Summary of Changes:
- Moved the Boost library detection and configuration logic from `CMakeLists.txt` into a new module, `cmake_modules/KratosBoost.cmake`.
- Simplified the Boost configuration process by checking predefined Boost paths and environment variables (`BOOST_ROOT`). Also allows to manually define the Boost library includes and binaries in a separate manner.
- Updated `CMakeLists.txt` to include the new `KratosBoost.cmake` module instead of handling Boost configuration directly.

# **🆕 Changelog**

- [Move Boost library detection to independent CMake module](https://github.com/KratosMultiphysics/Kratos/commit/682e57e91e0a814ad4b7ba60bef07c557886da44)
