### PR TITLE
[Core] Parallel redistance add option to preserve interface

### DIFF
--- a/kratos/processes/parallel_distance_calculation_process.cpp
+++ b/kratos/processes/parallel_distance_calculation_process.cpp
@@ -169,6 +169,7 @@ void ParallelDistanceCalculationProcess<TDim>::AddDistanceToNodes(
     const BoundedMatrix<double,TDim+1,TDim>& rDN_DX,
     const double& Volume)
 {
+    constexpr double zero_tolerance = 1e-12;
     unsigned int unknown_node_index = 0;
     array_1d<double,TDim> d;
     double nodal_vol = Volume/static_cast<double>(TDim+1);
@@ -206,21 +207,8 @@ void ParallelDistanceCalculationProcess<TDim>::AddDistanceToNodes(
 
     double discriminant = b * b - 4.0 * a*c;
 
-    if (discriminant < 0.0) //here we solve (2ax+b) = 0
+    if (discriminant < zero_tolerance) //here we solve (2ax+b) = 0
     {
-//                  double numerator = 0.0;
-//                  double denominator = 0.0;
-//                  for(unsigned int i=0; i<TDim+1; i++)
-//                  {
-//                      for (unsigned int jjj = 0; jjj < TDim; jjj++)
-//                      {
-//                          if(i != unknown_node_index)
-//                            numerator += rDN_DX(unknown_node_index, jjj) * rDN_DX(i, jjj);
-//                          else
-//                            denominator += rDN_DX(unknown_node_index, jjj)*rDN_DX(unknown_node_index, jjj);
-//                      }
-//                  }
-//                  distance = - numerator/denominator;
 
         distance = -b / (2.0*a); //avg_dist ; //
     }
@@ -229,14 +217,14 @@ void ParallelDistanceCalculationProcess<TDim>::AddDistanceToNodes(
         //(accurate) computation of the distance
         //requires the solution of a*x^2+b*x+c=0
         double q, root1, root2;
-        double sqrt_det = sqrt(discriminant);
-        if (a != 0.0)
+        const double sqrt_det = std::sqrt(discriminant);
+        if (std::abs(a) > zero_tolerance)
         {
             if (b > 0) q = -0.5 * (b + sqrt_det);
             else q = -0.5 * (b - sqrt_det);
             root1 = q / a;
             distance = root1;
-            if(std::abs(q) > 0.0) {
+            if(std::abs(q) > zero_tolerance) {
                 root2 = c / q;
                 if (root2 > root1) distance = root2;
             }

--- a/kratos/processes/parallel_distance_calculation_process.h
+++ b/kratos/processes/parallel_distance_calculation_process.h
@@ -11,8 +11,7 @@
 //
 //
 
-#if !defined(KRATOS_PARALLEL_DISTANCE_CALCULATOR_H_INCLUDED )
-#define  KRATOS_PARALLEL_DISTANCE_CALCULATOR_H_INCLUDED
+#pragma once
 
 // System includes
 #include <string>
@@ -165,6 +164,7 @@ protected:
         const Variable<double>* mpAreaVar;
         unsigned int mMaxLevels;
         double mMaxDistance;
+        bool mPreserveInterface;
         bool mCalculateExactDistancesToPlane;
 
 
@@ -222,7 +222,15 @@ private:
 
     void ResetVariables();
 
-    void CalculateExactDistancesOnDividedElements();
+    void SetDistancesOnDividedElements();
+
+    void CalculateExactDistancesOnDividedElements(
+        Geometry<Node>& rGeometry,
+        array_1d<double,TDim+1>& rDist);
+
+    void PreserveDistancesOnDividedElements(
+        Geometry<Node>& rGeometry,
+        const array_1d<double,TDim+1>& rDist);
 
 	void ExtendDistancesByLayer();
 
@@ -283,5 +291,3 @@ inline std::ostream& operator << (
 ///@}
 
 }  // namespace Kratos.
-
-#endif // KRATOS_PARALLEL_DISTANCE_CALCULATOR_H_INCLUDED  defined

--- a/kratos/tests/cpp_tests/processes/test_parallel_distance_calculation_process.cpp
+++ b/kratos/tests/cpp_tests/processes/test_parallel_distance_calculation_process.cpp
@@ -173,4 +173,56 @@ KRATOS_TEST_CASE_IN_SUITE(ParallelDistanceProcessQuadrilateralNonHistorical2D, K
     }
 }
 
+KRATOS_TEST_CASE_IN_SUITE(ParallelDistanceProcessPreserveInterface, KratosCoreFastSuite)
+{
+    // Generate a volume mesh (done with the StructuredMeshGeneratorProcess)
+    Node::Pointer p_point_1 = Kratos::make_intrusive<Node>(1, 0.0, 0.0, 0.0);
+    Node::Pointer p_point_2 = Kratos::make_intrusive<Node>(2, 0.0, 10.0, 0.0);
+    Node::Pointer p_point_3 = Kratos::make_intrusive<Node>(3, 10.0, 10.0, 0.0);
+    Node::Pointer p_point_4 = Kratos::make_intrusive<Node>(4, 10.0, 0.0, 0.0);
+    Quadrilateral2D4<Node> geometry(p_point_1, p_point_2, p_point_3, p_point_4);
+
+    Parameters mesher_parameters(R"({
+        "number_of_divisions" : 7,
+        "element_name" : "Element2D3N",
+        "create_skin_sub_model_part" : false
+    })");
+    Model current_model;
+    auto& r_model_part = current_model.CreateModelPart("MainModelPart");
+    r_model_part.AddNodalSolutionStepVariable(DISTANCE);
+    r_model_part.AddNodalSolutionStepVariable(NODAL_AREA);
+    StructuredMeshGeneratorProcess(geometry, r_model_part, mesher_parameters).Execute();
+
+    // Set up the intersected elements distance
+    std::function<double(Node& rNode)> nodal_value_function = [](Node& rNode){return rNode.X() + rNode.Y() - 100.0/9.9;};
+    std::function<double&(Node& rNode)> distance_getter = [](Node& rNode)->double&{return rNode.FastGetSolutionStepValue(DISTANCE);};
+    ParallelDistanceCalculationProcessTestInternals::SetUpDistanceField(r_model_part, nodal_value_function, distance_getter);
+
+    const double distance_node_7 = r_model_part.GetNode(7).FastGetSolutionStepValue(DISTANCE);
+
+    // Compute distance
+    Parameters parallel_distance_settings(R"({
+        "model_part_name" : "MainModelPart",
+        "distance_variable" : "DISTANCE",
+        "nodal_area_variable" : "NODAL_AREA",
+        "distance_database" : "nodal_historical",
+        "preserve_interface" : true,
+        "max_levels" : 10.0,
+        "max_distance" : 10.0,
+        "calculate_exact_distances_to_plane" : false
+    })");
+    ParallelDistanceCalculationProcess<2>(r_model_part, parallel_distance_settings).Execute();
+
+    // Check results
+    const double tolerance = 1.0e-8;
+    const std::array<std::size_t,5> nodal_ids = {1,28,37,64,7};
+    //node 7 is an interface node and its distance should be preserved
+    const std::array<double, 5> exact_dist = {-5.8153358548852685, -1.5295815295815309, 1.3275613275613267, 5.6133194453527846, distance_node_7};
+    for (std::size_t i = 0; i < nodal_ids.size(); ++i) {
+        const auto& r_node = r_model_part.GetNode(nodal_ids[i]);
+        const double dist = r_node.FastGetSolutionStepValue(DISTANCE);
+        KRATOS_EXPECT_NEAR(dist, exact_dist[i], tolerance);
+    }
+}
+
 }  // namespace Kratos::Testing.

--- a/kratos/tests/cpp_tests/processes/test_parallel_distance_calculation_process.cpp
+++ b/kratos/tests/cpp_tests/processes/test_parallel_distance_calculation_process.cpp
@@ -217,7 +217,7 @@ KRATOS_TEST_CASE_IN_SUITE(ParallelDistanceProcessPreserveInterface, KratosCoreFa
     const double tolerance = 1.0e-8;
     const std::array<std::size_t,5> nodal_ids = {1,28,37,64,7};
     //node 7 is an interface node and its distance should be preserved
-    const std::array<double, 5> exact_dist = {-5.8153358548852685, -1.5295815295815309, 1.3275613275613267, 5.6133194453527846, distance_node_7};
+    const std::array<double, 5> exact_dist = {-5.8152958152958174, -1.5295815295815309, 1.3275613275613267, 5.613275613275615, distance_node_7};
     for (std::size_t i = 0; i < nodal_ids.size(); ++i) {
         const auto& r_node = r_model_part.GetNode(nodal_ids[i]);
         const double dist = r_node.FastGetSolutionStepValue(DISTANCE);


### PR DESCRIPTION
This is a slightly different implementation of https://github.com/KratosMultiphysics/Kratos/pull/10396 , but behaviour is the same: we are adding an option in redistance process to preserve interface distances. Although this requires further testing, I've seen that this can lead to a big improvement in two fluid simulations under certain circumstances.
