### PR TITLE
[GeoMechanicsApplication] Avoid division by zero when calculating Lode angle

### DIFF
--- a/applications/GeoMechanicsApplication/custom_utilities/stress_strain_utilities.cpp
+++ b/applications/GeoMechanicsApplication/custom_utilities/stress_strain_utilities.cpp
@@ -64,14 +64,16 @@ double StressStrainUtilities::CalculateLodeAngle(const Vector& rStressVector)
 {
     KRATOS_ERROR_IF(rStressVector.size() < 4);
 
-    const double p                   = CalculateMeanStress(rStressVector);
-    const double q                   = CalculateVonMisesStress(rStressVector);
-    const Matrix local_stress_tensor = MathUtils<double>::StressVectorToTensor(rStressVector);
-    Matrix       sigma_princi;
-    Matrix       eigen_vectors;
-    MathUtils<double>::GaussSeidelEigenSystem(local_stress_tensor, eigen_vectors, sigma_princi, 1.0e-16, 20);
-    const double numerator = (sigma_princi(0, 0) - p) * (sigma_princi(1, 1) - p) * (sigma_princi(2, 2) - p);
-    if (std::abs(numerator) < 1.0E-12) return 0.;
+    const auto q = CalculateVonMisesStress(rStressVector);
+    if (constexpr auto tolerance = 1.0E-12; q < tolerance) return 0.0;
+
+    Matrix sigma_princi;
+    Matrix eigen_vectors;
+    MathUtils<>::GaussSeidelEigenSystem(MathUtils<>::StressVectorToTensor(rStressVector),
+                                        eigen_vectors, sigma_princi, 1.0e-16, 20);
+    const auto p = CalculateMeanStress(rStressVector);
+    const auto numerator = (sigma_princi(0, 0) - p) * (sigma_princi(1, 1) - p) * (sigma_princi(2, 2) - p);
+
     return std::asin((-27. / 2.) * numerator / (q * q * q)) / 3.0;
 }
 

--- a/applications/GeoMechanicsApplication/custom_utilities/stress_strain_utilities.cpp
+++ b/applications/GeoMechanicsApplication/custom_utilities/stress_strain_utilities.cpp
@@ -73,8 +73,10 @@ double StressStrainUtilities::CalculateLodeAngle(const Vector& rStressVector)
                                         eigen_vectors, sigma_princi, 1.0e-16, 20);
     const auto p = CalculateMeanStress(rStressVector);
     const auto numerator = (sigma_princi(0, 0) - p) * (sigma_princi(1, 1) - p) * (sigma_princi(2, 2) - p);
+    // Avoid a domain error when computing the arc sine (which results in a NaN value)
+    const auto arg_to_asin = std::clamp((-27. / 2.) * numerator / (q * q * q), -1.0, 1.0);
 
-    return std::asin((-27. / 2.) * numerator / (q * q * q)) / 3.0;
+    return std::asin(arg_to_asin) / 3.0;
 }
 
 double StressStrainUtilities::CalculateMohrCoulombShearCapacity(const Vector& rStressVector, double C, double Phi)

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_utilities/test_stress_strain_utitlities.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_utilities/test_stress_strain_utitlities.cpp
@@ -69,6 +69,14 @@ KRATOS_TEST_CASE_IN_SUITE(CheckCalculateLodeAngle, KratosGeoMechanicsFastSuiteWi
     stress_vector <<= -1.0, 0.0, 1.0, 0.0;
     KRATOS_EXPECT_DOUBLE_EQ(MathUtils<>::DegreesToRadians(0.),
                             StressStrainUtilities::CalculateLodeAngle(stress_vector));
+
+    // Regression tests with a small perturbation
+    constexpr auto perturbation = 1.0e-8;
+    stress_vector <<= 0.5 + perturbation, -1.0, 0.5 + perturbation, 0.0;
+    KRATOS_EXPECT_DOUBLE_EQ(MathUtils<>::DegreesToRadians(30.),
+                            StressStrainUtilities::CalculateLodeAngle(stress_vector));
+    KRATOS_EXPECT_DOUBLE_EQ(MathUtils<>::DegreesToRadians(-30.),
+                            StressStrainUtilities::CalculateLodeAngle(-1. * stress_vector));
 }
 
 KRATOS_TEST_CASE_IN_SUITE(CheckCalculateMohrCoulombShearCapacityZeroStress, KratosGeoMechanicsFastSuiteWithoutKernel)

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_utilities/test_stress_strain_utitlities.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_utilities/test_stress_strain_utitlities.cpp
@@ -58,15 +58,17 @@ KRATOS_TEST_CASE_IN_SUITE(CheckCalculateVonMisesStressPureShear, KratosGeoMechan
 KRATOS_TEST_CASE_IN_SUITE(CheckCalculateLodeAngle, KratosGeoMechanicsFastSuiteWithoutKernel)
 {
     Vector stress_vector(4);
+    // Validate Triaxial Extension (TXE)
     stress_vector <<= 0.5, -1.0, 0.5, 0.0;
     KRATOS_EXPECT_DOUBLE_EQ(MathUtils<>::DegreesToRadians(30.),
                             StressStrainUtilities::CalculateLodeAngle(stress_vector));
+    // Validate Triaxial Compression (TXC)
     KRATOS_EXPECT_DOUBLE_EQ(MathUtils<>::DegreesToRadians(-30.),
                             StressStrainUtilities::CalculateLodeAngle(-1. * stress_vector));
-    Vector stress_vector2(4);
-    stress_vector2 <<= -1.0, 0.0, 1.0, 0.0;
+    // Validate Shear (SHR)
+    stress_vector <<= -1.0, 0.0, 1.0, 0.0;
     KRATOS_EXPECT_DOUBLE_EQ(MathUtils<>::DegreesToRadians(0.),
-                            StressStrainUtilities::CalculateLodeAngle(stress_vector2));
+                            StressStrainUtilities::CalculateLodeAngle(stress_vector));
 }
 
 KRATOS_TEST_CASE_IN_SUITE(CheckCalculateMohrCoulombShearCapacityZeroStress, KratosGeoMechanicsFastSuiteWithoutKernel)


### PR DESCRIPTION
**📝 Description**
When calculating Lode angle, avoid division by zero. When the Von Mises stress equals (nearly) zero, Lode angle should be zero, too.


**🆕 Changelog**
Other changes include:
- No special handling is needed when the `numerator` equals (nearly) zero.
- The calculation of Lode angle first checks for the special case where the Von Mises stress equals (nearly) zero. Only calculate the principal stresses and eigenvectors when they are needed, rather than upfront.
- Avoid a domain error raised by `std::asin` by clamping the input value to [-1, +1].
- Reuse a vector instance in the unit test for the calculation of Lode angle.
- Added some comments to the unit test to make clear that all relevant cases (i.e. triaxial extension [TXE], triaxial compression [TXC], and shear [SHR]) have been covered.
