### PR TITLE
Fix typos in application/ConstructiveModelsApplication

### DIFF
--- a/applications/ConstitutiveModelsApplication/custom_laws/constitutive_3D_law.cpp
+++ b/applications/ConstitutiveModelsApplication/custom_laws/constitutive_3D_law.cpp
@@ -31,7 +31,7 @@ namespace Kratos
   {
   }
 
-  //*******************************ASSIGMENT OPERATOR***********************************
+  //******************************ASSIGNMENT OPERATOR***********************************
   //************************************************************************************
 
   Constitutive3DLaw& Constitutive3DLaw::operator=(const Constitutive3DLaw& rOther)

--- a/applications/ConstitutiveModelsApplication/custom_laws/constitutive_3D_law.hpp
+++ b/applications/ConstitutiveModelsApplication/custom_laws/constitutive_3D_law.hpp
@@ -77,7 +77,7 @@ namespace Kratos
     ///@{
 
     /**
-     * Material parameters are inizialized
+     * Material parameters are initialized
      */
     void InitializeMaterial(const Properties& rProperties,
 			    const GeometryType& rElementGeometry,

--- a/applications/ConstitutiveModelsApplication/custom_laws/large_strain_laws/large_strain_3D_law.cpp
+++ b/applications/ConstitutiveModelsApplication/custom_laws/large_strain_laws/large_strain_3D_law.cpp
@@ -66,7 +66,7 @@ namespace Kratos
     mpModel = rOther.mpModel->Clone();
   }
 
-  //*******************************ASSIGMENT OPERATOR***********************************
+  //******************************ASSIGNMENT OPERATOR***********************************
   //************************************************************************************
 
   LargeStrain3DLaw& LargeStrain3DLaw::operator=(const LargeStrain3DLaw& rOther)

--- a/applications/ConstitutiveModelsApplication/custom_laws/large_strain_laws/large_strain_3D_law.hpp
+++ b/applications/ConstitutiveModelsApplication/custom_laws/large_strain_laws/large_strain_3D_law.hpp
@@ -69,7 +69,7 @@ namespace Kratos
     ///@{
 
     /**
-     * Material parameters are inizialized
+     * Material parameters are initialized
      */
     void InitializeMaterial(const Properties& rProperties,
 			    const GeometryType& rElementGeometry,

--- a/applications/ConstitutiveModelsApplication/custom_laws/small_strain_laws/small_strain_3D_law.cpp
+++ b/applications/ConstitutiveModelsApplication/custom_laws/small_strain_laws/small_strain_3D_law.cpp
@@ -53,7 +53,7 @@ namespace Kratos
     mpModel = rOther.mpModel->Clone();
   }
 
-  //*******************************ASSIGMENT OPERATOR***********************************
+  //******************************ASSIGNMENT OPERATOR***********************************
   //************************************************************************************
 
   SmallStrain3DLaw& SmallStrain3DLaw::operator=(const SmallStrain3DLaw& rOther)

--- a/applications/ConstitutiveModelsApplication/custom_laws/small_strain_laws/small_strain_3D_law.hpp
+++ b/applications/ConstitutiveModelsApplication/custom_laws/small_strain_laws/small_strain_3D_law.hpp
@@ -74,7 +74,7 @@ namespace Kratos
     ///@{
 
     /**
-     * Material parameters are inizialized
+     * Material parameters are initialized
      */
     void InitializeMaterial(const Properties& rProperties,
 			    const GeometryType& rElementGeometry,

--- a/applications/ConstitutiveModelsApplication/custom_laws/strain_rate_laws/newtonian_3D_law.cpp
+++ b/applications/ConstitutiveModelsApplication/custom_laws/strain_rate_laws/newtonian_3D_law.cpp
@@ -37,7 +37,7 @@ namespace Kratos
 
   }
 
-  //*******************************ASSIGMENT OPERATOR***********************************
+  //******************************ASSIGNMENT OPERATOR***********************************
   //************************************************************************************
 
   NewtonianFluid3DLaw& NewtonianFluid3DLaw::operator=(const NewtonianFluid3DLaw& rOther)

