### PR TITLE
[GeoMechanicsApplication] Made input providers of the calculators structs and remove redundant getters

### DIFF
--- a/applications/GeoMechanicsApplication/custom_elements/compressibility_calculator.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/compressibility_calculator.cpp
@@ -80,34 +80,4 @@ double CompressibilityCalculator::CalculateBiotModulusInverse(const RetentionLaw
     return result;
 }
 
-const Properties& CompressibilityCalculator::InputProvider::GetElementProperties() const
-{
-    return mGetElementProperties();
-}
-
-const std::vector<RetentionLaw::Pointer>& CompressibilityCalculator::InputProvider::GetRetentionLaws() const
-{
-    return mGetRetentionLaws();
-}
-
-const Matrix& CompressibilityCalculator::InputProvider::GetNContainer() const
-{
-    return mGetNContainer();
-}
-
-Vector CompressibilityCalculator::InputProvider::GetIntegrationCoefficients() const
-{
-    return mGetIntegrationCoefficients();
-}
-
-double CompressibilityCalculator::InputProvider::GetMatrixScalarFactor() const
-{
-    return mGetMatrixScalarFactor();
-}
-
-Vector CompressibilityCalculator::InputProvider::GetNodalValues(const Variable<double>& rVariable) const
-{
-    return mGetNodalValues(rVariable);
-}
-
 } // namespace Kratos

