### PR TITLE
[GeoMechanicsApplication] Modify the input parameters for the elastic matrix calculation

### DIFF
--- a/applications/GeoMechanicsApplication/custom_constitutive/constitutive_law_dimension.h
+++ b/applications/GeoMechanicsApplication/custom_constitutive/constitutive_law_dimension.h
@@ -26,10 +26,11 @@ public:
     virtual ~ConstitutiveLawDimension() = default;
 
     [[nodiscard]] virtual Matrix CalculateElasticMatrix(double YoungsModulus, double PoissonsRatio) const = 0;
-    [[nodiscard]] virtual std::unique_ptr<ConstitutiveLawDimension> Clone() const          = 0;
-    [[nodiscard]] virtual std::size_t                               GetStrainSize() const  = 0;
-    [[nodiscard]] virtual std::size_t                               GetDimension() const   = 0;
-    [[nodiscard]] virtual Flags                                     GetSpatialType() const = 0;
+    [[nodiscard]] virtual std::unique_ptr<ConstitutiveLawDimension> Clone() const         = 0;
+    [[nodiscard]] virtual std::size_t                               GetStrainSize() const = 0;
+    [[nodiscard]] virtual std::size_t                               GetDimension() const  = 0;
+    [[nodiscard]] virtual std::size_t GetNumberOfNormalComponents() const                 = 0;
+    [[nodiscard]] virtual Flags       GetSpatialType() const                              = 0;
 };
 
 } // namespace Kratos

--- a/applications/GeoMechanicsApplication/custom_constitutive/constitutive_law_dimension.h
+++ b/applications/GeoMechanicsApplication/custom_constitutive/constitutive_law_dimension.h
@@ -25,11 +25,11 @@ class ConstitutiveLawDimension
 public:
     virtual ~ConstitutiveLawDimension() = default;
 
-    virtual Matrix FillConstitutiveMatrix(double c1, double c2, double c3) const = 0;
-    virtual std::unique_ptr<ConstitutiveLawDimension> Clone() const              = 0;
-    virtual std::size_t                               GetStrainSize() const      = 0;
-    virtual std::size_t                               GetDimension() const       = 0;
-    virtual Flags                                     GetSpatialType() const     = 0;
+    [[nodiscard]] virtual Matrix CalculateElasticMatrix(double YoungsModulus, double PoissonsRatio) const = 0;
+    [[nodiscard]] virtual std::unique_ptr<ConstitutiveLawDimension> Clone() const          = 0;
+    [[nodiscard]] virtual std::size_t                               GetStrainSize() const  = 0;
+    [[nodiscard]] virtual std::size_t                               GetDimension() const   = 0;
+    [[nodiscard]] virtual Flags                                     GetSpatialType() const = 0;
 };
 
 } // namespace Kratos

