### PR TITLE
Fix typos in applications/ContactStructuralMechanicsApplication

### DIFF
--- a/applications/ContactStructuralMechanicsApplication/custom_conditions/ALM_frictional_mortar_contact_condition.h
+++ b/applications/ContactStructuralMechanicsApplication/custom_conditions/ALM_frictional_mortar_contact_condition.h
@@ -207,7 +207,7 @@ public:
     void Initialize(const ProcessInfo& rCurrentProcessInfo) override;
 
     /**
-     * @brief Called at the begining of each solution step
+     * @brief Called at the beginning of each solution step
      * @param rCurrentProcessInfo the current process info instance
      */
     void InitializeSolutionStep(const ProcessInfo& rCurrentProcessInfo) override;

--- a/applications/ContactStructuralMechanicsApplication/custom_conditions/mortar_contact_condition.h
+++ b/applications/ContactStructuralMechanicsApplication/custom_conditions/mortar_contact_condition.h
@@ -306,7 +306,7 @@ public:
 
     /**
      * @brief This is called during the assembling process in order to calculate the condition contribution in explicit calculation.
-     * @details NodalData is modified Inside the function, so the the "AddEXplicit" FUNCTIONS THE ONLY FUNCTIONS IN WHICH A CONDITION IS ALLOWED TO WRITE ON ITS NODES. The caller is expected to ensure thread safety hence SET/UNSETLOCK MUST BE PERFORMED IN THE STRATEGY BEFORE CALLING THIS FUNCTION
+     * @details NodalData is modified Inside the function, so the "AddEXplicit" FUNCTIONS THE ONLY FUNCTIONS IN WHICH A CONDITION IS ALLOWED TO WRITE ON ITS NODES. The caller is expected to ensure thread safety hence SET/UNSETLOCK MUST BE PERFORMED IN THE STRATEGY BEFORE CALLING THIS FUNCTION
      * @param rCurrentProcessInfo the current process info instance
      */
     void AddExplicitContribution(const ProcessInfo& rCurrentProcessInfo) override;

--- a/applications/ContactStructuralMechanicsApplication/custom_conditions/penalty_frictional_mortar_contact_condition.h
+++ b/applications/ContactStructuralMechanicsApplication/custom_conditions/penalty_frictional_mortar_contact_condition.h
@@ -208,7 +208,7 @@ public:
     void Initialize(const ProcessInfo& rCurrentProcessInfo) override;
 
     /**
-     * @brief Called at the begining of each solution step
+     * @brief Called at the beginning of each solution step
      * @param rCurrentProcessInfo the current process info instance
      */
     void InitializeSolutionStep(const ProcessInfo& rCurrentProcessInfo) override;

--- a/applications/ContactStructuralMechanicsApplication/custom_master_slave_constraints/contact_master_slave_constraint.h
+++ b/applications/ContactStructuralMechanicsApplication/custom_master_slave_constraints/contact_master_slave_constraint.h
@@ -231,7 +231,7 @@ private:
     void load(Serializer &rSerializer) override;
 };
 
-///@name Input/Output funcitons
+///@name Input/Output functions
 ///@{
 
 /// input stream function

--- a/applications/ContactStructuralMechanicsApplication/custom_processes/base_contact_search_process.h
+++ b/applications/ContactStructuralMechanicsApplication/custom_processes/base_contact_search_process.h
@@ -624,7 +624,7 @@ private:
     /**
      * @brief This method creates a debug file for normals
      * @param rModelPart The corresponding model part
-     * @param rName The begining of the file name
+     * @param rName The beginning of the file name
      */
     void CreateDebugFile(
         ModelPart& rModelPart,

--- a/applications/ContactStructuralMechanicsApplication/custom_processes/contact_spr_error_process.h
+++ b/applications/ContactStructuralMechanicsApplication/custom_processes/contact_spr_error_process.h
@@ -47,7 +47,7 @@ namespace Kratos
 /**
  * @class ContactSPRErrorProcess
  * @ingroup ContactStructuralMechanicsApplication
- * @brief This class is can be used to compute the metrics of the model part with a superconvergent patch recovery (SPR) approach
+ * @brief This class can be used to compute the metrics of the model part with a superconvergent patch recovery (SPR) approach
  * @details The formulation employed in order to compute the super patch recovery is based on the work of O. C. Zienkiewicz
 J. Z. Zhu, and extended for contact mechanics. In the papers:
  * - The superconvergent patch recovery and a posteriori error estimates. Part 1: The recovery technique https://onlinelibrary.wiley.com/doi/abs/10.1002/nme.1620330702

--- a/applications/ContactStructuralMechanicsApplication/custom_python/process_factory_utility.h
+++ b/applications/ContactStructuralMechanicsApplication/custom_python/process_factory_utility.h
@@ -81,7 +81,7 @@ public:
 
     /**
      * @brief Constructor using just one process
-     * @param rProcess The process that will be added  at the begining of the vector of processes
+     * @param rProcess The process that will be added  at the beginning of the vector of processes
      * @note This constructor overrides the previous ones ("everything" is an object, so here I try first to work as it is a list)
      */
     ProcessFactoryUtility(ObjectType& rProcess);

--- a/applications/ContactStructuralMechanicsApplication/custom_strategies/custom_convergencecriterias/alm_frictional_mortar_criteria.h
+++ b/applications/ContactStructuralMechanicsApplication/custom_strategies/custom_convergencecriterias/alm_frictional_mortar_criteria.h
@@ -314,7 +314,7 @@ public:
     }
 
     ///@}
