### PR TITLE
[GeoMechanicsApplication] Create a calculator for the fluid body vector RHS

### DIFF
--- a/applications/GeoMechanicsApplication/custom_elements/calculation_contribution.h
+++ b/applications/GeoMechanicsApplication/custom_elements/calculation_contribution.h
@@ -14,6 +14,6 @@
 namespace Kratos
 {
 
-enum class CalculationContribution { Permeability, Compressibility };
+enum class CalculationContribution { Permeability, Compressibility, FluidBodyFlow };
 
 }

--- a/applications/GeoMechanicsApplication/custom_elements/compressibility_calculator.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/compressibility_calculator.cpp
@@ -26,9 +26,9 @@ std::optional<Matrix> CompressibilityCalculator::LHSContribution()
     return std::make_optional(LHSContribution(CalculateCompressibilityMatrix()));
 }
 
-std::optional<Vector> CompressibilityCalculator::RHSContribution()
+Vector CompressibilityCalculator::RHSContribution()
 {
-    return std::make_optional(RHSContribution(CalculateCompressibilityMatrix()));
+    return RHSContribution(CalculateCompressibilityMatrix());
 }
 
 Vector CompressibilityCalculator::RHSContribution(const Matrix& rCompressibilityMatrix) const
@@ -41,11 +41,10 @@ Matrix CompressibilityCalculator::LHSContribution(const Matrix& rCompressibility
     return mInputProvider.GetMatrixScalarFactor() * rCompressibilityMatrix;
 }
 
-std::pair<std::optional<Matrix>, std::optional<Vector>> CompressibilityCalculator::LocalSystemContribution()
+std::pair<std::optional<Matrix>, Vector> CompressibilityCalculator::LocalSystemContribution()
 {
     const auto compressibility_matrix = CalculateCompressibilityMatrix();
-    return {std::make_optional(LHSContribution(compressibility_matrix)),
-            std::make_optional(RHSContribution(compressibility_matrix))};
+    return {std::make_optional(LHSContribution(compressibility_matrix)), RHSContribution(compressibility_matrix)};
 }
 
 Matrix CompressibilityCalculator::CalculateCompressibilityMatrix() const

--- a/applications/GeoMechanicsApplication/custom_elements/compressibility_calculator.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/compressibility_calculator.cpp
@@ -23,12 +23,12 @@ CompressibilityCalculator::CompressibilityCalculator(InputProvider rInputProvide
 
 std::optional<Matrix> CompressibilityCalculator::LHSContribution()
 {
-    return LHSContribution(CalculateCompressibilityMatrix());
+    return std::make_optional(LHSContribution(CalculateCompressibilityMatrix()));
 }
 
 std::optional<Vector> CompressibilityCalculator::RHSContribution()
 {
-    return RHSContribution(CalculateCompressibilityMatrix());
+    return std::make_optional(RHSContribution(CalculateCompressibilityMatrix()));
 }
 
 Vector CompressibilityCalculator::RHSContribution(const Matrix& rCompressibilityMatrix) const
@@ -44,7 +44,8 @@ Matrix CompressibilityCalculator::LHSContribution(const Matrix& rCompressibility
 std::pair<std::optional<Matrix>, std::optional<Vector>> CompressibilityCalculator::LocalSystemContribution()
 {
     const auto compressibility_matrix = CalculateCompressibilityMatrix();
-    return {LHSContribution(compressibility_matrix), RHSContribution(compressibility_matrix)};
+    return {std::make_optional(LHSContribution(compressibility_matrix)),
+            std::make_optional(RHSContribution(compressibility_matrix))};
 }
 
 Matrix CompressibilityCalculator::CalculateCompressibilityMatrix() const

--- a/applications/GeoMechanicsApplication/custom_elements/compressibility_calculator.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/compressibility_calculator.cpp
@@ -21,12 +21,12 @@ CompressibilityCalculator::CompressibilityCalculator(InputProvider rInputProvide
 {
 }
 
-Matrix CompressibilityCalculator::LHSContribution()
+std::optional<Matrix> CompressibilityCalculator::LHSContribution()
 {
     return LHSContribution(CalculateCompressibilityMatrix());
 }
 
-Vector CompressibilityCalculator::RHSContribution()
+std::optional<Vector> CompressibilityCalculator::RHSContribution()
 {
     return RHSContribution(CalculateCompressibilityMatrix());
 }
@@ -41,7 +41,7 @@ Matrix CompressibilityCalculator::LHSContribution(const Matrix& rCompressibility
     return mInputProvider.GetMatrixScalarFactor() * rCompressibilityMatrix;
 }
 
-std::pair<Matrix, Vector> CompressibilityCalculator::LocalSystemContribution()
+std::pair<std::optional<Matrix>, std::optional<Vector>> CompressibilityCalculator::LocalSystemContribution()
 {
     const auto compressibility_matrix = CalculateCompressibilityMatrix();
     return {LHSContribution(compressibility_matrix), RHSContribution(compressibility_matrix)};

--- a/applications/GeoMechanicsApplication/custom_elements/compressibility_calculator.h
+++ b/applications/GeoMechanicsApplication/custom_elements/compressibility_calculator.h
@@ -52,8 +52,8 @@ public:
 
     explicit CompressibilityCalculator(InputProvider rInputProvider);
 
-    std::optional<Matrix>                    LHSContribution() override;
-    std::optional<Vector>                    RHSContribution() override;
+    std::optional<Matrix>                                   LHSContribution() override;
+    std::optional<Vector>                                   RHSContribution() override;
     std::pair<std::optional<Matrix>, std::optional<Vector>> LocalSystemContribution() override;
 
 private:

--- a/applications/GeoMechanicsApplication/custom_elements/compressibility_calculator.h
+++ b/applications/GeoMechanicsApplication/custom_elements/compressibility_calculator.h
@@ -52,9 +52,9 @@ public:
 
     explicit CompressibilityCalculator(InputProvider rInputProvider);
 
-    std::optional<Matrix>                                   LHSContribution() override;
-    std::optional<Vector>                                   RHSContribution() override;
-    std::pair<std::optional<Matrix>, std::optional<Vector>> LocalSystemContribution() override;
+    std::optional<Matrix>                    LHSContribution() override;
+    Vector                                   RHSContribution() override;
+    std::pair<std::optional<Matrix>, Vector> LocalSystemContribution() override;
 
 private:
     [[nodiscard]] Matrix CalculateCompressibilityMatrix() const;

--- a/applications/GeoMechanicsApplication/custom_elements/compressibility_calculator.h
+++ b/applications/GeoMechanicsApplication/custom_elements/compressibility_calculator.h
@@ -52,9 +52,9 @@ public:
 
     explicit CompressibilityCalculator(InputProvider rInputProvider);
 
-    Matrix                    LHSContribution() override;
-    Vector                    RHSContribution() override;
-    std::pair<Matrix, Vector> LocalSystemContribution() override;
+    std::optional<Matrix>                    LHSContribution() override;
+    std::optional<Vector>                    RHSContribution() override;
+    std::pair<std::optional<Matrix>, std::optional<Vector>> LocalSystemContribution() override;
 
 private:
     [[nodiscard]] Matrix CalculateCompressibilityMatrix() const;

--- a/applications/GeoMechanicsApplication/custom_elements/contribution_calculator.h
+++ b/applications/GeoMechanicsApplication/custom_elements/contribution_calculator.h
@@ -13,6 +13,8 @@
 
 #include "includes/ublas_interface.h"
 
+#include <optional>
+
 namespace Kratos
 {
 
@@ -21,9 +23,9 @@ class ContributionCalculator
 public:
     virtual ~ContributionCalculator() = default;
 
-    virtual Matrix                    LHSContribution()         = 0;
-    virtual Vector                    RHSContribution()         = 0;
-    virtual std::pair<Matrix, Vector> LocalSystemContribution() = 0;
+    virtual std::optional<Matrix>                    LHSContribution()         = 0;
+    virtual std::optional<Vector>                    RHSContribution()         = 0;
+    virtual std::pair<std::optional<Matrix>, std::optional<Vector>> LocalSystemContribution() = 0;
 };
 
 } // namespace Kratos

--- a/applications/GeoMechanicsApplication/custom_elements/contribution_calculator.h
+++ b/applications/GeoMechanicsApplication/custom_elements/contribution_calculator.h
@@ -23,8 +23,8 @@ class ContributionCalculator
 public:
     virtual ~ContributionCalculator() = default;
 
-    virtual std::optional<Matrix>                    LHSContribution()         = 0;
-    virtual std::optional<Vector>                    RHSContribution()         = 0;
+    virtual std::optional<Matrix>                                   LHSContribution()         = 0;
+    virtual std::optional<Vector>                                   RHSContribution()         = 0;
     virtual std::pair<std::optional<Matrix>, std::optional<Vector>> LocalSystemContribution() = 0;
 };
 

--- a/applications/GeoMechanicsApplication/custom_elements/contribution_calculator.h
+++ b/applications/GeoMechanicsApplication/custom_elements/contribution_calculator.h
@@ -23,9 +23,9 @@ class ContributionCalculator
 public:
     virtual ~ContributionCalculator() = default;
 
-    virtual std::optional<Matrix>                                   LHSContribution()         = 0;
-    virtual std::optional<Vector>                                   RHSContribution()         = 0;
-    virtual std::pair<std::optional<Matrix>, std::optional<Vector>> LocalSystemContribution() = 0;
+    virtual std::optional<Matrix>                    LHSContribution()         = 0;
+    virtual Vector                                   RHSContribution()         = 0;
+    virtual std::pair<std::optional<Matrix>, Vector> LocalSystemContribution() = 0;
 };
 
 } // namespace Kratos

