### PR TITLE
[Core] Refactor `Dot` function in `math_utils.h` to support template types

### DIFF
--- a/kratos/utilities/math_utils.h
+++ b/kratos/utilities/math_utils.h
@@ -704,7 +704,7 @@ public:
         const TVector2& rSecondVector
         )
     {
-        double temp = 0.0;
+        TDataType temp {};
         for (std::size_t i=0; i<rFirstVector.size(); ++i){
             temp += rFirstVector[i] * rSecondVector[i];
         }

--- a/kratos/utilities/math_utils.h
+++ b/kratos/utilities/math_utils.h
@@ -698,9 +698,10 @@ public:
      * @param rSecondVector Second input vector
      * @return The resulting norm
      */
+    template<class TVector1, clas TVector2>
     static inline double Dot(
-        const Vector& rFirstVector,
-        const Vector& rSecondVector
+        const TVector1& rFirstVector,
+        const TVector2& rSecondVector
         )
     {
         double temp = 0.0;

--- a/kratos/utilities/math_utils.h
+++ b/kratos/utilities/math_utils.h
@@ -698,7 +698,7 @@ public:
      * @param rSecondVector Second input vector
      * @return The resulting norm
      */
-    template<class TVector1, clas TVector2>
+    template<class TVector1, class TVector2>
     static inline double Dot(
         const TVector1& rFirstVector,
         const TVector2& rSecondVector

--- a/kratos/utilities/math_utils.h
+++ b/kratos/utilities/math_utils.h
@@ -699,7 +699,7 @@ public:
      * @return The resulting norm
      */
     template<class TVector1, class TVector2>
-    static inline double Dot(
+    static inline TDataType Dot(
         const TVector1& rFirstVector,
         const TVector2& rSecondVector
         )


### PR DESCRIPTION
# **📝 Description**

This change enhances the flexibility of the `Dot` function by making it compatible with various vector types beyond the default `Vector` type.

After https://github.com/KratosMultiphysics/Kratos/pull/13106

## Commit Summary:
- Modified the `Dot` function in the `MathUtils` class within `kratos/utilities/math_utils.h` to accept template parameters for the input vectors, allowing the function to handle different vector types (`TVector1` and `TVector2`).
- Updated function signature to use templated vector types instead of the specific `Vector` type.

# **🆕 Changelog**

- [Templated `Dot` product](https://github.com/KratosMultiphysics/Kratos/commit/362bca6ad614ae632abaa143a7df7d7606d3eeed)