-    ///@name Acces
+    ///@name Access
     ///@{
 
     ///@}

--- a/applications/ContactStructuralMechanicsApplication/custom_strategies/custom_convergencecriterias/alm_frictionless_components_mortar_criteria.h
+++ b/applications/ContactStructuralMechanicsApplication/custom_strategies/custom_convergencecriterias/alm_frictionless_components_mortar_criteria.h
@@ -281,7 +281,7 @@ public:
     }
 
     ///@}
-    ///@name Acces
+    ///@name Access
     ///@{
 
     ///@}

--- a/applications/ContactStructuralMechanicsApplication/custom_strategies/custom_convergencecriterias/alm_frictionless_mortar_criteria.h
+++ b/applications/ContactStructuralMechanicsApplication/custom_strategies/custom_convergencecriterias/alm_frictionless_mortar_criteria.h
@@ -279,7 +279,7 @@ public:
     }
 
     ///@}
-    ///@name Acces
+    ///@name Access
     ///@{
 
     ///@}

--- a/applications/ContactStructuralMechanicsApplication/custom_strategies/custom_convergencecriterias/base_mortar_criteria.h
+++ b/applications/ContactStructuralMechanicsApplication/custom_strategies/custom_convergencecriterias/base_mortar_criteria.h
@@ -420,7 +420,7 @@ public:
     }
 
     ///@}
-    ///@name Acces
+    ///@name Access
     ///@{
 
     ///@}

--- a/applications/ContactStructuralMechanicsApplication/custom_strategies/custom_convergencecriterias/contact_error_mesh_criteria.h
+++ b/applications/ContactStructuralMechanicsApplication/custom_strategies/custom_convergencecriterias/contact_error_mesh_criteria.h
@@ -233,7 +233,7 @@ public:
     }
 
     ///@}
-    ///@name Acces
+    ///@name Access
     ///@{
 
     ///@}

--- a/applications/ContactStructuralMechanicsApplication/custom_strategies/custom_convergencecriterias/displacement_contact_criteria.h
+++ b/applications/ContactStructuralMechanicsApplication/custom_strategies/custom_convergencecriterias/displacement_contact_criteria.h
@@ -387,7 +387,7 @@ public:
     }
 
     ///@}
-    ///@name Acces
+    ///@name Access
     ///@{
 
     ///@}

--- a/applications/ContactStructuralMechanicsApplication/custom_strategies/custom_convergencecriterias/displacement_lagrangemultiplier_contact_criteria.h
+++ b/applications/ContactStructuralMechanicsApplication/custom_strategies/custom_convergencecriterias/displacement_lagrangemultiplier_contact_criteria.h
@@ -448,7 +448,7 @@ public:
     }
 
     ///@}
-    ///@name Acces
+    ///@name Access
     ///@{
 
     ///@}

--- a/applications/ContactStructuralMechanicsApplication/custom_strategies/custom_convergencecriterias/displacement_lagrangemultiplier_frictional_contact_criteria.h
+++ b/applications/ContactStructuralMechanicsApplication/custom_strategies/custom_convergencecriterias/displacement_lagrangemultiplier_frictional_contact_criteria.h
@@ -547,7 +547,7 @@ public:
     }
 
     ///@}
-    ///@name Acces
+    ///@name Access
     ///@{
 
     ///@}