--- a/applications/GeoMechanicsApplication/custom_elements/filter_compressibility_calculator.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/filter_compressibility_calculator.cpp
@@ -27,9 +27,9 @@ std::optional<Matrix> FilterCompressibilityCalculator::LHSContribution()
     return std::make_optional(LHSContribution(CalculateCompressibilityMatrix()));
 }
 
-std::optional<Vector> FilterCompressibilityCalculator::RHSContribution()
+Vector FilterCompressibilityCalculator::RHSContribution()
 {
-    return std::make_optional(RHSContribution(CalculateCompressibilityMatrix()));
+    return RHSContribution(CalculateCompressibilityMatrix());
 }
 
 Vector FilterCompressibilityCalculator::RHSContribution(const Matrix& rCompressibilityMatrix) const
@@ -42,11 +42,10 @@ Matrix FilterCompressibilityCalculator::LHSContribution(const Matrix& rCompressi
     return mInputProvider.GetMatrixScalarFactor() * rCompressibilityMatrix;
 }
 
-std::pair<std::optional<Matrix>, std::optional<Vector>> FilterCompressibilityCalculator::LocalSystemContribution()
+std::pair<std::optional<Matrix>, Vector> FilterCompressibilityCalculator::LocalSystemContribution()
 {
     const auto compressibility_matrix = CalculateCompressibilityMatrix();
-    return {std::make_optional(LHSContribution(compressibility_matrix)),
-            std::make_optional(RHSContribution(compressibility_matrix))};
+    return {std::make_optional(LHSContribution(compressibility_matrix)), RHSContribution(compressibility_matrix)};
 }
 
 Matrix FilterCompressibilityCalculator::CalculateCompressibilityMatrix() const
@@ -54,7 +53,7 @@ Matrix FilterCompressibilityCalculator::CalculateCompressibilityMatrix() const
     const auto& r_N_container            = mInputProvider.GetNContainer();
     const auto& integration_coefficients = mInputProvider.GetIntegrationCoefficients();
     const auto& projected_gravity_on_integration_points =
-        mInputProvider.GetProjectedGravityForIntegrationPoints();
+        mInputProvider.GetProjectedGravityAtIntegrationPoints();
     auto result = Matrix{ZeroMatrix{r_N_container.size2(), r_N_container.size2()}};
     for (unsigned int integration_point_index = 0;
          integration_point_index < integration_coefficients.size(); ++integration_point_index) {

--- a/applications/GeoMechanicsApplication/custom_elements/filter_compressibility_calculator.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/filter_compressibility_calculator.cpp
@@ -60,7 +60,7 @@ Matrix FilterCompressibilityCalculator::CalculateCompressibilityMatrix() const
          integration_point_index < integration_coefficients.size(); ++integration_point_index) {
         const auto N = Vector{row(r_N_container, integration_point_index)};
         result += GeoTransportEquationUtilities::CalculateCompressibilityMatrix(
-            N, CalculateElasticCapacity(projected_gravity_on_integration_points[integration_point_index]),
+            N, CalculateElasticCapacity(projected_gravity_on_integration_points[integration_point_index][0]),
             integration_coefficients[integration_point_index]);
     }
     return result;

