### PR TITLE
[Core] Fix fulldebug in windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,11 @@ if(POLICY CMP0177)
   cmake_policy(SET CMP0177 NEW)
 endif(POLICY CMP0177)
 
+# Boost config
+if(POLICY CMP0167)
+  cmake_policy(SET CMP0167 OLD)
+endif(POLICY CMP0167)
+
 # Set here the version number **** only update upon tagging a release!
 set (KratosMultiphysics_MAJOR_VERSION 10)
 set (KratosMultiphysics_MINOR_VERSION 2)
@@ -113,6 +118,7 @@ SET( BASIC_DEBUG_FLAGS "${CMAKE_CXX_FLAGS_DEBUG}")
 SET( CMAKE_CXX_FLAGS_DEBUG "${BASIC_DEBUG_FLAGS} -DNDEBUG -DKRATOS_DEBUG" )
 SET( CMAKE_CXX_FLAGS_FULLDEBUG "${BASIC_DEBUG_FLAGS} -D_DEBUG -DKRATOS_DEBUG" )
 SET( CMAKE_CXX_FLAGS_CUSTOM "${CMAKE_CXX_FLAGS_CUSTOM}" )
+set( CMAKE_MAP_IMPORTED_CONFIG_FULLDEBUG Debug)
 
 # Define internal CMake flags needed
 SET( CMAKE_C_FLAGS_FULLDEBUG "${CMAKE_C_FLAGS_DEBUG}" )
@@ -283,6 +289,10 @@ if(${MSVC})
   SET (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /W1 /bigobj /EHsc /Zc:__cplusplus -DBOOST_ALL_NO_LIB -D_SCL_SECURE_NO_WARNINGS")
   string( REPLACE "/W3" "" CMAKE_C_FLAGS ${CMAKE_C_FLAGS} )
   string( REPLACE "/W3" "" CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS} )
+  # CMake does not select the correct runtime library for FullDebug now, no idea why
+  if( ${CMAKE_BUILD_TYPE} MATCHES "FullDebug" )
+    set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreadedDebugDLL" CACHE STRING "" FORCE)
+  endif( ${CMAKE_BUILD_TYPE} MATCHES "FullDebug" )
 endif(${MSVC})
 
 # Specific flags for different versions of MSVC


### PR DESCRIPTION
**📝 Description**
FullDebug builds in windows were failing for some people. 
The cause is that, for some reason, now it defaults to `/MD` instead of `/MDd`. 🤷 @AlejandroCornejo  This should fix your problem.

Also took the chance to prepare the CMake to use the new findboost, just setting the policy for now ( @rfaasse we will need this prior to upgrading boost and cmake to newer versions because they changed how the FindBoost works from 3.30 onwards and newer versions of boost are designed to work with that )

**🆕 Changelog**
- Mapping the Debug config to FullDebug and manually selecting the runtime lib
- Preparing for using the new FindBoost Mechanism.
