### PR TITLE
[StructApp][Core] Extending adjoint finite differencing to temperature. Minor Fix in sensitivity builder scheme.

### DIFF
--- a/applications/StructuralMechanicsApplication/custom_response_functions/adjoint_elements/adjoint_finite_difference_base_element.cpp
+++ b/applications/StructuralMechanicsApplication/custom_response_functions/adjoint_elements/adjoint_finite_difference_base_element.cpp
@@ -370,7 +370,7 @@ void AdjointFiniteDifferencingBaseElement<TPrimalElement>::CalculateSensitivityM
                                                                       mpPrimalElement->GetGeometry()[i_node], delta, 
                                                                       derived_RHS, rCurrentProcessInfo);
 
-            KRATOS_ERROR_IF_NOT(derived_RHS.size() == local_size) << "Size of the pseudo-load does not fit!" << std::endl;
+            KRATOS_ERROR_IF_NOT(derived_RHS.size() == local_size) << "Size of the pseudo-load does not fit! [ derived_RHS.size() = " << derived_RHS.size() << ", local_size = " << local_size << " ]." << std::endl;
 
             for(IndexType i = 0; i < derived_RHS.size(); ++i)
                 rOutput(i_node, i) = derived_RHS[i];

--- a/applications/StructuralMechanicsApplication/custom_response_functions/response_utilities/finite_difference_utility.h
+++ b/applications/StructuralMechanicsApplication/custom_response_functions/response_utilities/finite_difference_utility.h
@@ -87,8 +87,7 @@ public:
             // define working variables
             Vector RHS_perturbed;
 
-            if (rOutput.size() != rRHS.size())
-                rOutput.resize(rRHS.size(), false);
+            rOutput.resize(rRHS.size(), false);
 
             // perturb the design variable
             rNode.FastGetSolutionStepValue(rDesignVariable) += rPertubationSize;

--- a/applications/StructuralMechanicsApplication/custom_response_functions/response_utilities/finite_difference_utility.h
+++ b/applications/StructuralMechanicsApplication/custom_response_functions/response_utilities/finite_difference_utility.h
@@ -82,9 +82,31 @@ public:
             rNode.GetInitialPosition()[coord_dir] -= rPertubationSize;
             rNode.Coordinates()[coord_dir] -= rPertubationSize;
         }
+        else if( rDesignVariable == TEMPERATURE )
+        {
+            // define working variables
+            Vector RHS_perturbed;
+
+            if (rOutput.size() != rRHS.size())
+                rOutput.resize(rRHS.size(), false);
+
+            // perturb the design variable
+            rNode.FastGetSolutionStepValue(rDesignVariable) += rPertubationSize;
+
+            // compute LHS after perturbation
+            rElement.CalculateRightHandSide(RHS_perturbed, rCurrentProcessInfo);
+
+            // compute derivative of RHS w.r.t. design variable with finite differences
+            noalias(rOutput) = (RHS_perturbed - rRHS) / rPertubationSize;
+
+            // unperturb the design variable
+            rNode.FastGetSolutionStepValue(rDesignVariable) -= rPertubationSize;
+
+        }
         else
         {
-            KRATOS_WARNING("FiniteDifferenceUtility") << "Unsupported nodal design variable: " << rDesignVariable << std::endl;
+            KRATOS_WARNING("FiniteDifferenceUtility") << "Unsupported nodal design variable: " << rDesignVariable << ". " << std::endl
+            << "Supported variables are SHAPE_SENSITIVITY_X, SHAPE_SENSITIVITY_Y, SHAPE_SENSITIVITY_Z, TEMPERATURE." << std::endl;
             if ( (rOutput.size() != 0) )
                 rOutput.resize(0,false);
         }

--- a/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_adjoint_static_solver.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_adjoint_static_solver.py
@@ -32,6 +32,7 @@ class StructuralMechanicsAdjointStaticSolver(MechanicalSolver):
             self.main_model_part.AddNodalSolutionStepVariable(StructuralMechanicsApplication.ADJOINT_ROTATION)
         # TODO evaluate if these variables should be historical
         self.main_model_part.AddNodalSolutionStepVariable(KratosMultiphysics.SHAPE_SENSITIVITY)
+        self.main_model_part.AddNodalSolutionStepVariable(StructuralMechanicsApplication.TEMPERATURE_SENSITIVITY)
         KratosMultiphysics.Logger.PrintInfo("::[AdjointMechanicalSolver]:: ", "Variables ADDED")
 
     def PrepareModelPart(self):

--- a/kratos/solving_strategies/schemes/sensitivity_builder_scheme.h
+++ b/kratos/solving_strategies/schemes/sensitivity_builder_scheme.h
@@ -569,16 +569,18 @@ private:
 
         this->CalculateLocalSensitivity(rEntity, rResponseFunction,
                                         rSensitivityVector, rVariable, rProcessInfo);
-
-        auto& r_geometry = rEntity.GetGeometry();
-        if (rGPSensitivityVector.size() != r_geometry.PointsNumber()) {
-            rGPSensitivityVector.resize(r_geometry.PointsNumber());
+        
+        if (rSensitivityVector.size() > 0) {
+            auto& r_geometry = rEntity.GetGeometry();
+            if (rGPSensitivityVector.size() != r_geometry.PointsNumber()) {
+                rGPSensitivityVector.resize(r_geometry.PointsNumber());
+            }
+            
+            for (unsigned int i = 0; i < r_geometry.PointsNumber(); ++i) {
+                rGPSensitivityVector(i) = mGlobalPointerNodalMap[r_geometry[i].Id()];
+            }
         }
-
-        for (unsigned int i = 0; i < r_geometry.PointsNumber(); ++i) {
-            rGPSensitivityVector(i) = mGlobalPointerNodalMap[r_geometry[i].Id()];
-        }
-
+        
         KRATOS_CATCH("");
     }
 

--- a/kratos/solving_strategies/schemes/sensitivity_builder_scheme.h
+++ b/kratos/solving_strategies/schemes/sensitivity_builder_scheme.h
@@ -572,9 +572,8 @@ private:
         
         if (rSensitivityVector.size() > 0) {
             auto& r_geometry = rEntity.GetGeometry();
-            if (rGPSensitivityVector.size() != r_geometry.PointsNumber()) {
-                rGPSensitivityVector.resize(r_geometry.PointsNumber());
-            }
+
+            rGPSensitivityVector.resize(r_geometry.PointsNumber());
             
             for (unsigned int i = 0; i < r_geometry.PointsNumber(); ++i) {
                 rGPSensitivityVector(i) = mGlobalPointerNodalMap[r_geometry[i].Id()];


### PR DESCRIPTION
**📝 Description**
Extending adjoint finite differencing from shape sensitivity to also include temperature sensitivity. 
Minor Fix in sensitivity builder scheme for condition w.r.t. nodal values.

Tested through TEMPERATURE_SENSITIVITY in SystemIdentificationApplication response 'temperature_detection_response.py' (next PR).

**🆕 Changelog**
- Extended finite differencing in 'adjoint_finite_difference_base_element.cpp' to 'CalculateSensitivityMatrix()' for temperature variable.
- Extended 'CalculateRightHandSideDerivative()' calculation in 'finite_difference_utility.h' for temperature variable.
- Added TEMPERATURE_SENSITIVITY variable similar to SHAPE_SENSITTIVITY variable in the adjoint solver 'structural_mechanics_adjoint_static_solver.py'.
- Minor fix in 'sensitivity_builder_scheme.h' to properly handle condition sensitivity w.r.t nodal variables.