--- a/applications/GeoMechanicsApplication/custom_elements/filter_compressibility_calculator.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/filter_compressibility_calculator.cpp
@@ -22,12 +22,12 @@ FilterCompressibilityCalculator::FilterCompressibilityCalculator(InputProvider A
 {
 }
 
-Matrix FilterCompressibilityCalculator::LHSContribution()
+std::optional<Matrix> FilterCompressibilityCalculator::LHSContribution()
 {
     return LHSContribution(CalculateCompressibilityMatrix());
 }
 
-Vector FilterCompressibilityCalculator::RHSContribution()
+std::optional<Vector> FilterCompressibilityCalculator::RHSContribution()
 {
     return RHSContribution(CalculateCompressibilityMatrix());
 }
@@ -42,7 +42,7 @@ Matrix FilterCompressibilityCalculator::LHSContribution(const Matrix& rCompressi
     return mInputProvider.GetMatrixScalarFactor() * rCompressibilityMatrix;
 }
 
-std::pair<Matrix, Vector> FilterCompressibilityCalculator::LocalSystemContribution()
+std::pair<std::optional<Matrix>, std::optional<Vector>> FilterCompressibilityCalculator::LocalSystemContribution()
 {
     const auto compressibility_matrix = CalculateCompressibilityMatrix();
     return {LHSContribution(compressibility_matrix), RHSContribution(compressibility_matrix)};

--- a/applications/GeoMechanicsApplication/custom_elements/filter_compressibility_calculator.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/filter_compressibility_calculator.cpp
@@ -24,12 +24,12 @@ FilterCompressibilityCalculator::FilterCompressibilityCalculator(InputProvider A
 
 std::optional<Matrix> FilterCompressibilityCalculator::LHSContribution()
 {
-    return LHSContribution(CalculateCompressibilityMatrix());
+    return std::make_optional(LHSContribution(CalculateCompressibilityMatrix()));
 }
 
 std::optional<Vector> FilterCompressibilityCalculator::RHSContribution()
 {
-    return RHSContribution(CalculateCompressibilityMatrix());
+    return std::make_optional(RHSContribution(CalculateCompressibilityMatrix()));
 }
 
 Vector FilterCompressibilityCalculator::RHSContribution(const Matrix& rCompressibilityMatrix) const
@@ -45,7 +45,8 @@ Matrix FilterCompressibilityCalculator::LHSContribution(const Matrix& rCompressi
 std::pair<std::optional<Matrix>, std::optional<Vector>> FilterCompressibilityCalculator::LocalSystemContribution()
 {
     const auto compressibility_matrix = CalculateCompressibilityMatrix();
-    return {LHSContribution(compressibility_matrix), RHSContribution(compressibility_matrix)};
+    return {std::make_optional(LHSContribution(compressibility_matrix)),
+            std::make_optional(RHSContribution(compressibility_matrix))};
 }
 
 Matrix FilterCompressibilityCalculator::CalculateCompressibilityMatrix() const

--- a/applications/GeoMechanicsApplication/custom_elements/filter_compressibility_calculator.h
+++ b/applications/GeoMechanicsApplication/custom_elements/filter_compressibility_calculator.h
@@ -27,16 +27,16 @@ class FilterCompressibilityCalculator : public ContributionCalculator
 {
 public:
     struct InputProvider {
-        InputProvider(std::function<const Properties&()> GetElementProperties,
-                      std::function<const Matrix&()>     GetNContainer,
-                      std::function<Vector()>            GetIntegrationCoefficients,
-                      std::function<std::vector<Vector>()>            GetProjectedGravityForIntegrationPoints,
-                      std::function<double()>            GetMatrixScalarFactor,
+        InputProvider(std::function<const Properties&()>   GetElementProperties,
+                      std::function<const Matrix&()>       GetNContainer,
+                      std::function<Vector()>              GetIntegrationCoefficients,
+                      std::function<std::vector<Vector>()> GetProjectedGravityAtIntegrationPoints,
+                      std::function<double()>              GetMatrixScalarFactor,
                       std::function<Vector(const Variable<double>&)> GetNodalValuesOf)
             : GetElementProperties(std::move(GetElementProperties)),
               GetNContainer(std::move(GetNContainer)),
               GetIntegrationCoefficients(std::move(GetIntegrationCoefficients)),
-              GetProjectedGravityForIntegrationPoints(std::move(GetProjectedGravityForIntegrationPoints)),
+              GetProjectedGravityAtIntegrationPoints(std::move(GetProjectedGravityAtIntegrationPoints)),
               GetMatrixScalarFactor(std::move(GetMatrixScalarFactor)),
               GetNodalValues(std::move(GetNodalValuesOf))
         {
@@ -45,16 +45,16 @@ public:
         std::function<const Properties&()>             GetElementProperties;
         std::function<const Matrix&()>                 GetNContainer;
         std::function<Vector()>                        GetIntegrationCoefficients;
-        std::function<std::vector<Vector>()>                        GetProjectedGravityForIntegrationPoints;
+        std::function<std::vector<Vector>()>           GetProjectedGravityAtIntegrationPoints;
         std::function<double()>                        GetMatrixScalarFactor;
         std::function<Vector(const Variable<double>&)> GetNodalValues;
     };
 
     explicit FilterCompressibilityCalculator(InputProvider AnInputProvider);
 
-    std::optional<Matrix>                                   LHSContribution() override;
-    std::optional<Vector>                                   RHSContribution() override;
-    std::pair<std::optional<Matrix>, std::optional<Vector>> LocalSystemContribution() override;
+    std::optional<Matrix>                    LHSContribution() override;
+    Vector                                   RHSContribution() override;
+    std::pair<std::optional<Matrix>, Vector> LocalSystemContribution() override;
 
 private:
     [[nodiscard]] Matrix CalculateCompressibilityMatrix() const;

--- a/applications/GeoMechanicsApplication/custom_elements/filter_compressibility_calculator.h
+++ b/applications/GeoMechanicsApplication/custom_elements/filter_compressibility_calculator.h
@@ -52,9 +52,9 @@ public:
 
     explicit FilterCompressibilityCalculator(InputProvider AnInputProvider);
 
-    Matrix                    LHSContribution() override;
-    Vector                    RHSContribution() override;
-    std::pair<Matrix, Vector> LocalSystemContribution() override;
+    std::optional<Matrix>                    LHSContribution() override;
+    std::optional<Vector>                    RHSContribution() override;
+    std::pair<std::optional<Matrix>, std::optional<Vector>> LocalSystemContribution() override;
 
 private:
     [[nodiscard]] Matrix CalculateCompressibilityMatrix() const;

--- a/applications/GeoMechanicsApplication/custom_elements/filter_compressibility_calculator.h
+++ b/applications/GeoMechanicsApplication/custom_elements/filter_compressibility_calculator.h
@@ -52,8 +52,8 @@ public:
 
     explicit FilterCompressibilityCalculator(InputProvider AnInputProvider);
 
-    std::optional<Matrix>                    LHSContribution() override;
-    std::optional<Vector>                    RHSContribution() override;
+    std::optional<Matrix>                                   LHSContribution() override;
+    std::optional<Vector>                                   RHSContribution() override;
     std::pair<std::optional<Matrix>, std::optional<Vector>> LocalSystemContribution() override;
 
 private:

--- a/applications/GeoMechanicsApplication/custom_elements/filter_compressibility_calculator.h
+++ b/applications/GeoMechanicsApplication/custom_elements/filter_compressibility_calculator.h
@@ -30,7 +30,7 @@ public:
         InputProvider(std::function<const Properties&()> GetElementProperties,
                       std::function<const Matrix&()>     GetNContainer,
                       std::function<Vector()>            GetIntegrationCoefficients,
-                      std::function<Vector()>            GetProjectedGravityForIntegrationPoints,
+                      std::function<std::vector<Vector>()>            GetProjectedGravityForIntegrationPoints,
                       std::function<double()>            GetMatrixScalarFactor,
                       std::function<Vector(const Variable<double>&)> GetNodalValuesOf)
             : GetElementProperties(std::move(GetElementProperties)),
@@ -45,7 +45,7 @@ public:
         std::function<const Properties&()>             GetElementProperties;
         std::function<const Matrix&()>                 GetNContainer;
         std::function<Vector()>                        GetIntegrationCoefficients;
-        std::function<Vector()>                        GetProjectedGravityForIntegrationPoints;
+        std::function<std::vector<Vector>()>                        GetProjectedGravityForIntegrationPoints;
         std::function<double()>                        GetMatrixScalarFactor;
         std::function<Vector(const Variable<double>&)> GetNodalValues;
     };

--- a/applications/GeoMechanicsApplication/custom_elements/fluid_body_flow_calculator.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/fluid_body_flow_calculator.cpp
@@ -7,12 +7,11 @@
 //
 //  License:         geo_mechanics_application/license.txt
 //
-//  Main authors:    Mohamed Nabi
-//                   Richard Faasse
+//  Main authors:    Richard Faasse
 //
+
 #include "fluid_body_flow_calculator.h"
 #include "custom_utilities/transport_equation_utilities.hpp"
-#include "geo_mechanics_application_variables.h"
 #include "includes/cfd_variables.h"
 
 #include <custom_utilities/element_utilities.hpp>

--- a/applications/GeoMechanicsApplication/custom_elements/fluid_body_flow_calculator.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/fluid_body_flow_calculator.cpp
@@ -22,9 +22,9 @@ FluidBodyFlowCalculator::FluidBodyFlowCalculator(InputProvider AnInputProvider)
 {
 }
 
-Matrix FluidBodyFlowCalculator::LHSContribution() { return {}; }
+std::optional<Matrix> FluidBodyFlowCalculator::LHSContribution() { return {}; }
 
-Vector FluidBodyFlowCalculator::RHSContribution()
+std::optional<Vector> FluidBodyFlowCalculator::RHSContribution()
 {
     const auto    shape_function_gradients = mInputProvider.GetShapeFunctionGradients();
     const Matrix& N_container              = mInputProvider.GetNContainer();
@@ -54,7 +54,7 @@ Vector FluidBodyFlowCalculator::RHSContribution()
     return fluid_body_vector;
 }
 
-std::pair<Matrix, Vector> FluidBodyFlowCalculator::LocalSystemContribution()
+std::pair<std::optional<Matrix>, std::optional<Vector>> FluidBodyFlowCalculator::LocalSystemContribution()
 {
     return {{}, RHSContribution()};
 }

--- a/applications/GeoMechanicsApplication/custom_elements/fluid_body_flow_calculator.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/fluid_body_flow_calculator.cpp
@@ -32,7 +32,8 @@ Vector FluidBodyFlowCalculator::RHSContribution()
     const auto integration_coefficients = mInputProvider.GetIntegrationCoefficients();
 
     const auto& r_properties        = mInputProvider.GetElementProperties();
-    const auto  constitutive_matrix = GeoElementUtilities::FillPermeabilityMatrix(r_properties, 1);
+    const auto  constitutive_matrix = GeoElementUtilities::FillPermeabilityMatrix(
+        r_properties, mInputProvider.GetLocalSpaceDimension());
 
     RetentionLaw::Parameters RetentionParameters(r_properties);
 

--- a/applications/GeoMechanicsApplication/custom_elements/fluid_body_flow_calculator.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/fluid_body_flow_calculator.cpp
@@ -27,7 +27,7 @@ std::optional<Matrix> FluidBodyFlowCalculator::LHSContribution() { return std::n
 std::optional<Vector> FluidBodyFlowCalculator::RHSContribution()
 {
     const auto    shape_function_gradients = mInputProvider.GetShapeFunctionGradients();
-    const Matrix& r_N_container              = mInputProvider.GetNContainer();
+    const Matrix& r_N_container            = mInputProvider.GetNContainer();
 
     const auto integration_coefficients = mInputProvider.GetIntegrationCoefficients();
 
@@ -36,7 +36,8 @@ std::optional<Vector> FluidBodyFlowCalculator::RHSContribution()
         r_properties, mInputProvider.GetLocalSpaceDimension());
 
     RetentionLaw::Parameters RetentionParameters(r_properties);
-    const auto projected_gravity_on_integration_points = mInputProvider.GetProjectedGravityForIntegrationPoints();
+    const auto               projected_gravity_on_integration_points =
+        mInputProvider.GetProjectedGravityForIntegrationPoints();
     Vector fluid_body_vector = ZeroVector(shape_function_gradients[0].size1());
     for (unsigned int integration_point_index = 0;
          integration_point_index < integration_coefficients.size(); ++integration_point_index) {
@@ -49,7 +50,7 @@ std::optional<Vector> FluidBodyFlowCalculator::RHSContribution()
                  ScalarVector(1, projected_gravity_on_integration_points[integration_point_index])) *
             integration_coefficients[integration_point_index] / r_properties[DYNAMIC_VISCOSITY];
     }
-    return fluid_body_vector;
+    return std::make_optional(fluid_body_vector);
 }
 
 std::pair<std::optional<Matrix>, std::optional<Vector>> FluidBodyFlowCalculator::LocalSystemContribution()

--- a/applications/GeoMechanicsApplication/custom_elements/fluid_body_flow_calculator.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/fluid_body_flow_calculator.cpp
@@ -45,7 +45,7 @@ std::optional<Vector> FluidBodyFlowCalculator::RHSContribution()
         noalias(fluid_body_vector) +=
             r_properties[DENSITY_WATER] * relative_permeability *
             prod(prod(shape_function_gradients[integration_point_index], constitutive_matrix),
-                 ScalarVector(1, projected_gravity_on_integration_points[integration_point_index])) *
+                 projected_gravity_on_integration_points[integration_point_index]) *
             integration_coefficients[integration_point_index] / r_properties[DYNAMIC_VISCOSITY];
     }
     return std::make_optional(fluid_body_vector);

--- a/applications/GeoMechanicsApplication/custom_elements/fluid_body_flow_calculator.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/fluid_body_flow_calculator.cpp
@@ -38,7 +38,8 @@ Vector FluidBodyFlowCalculator::RHSContribution()
     const auto               projected_gravity_on_integration_points =
         mInputProvider.GetProjectedGravityAtIntegrationPoints();
 
-    auto result = Vector{ZeroVector(shape_function_gradients[0].size1())};
+    const auto fluid_body_vector_length  = shape_function_gradients[0].size1();
+    auto result = Vector{ZeroVector(fluid_body_vector_length)};
     for (unsigned int integration_point_index = 0;
          integration_point_index < integration_coefficients.size(); ++integration_point_index) {
         const auto relative_permeability =

--- a/applications/GeoMechanicsApplication/custom_elements/fluid_body_flow_calculator.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/fluid_body_flow_calculator.cpp
@@ -22,7 +22,7 @@ FluidBodyFlowCalculator::FluidBodyFlowCalculator(InputProvider AnInputProvider)
 {
 }
 
-std::optional<Matrix> FluidBodyFlowCalculator::LHSContribution() { return {}; }
+std::optional<Matrix> FluidBodyFlowCalculator::LHSContribution() { return std::nullopt; }
 
 std::optional<Vector> FluidBodyFlowCalculator::RHSContribution()
 {
@@ -56,7 +56,7 @@ std::optional<Vector> FluidBodyFlowCalculator::RHSContribution()
 
 std::pair<std::optional<Matrix>, std::optional<Vector>> FluidBodyFlowCalculator::LocalSystemContribution()
 {
-    return {{}, RHSContribution()};
+    return {std::nullopt, RHSContribution()};
 }
 
 } // namespace Kratos

--- a/applications/GeoMechanicsApplication/custom_elements/fluid_body_flow_calculator.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/fluid_body_flow_calculator.cpp
@@ -11,10 +11,8 @@
 //
 
 #include "fluid_body_flow_calculator.h"
-#include "custom_utilities/transport_equation_utilities.hpp"
+#include "custom_utilities/element_utilities.hpp"
 #include "includes/cfd_variables.h"
-
-#include <custom_utilities/element_utilities.hpp>
 
 namespace Kratos
 {
@@ -28,13 +26,13 @@ Matrix FluidBodyFlowCalculator::LHSContribution() { return {}; }
 
 Vector FluidBodyFlowCalculator::RHSContribution()
 {
-    const auto shape_function_gradients = mInputProvider.GetShapeFunctionGradients();
-    const Matrix& N_container = mInputProvider.GetNContainer();
+    const auto    shape_function_gradients = mInputProvider.GetShapeFunctionGradients();
+    const Matrix& N_container              = mInputProvider.GetNContainer();
 
     const auto integration_coefficients = mInputProvider.GetIntegrationCoefficients();
 
-    const auto&                 r_properties = mInputProvider.GetElementProperties();
-    const auto constitutive_matrix = GeoElementUtilities::FillPermeabilityMatrix(r_properties, 1);
+    const auto& r_properties        = mInputProvider.GetElementProperties();
+    const auto  constitutive_matrix = GeoElementUtilities::FillPermeabilityMatrix(r_properties, 1);
 
     RetentionLaw::Parameters RetentionParameters(r_properties);
 
@@ -55,6 +53,9 @@ Vector FluidBodyFlowCalculator::RHSContribution()
     return fluid_body_vector;
 }
 
-std::pair<Matrix, Vector> FluidBodyFlowCalculator::LocalSystemContribution() { return {{}, RHSContribution()}; }
+std::pair<Matrix, Vector> FluidBodyFlowCalculator::LocalSystemContribution()
+{
+    return {{}, RHSContribution()};
+}
 
 } // namespace Kratos

--- a/applications/GeoMechanicsApplication/custom_elements/fluid_body_flow_calculator.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/fluid_body_flow_calculator.cpp
@@ -1,0 +1,61 @@
+// KRATOS___
+//     //   ) )
+//    //         ___      ___
+//   //  ____  //___) ) //   ) )
+//  //    / / //       //   / /
+// ((____/ / ((____   ((___/ /  MECHANICS
+//
+//  License:         geo_mechanics_application/license.txt
+//
+//  Main authors:    Mohamed Nabi
+//                   Richard Faasse
+//
+#include "fluid_body_flow_calculator.h"
+#include "custom_utilities/transport_equation_utilities.hpp"
+#include "geo_mechanics_application_variables.h"
+#include "includes/cfd_variables.h"
+
+#include <custom_utilities/element_utilities.hpp>
+
+namespace Kratos
+{
+
+FluidBodyFlowCalculator::FluidBodyFlowCalculator(InputProvider AnInputProvider)
+    : mInputProvider(std::move(AnInputProvider))
+{
+}
+
+Matrix FluidBodyFlowCalculator::LHSContribution() { return {}; }
+
+Vector FluidBodyFlowCalculator::RHSContribution()
+{
+    const auto shape_function_gradients = mInputProvider.GetShapeFunctionGradients();
+    const Matrix& N_container = mInputProvider.GetNContainer();
+
+    const auto integration_coefficients = mInputProvider.GetIntegrationCoefficients();
+
+    const auto&                 r_properties = mInputProvider.GetElementProperties();
+    const auto constitutive_matrix = GeoElementUtilities::FillPermeabilityMatrix(r_properties, 1);
+
+    RetentionLaw::Parameters RetentionParameters(r_properties);
+
+    const auto projected_gravity = mInputProvider.GetProjectedGravityForIntegrationPoints();
+
+    Vector fluid_body_vector = ZeroVector(shape_function_gradients[0].size1());
+    for (unsigned int integration_point_index = 0;
+         integration_point_index < integration_coefficients.size(); ++integration_point_index) {
+        const auto N = Vector{row(N_container, integration_point_index)};
+        double     RelativePermeability =
+            mInputProvider.GetRetentionLaws()[integration_point_index]->CalculateRelativePermeability(RetentionParameters);
+        fluid_body_vector +=
+            r_properties[DENSITY_WATER] * RelativePermeability *
+            prod(prod(shape_function_gradients[integration_point_index], constitutive_matrix),
+                 ScalarVector(1, projected_gravity[integration_point_index])) *
+            integration_coefficients[integration_point_index] / r_properties[DYNAMIC_VISCOSITY];
+    }
+    return fluid_body_vector;
+}
+
+std::pair<Matrix, Vector> FluidBodyFlowCalculator::LocalSystemContribution() { return {{}, RHSContribution()}; }
+
+} // namespace Kratos

--- a/applications/GeoMechanicsApplication/custom_elements/fluid_body_flow_calculator.h
+++ b/applications/GeoMechanicsApplication/custom_elements/fluid_body_flow_calculator.h
@@ -56,8 +56,8 @@ public:
 
     explicit FluidBodyFlowCalculator(InputProvider AnInputProvider);
 
-    std::optional<Matrix>                    LHSContribution() override;
-    std::optional<Vector>                    RHSContribution() override;
+    std::optional<Matrix>                                   LHSContribution() override;
+    std::optional<Vector>                                   RHSContribution() override;
     std::pair<std::optional<Matrix>, std::optional<Vector>> LocalSystemContribution() override;
 
 private:

--- a/applications/GeoMechanicsApplication/custom_elements/fluid_body_flow_calculator.h
+++ b/applications/GeoMechanicsApplication/custom_elements/fluid_body_flow_calculator.h
@@ -30,7 +30,7 @@ public:
         InputProvider(std::function<const Properties&()> GetElementProperties,
                       std::function<const std::vector<RetentionLaw::Pointer>&()> GetRetentionLaws,
                       std::function<Vector()> GetIntegrationCoefficients,
-                      std::function<Vector()> GetProjectedGravityForIntegrationPoints,
+                      std::function<std::vector<Vector>()> GetProjectedGravityForIntegrationPoints,
                       std::function<Geometry<Node>::ShapeFunctionsGradientsType()> GetShapeFunctionGradients,
                       std::function<std::size_t()> GetLocalSpaceDimension)
 
@@ -45,7 +45,7 @@ public:
 
         std::function<const Properties&()> GetElementProperties;
         std::function<Vector()>            GetIntegrationCoefficients;
-        std::function<Vector()>            GetProjectedGravityForIntegrationPoints;
+        std::function<std::vector<Vector>()>            GetProjectedGravityForIntegrationPoints;
         std::function<const std::vector<RetentionLaw::Pointer>&()>   GetRetentionLaws;
         std::function<Geometry<Node>::ShapeFunctionsGradientsType()> GetShapeFunctionGradients;
         std::function<std::size_t()>                                 GetLocalSpaceDimension;

--- a/applications/GeoMechanicsApplication/custom_elements/fluid_body_flow_calculator.h
+++ b/applications/GeoMechanicsApplication/custom_elements/fluid_body_flow_calculator.h
@@ -7,8 +7,8 @@
 //
 //  License:         geo_mechanics_application/license.txt
 //
-//  Main authors:    Mohamed Nabi
-//                   Richard Faasse
+//  Main authors:    Richard Faasse
+//
 
 #pragma once
 
@@ -32,16 +32,12 @@ public:
                       std::function<const Matrix&()>     GetNContainer,
                       std::function<Vector()>            GetIntegrationCoefficients,
                       std::function<Vector()>            GetProjectedGravityForIntegrationPoints,
-                      std::function<double()>            GetMatrixScalarFactor,
-                      std::function<Vector(const Variable<double>&)>             GetNodalValuesOf,
                       std::function<Geometry<Node>::ShapeFunctionsGradientsType()> GetShapeFunctionGradients)
 
             : GetElementProperties(std::move(GetElementProperties)),
               GetNContainer(std::move(GetNContainer)),
               GetIntegrationCoefficients(std::move(GetIntegrationCoefficients)),
               GetProjectedGravityForIntegrationPoints(std::move(GetProjectedGravityForIntegrationPoints)),
-              GetMatrixScalarFactor(std::move(GetMatrixScalarFactor)),
-              GetNodalValues(std::move(GetNodalValuesOf)),
               GetRetentionLaws(std::move(GetRetentionLaws)),
               GetShapeFunctionGradients(std::move(GetShapeFunctionGradients))
         {
@@ -51,8 +47,6 @@ public:
         std::function<const Matrix&()>                 GetNContainer;
         std::function<Vector()>                        GetIntegrationCoefficients;
         std::function<Vector()>                        GetProjectedGravityForIntegrationPoints;
-        std::function<double()>                        GetMatrixScalarFactor;
-        std::function<Vector(const Variable<double>&)> GetNodalValues;
         std::function<const std::vector<RetentionLaw::Pointer>&()>   GetRetentionLaws;
         std::function<Geometry<Node>::ShapeFunctionsGradientsType()> GetShapeFunctionGradients;
     };

--- a/applications/GeoMechanicsApplication/custom_elements/fluid_body_flow_calculator.h
+++ b/applications/GeoMechanicsApplication/custom_elements/fluid_body_flow_calculator.h
@@ -56,9 +56,9 @@ public:
 
     explicit FluidBodyFlowCalculator(InputProvider AnInputProvider);
 
-    Matrix                    LHSContribution() override;
-    Vector                    RHSContribution() override;
-    std::pair<Matrix, Vector> LocalSystemContribution() override;
+    std::optional<Matrix>                    LHSContribution() override;
+    std::optional<Vector>                    RHSContribution() override;
+    std::pair<std::optional<Matrix>, std::optional<Vector>> LocalSystemContribution() override;
 
 private:
     InputProvider mInputProvider;

--- a/applications/GeoMechanicsApplication/custom_elements/fluid_body_flow_calculator.h
+++ b/applications/GeoMechanicsApplication/custom_elements/fluid_body_flow_calculator.h
@@ -29,14 +29,12 @@ public:
     struct InputProvider {
         InputProvider(std::function<const Properties&()> GetElementProperties,
                       std::function<const std::vector<RetentionLaw::Pointer>&()> GetRetentionLaws,
-                      std::function<const Matrix&()>                             GetNContainer,
                       std::function<Vector()> GetIntegrationCoefficients,
                       std::function<Vector()> GetProjectedGravityForIntegrationPoints,
                       std::function<Geometry<Node>::ShapeFunctionsGradientsType()> GetShapeFunctionGradients,
                       std::function<std::size_t()> GetLocalSpaceDimension)
 
             : GetElementProperties(std::move(GetElementProperties)),
-              GetNContainer(std::move(GetNContainer)),
               GetIntegrationCoefficients(std::move(GetIntegrationCoefficients)),
               GetProjectedGravityForIntegrationPoints(std::move(GetProjectedGravityForIntegrationPoints)),
               GetRetentionLaws(std::move(GetRetentionLaws)),
@@ -46,7 +44,6 @@ public:
         }
 
         std::function<const Properties&()> GetElementProperties;
-        std::function<const Matrix&()>     GetNContainer;
         std::function<Vector()>            GetIntegrationCoefficients;
         std::function<Vector()>            GetProjectedGravityForIntegrationPoints;
         std::function<const std::vector<RetentionLaw::Pointer>&()>   GetRetentionLaws;

--- a/applications/GeoMechanicsApplication/custom_elements/fluid_body_flow_calculator.h
+++ b/applications/GeoMechanicsApplication/custom_elements/fluid_body_flow_calculator.h
@@ -29,9 +29,9 @@ public:
     struct InputProvider {
         InputProvider(std::function<const Properties&()> GetElementProperties,
                       std::function<const std::vector<RetentionLaw::Pointer>&()> GetRetentionLaws,
-                      std::function<const Matrix&()>     GetNContainer,
-                      std::function<Vector()>            GetIntegrationCoefficients,
-                      std::function<Vector()>            GetProjectedGravityForIntegrationPoints,
+                      std::function<const Matrix&()>                             GetNContainer,
+                      std::function<Vector()> GetIntegrationCoefficients,
+                      std::function<Vector()> GetProjectedGravityForIntegrationPoints,
                       std::function<Geometry<Node>::ShapeFunctionsGradientsType()> GetShapeFunctionGradients)
 
             : GetElementProperties(std::move(GetElementProperties)),
@@ -43,10 +43,10 @@ public:
         {
         }
 
-        std::function<const Properties&()>             GetElementProperties;
-        std::function<const Matrix&()>                 GetNContainer;
-        std::function<Vector()>                        GetIntegrationCoefficients;
-        std::function<Vector()>                        GetProjectedGravityForIntegrationPoints;
+        std::function<const Properties&()> GetElementProperties;
+        std::function<const Matrix&()>     GetNContainer;
+        std::function<Vector()>            GetIntegrationCoefficients;
+        std::function<Vector()>            GetProjectedGravityForIntegrationPoints;
         std::function<const std::vector<RetentionLaw::Pointer>&()>   GetRetentionLaws;
         std::function<Geometry<Node>::ShapeFunctionsGradientsType()> GetShapeFunctionGradients;
     };

--- a/applications/GeoMechanicsApplication/custom_elements/fluid_body_flow_calculator.h
+++ b/applications/GeoMechanicsApplication/custom_elements/fluid_body_flow_calculator.h
@@ -32,14 +32,16 @@ public:
                       std::function<const Matrix&()>                             GetNContainer,
                       std::function<Vector()> GetIntegrationCoefficients,
                       std::function<Vector()> GetProjectedGravityForIntegrationPoints,
-                      std::function<Geometry<Node>::ShapeFunctionsGradientsType()> GetShapeFunctionGradients)
+                      std::function<Geometry<Node>::ShapeFunctionsGradientsType()> GetShapeFunctionGradients,
+                      std::function<std::size_t()> GetLocalSpaceDimension)
 
             : GetElementProperties(std::move(GetElementProperties)),
               GetNContainer(std::move(GetNContainer)),
               GetIntegrationCoefficients(std::move(GetIntegrationCoefficients)),
               GetProjectedGravityForIntegrationPoints(std::move(GetProjectedGravityForIntegrationPoints)),
               GetRetentionLaws(std::move(GetRetentionLaws)),
-              GetShapeFunctionGradients(std::move(GetShapeFunctionGradients))
+              GetShapeFunctionGradients(std::move(GetShapeFunctionGradients)),
+              GetLocalSpaceDimension(std::move(GetLocalSpaceDimension))
         {
         }
 
@@ -49,6 +51,7 @@ public:
         std::function<Vector()>            GetProjectedGravityForIntegrationPoints;
         std::function<const std::vector<RetentionLaw::Pointer>&()>   GetRetentionLaws;
         std::function<Geometry<Node>::ShapeFunctionsGradientsType()> GetShapeFunctionGradients;
+        std::function<std::size_t()>                                 GetLocalSpaceDimension;
     };
 
     explicit FluidBodyFlowCalculator(InputProvider AnInputProvider);

