### PR TITLE
Expose `Dof` Index

### DIFF
--- a/kratos/includes/dof.h
+++ b/kratos/includes/dof.h
@@ -270,6 +270,12 @@ public:
         return mpNodalData->GetId();
     }
 
+    /// @brief Return the index of this Dof within the node that contains it.
+    int GetIndex() const noexcept
+    {
+        return mIndex;
+    }
+
     /** Returns variable assigned to this degree of freedom. */
     const VariableData& GetVariable() const
     {


### PR DESCRIPTION
A requirement for solving #13160. This PR makes it possible to refer to `Dof`s with two integers (node ID, dof index within node) instead of a direct pointer.