--- a/applications/ConstitutiveModelsApplication/custom_laws/strain_rate_laws/newtonian_3D_law.hpp
+++ b/applications/ConstitutiveModelsApplication/custom_laws/strain_rate_laws/newtonian_3D_law.hpp
@@ -65,7 +65,7 @@ namespace Kratos
     ///@{
 
     /**
-     * Material parameters are inizialized
+     * Material parameters are initialized
      */
     void InitializeMaterial(const Properties& rProperties,
 			    const GeometryType& rElementGeometry,

--- a/applications/ConstitutiveModelsApplication/custom_laws/strain_rate_laws/strain_rate_3D_law.cpp
+++ b/applications/ConstitutiveModelsApplication/custom_laws/strain_rate_laws/strain_rate_3D_law.cpp
@@ -51,7 +51,7 @@ namespace Kratos
     mpModel = rOther.mpModel->Clone();
   }
 
-  //*******************************ASSIGMENT OPERATOR***********************************
+  //******************************ASSIGNMENT OPERATOR***********************************
   //************************************************************************************
 
   StrainRate3DLaw& StrainRate3DLaw::operator=(const StrainRate3DLaw& rOther)

--- a/applications/ConstitutiveModelsApplication/custom_laws/strain_rate_laws/strain_rate_3D_law.hpp
+++ b/applications/ConstitutiveModelsApplication/custom_laws/strain_rate_laws/strain_rate_3D_law.hpp
@@ -69,7 +69,7 @@ namespace Kratos
     ///@{
 
     /**
-     * Material parameters are inizialized
+     * Material parameters are initialized
      */
     void InitializeMaterial(const Properties& rProperties,
 			    const GeometryType& rElementGeometry,

--- a/applications/ConstitutiveModelsApplication/custom_models/constitutive_model.cpp
+++ b/applications/ConstitutiveModelsApplication/custom_models/constitutive_model.cpp
@@ -39,7 +39,7 @@ namespace Kratos
   {
   }
 
-  //*******************************ASSIGMENT OPERATOR***********************************
+  //******************************ASSIGNMENT OPERATOR***********************************
   //************************************************************************************
 
   ConstitutiveModel& ConstitutiveModel::operator=(const ConstitutiveModel& rOther)

--- a/applications/ConstitutiveModelsApplication/custom_models/constitutive_model_data.hpp
+++ b/applications/ConstitutiveModelsApplication/custom_models/constitutive_model_data.hpp
@@ -436,7 +436,7 @@ namespace Kratos
       const SizeType&       GetVoigtSize                   () const {return  mVoigtSize;};
       const VoigtIndexType& GetVoigtIndexTensor            () const {return  mIndexVoigtTensor;};
 
-      //Acces non const Data
+      //Access non const Data
       ConstitutiveLawData& rConstitutiveLawData            () {return mConstitutiveLawData;};
       MatrixType&          rStrainMatrix                   () {return StrainMatrix;};
       MatrixType&          rStressMatrix                   () {return StressMatrix;};

--- a/applications/ConstitutiveModelsApplication/custom_models/plasticity_models/damage_model.hpp
+++ b/applications/ConstitutiveModelsApplication/custom_models/plasticity_models/damage_model.hpp
@@ -516,7 +516,7 @@ namespace Kratos
     {
       KRATOS_TRY
 
-      // Compute strenght type parameter
+      // Compute strength type parameter
       rVariables.RateFactor = 0.0;
 
       const SizeType& VoigtSize = rVariables.GetModelData().GetVoigtSize();

--- a/applications/ConstitutiveModelsApplication/custom_models/plasticity_models/hardening_rules/baker_johnson_cook_thermal_hardening_rule.cpp
+++ b/applications/ConstitutiveModelsApplication/custom_models/plasticity_models/hardening_rules/baker_johnson_cook_thermal_hardening_rule.cpp
@@ -27,7 +27,7 @@ namespace Kratos
   }
 
 
-  //*******************************ASSIGMENT OPERATOR***********************************
+  //******************************ASSIGNMENT OPERATOR***********************************
   //************************************************************************************
 
   BakerJohnsonCookThermalHardeningRule& BakerJohnsonCookThermalHardeningRule::operator=(BakerJohnsonCookThermalHardeningRule const& rOther)

--- a/applications/ConstitutiveModelsApplication/custom_models/plasticity_models/hardening_rules/cam_clay_hardening_rule.cpp
+++ b/applications/ConstitutiveModelsApplication/custom_models/plasticity_models/hardening_rules/cam_clay_hardening_rule.cpp
@@ -26,7 +26,7 @@ namespace Kratos
   }
 
 