--- a/applications/GeoMechanicsApplication/custom_elements/fluid_body_flow_calculator.h
+++ b/applications/GeoMechanicsApplication/custom_elements/fluid_body_flow_calculator.h
@@ -29,23 +29,23 @@ public:
     struct InputProvider {
         InputProvider(std::function<const Properties&()> GetElementProperties,
                       std::function<const std::vector<RetentionLaw::Pointer>&()> GetRetentionLaws,
-                      std::function<Vector()> GetIntegrationCoefficients,
-                      std::function<std::vector<Vector>()> GetProjectedGravityForIntegrationPoints,
+                      std::function<Vector()>              GetIntegrationCoefficients,
+                      std::function<std::vector<Vector>()> GetProjectedGravityAtIntegrationPoints,
                       std::function<Geometry<Node>::ShapeFunctionsGradientsType()> GetShapeFunctionGradients,
                       std::function<std::size_t()> GetLocalSpaceDimension)
 
             : GetElementProperties(std::move(GetElementProperties)),
               GetIntegrationCoefficients(std::move(GetIntegrationCoefficients)),
-              GetProjectedGravityForIntegrationPoints(std::move(GetProjectedGravityForIntegrationPoints)),
+              GetProjectedGravityAtIntegrationPoints(std::move(GetProjectedGravityAtIntegrationPoints)),
               GetRetentionLaws(std::move(GetRetentionLaws)),
               GetShapeFunctionGradients(std::move(GetShapeFunctionGradients)),
               GetLocalSpaceDimension(std::move(GetLocalSpaceDimension))
         {
         }
 
-        std::function<const Properties&()> GetElementProperties;
-        std::function<Vector()>            GetIntegrationCoefficients;
-        std::function<std::vector<Vector>()>            GetProjectedGravityForIntegrationPoints;
+        std::function<const Properties&()>   GetElementProperties;
+        std::function<Vector()>              GetIntegrationCoefficients;
+        std::function<std::vector<Vector>()> GetProjectedGravityAtIntegrationPoints;
         std::function<const std::vector<RetentionLaw::Pointer>&()>   GetRetentionLaws;
         std::function<Geometry<Node>::ShapeFunctionsGradientsType()> GetShapeFunctionGradients;
         std::function<std::size_t()>                                 GetLocalSpaceDimension;
@@ -53,9 +53,9 @@ public:
 
     explicit FluidBodyFlowCalculator(InputProvider AnInputProvider);
 
-    std::optional<Matrix>                                   LHSContribution() override;
-    std::optional<Vector>                                   RHSContribution() override;
-    std::pair<std::optional<Matrix>, std::optional<Vector>> LocalSystemContribution() override;
+    std::optional<Matrix>                    LHSContribution() override;
+    Vector                                   RHSContribution() override;
+    std::pair<std::optional<Matrix>, Vector> LocalSystemContribution() override;
 
 private:
     InputProvider mInputProvider;

--- a/applications/GeoMechanicsApplication/custom_elements/fluid_body_flow_calculator.h
+++ b/applications/GeoMechanicsApplication/custom_elements/fluid_body_flow_calculator.h
@@ -1,0 +1,70 @@
+// KRATOS___
+//     //   ) )
+//    //         ___      ___
+//   //  ____  //___) ) //   ) )
+//  //    / / //       //   / /
+// ((____/ / ((____   ((___/ /  MECHANICS
+//
+//  License:         geo_mechanics_application/license.txt
+//
+//  Main authors:    Mohamed Nabi
+//                   Richard Faasse
+
+#pragma once
+
+#include "contribution_calculator.h"
+#include "custom_retention/retention_law.h"
+#include "includes/properties.h"
+#include "includes/ublas_interface.h"
+
+#include <utility>
+#include <vector>
+
+namespace Kratos
+{
+
+class FluidBodyFlowCalculator : public ContributionCalculator
+{
+public:
+    struct InputProvider {
+        InputProvider(std::function<const Properties&()> GetElementProperties,
+                      std::function<const std::vector<RetentionLaw::Pointer>&()> GetRetentionLaws,
+                      std::function<const Matrix&()>     GetNContainer,
+                      std::function<Vector()>            GetIntegrationCoefficients,
+                      std::function<Vector()>            GetProjectedGravityForIntegrationPoints,
+                      std::function<double()>            GetMatrixScalarFactor,
+                      std::function<Vector(const Variable<double>&)>             GetNodalValuesOf,
+                      std::function<Geometry<Node>::ShapeFunctionsGradientsType()> GetShapeFunctionGradients)
+
+            : GetElementProperties(std::move(GetElementProperties)),
+              GetNContainer(std::move(GetNContainer)),
+              GetIntegrationCoefficients(std::move(GetIntegrationCoefficients)),
+              GetProjectedGravityForIntegrationPoints(std::move(GetProjectedGravityForIntegrationPoints)),
+              GetMatrixScalarFactor(std::move(GetMatrixScalarFactor)),
+              GetNodalValues(std::move(GetNodalValuesOf)),
+              GetRetentionLaws(std::move(GetRetentionLaws)),
+              GetShapeFunctionGradients(std::move(GetShapeFunctionGradients))
+        {
+        }
+
+        std::function<const Properties&()>             GetElementProperties;
+        std::function<const Matrix&()>                 GetNContainer;
+        std::function<Vector()>                        GetIntegrationCoefficients;
+        std::function<Vector()>                        GetProjectedGravityForIntegrationPoints;
+        std::function<double()>                        GetMatrixScalarFactor;
+        std::function<Vector(const Variable<double>&)> GetNodalValues;
+        std::function<const std::vector<RetentionLaw::Pointer>&()>   GetRetentionLaws;
+        std::function<Geometry<Node>::ShapeFunctionsGradientsType()> GetShapeFunctionGradients;
+    };
+
+    explicit FluidBodyFlowCalculator(InputProvider AnInputProvider);
+
+    Matrix                    LHSContribution() override;
+    Vector                    RHSContribution() override;
+    std::pair<Matrix, Vector> LocalSystemContribution() override;
+
+private:
+    InputProvider mInputProvider;
+};
+
+} // namespace Kratos

--- a/applications/GeoMechanicsApplication/custom_elements/permeability_calculator.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/permeability_calculator.cpp
@@ -28,15 +28,15 @@ std::optional<Matrix> PermeabilityCalculator::LHSContribution()
     return std::make_optional(CalculatePermeabilityMatrix());
 }
 
