### PR TITLE
Fix typos in applications/CompressiblePotentialFlowApplication

### DIFF
--- a/applications/CompressiblePotentialFlowApplication/custom_elements/compressible_perturbation_potential_flow_element.h
+++ b/applications/CompressiblePotentialFlowApplication/custom_elements/compressible_perturbation_potential_flow_element.h
@@ -75,7 +75,7 @@ public:
 
     // Constructors.
 
-    /// Default constuctor.
+    /// Default constructor.
     /**
      * @param NewId Index number of the new element (optional)
      */

--- a/applications/CompressiblePotentialFlowApplication/custom_elements/compressible_potential_flow_element.h
+++ b/applications/CompressiblePotentialFlowApplication/custom_elements/compressible_potential_flow_element.h
@@ -75,7 +75,7 @@ public:
 
     // Constructors.
 
-    /// Default constuctor.
+    /// Default constructor.
     /**
      * @param NewId Index number of the new element (optional)
      */

--- a/applications/CompressiblePotentialFlowApplication/custom_elements/embedded_compressible_potential_flow_element.h
+++ b/applications/CompressiblePotentialFlowApplication/custom_elements/embedded_compressible_potential_flow_element.h
@@ -50,7 +50,7 @@ public:
 
     // Constructors.
 
-    /// Default constuctor.
+    /// Default constructor.
     /**
      * @param NewId Index number of the new element (optional)
      */

--- a/applications/CompressiblePotentialFlowApplication/custom_elements/embedded_incompressible_potential_flow_element.h
+++ b/applications/CompressiblePotentialFlowApplication/custom_elements/embedded_incompressible_potential_flow_element.h
@@ -50,7 +50,7 @@ public:
 
     // Constructors.
 
-    /// Default constuctor.
+    /// Default constructor.
     /**
      * @param NewId Index number of the new element (optional)
      */

--- a/applications/CompressiblePotentialFlowApplication/custom_elements/embedded_transonic_perturbation_potential_flow_element.h
+++ b/applications/CompressiblePotentialFlowApplication/custom_elements/embedded_transonic_perturbation_potential_flow_element.h
@@ -74,7 +74,7 @@ public:
 
     // Constructors.
 
-    /// Default constuctor.
+    /// Default constructor.
     /**
      * @param NewId Index number of the new element (optional)
      */

--- a/applications/CompressiblePotentialFlowApplication/custom_elements/incompressible_perturbation_potential_flow_element.h
+++ b/applications/CompressiblePotentialFlowApplication/custom_elements/incompressible_perturbation_potential_flow_element.h
@@ -56,7 +56,7 @@ public:
 
     // Constructors.
 
-    /// Default constuctor.
+    /// Default constructor.
     /**
      * @param NewId Index number of the new element (optional)
      */

--- a/applications/CompressiblePotentialFlowApplication/custom_elements/incompressible_potential_flow_element.h
+++ b/applications/CompressiblePotentialFlowApplication/custom_elements/incompressible_potential_flow_element.h
@@ -56,7 +56,7 @@ public:
 
     // Constructors.
 
-    /// Default constuctor.
+    /// Default constructor.
     /**
      * @param NewId Index number of the new element (optional)
      */

--- a/applications/CompressiblePotentialFlowApplication/custom_elements/transonic_perturbation_potential_flow_element.h
+++ b/applications/CompressiblePotentialFlowApplication/custom_elements/transonic_perturbation_potential_flow_element.h
@@ -65,7 +65,7 @@ public:
 
     // Constructors.
 
-    /// Default constuctor.
+    /// Default constructor.
     /**
      * @param NewId Index number of the new element (optional)
      */

--- a/applications/CompressiblePotentialFlowApplication/custom_processes/define_2d_wake_process.h
+++ b/applications/CompressiblePotentialFlowApplication/custom_processes/define_2d_wake_process.h
@@ -90,7 +90,7 @@ private:
     ///@name Member Variables
     ///@{
 
-    // The airfoil model part conatining the trailing edge
+    // The airfoil model part containing the trailing edge
     ModelPart& mrBodyModelPart;
     // Tolerance to avoid nodes laying exactly on the wake
     const double mTolerance;

--- a/applications/CompressiblePotentialFlowApplication/custom_processes/define_3d_wake_process.h
+++ b/applications/CompressiblePotentialFlowApplication/custom_processes/define_3d_wake_process.h
@@ -90,7 +90,7 @@ private:
     ///@name Member Variables
     ///@{
 
-    // The airfoil model part conatining the trailing edge
+    // The airfoil model part containing the trailing edge
     ModelPart& mrTrailingEdgeModelPart;
     ModelPart& mrBodyModelPart;
     ModelPart& mrStlWakeModelPart;

--- a/applications/CompressiblePotentialFlowApplication/tests/test_CompressiblePotentialFlowApplication.py
+++ b/applications/CompressiblePotentialFlowApplication/tests/test_CompressiblePotentialFlowApplication.py
@@ -15,8 +15,8 @@ import KratosMultiphysics.KratosUnittest as KratosUnittest
 def AssembleTestSuites():
     ''' Populates the test suites to run.
 
-    Populates the test suites to run. At least, it should pupulate the suites:
-    "small", "nighlty" and "all"
+    Populates the test suites to run. At least, it should populate the suites:
+    "small", "nightly" and "all"
 
     Return
     ------


### PR DESCRIPTION
**📝 Description**
Fixes source comments and doxygen typos.
Found via codespell

**🆕 Changelog**
- Fixes source comments and doxygen typos within application/CompressiblePotentialFlowApplication