### PR TITLE
[StructuralMechanicsApplication] Harmonic Analysis Strategy - Moving BuildRHS() from Initialize() to SolveSolutionStep() in order to be able to do CoSimulation

### DIFF
--- a/applications/StructuralMechanicsApplication/custom_strategies/custom_strategies/harmonic_analysis_strategy.hpp
+++ b/applications/StructuralMechanicsApplication/custom_strategies/custom_strategies/harmonic_analysis_strategy.hpp
@@ -245,7 +245,6 @@ public:
             if (r_force_vector.size() != system_size)
                 r_force_vector.resize(system_size, false);
             r_force_vector = ZeroVector( system_size );
-            p_builder_and_solver->BuildRHS(p_scheme,r_model_part,r_force_vector);
 
             KRATOS_INFO_IF("Force Vector Build Time", BaseType::GetEchoLevel() > 0 && rank == 0)
                 << force_vector_build_time << std::endl;
@@ -393,6 +392,11 @@ public:
         const std::size_t n_dofs = this->pGetBuilderAndSolver()->GetEquationSystemSize();
 
         auto& f = *mpForceVector;
+
+         // Build your RHS
+        auto& p_builder_and_solver = this->pGetBuilderAndSolver();
+        auto& p_scheme = this->pGetScheme();
+        p_builder_and_solver->BuildRHS(p_scheme,r_model_part,f);
 
         ComplexType mode_weight;
         ComplexVectorType modal_displacement;

--- a/applications/StructuralMechanicsApplication/custom_strategies/custom_strategies/harmonic_analysis_strategy.hpp
+++ b/applications/StructuralMechanicsApplication/custom_strategies/custom_strategies/harmonic_analysis_strategy.hpp
@@ -245,7 +245,7 @@ public:
             if (r_force_vector.size() != system_size)
                 r_force_vector.resize(system_size, false);
             r_force_vector = ZeroVector( system_size );
-            p_builder_and_solver->BuildRHS(p_scheme,r_model_part,f);
+            p_builder_and_solver->BuildRHS(p_scheme,r_model_part, r_force_vector);
 
             KRATOS_INFO_IF("Force Vector Build Time", BaseType::GetEchoLevel() > 0 && rank == 0)
                 << force_vector_build_time << std::endl;

--- a/applications/StructuralMechanicsApplication/custom_strategies/custom_strategies/harmonic_analysis_strategy.hpp
+++ b/applications/StructuralMechanicsApplication/custom_strategies/custom_strategies/harmonic_analysis_strategy.hpp
@@ -244,7 +244,7 @@ public:
             BuiltinTimer force_vector_build_time;
             if (r_force_vector.size() != system_size)
                 r_force_vector.resize(system_size, false);
-            r_force_vector = ZeroVector( system_size );
+            TSparseSpace::SetToZero(r_force_vector);
 
             KRATOS_INFO_IF("Force Vector Build Time", BaseType::GetEchoLevel() > 0 && rank == 0)
                 << force_vector_build_time << std::endl;

--- a/applications/StructuralMechanicsApplication/custom_strategies/custom_strategies/harmonic_analysis_strategy.hpp
+++ b/applications/StructuralMechanicsApplication/custom_strategies/custom_strategies/harmonic_analysis_strategy.hpp
@@ -393,10 +393,10 @@ public:
 
         auto& f = *mpForceVector;
         block_for_each(this->pGetBuilderAndSolver()->GetDofSet(),
-                       [](Dof<double>& r_dof){
-                            if (not r_dof.IsFixed())
-                                r_dof.GetSolutionStepValue() = 0.0;
-                        });
+               [](Dof<double>& r_dof){
+                   if (!r_dof.IsFixed())
+                       r_dof.GetSolutionStepValue() = 0.0;
+               });
 
         // Build your RHS
         auto& p_builder_and_solver = this->pGetBuilderAndSolver();

--- a/applications/StructuralMechanicsApplication/custom_strategies/custom_strategies/harmonic_analysis_strategy.hpp
+++ b/applications/StructuralMechanicsApplication/custom_strategies/custom_strategies/harmonic_analysis_strategy.hpp
@@ -395,9 +395,9 @@ public:
         auto& f = *mpForceVector;
 
          // Build your RHS
-        auto& p_builder_and_solver = this->pGetBuilderAndSolver();
-        auto& p_scheme = this->pGetScheme();
-        p_builder_and_solver->BuildRHS(p_scheme,r_model_part,f);
+        //auto& p_builder_and_solver = this->pGetBuilderAndSolver();
+        //auto& p_scheme = this->pGetScheme();
+        //p_builder_and_solver->BuildRHS(p_scheme,r_model_part,f);
 
         ComplexType mode_weight;
         ComplexVectorType modal_displacement;

--- a/applications/StructuralMechanicsApplication/custom_strategies/custom_strategies/harmonic_analysis_strategy.hpp
+++ b/applications/StructuralMechanicsApplication/custom_strategies/custom_strategies/harmonic_analysis_strategy.hpp
@@ -245,7 +245,6 @@ public:
             if (r_force_vector.size() != system_size)
                 r_force_vector.resize(system_size, false);
             r_force_vector = ZeroVector( system_size );