-  //*******************************ASSIGMENT OPERATOR***********************************
+  //******************************ASSIGNMENT OPERATOR***********************************
   //************************************************************************************
 
   CamClayHardeningRule& CamClayHardeningRule::operator=(CamClayHardeningRule const& rOther)

--- a/applications/ConstitutiveModelsApplication/custom_models/plasticity_models/hardening_rules/exponential_damage_hardening_rule.cpp
+++ b/applications/ConstitutiveModelsApplication/custom_models/plasticity_models/hardening_rules/exponential_damage_hardening_rule.cpp
@@ -27,7 +27,7 @@ namespace Kratos
   }
 
 
-  //*******************************ASSIGMENT OPERATOR***********************************
+  //******************************ASSIGNMENT OPERATOR***********************************
   //************************************************************************************
 
   ExponentialDamageHardeningRule& ExponentialDamageHardeningRule::operator=(ExponentialDamageHardeningRule const& rOther)

--- a/applications/ConstitutiveModelsApplication/custom_models/plasticity_models/hardening_rules/gens_nova_hardening_rule.cpp
+++ b/applications/ConstitutiveModelsApplication/custom_models/plasticity_models/hardening_rules/gens_nova_hardening_rule.cpp
@@ -26,7 +26,7 @@ namespace Kratos
   }
 
 
-  //*******************************ASSIGMENT OPERATOR***********************************
+  //******************************ASSIGNMENT OPERATOR***********************************
   //************************************************************************************
 
   GensNovaHardeningRule& GensNovaHardeningRule::operator=(GensNovaHardeningRule const& rOther)

--- a/applications/ConstitutiveModelsApplication/custom_models/plasticity_models/hardening_rules/johnson_cook_thermal_hardening_rule.cpp
+++ b/applications/ConstitutiveModelsApplication/custom_models/plasticity_models/hardening_rules/johnson_cook_thermal_hardening_rule.cpp
@@ -27,7 +27,7 @@ namespace Kratos
   }
 
 
-  //*******************************ASSIGMENT OPERATOR***********************************
+  //******************************ASSIGNMENT OPERATOR***********************************
   //************************************************************************************
 
   JohnsonCookThermalHardeningRule& JohnsonCookThermalHardeningRule::operator=(JohnsonCookThermalHardeningRule const& rOther)

--- a/applications/ConstitutiveModelsApplication/custom_models/plasticity_models/hardening_rules/modified_exponential_damage_hardening_rule.cpp
+++ b/applications/ConstitutiveModelsApplication/custom_models/plasticity_models/hardening_rules/modified_exponential_damage_hardening_rule.cpp
@@ -27,7 +27,7 @@ namespace Kratos
   }
 
 
-  //*******************************ASSIGMENT OPERATOR***********************************
+  //******************************ASSIGNMENT OPERATOR***********************************
   //************************************************************************************
 
   ModifiedExponentialDamageHardeningRule& ModifiedExponentialDamageHardeningRule::operator=(ModifiedExponentialDamageHardeningRule const& rOther)

--- a/applications/ConstitutiveModelsApplication/custom_models/plasticity_models/hardening_rules/simo_exponential_hardening_rule.cpp
+++ b/applications/ConstitutiveModelsApplication/custom_models/plasticity_models/hardening_rules/simo_exponential_hardening_rule.cpp
@@ -29,7 +29,7 @@ namespace Kratos
   }
 
 
-  //*******************************ASSIGMENT OPERATOR***********************************
+  //******************************ASSIGNMENT OPERATOR***********************************
   //************************************************************************************
 
   SimoExponentialHardeningRule& SimoExponentialHardeningRule::operator=(SimoExponentialHardeningRule const& rOther)

--- a/applications/ConstitutiveModelsApplication/custom_models/plasticity_models/hardening_rules/simo_exponential_thermal_hardening_rule.cpp
+++ b/applications/ConstitutiveModelsApplication/custom_models/plasticity_models/hardening_rules/simo_exponential_thermal_hardening_rule.cpp
@@ -27,7 +27,7 @@ namespace Kratos
   }
 
 
-  //*******************************ASSIGMENT OPERATOR***********************************
+  //******************************ASSIGNMENT OPERATOR***********************************
   //************************************************************************************
 
   SimoExponentialThermalHardeningRule& SimoExponentialThermalHardeningRule::operator=(SimoExponentialThermalHardeningRule const& rOther)