--- a/applications/ContactStructuralMechanicsApplication/custom_strategies/custom_convergencecriterias/displacement_lagrangemultiplier_mixed_contact_criteria.h
+++ b/applications/ContactStructuralMechanicsApplication/custom_strategies/custom_convergencecriterias/displacement_lagrangemultiplier_mixed_contact_criteria.h
@@ -476,7 +476,7 @@ public:
     }
 
     ///@}
-    ///@name Acces
+    ///@name Access
     ///@{
 
     ///@}

--- a/applications/ContactStructuralMechanicsApplication/custom_strategies/custom_convergencecriterias/displacement_lagrangemultiplier_mixed_frictional_contact_criteria.h
+++ b/applications/ContactStructuralMechanicsApplication/custom_strategies/custom_convergencecriterias/displacement_lagrangemultiplier_mixed_frictional_contact_criteria.h
@@ -588,7 +588,7 @@ public:
     }
 
     ///@}
-    ///@name Acces
+    ///@name Access
     ///@{
 
     ///@}

--- a/applications/ContactStructuralMechanicsApplication/custom_strategies/custom_convergencecriterias/displacement_lagrangemultiplier_residual_contact_criteria.h
+++ b/applications/ContactStructuralMechanicsApplication/custom_strategies/custom_convergencecriterias/displacement_lagrangemultiplier_residual_contact_criteria.h
@@ -479,7 +479,7 @@ public:
     }
 
     ///@}
-    ///@name Acces
+    ///@name Access
     ///@{
 
     ///@}

--- a/applications/ContactStructuralMechanicsApplication/custom_strategies/custom_convergencecriterias/displacement_lagrangemultiplier_residual_frictional_contact_criteria.h
+++ b/applications/ContactStructuralMechanicsApplication/custom_strategies/custom_convergencecriterias/displacement_lagrangemultiplier_residual_frictional_contact_criteria.h
@@ -654,7 +654,7 @@ public:
     }
 
     ///@}
-    ///@name Acces
+    ///@name Access
     ///@{
 
     ///@}

--- a/applications/ContactStructuralMechanicsApplication/custom_strategies/custom_convergencecriterias/displacement_residual_contact_criteria.h
+++ b/applications/ContactStructuralMechanicsApplication/custom_strategies/custom_convergencecriterias/displacement_residual_contact_criteria.h
@@ -428,7 +428,7 @@ public:
     }
 
     ///@}
-    ///@name Acces
+    ///@name Access
     ///@{
 
     ///@}

--- a/applications/ContactStructuralMechanicsApplication/custom_strategies/custom_convergencecriterias/mesh_tying_mortar_criteria.h
+++ b/applications/ContactStructuralMechanicsApplication/custom_strategies/custom_convergencecriterias/mesh_tying_mortar_criteria.h
@@ -201,7 +201,7 @@ public:
     }
 
     ///@}
-    ///@name Acces
+    ///@name Access
     ///@{
 
     ///@}

--- a/applications/ContactStructuralMechanicsApplication/custom_strategies/custom_convergencecriterias/mpc_contact_criteria.h
+++ b/applications/ContactStructuralMechanicsApplication/custom_strategies/custom_convergencecriterias/mpc_contact_criteria.h
@@ -410,7 +410,7 @@ public:
     }
 
     ///@}
-    ///@name Acces
+    ///@name Access
     ///@{
 
     ///@}

--- a/applications/ContactStructuralMechanicsApplication/custom_strategies/custom_convergencecriterias/penalty_frictional_mortar_criteria.h
+++ b/applications/ContactStructuralMechanicsApplication/custom_strategies/custom_convergencecriterias/penalty_frictional_mortar_criteria.h
@@ -300,7 +300,7 @@ public:
     }
 
     ///@}
-    ///@name Acces
+    ///@name Access
     ///@{
 
     ///@}

--- a/applications/ContactStructuralMechanicsApplication/custom_strategies/custom_convergencecriterias/penalty_frictionless_mortar_criteria.h
+++ b/applications/ContactStructuralMechanicsApplication/custom_strategies/custom_convergencecriterias/penalty_frictionless_mortar_criteria.h
@@ -273,7 +273,7 @@ public:
     }
 
     ///@}
-    ///@name Acces
+    ///@name Access
     ///@{
 
     ///@}

--- a/applications/ContactStructuralMechanicsApplication/python_scripts/adaptative_remeshing_contact_structural_mechanics_analysis.py
+++ b/applications/ContactStructuralMechanicsApplication/python_scripts/adaptative_remeshing_contact_structural_mechanics_analysis.py
@@ -175,7 +175,7 @@ class AdaptativeRemeshingContactStructuralMechanicsAnalysis(BaseClass):
 
     #### Internal functions ####
     def _CreateSolver(self):
