### PR TITLE
Fix typos in applications/ChimeraApplication and applications/ConstitutiveLawsApplication 

### DIFF
--- a/applications/ChimeraApplication/custom_processes/apply_chimera_process.h
+++ b/applications/ChimeraApplication/custom_processes/apply_chimera_process.h
@@ -234,7 +234,7 @@ protected:
      * added.
      * @param rConstraintIdVector The vector of the constraints Ids which is
      * accessed with StartIndex.
-     * @param rMsContainer The Constraint container to which the contraints are
+     * @param rMsContainer The Constraint container to which the constraints are
      * added.
      */
     template <typename TVariableType>
@@ -247,7 +247,7 @@ protected:
                                     MasterSlaveConstraintContainerType& rMsContainer);
 
     /**
-     * @brief This function reserves the necessary memory for the contraints in
+     * @brief This function reserves the necessary memory for the constraints in
      * each thread
      * @param rModelPart The modelpart to which the constraints are to be added.
      * @param rContainerVector The container vector which has constraints to
@@ -257,7 +257,7 @@ protected:
                                               MasterSlaveContainerVectorType& rContainerVector);
 
     /**
-     * @brief Given a node, this funcition finds and deletes all the existing
+     * @brief Given a node, this function finds and deletes all the existing
      * constraints for that node
      * @param rBoundaryNode The boundary node for which the connections are to
      * be made.

--- a/applications/ChimeraApplication/custom_utilities/hole_cutting_utility.h
+++ b/applications/ChimeraApplication/custom_utilities/hole_cutting_utility.h
@@ -100,7 +100,7 @@ public:
      * @param rModelPart The modelpart where the hole is to be cut.
      * @param rHoleModelPart The modelpart containing the nodes and corresponding elements from the cut hole. (deactivated elements)
      * @param rHoleBoundaryModelPart Boundary modelpart of the rHoleModelPart
-     * @param Distance is the the distance (magnitude) at which hole is to be cut from the zero distance layer.
+     * @param Distance is the distance (magnitude) at which hole is to be cut from the zero distance layer.
      */
     template<int TDim>
     void CreateHoleAfterDistance(ModelPart &rModelPart,
@@ -113,9 +113,9 @@ public:
      * @brief Removes the elements which are out of the domain.
      *          An element is removed even if one of its nodes is out of the domain (-ve or +ve) as indicated by GetInside and MainDomainOrNot
      * @param rModelPart The modelpart From where the elements are to be removed.
-     * @param rModifiedModelPart The modified modelpart without the the elements which are out side.
+     * @param rModifiedModelPart The modified modelpart without the elements which are out side.
      * @param DomainType says which sign (-ve or +ve) is inside
-     * @param OverLapDistance is the the distance (magnitude) at which hole is to be cut from the zero distance layer.
+     * @param OverLapDistance is the distance (magnitude) at which hole is to be cut from the zero distance layer.
      * @param GetInside works in combination with MainDomainOrNot to get the feeling of what is inside or what is outside.
      */
     template<int TDim>

--- a/applications/ChimeraApplication/tests/test_ChimeraApplication.py
+++ b/applications/ChimeraApplication/tests/test_ChimeraApplication.py
@@ -13,7 +13,7 @@ def AssembleTestSuites():
     ''' Populates the test suites to run.
 
     Populates the test suites to run. At least, it should populate the suites:
-    "small", "nighlty" and "all"
+    "small", "nightly" and "all"
 
     Return
     ------

--- a/applications/ConstitutiveLawsApplication/custom_constitutive/small_strains/damage/d_plus_d_minus_damage_masonry_3d.h
+++ b/applications/ConstitutiveLawsApplication/custom_constitutive/small_strains/damage/d_plus_d_minus_damage_masonry_3d.h
@@ -623,7 +623,7 @@ private:
 
     /**
      *  BRIEF DOCUMENTATION OF THE USED UNIAXIAL SOFTENING BEHAVIOR IN COMPRESSION
-     *  Entire documentation can be found in the the Phd Thesis of Massimo Petracca
+     *  Entire documentation can be found in the Phd Thesis of Massimo Petracca
      *  << Computational Multiscale Analysis of Masonry Structures>>
      *
      *  UNIAXIAL BEZIER COMPRESSION DAMAGE

--- a/applications/ConstitutiveLawsApplication/custom_constitutive/small_strains/damage/plane_stress_d_plus_d_minus_damage_masonry_2d.h
+++ b/applications/ConstitutiveLawsApplication/custom_constitutive/small_strains/damage/plane_stress_d_plus_d_minus_damage_masonry_2d.h
@@ -526,7 +526,7 @@ protected:
 
 	/**
 	*  BRIEF DOCUMENTATION OF THE USED UNIAXIAL SOFTENING BEHAVIOR IN COMPRESSION
-	*  Entire documentation can be found in the the Phd Thesis of Massimo Petracca
+	*  Entire documentation can be found in the Phd Thesis of Massimo Petracca
 	*  << Computational Multiscale Analysis of Masonry Structures>>
 	*
 	*  UNIAXIAL BEZIER COMPRESSION DAMAGE

--- a/applications/ConstitutiveLawsApplication/tests/test_ConstitutiveLawsApplication.py
+++ b/applications/ConstitutiveLawsApplication/tests/test_ConstitutiveLawsApplication.py
@@ -33,8 +33,8 @@ from test_factory import CurveByPointsPlasticityTest
 def AssembleTestSuites():
     ''' Populates the test suites to run.
 
-    Populates the test suites to run. At least, it should pupulate the suites:
-    "small", "nighlty" and "all"
+    Populates the test suites to run. At least, it should populate the suites:
+    "small", "nightly" and "all"
 
     Return
     ------


### PR DESCRIPTION
**📝 Description**
Fixes source comments and doxygen typos.
Found via codespell

**🆕 Changelog**
- Fixes source comments and doxygen typos within application/ChimeraApplication
- Fixes source comments and doxygen typos within application/ConstitutiveLawsApplication