### PR TITLE
[Doc] Adding Google libraries to README thanks

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,8 @@ Some users of the technologies developed in Kratos are:
 - [AMGCL](https://github.com/ddemidov/amgcl) for its highly scalable multigrid solver
 - [JSON](https://github.com/nlohmann/json) JSON for Modern C++
 - [ZLib](https://zlib.net/) The compression library
+- [Google Test](https://github.com/google/googletest) for unit testing C++ code
+- [Google Benchmark](https://github.com/google/benchmark) for microbenchmarking and performance testing
 
 ## In applications:
 - [Eigen](http://eigen.tuxfamily.org) For linear solvers used in the [LinearSolversApplication](applications/LinearSolversApplication)


### PR DESCRIPTION
**📝 Description**

The PR updates the `README.md` file to include references to the two Google libs in the list of tools used by Kratos:  
- **Google Test** for unit testing C++ code
- **Google Benchmark** for microbenchmarking and performance testing

**🆕 Changelog**

- [Adding Google libraries to README thanks](https://github.com/KratosMultiphysics/Kratos/commit/bf1a2fa9153ee2c9c6baff72353e5682a64c51c1)