-        """ Create the Solver (and create and import the ModelPart if it is not alread in the model) """
+        """ Create the Solver (and create and import the ModelPart if it is not already in the model) """
 
         # To avoid many prints
         if self.echo_level == 0:

--- a/applications/ContactStructuralMechanicsApplication/python_scripts/adaptative_remeshing_contact_structural_mechanics_implicit_dynamic_solver.py
+++ b/applications/ContactStructuralMechanicsApplication/python_scripts/adaptative_remeshing_contact_structural_mechanics_implicit_dynamic_solver.py
@@ -21,7 +21,7 @@ def CreateSolver(model, custom_settings):
     return AdaptativeRemeshingContactImplicitMechanicalSolver(model, custom_settings)
 
 class AdaptativeRemeshingContactImplicitMechanicalSolver(contact_structural_mechanics_implicit_dynamic_solver.ContactImplicitMechanicalSolver):
-    """The contact structural mechanics implicit dynamic solver. (Fot adaptative remeshing)
+    """The contact structural mechanics implicit dynamic solver. (For adaptative remeshing)
     See contact_structural_mechanics_implicit_dynamic_solver.py for more information.
     """
     def __init__(self, model, custom_settings):

--- a/applications/ContactStructuralMechanicsApplication/python_scripts/adaptative_remeshing_contact_structural_mechanics_static_solver.py
+++ b/applications/ContactStructuralMechanicsApplication/python_scripts/adaptative_remeshing_contact_structural_mechanics_static_solver.py
@@ -21,7 +21,7 @@ def CreateSolver(model, custom_settings):
     return AdaptativeRemeshingContactStaticMechanicalSolver(model, custom_settings)
 
 class AdaptativeRemeshingContactStaticMechanicalSolver(contact_structural_mechanics_static_solver.ContactStaticMechanicalSolver):
-    """The structural mechanics static solver. (Fot adaptative remeshing)
+    """The structural mechanics static solver. (For adaptative remeshing)
     See contact_structural_mechanics_static_solver.py for more information.
     """
     def __init__(self, model, custom_settings):

--- a/applications/ContactStructuralMechanicsApplication/python_scripts/alm_contact_process.py
+++ b/applications/ContactStructuralMechanicsApplication/python_scripts/alm_contact_process.py
@@ -173,7 +173,7 @@ class ALMContactProcess(search_base_process.SearchBaseProcess):
                 self.normal_variation = CSMA.NormalDerivativesComputation.NO_DERIVATIVES_COMPUTATION_WITH_NORMAL_UPDATE
 
     def ExecuteInitialize(self):
-        """ This method is executed at the begining to initialize the process
+        """ This method is executed at the beginning to initialize the process
 
         Keyword arguments:
         self -- It signifies an instance of a class.

--- a/applications/ContactStructuralMechanicsApplication/python_scripts/contact_remesh_mmg_process.py
+++ b/applications/ContactStructuralMechanicsApplication/python_scripts/contact_remesh_mmg_process.py
@@ -240,7 +240,7 @@ class ContactRemeshMmgProcess(MmgProcess):
         self.integration_values_extrapolation_to_nodes_process = KratosMultiphysics.IntegrationValuesExtrapolationToNodesProcess(self.main_model_part, extrapolation_parameters)
 
     def ExecuteInitialize(self):
-        """ This method is executed at the begining to initialize the process
+        """ This method is executed at the beginning to initialize the process
 
         Keyword arguments:
         self -- It signifies an instance of a class.