--- a/applications/GeoMechanicsApplication/custom_elements/compressibility_calculator.h
+++ b/applications/GeoMechanicsApplication/custom_elements/compressibility_calculator.h
@@ -26,38 +26,28 @@ namespace Kratos
 class CompressibilityCalculator : public ContributionCalculator
 {
 public:
-    class InputProvider
-    {
-    public:
+    struct InputProvider {
         InputProvider(std::function<const Properties&()> GetElementProperties,
                       std::function<const std::vector<RetentionLaw::Pointer>&()> GetRetentionLaws,
                       std::function<const Matrix&()>                             GetNContainer,
                       std::function<Vector()>                        GetIntegrationCoefficients,
                       std::function<double()>                        GetMatrixScalarFactor,
                       std::function<Vector(const Variable<double>&)> GetNodalValuesOf)
-            : mGetElementProperties(std::move(GetElementProperties)),
-              mGetRetentionLaws(std::move(GetRetentionLaws)),
-              mGetNContainer(std::move(GetNContainer)),
-              mGetIntegrationCoefficients(std::move(GetIntegrationCoefficients)),
-              mGetMatrixScalarFactor(std::move(GetMatrixScalarFactor)),
-              mGetNodalValues(std::move(GetNodalValuesOf))
+            : GetElementProperties(std::move(GetElementProperties)),
+              GetRetentionLaws(std::move(GetRetentionLaws)),
+              GetNContainer(std::move(GetNContainer)),
+              GetIntegrationCoefficients(std::move(GetIntegrationCoefficients)),
+              GetMatrixScalarFactor(std::move(GetMatrixScalarFactor)),
+              GetNodalValues(std::move(GetNodalValuesOf))
         {
         }
 
-        [[nodiscard]] const Properties&                         GetElementProperties() const;
-        [[nodiscard]] const std::vector<RetentionLaw::Pointer>& GetRetentionLaws() const;
-        [[nodiscard]] const Matrix&                             GetNContainer() const;
-        [[nodiscard]] Vector                                    GetIntegrationCoefficients() const;
-        [[nodiscard]] double                                    GetMatrixScalarFactor() const;
-        [[nodiscard]] Vector GetNodalValues(const Variable<double>& rVariable) const;
-
-    private:
-        std::function<const Properties&()>                         mGetElementProperties;
-        std::function<const std::vector<RetentionLaw::Pointer>&()> mGetRetentionLaws;
-        std::function<const Matrix&()>                             mGetNContainer;
-        std::function<Vector()>                                    mGetIntegrationCoefficients;
-        std::function<double()>                                    mGetMatrixScalarFactor;
-        std::function<Vector(const Variable<double>&)>             mGetNodalValues;
+        std::function<const Properties&()>                         GetElementProperties;
+        std::function<const std::vector<RetentionLaw::Pointer>&()> GetRetentionLaws;
+        std::function<const Matrix&()>                             GetNContainer;
+        std::function<Vector()>                                    GetIntegrationCoefficients;
+        std::function<double()>                                    GetMatrixScalarFactor;
+        std::function<Vector(const Variable<double>&)>             GetNodalValues;
     };
 
     explicit CompressibilityCalculator(InputProvider rInputProvider);

--- a/applications/GeoMechanicsApplication/custom_elements/filter_compressibility_calculator.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/filter_compressibility_calculator.cpp
@@ -72,34 +72,4 @@ double FilterCompressibilityCalculator::CalculateElasticCapacity(double Projecte
            1.0 / r_properties[BULK_MODULUS_FLUID];
 }
 
-const Properties& FilterCompressibilityCalculator::InputProvider::GetElementProperties() const
-{
-    return mGetElementProperties();
-}
-
-const Matrix& FilterCompressibilityCalculator::InputProvider::GetNContainer() const
-{
-    return mGetNContainer();
-}
-
-Vector FilterCompressibilityCalculator::InputProvider::GetIntegrationCoefficients() const
-{
-    return mGetIntegrationCoefficients();
-}
-
-Vector FilterCompressibilityCalculator::InputProvider::GetProjectedGravityForIntegrationPoints() const
-{
-    return mGetProjectedGravityForIntegrationPoints();
-}
-
-double FilterCompressibilityCalculator::InputProvider::GetMatrixScalarFactor() const
-{
-    return mGetMatrixScalarFactor();
-}
-
-Vector FilterCompressibilityCalculator::InputProvider::GetNodalValues(const Variable<double>& rVariable) const
-{
-    return mGetNodalValues(rVariable);
-}
-
 } // namespace Kratos

--- a/applications/GeoMechanicsApplication/custom_elements/filter_compressibility_calculator.h
+++ b/applications/GeoMechanicsApplication/custom_elements/filter_compressibility_calculator.h
@@ -26,38 +26,28 @@ namespace Kratos
 class FilterCompressibilityCalculator : public ContributionCalculator
 {
 public:
-    class InputProvider
-    {
-    public:
+    struct InputProvider {
         InputProvider(std::function<const Properties&()> GetElementProperties,
                       std::function<const Matrix&()>     GetNContainer,
                       std::function<Vector()>            GetIntegrationCoefficients,
                       std::function<Vector()>            GetProjectedGravityForIntegrationPoints,
                       std::function<double()>            GetMatrixScalarFactor,
                       std::function<Vector(const Variable<double>&)> GetNodalValuesOf)
-            : mGetElementProperties(std::move(GetElementProperties)),
-              mGetNContainer(std::move(GetNContainer)),
-              mGetIntegrationCoefficients(std::move(GetIntegrationCoefficients)),
-              mGetProjectedGravityForIntegrationPoints(std::move(GetProjectedGravityForIntegrationPoints)),
-              mGetMatrixScalarFactor(std::move(GetMatrixScalarFactor)),
-              mGetNodalValues(std::move(GetNodalValuesOf))
+            : GetElementProperties(std::move(GetElementProperties)),
+              GetNContainer(std::move(GetNContainer)),
+              GetIntegrationCoefficients(std::move(GetIntegrationCoefficients)),
+              GetProjectedGravityForIntegrationPoints(std::move(GetProjectedGravityForIntegrationPoints)),
+              GetMatrixScalarFactor(std::move(GetMatrixScalarFactor)),
+              GetNodalValues(std::move(GetNodalValuesOf))
         {
         }
 
-        [[nodiscard]] const Properties& GetElementProperties() const;
-        [[nodiscard]] const Matrix&     GetNContainer() const;
-        [[nodiscard]] Vector            GetIntegrationCoefficients() const;
-        [[nodiscard]] Vector            GetProjectedGravityForIntegrationPoints() const;
-        [[nodiscard]] double            GetMatrixScalarFactor() const;
-        [[nodiscard]] Vector            GetNodalValues(const Variable<double>& rVariable) const;
-
-    private:
-        std::function<const Properties&()>             mGetElementProperties;
-        std::function<const Matrix&()>                 mGetNContainer;
-        std::function<Vector()>                        mGetIntegrationCoefficients;
-        std::function<Vector()>                        mGetProjectedGravityForIntegrationPoints;
-        std::function<double()>                        mGetMatrixScalarFactor;
-        std::function<Vector(const Variable<double>&)> mGetNodalValues;
+        std::function<const Properties&()>             GetElementProperties;
+        std::function<const Matrix&()>                 GetNContainer;
+        std::function<Vector()>                        GetIntegrationCoefficients;
+        std::function<Vector()>                        GetProjectedGravityForIntegrationPoints;
+        std::function<double()>                        GetMatrixScalarFactor;
+        std::function<Vector(const Variable<double>&)> GetNodalValues;
     };
 
     explicit FilterCompressibilityCalculator(InputProvider AnInputProvider);

--- a/applications/GeoMechanicsApplication/custom_elements/permeability_calculator.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/permeability_calculator.cpp
@@ -65,29 +65,4 @@ Matrix PermeabilityCalculator::CalculatePermeabilityMatrix() const
     return result;
 }
 
-const Properties& PermeabilityCalculator::InputProvider::GetElementProperties() const
-{
-    return mGetElementProperties();
-}
-
-const std::vector<RetentionLaw::Pointer>& PermeabilityCalculator::InputProvider::GetRetentionLaws() const
-{
-    return mGetRetentionLaws();
-}
-
-Vector PermeabilityCalculator::InputProvider::GetIntegrationCoefficients() const
-{
-    return mGetIntegrationCoefficients();
-}
-
-Vector PermeabilityCalculator::InputProvider::GetNodalValues(const Variable<double>& rVariable) const
-{
-    return mGetNodalValues(rVariable);
-}
-
-Geometry<Node>::ShapeFunctionsGradientsType PermeabilityCalculator::InputProvider::GetShapeFunctionGradients() const
-{
-    return mGetShapeFunctionGradients();
-}
-
 } // namespace Kratos

--- a/applications/GeoMechanicsApplication/custom_elements/permeability_calculator.h
+++ b/applications/GeoMechanicsApplication/custom_elements/permeability_calculator.h
@@ -23,34 +23,25 @@ namespace Kratos
 class PermeabilityCalculator : public ContributionCalculator
 {
 public:
-    class InputProvider
-    {
-    public:
+    struct InputProvider {
         InputProvider(std::function<const Properties&()> GetElementProperties,
                       std::function<const std::vector<RetentionLaw::Pointer>&()> GetRetentionLaws,
                       std::function<Vector()>                        GetIntegrationCoefficients,
                       std::function<Vector(const Variable<double>&)> GetNodalValuesOf,
                       std::function<Geometry<Node>::ShapeFunctionsGradientsType()> GetShapeFunctionGradients)
-            : mGetElementProperties(std::move(GetElementProperties)),
-              mGetRetentionLaws(std::move(GetRetentionLaws)),
-              mGetIntegrationCoefficients(std::move(GetIntegrationCoefficients)),
-              mGetNodalValues(std::move(GetNodalValuesOf)),
-              mGetShapeFunctionGradients(std::move(GetShapeFunctionGradients))
+            : GetElementProperties(std::move(GetElementProperties)),
+              GetRetentionLaws(std::move(GetRetentionLaws)),
+              GetIntegrationCoefficients(std::move(GetIntegrationCoefficients)),
+              GetNodalValues(std::move(GetNodalValuesOf)),
+              GetShapeFunctionGradients(std::move(GetShapeFunctionGradients))
         {
         }
 
-        [[nodiscard]] const Properties&                         GetElementProperties() const;
-        [[nodiscard]] const std::vector<RetentionLaw::Pointer>& GetRetentionLaws() const;
-        [[nodiscard]] Vector                                    GetIntegrationCoefficients() const;
-        [[nodiscard]] Vector GetNodalValues(const Variable<double>& rVariable) const;
-        [[nodiscard]] Geometry<Node>::ShapeFunctionsGradientsType GetShapeFunctionGradients() const;
-
-    private:
-        std::function<const Properties&()>                           mGetElementProperties;
-        std::function<const std::vector<RetentionLaw::Pointer>&()>   mGetRetentionLaws;
-        std::function<Vector()>                                      mGetIntegrationCoefficients;
-        std::function<Vector(const Variable<double>&)>               mGetNodalValues;
-        std::function<Geometry<Node>::ShapeFunctionsGradientsType()> mGetShapeFunctionGradients;
+        std::function<const Properties&()>                           GetElementProperties;
+        std::function<const std::vector<RetentionLaw::Pointer>&()>   GetRetentionLaws;
+        std::function<Vector()>                                      GetIntegrationCoefficients;
+        std::function<Vector(const Variable<double>&)>               GetNodalValues;
+        std::function<Geometry<Node>::ShapeFunctionsGradientsType()> GetShapeFunctionGradients;
     };
 
     explicit PermeabilityCalculator(InputProvider InputProvider);


### PR DESCRIPTION
Some small clean-up: since the input providers only contain (the functions to obtain) data, a `struct` is more suitable. This also reduces the code, since we don't need the getters anymore.