--- a/applications/GeoMechanicsApplication/custom_constitutive/incremental_linear_elastic_law.cpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/incremental_linear_elastic_law.cpp
@@ -21,8 +21,6 @@ using namespace Kratos;
 
 void SetEntriesAboveDiagonalToZero(Matrix& rMatrix)
 {
-    KRATOS_DEBUG_ERROR_IF(rMatrix.size1() != rMatrix.size2()) << "Matrix must be square\n";
-
     for (auto i = std::size_t{0}; i < rMatrix.size1() - 1; ++i) {
         for (auto j = i + 1; j < rMatrix.size2(); ++j) {
             rMatrix(i, j) = 0.0;
@@ -32,8 +30,6 @@ void SetEntriesAboveDiagonalToZero(Matrix& rMatrix)
 
 void SetEntriesBelowDiagonalToZero(Matrix& rMatrix)
 {
-    KRATOS_DEBUG_ERROR_IF(rMatrix.size1() != rMatrix.size2()) << "Matrix must be square\n";
-
     for (auto i = std::size_t{1}; i < rMatrix.size1(); ++i) {
         for (auto j = std::size_t{0}; j < i; ++j) {
             rMatrix(i, j) = 0.0;
@@ -43,8 +39,6 @@ void SetEntriesBelowDiagonalToZero(Matrix& rMatrix)
 
 void SetShearEntriesToZero(Matrix& rMatrix, std::size_t NumberOfNormalComponents)
 {
-    KRATOS_DEBUG_ERROR_IF(rMatrix.size1() != rMatrix.size2()) << "Matrix must be square\n";
-
     for (auto i = NumberOfNormalComponents; i < rMatrix.size1(); ++i) {
         rMatrix(i, i) = 0.0;
     }

--- a/applications/GeoMechanicsApplication/custom_constitutive/incremental_linear_elastic_law.cpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/incremental_linear_elastic_law.cpp
@@ -101,15 +101,16 @@ void GeoIncrementalLinearElasticLaw::CalculateElasticMatrix(Matrix& C, Constitut
     KRATOS_TRY
 
     const Properties& r_material_properties = rValues.GetMaterialProperties();
-    const auto        E                     = r_material_properties[YOUNG_MODULUS];
-    const auto        NU                    = r_material_properties[POISSON_RATIO];
+    C = mpConstitutiveDimension->CalculateElasticMatrix(r_material_properties[YOUNG_MODULUS],
+                                                        r_material_properties[POISSON_RATIO]);
 
-    const double c0 = E / ((1.0 + NU) * (1.0 - 2.0 * NU));
-    const double c1 = (1.0 - NU) * c0;
-    const double c2 = this->GetConsiderDiagonalEntriesOnlyAndNoShear() ? 0.0 : c0 * NU;
-    const double c3 = this->GetConsiderDiagonalEntriesOnlyAndNoShear() ? 0.0 : (0.5 - NU) * c0;
-
-    C = mpConstitutiveDimension->FillConstitutiveMatrix(c1, c2, c3);
+    if (this->GetConsiderDiagonalEntriesOnlyAndNoShear()) {
+        auto result = Matrix{C.size1(), C.size2(), 0.0};
+        for (auto i = std::size_t{0}; i < 3; ++i) {
+            result(i, i) = C(i, i);
+        }
+        noalias(C) = result;
+    }
 
     KRATOS_CATCH("")
 }

--- a/applications/GeoMechanicsApplication/custom_constitutive/incremental_linear_elastic_law.cpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/incremental_linear_elastic_law.cpp
@@ -14,6 +14,38 @@
 #include "constitutive_law_dimension.h"
 #include "geo_mechanics_application_variables.h"
 
+namespace
+{
+
+using namespace Kratos;
+
+void SetEntriesAboveDiagonalToZero(Matrix& rMatrix)
+{
+    for (auto i = std::size_t{0}; i < rMatrix.size1(); ++i) {
+        for (auto j = i + 1; j < rMatrix.size2(); ++j) {
+            rMatrix(i, j) = 0.0;
+        }
+    }
+}
+
+void SetEntriesBelowDiagonalToZero(Matrix& rMatrix)
+{
+    for (auto i = std::size_t{1}; i < rMatrix.size1(); ++i) {
+        for (auto j = std::size_t{0}; j < i; ++j) {
+            rMatrix(i, j) = 0.0;
+        }
+    }
+}
+
+void SetShearEntriesToZero(Matrix& rMatrix, std::size_t NumberOfNormalComponents)
+{
+    for (auto i = NumberOfNormalComponents; i < rMatrix.size1(); ++i) {
+        rMatrix(i, i) = 0.0;
+    }
+}
+
+} // namespace
+
 namespace Kratos
 {
 
@@ -105,11 +137,9 @@ void GeoIncrementalLinearElasticLaw::CalculateElasticMatrix(Matrix& C, Constitut
                                                         r_material_properties[POISSON_RATIO]);
 
     if (this->GetConsiderDiagonalEntriesOnlyAndNoShear()) {
-        auto result = Matrix{C.size1(), C.size2(), 0.0};
-        for (auto i = std::size_t{0}; i < mpConstitutiveDimension->GetNumberOfNormalComponents(); ++i) {
-            result(i, i) = C(i, i);
-        }
-        noalias(C) = result;
+        SetEntriesAboveDiagonalToZero(C);
+        SetEntriesBelowDiagonalToZero(C);
+        SetShearEntriesToZero(C, mpConstitutiveDimension->GetNumberOfNormalComponents());
     }
 
     KRATOS_CATCH("")

--- a/applications/GeoMechanicsApplication/custom_constitutive/incremental_linear_elastic_law.cpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/incremental_linear_elastic_law.cpp
@@ -21,7 +21,9 @@ using namespace Kratos;
 
 void SetEntriesAboveDiagonalToZero(Matrix& rMatrix)
 {
-    for (auto i = std::size_t{0}; i < rMatrix.size1(); ++i) {
+    KRATOS_DEBUG_ERROR_IF(rMatrix.size1() != rMatrix.size2()) << "Matrix must be square\n";
+
+    for (auto i = std::size_t{0}; i < rMatrix.size1() - 1; ++i) {
         for (auto j = i + 1; j < rMatrix.size2(); ++j) {
             rMatrix(i, j) = 0.0;
         }
@@ -30,6 +32,8 @@ void SetEntriesAboveDiagonalToZero(Matrix& rMatrix)
 
 void SetEntriesBelowDiagonalToZero(Matrix& rMatrix)
 {
+    KRATOS_DEBUG_ERROR_IF(rMatrix.size1() != rMatrix.size2()) << "Matrix must be square\n";
+
     for (auto i = std::size_t{1}; i < rMatrix.size1(); ++i) {
         for (auto j = std::size_t{0}; j < i; ++j) {
             rMatrix(i, j) = 0.0;
@@ -39,6 +43,8 @@ void SetEntriesBelowDiagonalToZero(Matrix& rMatrix)
 
 void SetShearEntriesToZero(Matrix& rMatrix, std::size_t NumberOfNormalComponents)
 {
+    KRATOS_DEBUG_ERROR_IF(rMatrix.size1() != rMatrix.size2()) << "Matrix must be square\n";
+
     for (auto i = NumberOfNormalComponents; i < rMatrix.size1(); ++i) {
         rMatrix(i, i) = 0.0;
     }

--- a/applications/GeoMechanicsApplication/custom_constitutive/incremental_linear_elastic_law.cpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/incremental_linear_elastic_law.cpp
@@ -106,7 +106,7 @@ void GeoIncrementalLinearElasticLaw::CalculateElasticMatrix(Matrix& C, Constitut
 
     if (this->GetConsiderDiagonalEntriesOnlyAndNoShear()) {
         auto result = Matrix{C.size1(), C.size2(), 0.0};
-        for (auto i = std::size_t{0}; i < 3; ++i) {
+        for (auto i = std::size_t{0}; i < mpConstitutiveDimension->GetNumberOfNormalComponents(); ++i) {
             result(i, i) = C(i, i);
         }
         noalias(C) = result;

--- a/applications/GeoMechanicsApplication/custom_constitutive/plane_strain.cpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/plane_strain.cpp
@@ -18,8 +18,13 @@
 namespace Kratos
 {
 
-Matrix PlaneStrain::FillConstitutiveMatrix(double c1, double c2, double c3) const
+Matrix PlaneStrain::CalculateElasticMatrix(double YoungsModulus, double PoissonsRatio) const
 {
+    const auto c0 = YoungsModulus / ((1.0 + PoissonsRatio) * (1.0 - 2.0 * PoissonsRatio));
+    const auto c1 = (1.0 - PoissonsRatio) * c0;
+    const auto c2 = c0 * PoissonsRatio;
+    const auto c3 = (0.5 - PoissonsRatio) * c0;
+
     Matrix result = ZeroMatrix(4, 4);
 
     result(INDEX_2D_PLANE_STRAIN_XX, INDEX_2D_PLANE_STRAIN_XX) = c1;

--- a/applications/GeoMechanicsApplication/custom_constitutive/plane_strain.cpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/plane_strain.cpp
@@ -53,6 +53,8 @@ std::size_t PlaneStrain::GetStrainSize() const { return VOIGT_SIZE_2D_PLANE_STRA
 
 std::size_t PlaneStrain::GetDimension() const { return N_DIM_2D; }
 
+std::size_t PlaneStrain::GetNumberOfNormalComponents() const { return 3; }
+
 Flags PlaneStrain::GetSpatialType() const { return ConstitutiveLaw::PLANE_STRAIN_LAW; }
 
 } // namespace Kratos

--- a/applications/GeoMechanicsApplication/custom_constitutive/plane_strain.cpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/plane_strain.cpp
@@ -22,7 +22,7 @@ Matrix PlaneStrain::CalculateElasticMatrix(double YoungsModulus, double Poissons
 {
     const auto c0 = YoungsModulus / ((1.0 + PoissonsRatio) * (1.0 - 2.0 * PoissonsRatio));
     const auto c1 = (1.0 - PoissonsRatio) * c0;
-    const auto c2 = c0 * PoissonsRatio;
+    const auto c2 = PoissonsRatio * c0;
     const auto c3 = (0.5 - PoissonsRatio) * c0;
 
     Matrix result = ZeroMatrix(4, 4);

--- a/applications/GeoMechanicsApplication/custom_constitutive/plane_strain.h
+++ b/applications/GeoMechanicsApplication/custom_constitutive/plane_strain.h
@@ -20,7 +20,7 @@ namespace Kratos
 class KRATOS_API(GEO_MECHANICS_APPLICATION) PlaneStrain : public ConstitutiveLawDimension
 {
 public:
-    [[nodiscard]] Matrix FillConstitutiveMatrix(double c1, double c2, double c3) const override;
+    [[nodiscard]] Matrix CalculateElasticMatrix(double YoungsModulus, double PoissonsRatio) const override;
     [[nodiscard]] std::unique_ptr<ConstitutiveLawDimension> Clone() const override;
     [[nodiscard]] std::size_t                               GetStrainSize() const override;
     [[nodiscard]] std::size_t                               GetDimension() const override;

--- a/applications/GeoMechanicsApplication/custom_constitutive/plane_strain.h
+++ b/applications/GeoMechanicsApplication/custom_constitutive/plane_strain.h
@@ -24,7 +24,8 @@ public:
     [[nodiscard]] std::unique_ptr<ConstitutiveLawDimension> Clone() const override;
     [[nodiscard]] std::size_t                               GetStrainSize() const override;
     [[nodiscard]] std::size_t                               GetDimension() const override;
-    [[nodiscard]] Flags                                     GetSpatialType() const override;
+    [[nodiscard]] std::size_t GetNumberOfNormalComponents() const override;
+    [[nodiscard]] Flags       GetSpatialType() const override;
 };
 
 } // namespace Kratos

--- a/applications/GeoMechanicsApplication/custom_constitutive/three_dimensional.cpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/three_dimensional.cpp
@@ -19,8 +19,13 @@
 namespace Kratos
 {
 
-Matrix ThreeDimensional::FillConstitutiveMatrix(double c1, double c2, double c3) const
+Matrix ThreeDimensional::CalculateElasticMatrix(double YoungsModulus, double PoissonsRatio) const
 {
+    const auto c0 = YoungsModulus / ((1.0 + PoissonsRatio) * (1.0 - 2.0 * PoissonsRatio));
+    const auto c1 = (1.0 - PoissonsRatio) * c0;
+    const auto c2 = c0 * PoissonsRatio;
+    const auto c3 = (0.5 - PoissonsRatio) * c0;
+
     Matrix result = ZeroMatrix(GetStrainSize(), GetStrainSize());
 
     result(INDEX_3D_XX, INDEX_3D_XX) = c1;

--- a/applications/GeoMechanicsApplication/custom_constitutive/three_dimensional.cpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/three_dimensional.cpp
@@ -56,6 +56,8 @@ std::size_t ThreeDimensional::GetStrainSize() const { return VOIGT_SIZE_3D; }
 
 std::size_t ThreeDimensional::GetDimension() const { return N_DIM_3D; }
 
+std::size_t ThreeDimensional::GetNumberOfNormalComponents() const { return 3; }
+
 Flags ThreeDimensional::GetSpatialType() const { return ConstitutiveLaw::THREE_DIMENSIONAL_LAW; }
 
 } // namespace Kratos

--- a/applications/GeoMechanicsApplication/custom_constitutive/three_dimensional.cpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/three_dimensional.cpp
@@ -23,7 +23,7 @@ Matrix ThreeDimensional::CalculateElasticMatrix(double YoungsModulus, double Poi
 {
     const auto c0 = YoungsModulus / ((1.0 + PoissonsRatio) * (1.0 - 2.0 * PoissonsRatio));
     const auto c1 = (1.0 - PoissonsRatio) * c0;
-    const auto c2 = c0 * PoissonsRatio;
+    const auto c2 = PoissonsRatio * c0;
     const auto c3 = (0.5 - PoissonsRatio) * c0;
 
     Matrix result = ZeroMatrix(GetStrainSize(), GetStrainSize());

--- a/applications/GeoMechanicsApplication/custom_constitutive/three_dimensional.h
+++ b/applications/GeoMechanicsApplication/custom_constitutive/three_dimensional.h
@@ -22,7 +22,7 @@ namespace Kratos
 class KRATOS_API(GEO_MECHANICS_APPLICATION) ThreeDimensional : public ConstitutiveLawDimension
 {
 public:
-    [[nodiscard]] Matrix FillConstitutiveMatrix(double c1, double c2, double c3) const override;
+    [[nodiscard]] Matrix CalculateElasticMatrix(double YoungsModulus, double PoissonsRatio) const override;
     [[nodiscard]] std::unique_ptr<ConstitutiveLawDimension> Clone() const override;
     [[nodiscard]] std::size_t                               GetStrainSize() const override;
     [[nodiscard]] std::size_t                               GetDimension() const override;

--- a/applications/GeoMechanicsApplication/custom_constitutive/three_dimensional.h
+++ b/applications/GeoMechanicsApplication/custom_constitutive/three_dimensional.h
@@ -26,7 +26,8 @@ public:
     [[nodiscard]] std::unique_ptr<ConstitutiveLawDimension> Clone() const override;
     [[nodiscard]] std::size_t                               GetStrainSize() const override;
     [[nodiscard]] std::size_t                               GetDimension() const override;
-    [[nodiscard]] Flags                                     GetSpatialType() const override;
+    [[nodiscard]] std::size_t GetNumberOfNormalComponents() const override;
+    [[nodiscard]] Flags       GetSpatialType() const override;
 };
 
 } // namespace Kratos


### PR DESCRIPTION
**📝 Description**

When calculating the elastic matrix, it is natural to provide Young's modulus $`E`$ and Poisson's ratio $`\nu`$. These new parameters replace the set of three coefficients that had to be supplied previously.

**🆕 Changelog**

Other changes include:
- Renamed the member function that calculates the elastic matrix.
- Added a member function that returns the number of normal components in the stress/strain vectors.
- The incremental linear elastic constitutive law sets the off-diagonal entries as well as the shear-related entries to zero upon request.