--- a/applications/ContactStructuralMechanicsApplication/python_scripts/explicit_penalty_contact_process.py
+++ b/applications/ContactStructuralMechanicsApplication/python_scripts/explicit_penalty_contact_process.py
@@ -116,7 +116,7 @@ class ExplicitPenaltyContactProcess(penalty_contact_process.PenaltyContactProces
         super().__init__(Model, self.contact_settings)
 
     def ExecuteInitialize(self):
-        """ This method is executed at the begining to initialize the process
+        """ This method is executed at the beginning to initialize the process
 
         Keyword arguments:
         self -- It signifies an instance of a class.

--- a/applications/ContactStructuralMechanicsApplication/python_scripts/mesh_tying_process.py
+++ b/applications/ContactStructuralMechanicsApplication/python_scripts/mesh_tying_process.py
@@ -107,7 +107,7 @@ class MeshTyingProcess(search_base_process.SearchBaseProcess):
         self.consider_static_condensation = self.mesh_tying_settings["consider_static_condensation"].GetBool()
 
     def ExecuteInitialize(self):
-        """ This method is executed at the begining to initialize the process
+        """ This method is executed at the beginning to initialize the process
 
         Keyword arguments:
         self -- It signifies an instance of a class.
@@ -221,7 +221,7 @@ class MeshTyingProcess(search_base_process.SearchBaseProcess):
         zero_vector[1] = 0.0
         zero_vector[2] = 0.0
 
-        # Initilialize weighted variables and LM
+        # Initialize weighted variables and LM
         if self.type_variable == "Scalar":
             KM.VariableUtils().SetVariable(CSMA.WEIGHTED_SCALAR_RESIDUAL, 0.0, self._get_process_model_part().Nodes)
         else:

--- a/applications/ContactStructuralMechanicsApplication/python_scripts/mpc_contact_process.py
+++ b/applications/ContactStructuralMechanicsApplication/python_scripts/mpc_contact_process.py
@@ -162,7 +162,7 @@ class MPCContactProcess(search_base_process.SearchBaseProcess):
             self.main_model_part.Set(KM.RIGID, False)
 
     def ExecuteInitialize(self):
-        """ This method is executed at the begining to initialize the process
+        """ This method is executed at the beginning to initialize the process
 
         Keyword arguments:
         self -- It signifies an instance of a class.

--- a/applications/ContactStructuralMechanicsApplication/python_scripts/penalty_contact_process.py
+++ b/applications/ContactStructuralMechanicsApplication/python_scripts/penalty_contact_process.py
@@ -116,7 +116,7 @@ class PenaltyContactProcess(alm_contact_process.ALMContactProcess):
         super().__init__(Model, self.contact_settings)
 
     def ExecuteInitialize(self):
-        """ This method is executed at the begining to initialize the process
+        """ This method is executed at the beginning to initialize the process
 
         Keyword arguments:
         self -- It signifies an instance of a class.

--- a/applications/ContactStructuralMechanicsApplication/python_scripts/search_base_process.py
+++ b/applications/ContactStructuralMechanicsApplication/python_scripts/search_base_process.py
@@ -99,7 +99,7 @@ class SearchBaseProcess(KM.Process):
         self.interval = KM.IntervalUtility(self.settings)
 
     def ExecuteInitialize(self):
-        """ This method is executed at the begining to initialize the process
+        """ This method is executed at the beginning to initialize the process
 
         Keyword arguments:
         self -- It signifies an instance of a class.
@@ -330,7 +330,7 @@ class SearchBaseProcess(KM.Process):
         return ""
 
     def _assign_master_flags(self, partial_model_part):
-        """ This method initializes assigment of the master nodes and conditions
+        """ This method initializes assignment of the master nodes and conditions
 
         Keyword arguments:
         self -- It signifies an instance of a class.
@@ -345,7 +345,7 @@ class SearchBaseProcess(KM.Process):
                 KM.VariableUtils().SetFlag(KM.MASTER, True, partial_model_part.Conditions)
 
     def _assign_slave_flags(self, key = "0"):
-        """ This method initializes assigment of the slave nodes and conditions
+        """ This method initializes assignment of the slave nodes and conditions
 
         Keyword arguments:
         self -- It signifies an instance of a class.

--- a/applications/ContactStructuralMechanicsApplication/symbolic_generation/ALM_frictional_mortar_condition/generate_frictional_mortar_condition.py
+++ b/applications/ContactStructuralMechanicsApplication/symbolic_generation/ALM_frictional_mortar_condition/generate_frictional_mortar_condition.py
@@ -78,7 +78,7 @@ for normalvar in range(normal_combs):
         u2old = custom_sympy_fe_utilities.DefineMatrix('u2old', nnodes_master, dim, "Symbol") # u2(i,j) is the previous displacement of node i component j at domain 2
         LM = custom_sympy_fe_utilities.DefineMatrix('LM', nnodes, dim, "Symbol")              # Lm are the Lagrange multipliers
 
-        # Normal and tangets of the slave
+        # Normal and tangents of the slave
         if normalvar == 1:
             NormalSlave = custom_sympy_fe_utilities.DefineMatrix('NormalSlave', nnodes, dim)
         else:

--- a/applications/ContactStructuralMechanicsApplication/symbolic_generation/ALM_frictionless_components_mortar_condition/generate_frictionless_components_mortar_condition.py
+++ b/applications/ContactStructuralMechanicsApplication/symbolic_generation/ALM_frictionless_components_mortar_condition/generate_frictionless_components_mortar_condition.py
@@ -79,7 +79,7 @@ for normalvar in range(normal_combs):
             MOperator = custom_sympy_fe_utilities.DefineMatrix('MOperator',nnodes,nnodes_master)
 
             # Define other parameters
-            # Normal and tangets of the slave
+            # Normal and tangents of the slave
             NormalSlave = custom_sympy_fe_utilities.DefineMatrix('NormalSlave',nnodes,dim)
 
             X1 = custom_sympy_fe_utilities.DefineMatrix('X1',nnodes,dim)
@@ -87,7 +87,7 @@ for normalvar in range(normal_combs):
             x1 = X1 + u1
             x2 = X2 + u2
 
-            #Define other symbols
+            # Define other symbols
             DynamicFactor  = custom_sympy_fe_utilities.DefineVector('DynamicFactor',nnodes)
             PenaltyParameter  = custom_sympy_fe_utilities.DefineVector('PenaltyParameter',nnodes)
             ScaleFactor = sympy.Symbol('ScaleFactor', positive=True)

--- a/applications/ContactStructuralMechanicsApplication/symbolic_generation/ALM_frictionless_components_mortar_condition/generate_frictionless_components_mortar_condition_non_zero.py
+++ b/applications/ContactStructuralMechanicsApplication/symbolic_generation/ALM_frictionless_components_mortar_condition/generate_frictionless_components_mortar_condition_non_zero.py
@@ -70,7 +70,7 @@ for normalvar in range(normal_combs):
         MOperator = custom_sympy_fe_utilities.DefineMatrix('MOperator',nnodes,nnodes_master)
 
         # Define other parameters
-        # Normal and tangets of the slave
+        # Normal and tangents of the slave
         NormalSlave = custom_sympy_fe_utilities.DefineMatrix('NormalSlave',nnodes,dim)
 
         X1 = custom_sympy_fe_utilities.DefineMatrix('X1',nnodes,dim)
@@ -78,7 +78,7 @@ for normalvar in range(normal_combs):
         x1 = X1 + u1
         x2 = X2 + u2
 
-        #Define other symbols
+        # Define other symbols
         DynamicFactor  = custom_sympy_fe_utilities.DefineVector('DynamicFactor',nnodes)
         PenaltyParameter  = custom_sympy_fe_utilities.DefineVector('PenaltyParameter',nnodes)
         ScaleFactor = sympy.Symbol('ScaleFactor', positive=True)

--- a/applications/ContactStructuralMechanicsApplication/symbolic_generation/penalty_frictional_mortar_condition/generate_penalty_frictional_mortar_condition.py
+++ b/applications/ContactStructuralMechanicsApplication/symbolic_generation/penalty_frictional_mortar_condition/generate_penalty_frictional_mortar_condition.py
@@ -77,7 +77,7 @@ for normalvar in range(normal_combs):
         u1old = custom_sympy_fe_utilities.DefineMatrix('u1old', nnodes, dim, "Symbol")        # u1(i,j) is the previous displacement of node i component j at domain 1
         u2old = custom_sympy_fe_utilities.DefineMatrix('u2old', nnodes_master, dim, "Symbol") # u2(i,j) is the previous displacement of node i component j at domain 2
 
-        # Normal and tangets of the slave
+        # Normal and tangents of the slave
         if normalvar == 1:
             NormalSlave = custom_sympy_fe_utilities.DefineMatrix('NormalSlave', nnodes, dim)
         else:

--- a/applications/ContactStructuralMechanicsApplication/tests/test_ContactStructuralMechanicsApplication.py
+++ b/applications/ContactStructuralMechanicsApplication/tests/test_ContactStructuralMechanicsApplication.py
@@ -175,8 +175,8 @@ from ValidationTests import ALMBlockTestFrictionalContact                       
 def AssembleTestSuites():
     ''' Populates the test suites to run.
 
-    Populates the test suites to run. At least, it should pupulate the suites:
-    "small", "nighlty" and "all"
+    Populates the test suites to run. At least, it should populate the suites:
+    "small", "nightly" and "all"
 
     Return
     ------


### PR DESCRIPTION
**📝 Description**
Fixes source comments and doxygen typos.
Found via codespell

**🆕 Changelog**
- Fixes source comments and doxygen typos within application/ContactStructuralMechanicsApplication