### PR TITLE
[SMApp] Adding pre-stressing loads in Trusses and Timoshenko Beams

### DIFF
--- a/applications/StructuralMechanicsApplication/custom_constitutive/timoshenko_beam_elastic_constitutive_law.cpp
+++ b/applications/StructuralMechanicsApplication/custom_constitutive/timoshenko_beam_elastic_constitutive_law.cpp
@@ -139,7 +139,7 @@ void TimoshenkoBeamElasticConstitutiveLaw::CalculateMaterialResponseCauchy(Const
         AddInitialStressVectorContribution(r_generalized_stress_vector);
 
         if (r_material_properties.Has(BEAM_PRESTRESS_PK2)) {
-            r_generalized_stress_vector[0] += r_material_properties[BEAM_PRESTRESS_PK2][0] * A;
+            r_generalized_stress_vector += r_material_properties[BEAM_PRESTRESS_PK2];
         }
 
         if (r_cl_law_options.Is(ConstitutiveLaw::COMPUTE_CONSTITUTIVE_TENSOR)) {

--- a/applications/StructuralMechanicsApplication/custom_constitutive/timoshenko_beam_elastic_constitutive_law.cpp
+++ b/applications/StructuralMechanicsApplication/custom_constitutive/timoshenko_beam_elastic_constitutive_law.cpp
@@ -139,7 +139,7 @@ void TimoshenkoBeamElasticConstitutiveLaw::CalculateMaterialResponseCauchy(Const
         AddInitialStressVectorContribution(r_generalized_stress_vector);
 
         if (r_material_properties.Has(BEAM_PRESTRESS_PK2)) {
-            r_generalized_stress_vector += r_material_properties[BEAM_PRESTRESS_PK2];
+            r_generalized_stress_vector[0] += r_material_properties[BEAM_PRESTRESS_PK2][0] * A;
         }
 
         if (r_cl_law_options.Is(ConstitutiveLaw::COMPUTE_CONSTITUTIVE_TENSOR)) {

--- a/applications/StructuralMechanicsApplication/custom_constitutive/timoshenko_beam_elastic_constitutive_law.cpp
+++ b/applications/StructuralMechanicsApplication/custom_constitutive/timoshenko_beam_elastic_constitutive_law.cpp
@@ -138,11 +138,15 @@ void TimoshenkoBeamElasticConstitutiveLaw::CalculateMaterialResponseCauchy(Const
 
         AddInitialStressVectorContribution(r_generalized_stress_vector);
 
+        if (r_material_properties.Has(BEAM_PRESTRESS_PK2)) {
+            r_generalized_stress_vector += r_material_properties[BEAM_PRESTRESS_PK2];
+        }
+
         if (r_cl_law_options.Is(ConstitutiveLaw::COMPUTE_CONSTITUTIVE_TENSOR)) {
             auto &r_stress_derivatives = rValues.GetConstitutiveMatrix(); // dN_dEl, dM_dkappa, dV_dGamma_xy
             if (r_stress_derivatives.size1() != strain_size || r_stress_derivatives.size2() != strain_size)
                 r_stress_derivatives.resize(strain_size, strain_size, false);
-            noalias(r_stress_derivatives) = ZeroMatrix(strain_size, strain_size);
+            r_stress_derivatives.clear();
 
             r_stress_derivatives(0, 0) = EA;  // dN_dEl
             r_stress_derivatives(1, 1) = EI;  // dM_dkappa

--- a/applications/StructuralMechanicsApplication/custom_elements/beam_elements/timoshenko_beam_element_2D2N.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/beam_elements/timoshenko_beam_element_2D2N.cpp
@@ -978,9 +978,6 @@ void LinearTimoshenkoBeamElement2D2N::CalculateOnIntegrationPoints(
             CalculateGeneralizedStrainsVector(strain_vector, length, phi, integration_points[integration_point].X(), nodal_values);
             mConstitutiveLawVector[integration_point]->CalculateMaterialResponsePK2(cl_values);
             rOutput[integration_point] = cl_values.GetStressVector();
-            if ( this->GetProperties().Has(BEAM_PRESTRESS_PK2)) {
-                rOutput[integration_point] += this->GetProperties()[BEAM_PRESTRESS_PK2];
-            }
         }
     }
 }

--- a/applications/StructuralMechanicsApplication/custom_elements/beam_elements/timoshenko_curved_beam_element_2D3N.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/beam_elements/timoshenko_curved_beam_element_2D3N.cpp
@@ -741,9 +741,6 @@ void LinearTimoshenkoCurvedBeamElement2D3N::CalculateOnIntegrationPoints(
             mConstitutiveLawVector[integration_point]->CalculateMaterialResponsePK2(cl_values);
 
             rOutput[integration_point] = cl_values.GetStressVector();
-            if ( this->GetProperties().Has(BEAM_PRESTRESS_PK2)) {
-                rOutput[integration_point] += this->GetProperties()[BEAM_PRESTRESS_PK2];
-            }
         }
     }
 }

--- a/applications/StructuralMechanicsApplication/custom_elements/truss_elements/linear_truss_element.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/truss_elements/linear_truss_element.cpp
@@ -425,12 +425,12 @@ void LinearTrussElement<TDimension, TNNodes>::CalculateLocalSystem(
     if (rLHS.size1() != SystemSize || rLHS.size2() != SystemSize) {
         rLHS.resize(SystemSize, SystemSize, false);
     }
-    noalias(rLHS) = ZeroMatrix(SystemSize, SystemSize);
+    rLHS.clear();
 
     if (rRHS.size() != SystemSize) {
         rRHS.resize(SystemSize, false);
     }
-    noalias(rRHS) = ZeroVector(SystemSize);
+    rRHS.clear();
 
     const auto& integration_points = IntegrationPoints(GetIntegrationMethod());
 
@@ -471,8 +471,13 @@ void LinearTrussElement<TDimension, TNNodes>::CalculateLocalSystem(
         strain_vector[0] = inner_prod(B, nodal_values);
         mConstitutiveLawVector[IP]->CalculateMaterialResponsePK2(cl_values); // fills stress and const. matrix
 
+        double pre_stress = 0.0;
+        if (r_props.Has(TRUSS_PRESTRESS_PK2)) {
+            pre_stress = r_props[TRUSS_PRESTRESS_PK2];
+        }
+
         noalias(rLHS) += outer_prod(B, B) * constitutive_matrix(0, 0) * jacobian_weight;
-        noalias(rRHS) -= B * stress_vector[0] * jacobian_weight;
+        noalias(rRHS) -= B * (stress_vector[0] + pre_stress) * jacobian_weight;
 
         noalias(rRHS) += N_shape  * local_body_forces[0] * jacobian_weight;
         noalias(rRHS) += N_shapeY * local_body_forces[1] * jacobian_weight;
@@ -492,14 +497,14 @@ void LinearTrussElement<TDimension, TNNodes>::CalculateLeftHandSide(
     const ProcessInfo& rProcessInfo
     )
 {
-   KRATOS_TRY;
+    KRATOS_TRY;
     const auto &r_props = GetProperties();
     const auto &r_geometry = GetGeometry();
 
     if (rLHS.size1() != SystemSize || rLHS.size2() != SystemSize) {
         rLHS.resize(SystemSize, SystemSize, false);
     }
-    noalias(rLHS) = ZeroMatrix(SystemSize, SystemSize);
+    rLHS.clear();
 
     const auto& integration_points = IntegrationPoints(GetIntegrationMethod());
 
@@ -560,7 +565,7 @@ void LinearTrussElement<TDimension, TNNodes>::CalculateRightHandSide(
     if (rRHS.size() != SystemSize) {
         rRHS.resize(SystemSize, false);
     }
-    noalias(rRHS) = ZeroVector(SystemSize);
+    rRHS.clear();
 
     const auto& integration_points = IntegrationPoints(GetIntegrationMethod());
 
@@ -601,7 +606,12 @@ void LinearTrussElement<TDimension, TNNodes>::CalculateRightHandSide(
         strain_vector[0] = inner_prod(B, nodal_values);
         mConstitutiveLawVector[IP]->CalculateMaterialResponsePK2(cl_values); // fills stress and const. matrix
 
-        noalias(rRHS) -= B * stress_vector[0] * jacobian_weight;
+        double pre_stress = 0.0;
+        if (r_props.Has(TRUSS_PRESTRESS_PK2)) {
+            pre_stress = r_props[TRUSS_PRESTRESS_PK2];
+        }
+
+        noalias(rRHS) -= B * (stress_vector[0] + pre_stress) * jacobian_weight;
 
         noalias(rRHS) += N_shape  * local_body_forces[0] * jacobian_weight;
         noalias(rRHS) += N_shapeY * local_body_forces[1] * jacobian_weight;
@@ -745,12 +755,18 @@ void LinearTrussElement<TDimension, TNNodes>::CalculateOnIntegrationPoints(
         // Loop over the integration points
         for (SizeType IP = 0; IP < integration_points.size(); ++IP) {
             const double xi = integration_points[IP].X();
-             GetFirstDerivativesShapeFunctionsValues(B, length, xi);
+            GetFirstDerivativesShapeFunctionsValues(B, length, xi);
 
             strain_vector[0] = inner_prod(B, nodal_values);
 
             mConstitutiveLawVector[IP]->CalculateMaterialResponsePK2(cl_values);
-            rOutput[IP] = cl_values.GetStressVector()[0] * area;
+
+            double pre_stress = 0.0;
+            if (GetProperties().Has(TRUSS_PRESTRESS_PK2)) {
+                pre_stress = GetProperties()[TRUSS_PRESTRESS_PK2];
+            }
+
+            rOutput[IP] = (cl_values.GetStressVector()[0] + pre_stress) * area;
         }
     } else if (rVariable == AXIAL_STRAIN) {
         ConstitutiveLaw::Parameters cl_values(GetGeometry(), GetProperties(), rProcessInfo);
@@ -767,7 +783,7 @@ void LinearTrussElement<TDimension, TNNodes>::CalculateOnIntegrationPoints(
         // Loop over the integration points
         for (SizeType IP = 0; IP < integration_points.size(); ++IP) {
             const double xi = integration_points[IP].X();
-             GetFirstDerivativesShapeFunctionsValues(B, length, xi);
+            GetFirstDerivativesShapeFunctionsValues(B, length, xi);
             rOutput[IP] = inner_prod(B, nodal_values);
         }
     }

--- a/applications/StructuralMechanicsApplication/custom_elements/truss_elements/linear_truss_element.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/truss_elements/linear_truss_element.cpp
@@ -471,10 +471,7 @@ void LinearTrussElement<TDimension, TNNodes>::CalculateLocalSystem(
         strain_vector[0] = inner_prod(B, nodal_values);
         mConstitutiveLawVector[IP]->CalculateMaterialResponsePK2(cl_values); // fills stress and const. matrix
 
-        double pre_stress = 0.0;
-        if (r_props.Has(TRUSS_PRESTRESS_PK2)) {
-            pre_stress = r_props[TRUSS_PRESTRESS_PK2];
-        }
+        const auto pre_stress = r_props.Has(TRUSS_PRESTRESS_PK2) ? r_props[TRUSS_PRESTRESS_PK2] :  0.0;
 
         noalias(rLHS) += outer_prod(B, B) * constitutive_matrix(0, 0) * jacobian_weight;
         noalias(rRHS) -= B * (stress_vector[0] + pre_stress) * jacobian_weight;


### PR DESCRIPTION
**📝 Description**
In this PR I am adding the pre-stressing capability to the already implemented Linear Truss and Timoshenko beams. In the truss, the element is adding the pre-stressing load. In the Timoshenko beams is the constitutive law doing that. This decision is not consistent, BUT the fact that there are many truss elements adding the pre-stress via the Element makes difficult to intgrate without breaking many elements.

@rfaasse can you check if the implementation works for you?