-std::optional<Vector> PermeabilityCalculator::RHSContribution()
+Vector PermeabilityCalculator::RHSContribution()
 {
-    return std::make_optional(RHSContribution(CalculatePermeabilityMatrix()));
+    return RHSContribution(CalculatePermeabilityMatrix());
 }
 
-std::pair<std::optional<Matrix>, std::optional<Vector>> PermeabilityCalculator::LocalSystemContribution()
+std::pair<std::optional<Matrix>, Vector> PermeabilityCalculator::LocalSystemContribution()
 {
     const auto permeability_matrix = CalculatePermeabilityMatrix();
-    return {std::make_optional(permeability_matrix), std::make_optional(RHSContribution(permeability_matrix))};
+    return {std::make_optional(permeability_matrix), RHSContribution(permeability_matrix)};
 }
 
 Vector PermeabilityCalculator::RHSContribution(const Matrix& rPermeabilityMatrix) const

--- a/applications/GeoMechanicsApplication/custom_elements/permeability_calculator.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/permeability_calculator.cpp
@@ -23,14 +23,14 @@ PermeabilityCalculator::PermeabilityCalculator(InputProvider InputProvider)
 {
 }
 
-Matrix PermeabilityCalculator::LHSContribution() { return CalculatePermeabilityMatrix(); }
+std::optional<Matrix> PermeabilityCalculator::LHSContribution() { return CalculatePermeabilityMatrix(); }
 
