### PR TITLE
[Core] Support serialization through (smart) pointers to abstract classes

### DIFF
--- a/kratos/includes/serializer.h
+++ b/kratos/includes/serializer.h
@@ -233,7 +233,7 @@ public:
                 {
                     if constexpr (!std::is_abstract_v<TDataType>) {
                         if(!pValue) {
-                            pValue = Kratos::shared_ptr<TDataType>(new TDataType);
+                            pValue = this->MakeShared<TDataType>();
                         }
                     }
                     else {
@@ -1435,6 +1435,17 @@ private:
 
     /// Sets the pointer of the stream buffer at the end
     void SeekEnd();
+
+    template <typename T>
+    std::shared_ptr<T> MakeShared()
+    {
+        if constexpr (std::is_default_constructible_v<T>)
+        {
+            return std::make_shared<T>();
+        } else {
+            return std::shared_ptr<T>(new T);
+        }
+    }
 
     ///@}
     ///@name Private  Access

--- a/kratos/includes/serializer.h
+++ b/kratos/includes/serializer.h
@@ -203,6 +203,12 @@ public:
 	//msRegisteredObjects.insert(RegisteredObjectsContainerType::value_type(rName,&pPrototype));
     }
 
+    static void Deregister(const std::string& rName)
+    {
+        msRegisteredObjects.erase(rName);
+        msRegisteredObjectsName.erase(rName);
+    }
+
     template<class TDataType>
     void load(std::string const & rTag, TDataType& rObject)
     {
@@ -225,8 +231,13 @@ public:
             {
                 if(pointer_type == SP_BASE_CLASS_POINTER)
                 {
-                    if(!pValue) {
-                        pValue = Kratos::shared_ptr<TDataType>(new TDataType);
+                    if constexpr (!std::is_abstract_v<TDataType>) {
+                        if(!pValue) {
+                            pValue = Kratos::shared_ptr<TDataType>(new TDataType);
+                        }
+                    }
+                    else {
+                        KRATOS_ERROR << "Cannot instantiate an abstract class\n";
                     }
                 }
                 else if(pointer_type == SP_DERIVED_CLASS_POINTER)
@@ -270,8 +281,13 @@ public:
             {
                 if(pointer_type == SP_BASE_CLASS_POINTER)
                 {
-                    if(!pValue) {
-                        pValue = Kratos::intrusive_ptr<TDataType>(new TDataType);
+                    if constexpr (!std::is_abstract_v<TDataType>) {
+                        if(!pValue) {
+                            pValue = Kratos::intrusive_ptr<TDataType>(new TDataType);
+                        }
+                    }
+                    else {
+                        KRATOS_ERROR << "Cannot instantiate an abstract class\n";
                     }
                 }
                 else if(pointer_type == SP_DERIVED_CLASS_POINTER)
@@ -315,8 +331,13 @@ public:
             {
                 if(pointer_type == SP_BASE_CLASS_POINTER)
                 {
-                    if(!pValue) {
-                        pValue = Kratos::unique_ptr<TDataType>(new TDataType);
+                    if constexpr (!std::is_abstract_v<TDataType>) {
+                        if(!pValue) {
+                            pValue = Kratos::unique_ptr<TDataType>(new TDataType);
+                        }
+                    }
+                    else {
+                        KRATOS_ERROR << "Cannot instantiate an abstract class\n";
                     }
                 }
                 else if(pointer_type == SP_DERIVED_CLASS_POINTER)
@@ -360,8 +381,13 @@ public:
             {
                 if(pointer_type == SP_BASE_CLASS_POINTER)
                 {
-                    if(!pValue) {
-                        pValue = new TDataType;
+                    if constexpr (!std::is_abstract_v<TDataType>) {
+                        if(!pValue) {
+                            pValue = new TDataType;
+                        }
+                    }
+                    else {
+                        KRATOS_ERROR << "Cannot instantiate an abstract class\n";
                     }
                 }
                 else if(pointer_type == SP_DERIVED_CLASS_POINTER)

--- a/kratos/tests/cpp_tests/sources/test_serializer.cpp
+++ b/kratos/tests/cpp_tests/sources/test_serializer.cpp
@@ -25,8 +25,6 @@
 namespace Kratos::Testing 
 {
 
-using namespace Kratos;
-
 /*********************************************************************/
 /* Helper Functions */
 /*********************************************************************/
@@ -100,7 +98,7 @@ public:
     [[nodiscard]] virtual int foo() const = 0;
 
 private:
-    friend class Serializer;
+    friend class Kratos::Serializer;
     virtual void save(Serializer&) const = 0;
     virtual void load(Serializer&) = 0;
 
@@ -134,7 +132,7 @@ public:
     [[nodiscard]] int foo() const override { return mFooNumber; }
 
 private:
-    friend class Serializer;
+    friend class Kratos::Serializer;
 
     void save(Serializer& rSerializer) const override
     {

--- a/kratos/tests/cpp_tests/sources/test_serializer.cpp
+++ b/kratos/tests/cpp_tests/sources/test_serializer.cpp
@@ -132,6 +132,8 @@ public:
     [[nodiscard]] int foo() const override { return mFooNumber; }
 
 private:
+    friend class Serializer;
+
     void save(Serializer& rSerializer) const override
     {
         rSerializer.save("mFooNumber", mFooNumber);

--- a/kratos/tests/cpp_tests/sources/test_serializer.cpp
+++ b/kratos/tests/cpp_tests/sources/test_serializer.cpp
@@ -252,7 +252,7 @@ KRATOS_TEST_CASE_IN_SUITE(SerializerRawOwningPointerToAbstractBase, KratosCoreFa
     StreamSerializer serializer;
     ScopedTestClassRegistration scoped_registration;
 
-    const auto tag_string = std::string{"TestString"};
+    const std::string tag_string("TestString");
     const AbstractTestClass* p_instance = new DerivedTestClass{42};
     serializer.save(tag_string, p_instance);
     delete p_instance;
@@ -272,11 +272,11 @@ KRATOS_TEST_CASE_IN_SUITE(SerializerKratosUniquePtrToAbstractBase, KratosCoreFas
     StreamSerializer serializer;
     ScopedTestClassRegistration scoped_registration;
 
-    const auto tag_string = std::string{"TestString"};
-    const auto p_instance = Kratos::unique_ptr<AbstractTestClass>{Kratos::make_unique<DerivedTestClass>(42)};
+    const std::string tag_string("TestString");
+    const Kratos::unique_ptr<AbstractTestClass> p_instance = Kratos::make_unique<DerivedTestClass>(42);
     serializer.save(tag_string, p_instance);
 
-    auto p_loaded_instance = Kratos::unique_ptr<AbstractTestClass>{};
+    Kratos::unique_ptr<AbstractTestClass> p_loaded_instance;
     serializer.load(tag_string, p_loaded_instance);
 
     ASSERT_NE(p_loaded_instance, nullptr);
@@ -312,11 +312,11 @@ KRATOS_TEST_CASE_IN_SUITE(SerializerKratosSharedPtrToAbstractBase, KratosCoreFas
     StreamSerializer serializer;
     ScopedTestClassRegistration scoped_registration;
 
-    const auto tag_string = std::string{"TestString"};
-    const auto p_instance = Kratos::shared_ptr<AbstractTestClass>{Kratos::make_shared<DerivedTestClass>(42)};
+    const std::string tag_string("TestString");
+    const Kratos::shared_ptr<AbstractTestClass> p_instance = Kratos::make_shared<DerivedTestClass>(42);
     serializer.save(tag_string, p_instance);
 
-    auto p_loaded_instance = Kratos::shared_ptr<AbstractTestClass>{};
+    Kratos::shared_ptr<AbstractTestClass> p_loaded_instance;
     serializer.load(tag_string, p_loaded_instance);
 
     ASSERT_NE(p_loaded_instance, nullptr);
@@ -328,11 +328,11 @@ KRATOS_TEST_CASE_IN_SUITE(SerializerKratosIntrusivePtrToAbstractBase, KratosCore
     StreamSerializer serializer;
     ScopedTestClassRegistration scoped_registration;
 
-    const auto tag_string = std::string{"TestString"};
-    const auto p_instance = Kratos::intrusive_ptr<AbstractTestClass>{Kratos::make_intrusive<DerivedTestClass>(42)};
+    const std::string tag_string("TestString");
+    const Kratos::intrusive_ptr<AbstractTestClass> p_instance = Kratos::make_intrusive<DerivedTestClass>(42);
     serializer.save(tag_string, p_instance);
 
-    auto p_loaded_instance = Kratos::intrusive_ptr<AbstractTestClass>{};
+    Kratos::intrusive_ptr<AbstractTestClass> p_loaded_instance;
     serializer.load(tag_string, p_loaded_instance);
 
     ASSERT_NE(p_loaded_instance, nullptr);

--- a/kratos/tests/cpp_tests/sources/test_serializer.cpp
+++ b/kratos/tests/cpp_tests/sources/test_serializer.cpp
@@ -127,20 +127,21 @@ std::ostream& operator<<(std::ostream& rOStream, const AbstractTestClass&)
 class DerivedTestClass : public AbstractTestClass
 {
 public:
+    explicit DerivedTestClass(int FooNumber = 0) : mFooNumber(FooNumber) {}
     ~DerivedTestClass() override = default;
-    [[nodiscard]] int foo() const override { return mMagicNumber; }
+    [[nodiscard]] int foo() const override { return mFooNumber; }
 
 private:
     void save(Serializer& rSerializer) const override
     {
-        rSerializer.save("mMagicNumber", mMagicNumber);
+        rSerializer.save("mFooNumber", mFooNumber);
     }
 
     void load(Serializer& rSerializer) override {
-        rSerializer.load("mMagicNumber", mMagicNumber);
+        rSerializer.load("mFooNumber", mFooNumber);
     }
 
-    int mMagicNumber = 42;
+    int mFooNumber;
 };
 
 class ScopedTestClassRegistration
@@ -252,7 +253,7 @@ KRATOS_TEST_CASE_IN_SUITE(SerializerRawOwningPointerToAbstractBase, KratosCoreFa
     ScopedTestClassRegistration scoped_registration;
 
     const auto tag_string = std::string{"TestString"};
-    const AbstractTestClass* p_instance = new DerivedTestClass{};
+    const AbstractTestClass* p_instance = new DerivedTestClass{42};
     serializer.save(tag_string, p_instance);
     delete p_instance;
     p_instance = nullptr; // Avoid having a dangling pointer
@@ -272,7 +273,7 @@ KRATOS_TEST_CASE_IN_SUITE(SerializerKratosUniquePtrToAbstractBase, KratosCoreFas
     ScopedTestClassRegistration scoped_registration;
 
     const auto tag_string = std::string{"TestString"};
-    const auto p_instance = Kratos::unique_ptr<AbstractTestClass>{Kratos::make_unique<DerivedTestClass>()};
+    const auto p_instance = Kratos::unique_ptr<AbstractTestClass>{Kratos::make_unique<DerivedTestClass>(42)};
     serializer.save(tag_string, p_instance);
 
     auto p_loaded_instance = Kratos::unique_ptr<AbstractTestClass>{};
@@ -312,7 +313,7 @@ KRATOS_TEST_CASE_IN_SUITE(SerializerKratosSharedPtrToAbstractBase, KratosCoreFas
     ScopedTestClassRegistration scoped_registration;
 
     const auto tag_string = std::string{"TestString"};
-    const auto p_instance = Kratos::shared_ptr<AbstractTestClass>{Kratos::make_shared<DerivedTestClass>()};
+    const auto p_instance = Kratos::shared_ptr<AbstractTestClass>{Kratos::make_shared<DerivedTestClass>(42)};
     serializer.save(tag_string, p_instance);
 
     auto p_loaded_instance = Kratos::shared_ptr<AbstractTestClass>{};
@@ -328,7 +329,7 @@ KRATOS_TEST_CASE_IN_SUITE(SerializerKratosIntrusivePtrToAbstractBase, KratosCore
     ScopedTestClassRegistration scoped_registration;
 
     const auto tag_string = std::string{"TestString"};
-    const auto p_instance = Kratos::intrusive_ptr<AbstractTestClass>{Kratos::make_intrusive<DerivedTestClass>()};
+    const auto p_instance = Kratos::intrusive_ptr<AbstractTestClass>{Kratos::make_intrusive<DerivedTestClass>(42)};
     serializer.save(tag_string, p_instance);
 
     auto p_loaded_instance = Kratos::intrusive_ptr<AbstractTestClass>{};

--- a/kratos/tests/cpp_tests/sources/test_serializer.cpp
+++ b/kratos/tests/cpp_tests/sources/test_serializer.cpp
@@ -25,6 +25,8 @@
 namespace Kratos::Testing 
 {
 
+using namespace Kratos;
+
 /*********************************************************************/
 /* Helper Functions */
 /*********************************************************************/
@@ -139,7 +141,8 @@ private:
         rSerializer.save("mFooNumber", mFooNumber);
     }
 
-    void load(Serializer& rSerializer) override {
+    void load(Serializer& rSerializer) override
+    {
         rSerializer.load("mFooNumber", mFooNumber);
     }
 

--- a/kratos/tests/cpp_tests/sources/test_serializer.cpp
+++ b/kratos/tests/cpp_tests/sources/test_serializer.cpp
@@ -89,6 +89,81 @@ void FillMatrixWithValues(TObjectType& rObject)
     }
 }
 
+// Two dummy classes for testing (de)serialization of a derived class through
+// a pointer to an abstract base class
+class AbstractTestClass
+{
+public:
+    virtual ~AbstractTestClass() = default;
+    [[nodiscard]] virtual int foo() const = 0;
+
+private:
+    friend class Serializer;
+    virtual void save(Serializer&) const = 0;
+    virtual void load(Serializer&) = 0;
+
+    // The following members are required to use this class with intrusive_ptr
+    friend void intrusive_ptr_add_ref(const AbstractTestClass* pInstance)
+    {
+        if (pInstance) ++(pInstance->mRefCount);
+    }
+
+    friend void intrusive_ptr_release(const AbstractTestClass* pInstance)
+    {
+        if (pInstance) {
+            --(pInstance->mRefCount);
+            if (pInstance->mRefCount == 0) delete pInstance;
+        }
+    }
+
+    mutable std::size_t mRefCount = 0; // Must be mutable, since previous two members receive a pointer-to-const
+};
+
+std::ostream& operator<<(std::ostream& rOStream, const AbstractTestClass&)
+{
+    return rOStream;
+}
+
+class DerivedTestClass : public AbstractTestClass
+{
+public:
+    ~DerivedTestClass() override = default;
+    [[nodiscard]] int foo() const override { return mMagicNumber; }
+
+private:
+    void save(Serializer& rSerializer) const override
+    {
+        rSerializer.save("mMagicNumber", mMagicNumber);
+    }
+
+    void load(Serializer& rSerializer) override {
+        rSerializer.load("mMagicNumber", mMagicNumber);
+    }
+
+    int mMagicNumber = 42;
+};
+
+class ScopedTestClassRegistration
+{
+public:
+    ScopedTestClassRegistration()
+    {
+        Serializer::Register("DerivedTestClass", DerivedTestClass{});
+    }
+
+    ~ScopedTestClassRegistration()
+    {
+        Serializer::Deregister("DerivedTestClass");
+    }
+
+    // Since the destructor has been defined, use the Rule of Five
+    ScopedTestClassRegistration(const ScopedTestClassRegistration&) = delete;
+    ScopedTestClassRegistration& operator=(const ScopedTestClassRegistration&) = delete;
+
+    ScopedTestClassRegistration(ScopedTestClassRegistration&&) noexcept = default;
+    ScopedTestClassRegistration& operator=(ScopedTestClassRegistration&&) noexcept = default;
+};
+
 /*********************************************************************/
 /* Testing the Datatypes that for which the
     "KRATOS_SERIALIZATION_DIRECT_LOAD" macro is used */
@@ -171,6 +246,42 @@ KRATOS_TEST_CASE_IN_SUITE(SerializerLongLong, KratosCoreFastSuite)
 /* Testing the Datatypes that have a specific save/load implementation */
 /*********************************************************************/
 
+KRATOS_TEST_CASE_IN_SUITE(SerializerRawOwningPointerToAbstractBase, KratosCoreFastSuiteWithoutKernel)
+{
+    StreamSerializer serializer;
+    ScopedTestClassRegistration scoped_registration;
+
+    const auto tag_string = std::string{"TestString"};
+    const AbstractTestClass* p_instance = new DerivedTestClass{};
+    serializer.save(tag_string, p_instance);
+    delete p_instance;
+    p_instance = nullptr; // Avoid having a dangling pointer
+
+    AbstractTestClass* p_loaded_instance = nullptr;
+    serializer.load(tag_string, p_loaded_instance);
+
+    ASSERT_NE(p_loaded_instance, nullptr);
+    KRATOS_EXPECT_EQ(p_loaded_instance->foo(), 42);
+
+    delete p_loaded_instance;
+}
+
+KRATOS_TEST_CASE_IN_SUITE(SerializerKratosUniquePtrToAbstractBase, KratosCoreFastSuiteWithoutKernel)
+{
+    StreamSerializer serializer;
+    ScopedTestClassRegistration scoped_registration;
+
+    const auto tag_string = std::string{"TestString"};
+    const auto p_instance = Kratos::unique_ptr<AbstractTestClass>{Kratos::make_unique<DerivedTestClass>()};
+    serializer.save(tag_string, p_instance);
+
+    auto p_loaded_instance = Kratos::unique_ptr<AbstractTestClass>{};
+    serializer.load(tag_string, p_loaded_instance);
+
+    ASSERT_NE(p_loaded_instance, nullptr);
+    KRATOS_EXPECT_EQ(p_loaded_instance->foo(), 42);
+}
+
 KRATOS_TEST_CASE_IN_SUITE(SerializerKratosSharedPtr, KratosCoreFastSuite)
 {
     StreamSerializer serializer;
@@ -193,6 +304,38 @@ KRATOS_TEST_CASE_IN_SUITE(SerializerKratosSharedPtr, KratosCoreFastSuite)
     KRATOS_EXPECT_EQ(*p_point, *p_loaded_point);
     for (std::size_t i=0; i<(*p_array).size(); ++i)
         KRATOS_EXPECT_EQ((*p_loaded_array)[i], (*p_array)[i]);
+}
+
+KRATOS_TEST_CASE_IN_SUITE(SerializerKratosSharedPtrToAbstractBase, KratosCoreFastSuiteWithoutKernel)
+{
+    StreamSerializer serializer;
+    ScopedTestClassRegistration scoped_registration;
+
+    const auto tag_string = std::string{"TestString"};
+    const auto p_instance = Kratos::shared_ptr<AbstractTestClass>{Kratos::make_shared<DerivedTestClass>()};
+    serializer.save(tag_string, p_instance);
+
+    auto p_loaded_instance = Kratos::shared_ptr<AbstractTestClass>{};
+    serializer.load(tag_string, p_loaded_instance);
+
+    ASSERT_NE(p_loaded_instance, nullptr);
+    KRATOS_EXPECT_EQ(p_loaded_instance->foo(), 42);
+}
+
+KRATOS_TEST_CASE_IN_SUITE(SerializerKratosIntrusivePtrToAbstractBase, KratosCoreFastSuiteWithoutKernel)
+{
+    StreamSerializer serializer;
+    ScopedTestClassRegistration scoped_registration;
+
+    const auto tag_string = std::string{"TestString"};
+    const auto p_instance = Kratos::intrusive_ptr<AbstractTestClass>{Kratos::make_intrusive<DerivedTestClass>()};
+    serializer.save(tag_string, p_instance);
+
+    auto p_loaded_instance = Kratos::intrusive_ptr<AbstractTestClass>{};
+    serializer.load(tag_string, p_loaded_instance);
+
+    ASSERT_NE(p_loaded_instance, nullptr);
+    KRATOS_EXPECT_EQ(p_loaded_instance->foo(), 42);
 }
 
 KRATOS_TEST_CASE_IN_SUITE(SerializerStdArray, KratosCoreFastSuite)


### PR DESCRIPTION
**📝 Description**
This PR adds a few compile-time checks that avoid attempting to instantiate abstract base classes while loading objects from a serializer. So far, it was not possible to use (smart) pointers to abstract base classes when serializing objects of derived classes. By adding a few compile-time checks, we now can supply (smart) pointers to abstract base classes to the existing (de)serialization code.

For each modified `load` function, a corresponding unit test has been created.

To keep the scope of changes to the registry as local as possible during a test run, a test class is registered and deregistered as needed using the RAII idiom. To this end, class `Serializer` has been extended with a member function to deregister data types.