-            p_builder_and_solver->BuildRHS(p_scheme,r_model_part, r_force_vector);
 
             KRATOS_INFO_IF("Force Vector Build Time", BaseType::GetEchoLevel() > 0 && rank == 0)
                 << force_vector_build_time << std::endl;
@@ -393,11 +392,17 @@ public:
         const std::size_t n_dofs = this->pGetBuilderAndSolver()->GetEquationSystemSize();
 
         auto& f = *mpForceVector;
+        block_for_each(this->pGetBuilderAndSolver()->GetDofSet(),
+                       [](Dof<double>& r_dof){
+                            if (not r_dof.IsFixed())
+                                r_dof.GetSolutionStepValue() = 0.0;
+                        });
 
-         // Build your RHS
-        //auto& p_builder_and_solver = this->pGetBuilderAndSolver();
-        //auto& p_scheme = this->pGetScheme();
-        //p_builder_and_solver->BuildRHS(p_scheme,r_model_part,f);
+        // Build your RHS
+        auto& p_builder_and_solver = this->pGetBuilderAndSolver();
+        auto& p_scheme = this->pGetScheme();
+        TSparseSpace::SetToZero(f);
+        p_builder_and_solver->BuildRHS(p_scheme,r_model_part,f);
 
         ComplexType mode_weight;
         ComplexVectorType modal_displacement;

--- a/applications/StructuralMechanicsApplication/custom_strategies/custom_strategies/harmonic_analysis_strategy.hpp
+++ b/applications/StructuralMechanicsApplication/custom_strategies/custom_strategies/harmonic_analysis_strategy.hpp
@@ -406,10 +406,7 @@ public:
 
             // Assemble into global vector
             for (IndexType i = 0; i < equation_id.size(); ++i) {
-                const IndexType global_index = equation_id[i];
-                if (global_index < f.size()) { 
-                    f[global_index] += rhs[i];
-                }
+                     f[equation_id[i]] += rhs[i];
             }
         }
 

--- a/applications/StructuralMechanicsApplication/custom_strategies/custom_strategies/harmonic_analysis_strategy.hpp
+++ b/applications/StructuralMechanicsApplication/custom_strategies/custom_strategies/harmonic_analysis_strategy.hpp
@@ -80,6 +80,8 @@ public:
 
     typedef DenseVector<ComplexType> ComplexVectorType;
 
+    typedef std::vector<std::size_t> EquationIdVectorType;
+
     ///@}
     ///@name Life Cycle
     ///@{

--- a/applications/StructuralMechanicsApplication/custom_strategies/custom_strategies/harmonic_analysis_strategy.hpp
+++ b/applications/StructuralMechanicsApplication/custom_strategies/custom_strategies/harmonic_analysis_strategy.hpp
@@ -245,6 +245,7 @@ public:
             if (r_force_vector.size() != system_size)
                 r_force_vector.resize(system_size, false);
             TSparseSpace::SetToZero(r_force_vector);
+            p_builder_and_solver->BuildRHS(p_scheme,r_model_part,f);
 
             KRATOS_INFO_IF("Force Vector Build Time", BaseType::GetEchoLevel() > 0 && rank == 0)
                 << force_vector_build_time << std::endl;

--- a/applications/StructuralMechanicsApplication/custom_strategies/custom_strategies/harmonic_analysis_strategy.hpp
+++ b/applications/StructuralMechanicsApplication/custom_strategies/custom_strategies/harmonic_analysis_strategy.hpp
@@ -244,7 +244,7 @@ public:
             BuiltinTimer force_vector_build_time;
             if (r_force_vector.size() != system_size)
                 r_force_vector.resize(system_size, false);
-            TSparseSpace::SetToZero(r_force_vector);
+            r_force_vector = ZeroVector( system_size );
             p_builder_and_solver->BuildRHS(p_scheme,r_model_part,f);
 
             KRATOS_INFO_IF("Force Vector Build Time", BaseType::GetEchoLevel() > 0 && rank == 0)


### PR DESCRIPTION
## Summary  
This PR moves the `BuildLHS()` call from `Initialize()` to `SolveSolutionStep()` to enable **CoSimulation**.  You can see the change in [`harmonic_analysis_strategy.hpp`](https://github.com/KratosMultiphysics/Kratos/commit/38de9c68bbba65313677812d5b72f65dd459da94#diff-a60f91cac211bbc2c44fd30ca99b28b7aeac44c77a09275d1c8c9d451a77ddb9).

## Reason 
Previously, the **RHS** was not updated correctly after data transfer from the other solver.  
By relocating `BuildLHS()` to `SolveSolutionStep()`, we ensure that the **RHS is updated accordingly**, improving consistency in the simulation process.  

FYI: @matekelemen @sunethwarna @rickyaristio  