-Vector PermeabilityCalculator::RHSContribution()
+std::optional<Vector> PermeabilityCalculator::RHSContribution()
 {
     return RHSContribution(CalculatePermeabilityMatrix());
 }
 
-std::pair<Matrix, Vector> PermeabilityCalculator::LocalSystemContribution()
+std::pair<std::optional<Matrix>, std::optional<Vector>> PermeabilityCalculator::LocalSystemContribution()
 {
     const auto permeability_matrix = CalculatePermeabilityMatrix();
     return {permeability_matrix, RHSContribution(permeability_matrix)};

--- a/applications/GeoMechanicsApplication/custom_elements/permeability_calculator.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/permeability_calculator.cpp
@@ -25,18 +25,18 @@ PermeabilityCalculator::PermeabilityCalculator(InputProvider InputProvider)
 
 std::optional<Matrix> PermeabilityCalculator::LHSContribution()
 {
-    return CalculatePermeabilityMatrix();
+    return std::make_optional(CalculatePermeabilityMatrix());
 }
 
 std::optional<Vector> PermeabilityCalculator::RHSContribution()
 {
-    return RHSContribution(CalculatePermeabilityMatrix());
+    return std::make_optional(RHSContribution(CalculatePermeabilityMatrix()));
 }
 
 std::pair<std::optional<Matrix>, std::optional<Vector>> PermeabilityCalculator::LocalSystemContribution()
 {
     const auto permeability_matrix = CalculatePermeabilityMatrix();
-    return {permeability_matrix, RHSContribution(permeability_matrix)};
+    return {std::make_optional(permeability_matrix), std::make_optional(RHSContribution(permeability_matrix))};
 }
 
 Vector PermeabilityCalculator::RHSContribution(const Matrix& rPermeabilityMatrix) const

--- a/applications/GeoMechanicsApplication/custom_elements/permeability_calculator.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/permeability_calculator.cpp
@@ -23,7 +23,10 @@ PermeabilityCalculator::PermeabilityCalculator(InputProvider InputProvider)
 {
 }
 
-std::optional<Matrix> PermeabilityCalculator::LHSContribution() { return CalculatePermeabilityMatrix(); }
+std::optional<Matrix> PermeabilityCalculator::LHSContribution()
+{
+    return CalculatePermeabilityMatrix();
+}
 
 std::optional<Vector> PermeabilityCalculator::RHSContribution()
 {

--- a/applications/GeoMechanicsApplication/custom_elements/permeability_calculator.h
+++ b/applications/GeoMechanicsApplication/custom_elements/permeability_calculator.h
@@ -46,9 +46,9 @@ public:
 
     explicit PermeabilityCalculator(InputProvider InputProvider);
 
-    std::optional<Matrix>                                   LHSContribution() override;
-    std::optional<Vector>                                   RHSContribution() override;
-    std::pair<std::optional<Matrix>, std::optional<Vector>> LocalSystemContribution() override;
+    std::optional<Matrix>                    LHSContribution() override;
+    Vector                                   RHSContribution() override;
+    std::pair<std::optional<Matrix>, Vector> LocalSystemContribution() override;
 
 private:
     InputProvider mInputProvider;

--- a/applications/GeoMechanicsApplication/custom_elements/permeability_calculator.h
+++ b/applications/GeoMechanicsApplication/custom_elements/permeability_calculator.h
@@ -46,9 +46,9 @@ public:
 
     explicit PermeabilityCalculator(InputProvider InputProvider);
 
-    Matrix                    LHSContribution() override;
-    Vector                    RHSContribution() override;
-    std::pair<Matrix, Vector> LocalSystemContribution() override;
+    std::optional<Matrix>                    LHSContribution() override;
+    std::optional<Vector>                    RHSContribution() override;
+    std::pair<std::optional<Matrix>, std::optional<Vector>> LocalSystemContribution() override;
 
 private:
     InputProvider mInputProvider;

--- a/applications/GeoMechanicsApplication/custom_elements/permeability_calculator.h
+++ b/applications/GeoMechanicsApplication/custom_elements/permeability_calculator.h
@@ -46,8 +46,8 @@ public:
 
     explicit PermeabilityCalculator(InputProvider InputProvider);
 
-    std::optional<Matrix>                    LHSContribution() override;
-    std::optional<Vector>                    RHSContribution() override;
+    std::optional<Matrix>                                   LHSContribution() override;
+    std::optional<Vector>                                   RHSContribution() override;
     std::pair<std::optional<Matrix>, std::optional<Vector>> LocalSystemContribution() override;
 
 private:

--- a/applications/GeoMechanicsApplication/custom_elements/transient_Pw_line_element.h
+++ b/applications/GeoMechanicsApplication/custom_elements/transient_Pw_line_element.h
@@ -108,7 +108,8 @@ public:
         rRightHandSideVector = ZeroVector{TNumNodes};
         for (const auto& rContribution : mContributions) {
             const auto calculator = CreateCalculator(rContribution, rCurrentProcessInfo);
-            if (const auto RHSContribution = (calculator->RHSContribution())) rRightHandSideVector += *RHSContribution;
+            if (const auto RHSContribution = (calculator->RHSContribution()))
+                rRightHandSideVector += *RHSContribution;
         }
     }
 
@@ -116,8 +117,9 @@ public:
     {
         rLeftHandSideMatrix = ZeroMatrix{TNumNodes, TNumNodes};
         for (const auto& rContribution : mContributions) {
-            const auto calculator      = CreateCalculator(rContribution, rCurrentProcessInfo);
-            if (const auto LHSContribution = calculator->LHSContribution()) rLeftHandSideMatrix += *LHSContribution;
+            const auto calculator = CreateCalculator(rContribution, rCurrentProcessInfo);
+            if (const auto LHSContribution = calculator->LHSContribution())
+                rLeftHandSideMatrix += *LHSContribution;
         }
     }
 
@@ -406,10 +408,8 @@ private:
 
     auto MakeLocalSpaceDimensionGetter() const
     {
-        return
-            [this]() -> std::size_t { return this->GetGeometry().LocalSpaceDimension(); };
+        return [this]() -> std::size_t { return this->GetGeometry().LocalSpaceDimension(); };
     }
-
 
     [[nodiscard]] DofsVectorType GetDofs() const
     {

--- a/applications/GeoMechanicsApplication/custom_elements/transient_Pw_line_element.h
+++ b/applications/GeoMechanicsApplication/custom_elements/transient_Pw_line_element.h
@@ -96,8 +96,8 @@ public:
         for (const auto& rContribution : mContributions) {
             const auto calculator = CreateCalculator(rContribution, rCurrentProcessInfo);
             const auto [LHSContribution, RHSContribution] = calculator->LocalSystemContribution();
-            if (LHSContribution.size1() != 0) rLeftHandSideMatrix += LHSContribution;
-            if (!RHSContribution.empty()) rRightHandSideVector += RHSContribution;
+            if (LHSContribution) rLeftHandSideMatrix += *LHSContribution;
+            if (RHSContribution) rRightHandSideVector += *RHSContribution;
         }
 
         KRATOS_CATCH("")
@@ -108,7 +108,7 @@ public:
         rRightHandSideVector = ZeroVector{TNumNodes};
         for (const auto& rContribution : mContributions) {
             const auto calculator = CreateCalculator(rContribution, rCurrentProcessInfo);
-            rRightHandSideVector += calculator->RHSContribution();
+            if (const auto RHSContribution = (calculator->RHSContribution())) rRightHandSideVector += *RHSContribution;
         }
     }
 
@@ -117,8 +117,7 @@ public:
         rLeftHandSideMatrix = ZeroMatrix{TNumNodes, TNumNodes};
         for (const auto& rContribution : mContributions) {
             const auto calculator      = CreateCalculator(rContribution, rCurrentProcessInfo);
-            const auto LHSContribution = calculator->LHSContribution();
-            if (LHSContribution.size1() != 0) rLeftHandSideMatrix += LHSContribution;
+            if (const auto LHSContribution = calculator->LHSContribution()) rLeftHandSideMatrix += *LHSContribution;
         }
     }
 

