### PR TITLE
[Core] Make `MathUtils<>::DegreesToRadians` `constexpr`

### DIFF
--- a/kratos/utilities/math_utils.h
+++ b/kratos/utilities/math_utils.h
@@ -1915,7 +1915,7 @@ public:
     }
 
 
-    static double DegreesToRadians(double AngleInDegrees)
+    constexpr static double DegreesToRadians(double AngleInDegrees)
     {
         return (AngleInDegrees * Globals::Pi) / 180.0;
     }


### PR DESCRIPTION
**📝 Description**
By marking this function `constexpr`, we allow for compile-time conversion of angles when possible. This change complies with C++ Core Guideline [F.4: If a function might have to be evaluated at compile time, declare it `constexpr`](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#f4-if-a-function-might-have-to-be-evaluated-at-compile-time-declare-it-constexpr).