--- a/applications/ConstitutiveModelsApplication/custom_models/plasticity_models/hardening_rules/simo_linear_hardening_rule.cpp
+++ b/applications/ConstitutiveModelsApplication/custom_models/plasticity_models/hardening_rules/simo_linear_hardening_rule.cpp
@@ -27,7 +27,7 @@ namespace Kratos
   }
 
 
-  //*******************************ASSIGMENT OPERATOR***********************************
+  //******************************ASSIGNMENT OPERATOR***********************************
   //************************************************************************************
 
   SimoLinearHardeningRule& SimoLinearHardeningRule::operator=(SimoLinearHardeningRule const& rOther)

--- a/applications/ConstitutiveModelsApplication/custom_models/plasticity_models/non_associative_plasticity_model.hpp
+++ b/applications/ConstitutiveModelsApplication/custom_models/plasticity_models/non_associative_plasticity_model.hpp
@@ -430,7 +430,7 @@ namespace Kratos
 
 
 
-               // 2. Set the matrix to the appropiate size
+               // 2. Set the matrix to the appropriate size
 
                if ( rConstitutiveMatrix.size1() == 6) {
                   noalias( rConstitutiveMatrix ) = rConstMatrixBig;

--- a/applications/ConstitutiveModelsApplication/custom_models/plasticity_models/yield_surfaces/gens_nova_yield_surface.hpp
+++ b/applications/ConstitutiveModelsApplication/custom_models/plasticity_models/yield_surfaces/gens_nova_yield_surface.hpp
@@ -129,7 +129,7 @@ namespace Kratos
       double MeanStress, LodeAngle;
       double DeviatoricQ; // == sqrt(3)*J2
       
-      // more work is requiered
+      // more work is required
       StressInvariantsUtilities::CalculateStressInvariants( StressTranslated, MeanStress, DeviatoricQ, LodeAngle);
       DeviatoricQ *= sqrt(3.0);
 
@@ -170,7 +170,7 @@ namespace Kratos
       double MeanStress, J2, LodeAngle;
      
       VectorType V1, V2;
-      // more work is requiered
+      // more work is required
       StressInvariantsUtilities::CalculateStressInvariants( StressTranslated, MeanStress, J2, LodeAngle);
       StressInvariantsUtilities::CalculateDerivativeVectors( StressTranslated, V1, V2);
 

--- a/applications/ConstitutiveModelsApplication/custom_models/plasticity_models/yield_surfaces/modified_cam_clay_yield_surface.hpp
+++ b/applications/ConstitutiveModelsApplication/custom_models/plasticity_models/yield_surfaces/modified_cam_clay_yield_surface.hpp
@@ -128,7 +128,7 @@ namespace Kratos
       double MeanStress, LodeAngle;
       double DeviatoricQ; // == sqrt(3)*J2
 
-      // more work is requiered
+      // more work is required
       StressInvariantsUtilities::CalculateStressInvariants( rStressMatrix, MeanStress, DeviatoricQ, LodeAngle);
       DeviatoricQ *= sqrt(3.0);
 
@@ -164,7 +164,7 @@ namespace Kratos
       double MeanStress, J2, LodeAngle;
 
       VectorType V1, V2;
-      // more work is requiered
+      // more work is required
       StressInvariantsUtilities::CalculateStressInvariants( rStressMatrix, MeanStress, J2, LodeAngle);
       StressInvariantsUtilities::CalculateDerivativeVectors( rStressMatrix, V1, V2);
 

--- a/applications/ConstitutiveModelsApplication/custom_python/python_outfitted_constitutive_law.hpp
+++ b/applications/ConstitutiveModelsApplication/custom_python/python_outfitted_constitutive_law.hpp
@@ -127,7 +127,7 @@ public:
                    const Matrix& rValue,
                    const ProcessInfo& rCurrentProcessInfo );
     /**
-     * Material parameters are inizialized
+     * Material parameters are initialized
      */
     void InitializeMaterial( const Properties& rProperties,
                              const GeometryType& rElementGeometry,


### PR DESCRIPTION
**📝 Description**
Fixes source comments and doxygen typos.
Found via codespell

**🆕 Changelog**
- Fixes source comments and doxygen typos within application/ConstructiveModelsApplication