--- a/applications/GeoMechanicsApplication/custom_elements/transient_Pw_line_element.h
+++ b/applications/GeoMechanicsApplication/custom_elements/transient_Pw_line_element.h
@@ -342,7 +342,7 @@ private:
     FluidBodyFlowCalculator::InputProvider CreateFluidBodyFlowInputProvider()
     {
         return FluidBodyFlowCalculator::InputProvider(
-            MakePropertiesGetter(), MakeRetentionLawsGetter(), MakeNContainerGetter(),
+            MakePropertiesGetter(), MakeRetentionLawsGetter(),
             MakeIntegrationCoefficientsGetter(), MakeProjectedGravityForIntegrationPointsGetter(),
             MakeShapeFunctionLocalGradientsGetter(), MakeLocalSpaceDimensionGetter());
     }

--- a/applications/GeoMechanicsApplication/custom_elements/transient_Pw_line_element.h
+++ b/applications/GeoMechanicsApplication/custom_elements/transient_Pw_line_element.h
@@ -116,7 +116,7 @@ public:
     {
         rLeftHandSideMatrix = ZeroMatrix{TNumNodes, TNumNodes};
         for (const auto& rContribution : mContributions) {
-            const auto calculator = CreateCalculator(rContribution, rCurrentProcessInfo);
+            const auto calculator      = CreateCalculator(rContribution, rCurrentProcessInfo);
             const auto LHSContribution = calculator->LHSContribution();
             if (LHSContribution.size1() != 0) rLeftHandSideMatrix += LHSContribution;
         }

--- a/applications/GeoMechanicsApplication/custom_elements/transient_Pw_line_element.h
+++ b/applications/GeoMechanicsApplication/custom_elements/transient_Pw_line_element.h
@@ -97,7 +97,7 @@ public:
             const auto calculator = CreateCalculator(rContribution, rCurrentProcessInfo);
             const auto [LHSContribution, RHSContribution] = calculator->LocalSystemContribution();
             if (LHSContribution) rLeftHandSideMatrix += *LHSContribution;
-            if (RHSContribution) rRightHandSideVector += *RHSContribution;
+            rRightHandSideVector += RHSContribution;
         }
 
         KRATOS_CATCH("")
@@ -108,8 +108,7 @@ public:
         rRightHandSideVector = ZeroVector{TNumNodes};
         for (const auto& rContribution : mContributions) {
             const auto calculator = CreateCalculator(rContribution, rCurrentProcessInfo);
-            if (const auto RHSContribution = calculator->RHSContribution())
-                rRightHandSideVector += *RHSContribution;
+            noalias(rRightHandSideVector) += calculator->RHSContribution();
         }
     }
 
@@ -292,8 +291,9 @@ private:
                 body_acceleration, rNContainer, volume_acceleration, integration_point_index);
             array_1d<double, TDim> tangent_vector = column(J_container[integration_point_index], 0);
             tangent_vector /= norm_2(tangent_vector);
-            projected_gravity.push_back(ScalarVector(1, std::inner_product(
-                tangent_vector.begin(), tangent_vector.end(), body_acceleration.begin(), 0.0)));
+            projected_gravity.push_back(
+                ScalarVector(1, std::inner_product(tangent_vector.begin(), tangent_vector.end(),
+                                                   body_acceleration.begin(), 0.0)));
         }
         return projected_gravity;
     }
@@ -343,8 +343,8 @@ private:
     FluidBodyFlowCalculator::InputProvider CreateFluidBodyFlowInputProvider()
     {
         return FluidBodyFlowCalculator::InputProvider(
-            MakePropertiesGetter(), MakeRetentionLawsGetter(),
-            MakeIntegrationCoefficientsGetter(), MakeProjectedGravityForIntegrationPointsGetter(),
+            MakePropertiesGetter(), MakeRetentionLawsGetter(), MakeIntegrationCoefficientsGetter(),
+            MakeProjectedGravityForIntegrationPointsGetter(),
             MakeShapeFunctionLocalGradientsGetter(), MakeLocalSpaceDimensionGetter());
     }
 

--- a/applications/GeoMechanicsApplication/custom_elements/transient_Pw_line_element.h
+++ b/applications/GeoMechanicsApplication/custom_elements/transient_Pw_line_element.h
@@ -108,7 +108,7 @@ public:
         rRightHandSideVector = ZeroVector{TNumNodes};
         for (const auto& rContribution : mContributions) {
             const auto calculator = CreateCalculator(rContribution, rCurrentProcessInfo);
-            if (const auto RHSContribution = (calculator->RHSContribution()))
+            if (const auto RHSContribution = calculator->RHSContribution())
                 rRightHandSideVector += *RHSContribution;
         }
     }

--- a/applications/GeoMechanicsApplication/custom_elements/transient_Pw_line_element.h
+++ b/applications/GeoMechanicsApplication/custom_elements/transient_Pw_line_element.h
@@ -343,7 +343,7 @@ private:
         return FluidBodyFlowCalculator::InputProvider(
             MakePropertiesGetter(), MakeRetentionLawsGetter(), MakeNContainerGetter(),
             MakeIntegrationCoefficientsGetter(), MakeProjectedGravityForIntegrationPointsGetter(),
-            MakeShapeFunctionLocalGradientsGetter());
+            MakeShapeFunctionLocalGradientsGetter(), MakeLocalSpaceDimensionGetter());
     }
 
     auto MakePropertiesGetter()
@@ -404,6 +404,13 @@ private:
             return dN_dX_container;
         };
     }
+
+    auto MakeLocalSpaceDimensionGetter() const
+    {
+        return
+            [this]() -> std::size_t { return this->GetGeometry().LocalSpaceDimension(); };
+    }
+
 
     [[nodiscard]] DofsVectorType GetDofs() const
     {

--- a/applications/GeoMechanicsApplication/custom_elements/transient_Pw_line_element.h
+++ b/applications/GeoMechanicsApplication/custom_elements/transient_Pw_line_element.h
@@ -291,7 +291,7 @@ private:
                 body_acceleration, rNContainer, volume_acceleration, integration_point_index);
             array_1d<double, TDim> tangent_vector = column(J_container[integration_point_index], 0);
             tangent_vector /= norm_2(tangent_vector);
-            projected_gravity.push_back(
+            projected_gravity.emplace_back(
                 ScalarVector(1, std::inner_product(tangent_vector.begin(), tangent_vector.end(),
                                                    body_acceleration.begin(), 0.0)));
         }

