### PR TITLE
[StructApp] Minor fixes for negative perturb sizes and element condition deep copy

### DIFF
--- a/applications/StructuralMechanicsApplication/custom_response_functions/adjoint_conditions/adjoint_semi_analytic_base_condition.cpp
+++ b/applications/StructuralMechanicsApplication/custom_response_functions/adjoint_conditions/adjoint_semi_analytic_base_condition.cpp
@@ -393,7 +393,8 @@ namespace Kratos
         KRATOS_TRY;
 
         if ( mpPrimalCondition->Has(rDesignVariable) ) {
-            const double variable_value = mpPrimalCondition->GetValue(rDesignVariable);
+            // the rDesignVariable value may be negative, therefore adding a std::abs
+            const double variable_value = std::abs(mpPrimalCondition->GetValue(rDesignVariable));
             return variable_value;
         }
         else {

--- a/applications/StructuralMechanicsApplication/custom_response_functions/adjoint_processes/replace_multiple_elements_and_conditions_process.cpp
+++ b/applications/StructuralMechanicsApplication/custom_response_functions/adjoint_processes/replace_multiple_elements_and_conditions_process.cpp
@@ -76,8 +76,8 @@ void ReplaceEntities(TEntityContainer& rEntityContainer,
             it->pGetProperties()
         );
 
-        // Deep copy data and flags
-        p_entity->GetData() = it->GetData();
+        // Deep copy flags. Since we use the same geometry for the element and conditions, there is 
+        // no need to deep copy the data.
         p_entity->Set(Flags(*it));
 
         (*it.base()) = p_entity;


### PR DESCRIPTION
**📝 Description**
1. Fix for negative perturb sizes: the rDesignVariable value may be negative, therefore added a std::abs().
2. No need to deep copy the data in replace_multiple_elements_and_conditions_process, since we use the same geometry for the element and conditions.

**🆕 Changelog**
- Changed 'adjoint_semi_analytic_base_condition.cpp' 
- Changed 'replace_multiple_elements_and_conditions_process.cpp' 