--- a/applications/GeoMechanicsApplication/geo_mechanics_application.h
+++ b/applications/GeoMechanicsApplication/geo_mechanics_application.h
@@ -305,27 +305,27 @@ private:
     const TransientPwLineElement<2, 2> mTransientPwLineElement2D2N{
         0,
         Kratos::make_shared<Line2D2<NodeType>>(Element::GeometryType::PointsArrayType(2)),
-        {CalculationContribution::Permeability, CalculationContribution::Compressibility}};
+        {CalculationContribution::Permeability, CalculationContribution::Compressibility, CalculationContribution::FluidBodyFlow}};
     const TransientPwLineElement<2, 3> mTransientPwLineElement2D3N{
         0,
         Kratos::make_shared<Line2D3<NodeType>>(Element::GeometryType::PointsArrayType(3)),
-        {CalculationContribution::Permeability, CalculationContribution::Compressibility}};
+        {CalculationContribution::Permeability, CalculationContribution::Compressibility, CalculationContribution::FluidBodyFlow}};
     const TransientPwLineElement<2, 4> mTransientPwLineElement2D4N{
         0,
         Kratos::make_shared<Line2D4<NodeType>>(Element::GeometryType::PointsArrayType(4)),
-        {CalculationContribution::Permeability, CalculationContribution::Compressibility}};
+        {CalculationContribution::Permeability, CalculationContribution::Compressibility, CalculationContribution::FluidBodyFlow}};
     const TransientPwLineElement<2, 5> mTransientPwLineElement2D5N{
         0,
         Kratos::make_shared<Line2D5<NodeType>>(Element::GeometryType::PointsArrayType(5)),
-        {CalculationContribution::Permeability, CalculationContribution::Compressibility}};
+        {CalculationContribution::Permeability, CalculationContribution::Compressibility, CalculationContribution::FluidBodyFlow}};
     const TransientPwLineElement<3, 2> mTransientPwLineElement3D2N{
         0,
         Kratos::make_shared<Line3D2<NodeType>>(Element::GeometryType::PointsArrayType(2)),
-        {CalculationContribution::Permeability, CalculationContribution::Compressibility}};
+        {CalculationContribution::Permeability, CalculationContribution::Compressibility, CalculationContribution::FluidBodyFlow}};
     const TransientPwLineElement<3, 3> mTransientPwLineElement3D3N{
         0,
         Kratos::make_shared<Line3D3<NodeType>>(Element::GeometryType::PointsArrayType(3)),
-        {CalculationContribution::Permeability, CalculationContribution::Compressibility}};
+        {CalculationContribution::Permeability, CalculationContribution::Compressibility, CalculationContribution::FluidBodyFlow}};
 
     const TransientPwInterfaceElement<2, 4> mTransientPwInterfaceElement2D4N{
         0, Kratos::make_shared<QuadrilateralInterface2D4<NodeType>>(Element::GeometryType::PointsArrayType(4)),

--- a/applications/GeoMechanicsApplication/geo_mechanics_application.h
+++ b/applications/GeoMechanicsApplication/geo_mechanics_application.h
@@ -305,27 +305,33 @@ private:
     const TransientPwLineElement<2, 2> mTransientPwLineElement2D2N{
         0,
         Kratos::make_shared<Line2D2<NodeType>>(Element::GeometryType::PointsArrayType(2)),
-        {CalculationContribution::Permeability, CalculationContribution::Compressibility, CalculationContribution::FluidBodyFlow}};
+        {CalculationContribution::Permeability, CalculationContribution::Compressibility,
+         CalculationContribution::FluidBodyFlow}};
     const TransientPwLineElement<2, 3> mTransientPwLineElement2D3N{
         0,
         Kratos::make_shared<Line2D3<NodeType>>(Element::GeometryType::PointsArrayType(3)),
-        {CalculationContribution::Permeability, CalculationContribution::Compressibility, CalculationContribution::FluidBodyFlow}};
+        {CalculationContribution::Permeability, CalculationContribution::Compressibility,
+         CalculationContribution::FluidBodyFlow}};
     const TransientPwLineElement<2, 4> mTransientPwLineElement2D4N{
         0,
         Kratos::make_shared<Line2D4<NodeType>>(Element::GeometryType::PointsArrayType(4)),
-        {CalculationContribution::Permeability, CalculationContribution::Compressibility, CalculationContribution::FluidBodyFlow}};
+        {CalculationContribution::Permeability, CalculationContribution::Compressibility,
+         CalculationContribution::FluidBodyFlow}};
     const TransientPwLineElement<2, 5> mTransientPwLineElement2D5N{
         0,
         Kratos::make_shared<Line2D5<NodeType>>(Element::GeometryType::PointsArrayType(5)),
-        {CalculationContribution::Permeability, CalculationContribution::Compressibility, CalculationContribution::FluidBodyFlow}};
+        {CalculationContribution::Permeability, CalculationContribution::Compressibility,
+         CalculationContribution::FluidBodyFlow}};
     const TransientPwLineElement<3, 2> mTransientPwLineElement3D2N{
         0,
         Kratos::make_shared<Line3D2<NodeType>>(Element::GeometryType::PointsArrayType(2)),
-        {CalculationContribution::Permeability, CalculationContribution::Compressibility, CalculationContribution::FluidBodyFlow}};
+        {CalculationContribution::Permeability, CalculationContribution::Compressibility,
+         CalculationContribution::FluidBodyFlow}};
     const TransientPwLineElement<3, 3> mTransientPwLineElement3D3N{
         0,
         Kratos::make_shared<Line3D3<NodeType>>(Element::GeometryType::PointsArrayType(3)),
-        {CalculationContribution::Permeability, CalculationContribution::Compressibility, CalculationContribution::FluidBodyFlow}};
+        {CalculationContribution::Permeability, CalculationContribution::Compressibility,
+         CalculationContribution::FluidBodyFlow}};
 
     const TransientPwInterfaceElement<2, 4> mTransientPwInterfaceElement2D4N{
         0, Kratos::make_shared<QuadrilateralInterface2D4<NodeType>>(Element::GeometryType::PointsArrayType(4)),

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_elements/test_pw_line_element.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_elements/test_pw_line_element.cpp
@@ -36,7 +36,7 @@ TransientPwLineElement<2, 2> TransientPwLineElementWithoutPWDofs(const Propertie
                                                                  const Geometry<Node>::Pointer& rGeometry)
 {
     auto result = TransientPwLineElement<2, 2>{
-        1, rGeometry, rProperties, {CalculationContribution::Permeability, CalculationContribution::Compressibility}};
+        1, rGeometry, rProperties, {CalculationContribution::Permeability, CalculationContribution::Compressibility, CalculationContribution::FluidBodyFlow}};
 
     return result;
 }
@@ -71,7 +71,7 @@ intrusive_ptr<Element> CreatePwLineElementWithoutPWDofs(ModelPart& rModelPart, c
     nodes.push_back(rModelPart.CreateNewNode(1, 1.0, 1.0, 0.0));
     const auto                                 p_geometry = std::make_shared<Line2D2<Node>>(nodes);
     const std::vector<CalculationContribution> contirbutions = {
-        CalculationContribution::Permeability, CalculationContribution::Compressibility};
+        CalculationContribution::Permeability, CalculationContribution::Compressibility, CalculationContribution::FluidBodyFlow};
     auto element = make_intrusive<TransientPwLineElement<2, 2>>(
         rModelPart.NumberOfElements() + 1, p_geometry, rProperties, contirbutions);
     rModelPart.AddElement(element);

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_elements/test_pw_line_element.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_elements/test_pw_line_element.cpp
@@ -36,7 +36,11 @@ TransientPwLineElement<2, 2> TransientPwLineElementWithoutPWDofs(const Propertie
                                                                  const Geometry<Node>::Pointer& rGeometry)
 {
     auto result = TransientPwLineElement<2, 2>{
-        1, rGeometry, rProperties, {CalculationContribution::Permeability, CalculationContribution::Compressibility, CalculationContribution::FluidBodyFlow}};
+        1,
+        rGeometry,
+        rProperties,
+        {CalculationContribution::Permeability, CalculationContribution::Compressibility,
+         CalculationContribution::FluidBodyFlow}};
 
     return result;
 }
@@ -71,7 +75,8 @@ intrusive_ptr<Element> CreatePwLineElementWithoutPWDofs(ModelPart& rModelPart, c
     nodes.push_back(rModelPart.CreateNewNode(1, 1.0, 1.0, 0.0));
     const auto                                 p_geometry = std::make_shared<Line2D2<Node>>(nodes);
     const std::vector<CalculationContribution> contirbutions = {
-        CalculationContribution::Permeability, CalculationContribution::Compressibility, CalculationContribution::FluidBodyFlow};
+        CalculationContribution::Permeability, CalculationContribution::Compressibility,
+        CalculationContribution::FluidBodyFlow};
     auto element = make_intrusive<TransientPwLineElement<2, 2>>(
         rModelPart.NumberOfElements() + 1, p_geometry, rProperties, contirbutions);
     rModelPart.AddElement(element);

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_elements/test_pw_line_element.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_elements/test_pw_line_element.cpp
@@ -74,11 +74,11 @@ intrusive_ptr<Element> CreatePwLineElementWithoutPWDofs(ModelPart& rModelPart, c
     nodes.push_back(rModelPart.CreateNewNode(0, 0.0, 0.0, 0.0));
     nodes.push_back(rModelPart.CreateNewNode(1, 1.0, 1.0, 0.0));
     const auto                                 p_geometry = std::make_shared<Line2D2<Node>>(nodes);
-    const std::vector<CalculationContribution> contirbutions = {
+    const std::vector<CalculationContribution> contributions = {
         CalculationContribution::Permeability, CalculationContribution::Compressibility,
         CalculationContribution::FluidBodyFlow};
     auto element = make_intrusive<TransientPwLineElement<2, 2>>(
-        rModelPart.NumberOfElements() + 1, p_geometry, rProperties, contirbutions);
+        rModelPart.NumberOfElements() + 1, p_geometry, rProperties, contributions);
     rModelPart.AddElement(element);
     return element;
 }


### PR DESCRIPTION
**📝 Description**
This PR moves the calculation of the fluid body vector into the calculator structure which already contains the other water pressure contributions (compressibility + permeability). Since the FluidBodyFlowCalculator only calculates a right hand side, some changes needed to be done for the calculator interface, to allow for 'empty' contributions (this is done using std::optional<>)
