### PR TITLE
[GeoMechanicsApplication] Moved the 7 c-phi reduction tests to fast suite by avoiding registration

### DIFF
--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_processes/test_apply_c_phi_reduction_process.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_processes/test_apply_c_phi_reduction_process.cpp
@@ -21,15 +21,15 @@ using namespace Kratos;
 
 namespace
 {
-ModelPart& SetGeometryAndMesh(Model& rModel)
+ModelPart& CreateModelPartWithElements(Model& rModel)
 {
     auto& result = rModel.CreateModelPart("dummy");
     result.CreateNewProperties(0);
 
-    auto p_node1 = make_intrusive<Node>(1, 0.0, 0.0, 0.0);
-    auto p_node2 = make_intrusive<Node>(2, 1.0, 0.0, 0.0);
-    auto p_node3 = make_intrusive<Node>(3, 1.0, 1.0, 0.0);
-    auto p_node4 = make_intrusive<Node>(4, 0.0, 1.0, 0.0);
+    const auto p_node1 = make_intrusive<Node>(1, 0.0, 0.0, 0.0);
+    const auto p_node2 = make_intrusive<Node>(2, 1.0, 0.0, 0.0);
+    const auto p_node3 = make_intrusive<Node>(3, 1.0, 1.0, 0.0);
+    const auto p_node4 = make_intrusive<Node>(4, 0.0, 1.0, 0.0);
 
     result.AddElement(make_intrusive<Element>(
         1, std::make_shared<Triangle2D3<Node>>(p_node1, p_node2, p_node3), result.pGetProperties(0)));
@@ -41,7 +41,7 @@ ModelPart& SetGeometryAndMesh(Model& rModel)
 
 ModelPart& PrepareCPhiTestModelPart(Model& rModel)
 {
-    auto& result = SetGeometryAndMesh(rModel);
+    auto& result = CreateModelPartWithElements(rModel);
 
     auto& r_model_part_properties = result.GetProperties(0);
     auto  p_dummy_law             = std::make_shared<Testing::StubLinearElasticLaw>();
@@ -104,7 +104,7 @@ KRATOS_TEST_CASE_IN_SUITE(CheckCAndPhiTwiceReducedAfterCallingApplyCPhiReduction
 KRATOS_TEST_CASE_IN_SUITE(CheckFailureUmatInputsApplyCPhiReductionProcess, KratosGeoMechanicsFastSuiteWithoutKernel)
 {
     Model model;
-    auto& r_model_part = SetGeometryAndMesh(model);
+    auto& r_model_part = CreateModelPartWithElements(model);
 
     auto& r_model_part_properties = r_model_part.GetProperties(0);
     auto  p_dummy_law             = std::make_shared<Testing::StubLinearElasticLaw>();

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_processes/test_apply_c_phi_reduction_process.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_processes/test_apply_c_phi_reduction_process.cpp
@@ -27,31 +27,14 @@ ModelPart& SetGeometryAndMesh(Model& rModel)
     result.CreateNewProperties(0);
 
     auto p_node1 = make_intrusive<Node>(1, 0.0, 0.0, 0.0);
-    auto p_node2 = make_intrusive<Node>(2, 0.0, 0.5, 0.0);
-    auto p_node3 = make_intrusive<Node>(3, 0.0, 1.0, 0.0);
-    auto p_node4 = make_intrusive<Node>(4, 0.5, 0.0, 0.0);
-    auto p_node5 = make_intrusive<Node>(5, 0.5, 0.5, 0.0);
-    auto p_node6 = make_intrusive<Node>(6, 0.5, 1.0, 0.0);
-    auto p_node7 = make_intrusive<Node>(7, 1.0, 0.0, 0.0);
-    auto p_node8 = make_intrusive<Node>(8, 1.0, 0.5, 0.0);
-    auto p_node9 = make_intrusive<Node>(9, 1.0, 1.0, 0.0);
+    auto p_node2 = make_intrusive<Node>(2, 1.0, 0.0, 0.0);
+    auto p_node3 = make_intrusive<Node>(3, 1.0, 1.0, 0.0);
+    auto p_node4 = make_intrusive<Node>(4, 0.0, 1.0, 0.0);
 
     result.AddElement(make_intrusive<Element>(
-        1, std::make_shared<Triangle2D3<Node>>(p_node1, p_node5, p_node2), result.pGetProperties(0)));
+        1, std::make_shared<Triangle2D3<Node>>(p_node1, p_node2, p_node3), result.pGetProperties(0)));
     result.AddElement(make_intrusive<Element>(
-        2, std::make_shared<Triangle2D3<Node>>(p_node1, p_node4, p_node5), result.pGetProperties(0)));
-    result.AddElement(make_intrusive<Element>(
-        3, std::make_shared<Triangle2D3<Node>>(p_node5, p_node6, p_node3), result.pGetProperties(0)));
-    result.AddElement(make_intrusive<Element>(
-        4, std::make_shared<Triangle2D3<Node>>(p_node2, p_node5, p_node6), result.pGetProperties(0)));
-    result.AddElement(make_intrusive<Element>(
-        5, std::make_shared<Triangle2D3<Node>>(p_node4, p_node8, p_node5), result.pGetProperties(0)));
-    result.AddElement(make_intrusive<Element>(
-        6, std::make_shared<Triangle2D3<Node>>(p_node4, p_node7, p_node8), result.pGetProperties(0)));
-    result.AddElement(make_intrusive<Element>(
-        7, std::make_shared<Triangle2D3<Node>>(p_node5, p_node9, p_node6), result.pGetProperties(0)));
-    result.AddElement(make_intrusive<Element>(
-        8, std::make_shared<Triangle2D3<Node>>(p_node5, p_node8, p_node9), result.pGetProperties(0)));
+        3, std::make_shared<Triangle2D3<Node>>(p_node1, p_node3, p_node4), result.pGetProperties(0)));
 
     return result;
 }

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_processes/test_apply_c_phi_reduction_process.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_processes/test_apply_c_phi_reduction_process.cpp
@@ -24,7 +24,7 @@ namespace
 ModelPart& CreateModelPartWithElements(Model& rModel)
 {
     auto& result = rModel.CreateModelPart("dummy");
-    result.CreateNewProperties(0);
+    auto p_properties = result.CreateNewProperties(0);
 
     const auto p_node1 = make_intrusive<Node>(1, 0.0, 0.0, 0.0);
     const auto p_node2 = make_intrusive<Node>(2, 1.0, 0.0, 0.0);
@@ -32,9 +32,9 @@ ModelPart& CreateModelPartWithElements(Model& rModel)
     const auto p_node4 = make_intrusive<Node>(4, 0.0, 1.0, 0.0);
 
     result.AddElement(make_intrusive<Element>(
-        1, std::make_shared<Triangle2D3<Node>>(p_node1, p_node2, p_node3), result.pGetProperties(0)));
+        1, std::make_shared<Triangle2D3<Node>>(p_node1, p_node2, p_node3), p_properties));
     result.AddElement(make_intrusive<Element>(
-        3, std::make_shared<Triangle2D3<Node>>(p_node1, p_node3, p_node4), result.pGetProperties(0)));
+        3, std::make_shared<Triangle2D3<Node>>(p_node1, p_node3, p_node4), p_properties));
 
     return result;
 }

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_processes/test_apply_c_phi_reduction_process.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_processes/test_apply_c_phi_reduction_process.cpp
@@ -12,8 +12,7 @@
 //
 #include "containers/model.h"
 #include "custom_processes/apply_c_phi_reduction_process.h"
-#include "geometries/quadrilateral_2d_4.h"
-#include "processes/structured_mesh_generator_process.h"
+#include "geometries/triangle_2d_3.h"
 #include "tests/cpp_tests/geo_mechanics_fast_suite.h"
 #include "tests/cpp_tests/stub_linear_elastic_law.h"
 #include <boost/numeric/ublas/assignment.hpp>
@@ -25,22 +24,34 @@ namespace
 ModelPart& SetGeometryAndMesh(Model& rModel)
 {
     auto& result = rModel.CreateModelPart("dummy");
+    result.CreateNewProperties(0);
 
-    // Set up the test model part mesh
-    const auto             p_point_1 = make_intrusive<Node>(1, 0.0, 0.0, 0.0);
-    const auto             p_point_2 = make_intrusive<Node>(2, 0.0, 1.0, 0.0);
-    const auto             p_point_3 = make_intrusive<Node>(3, 1.0, 1.0, 0.0);
-    const auto             p_point_4 = make_intrusive<Node>(4, 1.0, 0.0, 0.0);
-    Quadrilateral2D4<Node> domain_geometry(p_point_1, p_point_2, p_point_3, p_point_4);
+    auto p_node1 = make_intrusive<Node>(1, 0.0, 0.0, 0.0);
+    auto p_node2 = make_intrusive<Node>(2, 0.0, 0.5, 0.0);
+    auto p_node3 = make_intrusive<Node>(3, 0.0, 1.0, 0.0);
+    auto p_node4 = make_intrusive<Node>(4, 0.5, 0.0, 0.0);
+    auto p_node5 = make_intrusive<Node>(5, 0.5, 0.5, 0.0);
+    auto p_node6 = make_intrusive<Node>(6, 0.5, 1.0, 0.0);
+    auto p_node7 = make_intrusive<Node>(7, 1.0, 0.0, 0.0);
+    auto p_node8 = make_intrusive<Node>(8, 1.0, 0.5, 0.0);
+    auto p_node9 = make_intrusive<Node>(9, 1.0, 1.0, 0.0);
 
-    Parameters mesher_parameters(R"({
-        "number_of_divisions": 2,
-        "element_name": "Element2D3N",
-        "condition_name": "LineCondition",
-        "create_skin_sub_model_part": true
-    })");
-
-    StructuredMeshGeneratorProcess(domain_geometry, result, mesher_parameters).Execute();
+    result.AddElement(make_intrusive<Element>(
+        1, std::make_shared<Triangle2D3<Node>>(p_node1, p_node5, p_node2), result.pGetProperties(0)));
+    result.AddElement(make_intrusive<Element>(
+        2, std::make_shared<Triangle2D3<Node>>(p_node1, p_node4, p_node5), result.pGetProperties(0)));
+    result.AddElement(make_intrusive<Element>(
+        3, std::make_shared<Triangle2D3<Node>>(p_node5, p_node6, p_node3), result.pGetProperties(0)));
+    result.AddElement(make_intrusive<Element>(
+        4, std::make_shared<Triangle2D3<Node>>(p_node2, p_node5, p_node6), result.pGetProperties(0)));
+    result.AddElement(make_intrusive<Element>(
+        5, std::make_shared<Triangle2D3<Node>>(p_node4, p_node8, p_node5), result.pGetProperties(0)));
+    result.AddElement(make_intrusive<Element>(
+        6, std::make_shared<Triangle2D3<Node>>(p_node4, p_node7, p_node8), result.pGetProperties(0)));
+    result.AddElement(make_intrusive<Element>(
+        7, std::make_shared<Triangle2D3<Node>>(p_node5, p_node9, p_node6), result.pGetProperties(0)));
+    result.AddElement(make_intrusive<Element>(
+        8, std::make_shared<Triangle2D3<Node>>(p_node5, p_node8, p_node9), result.pGetProperties(0)));
 
     return result;
 }
@@ -83,7 +94,7 @@ void CheckReducedCPhi(const ModelPart& rModelPart, double COrig, double PhiOrig,
 
 namespace Kratos::Testing
 {
-KRATOS_TEST_CASE_IN_SUITE(CheckCAndPhiReducedAfterCallingApplyCPhiReductionProcess, KratosGeoMechanicsFastSuite)
+KRATOS_TEST_CASE_IN_SUITE(CheckCAndPhiReducedAfterCallingApplyCPhiReductionProcess, KratosGeoMechanicsFastSuiteWithoutKernel)
 {
     Model model;
     auto& r_model_part = PrepareCPhiTestModelPart(model);
@@ -94,7 +105,7 @@ KRATOS_TEST_CASE_IN_SUITE(CheckCAndPhiReducedAfterCallingApplyCPhiReductionProce
     CheckReducedCPhi(r_model_part, 10.0, 25.0, 0.9);
 }
 
-KRATOS_TEST_CASE_IN_SUITE(CheckCAndPhiTwiceReducedAfterCallingApplyCPhiReductionProcessTwice, KratosGeoMechanicsFastSuite)
+KRATOS_TEST_CASE_IN_SUITE(CheckCAndPhiTwiceReducedAfterCallingApplyCPhiReductionProcessTwice, KratosGeoMechanicsFastSuiteWithoutKernel)
 {
     Model model;
     auto& r_model_part = PrepareCPhiTestModelPart(model);
@@ -107,7 +118,7 @@ KRATOS_TEST_CASE_IN_SUITE(CheckCAndPhiTwiceReducedAfterCallingApplyCPhiReduction
     CheckReducedCPhi(r_model_part, 10.0, 25.0, 0.8);
 }
 
-KRATOS_TEST_CASE_IN_SUITE(CheckFailureUmatInputsApplyCPhiReductionProcess, KratosGeoMechanicsFastSuite)
+KRATOS_TEST_CASE_IN_SUITE(CheckFailureUmatInputsApplyCPhiReductionProcess, KratosGeoMechanicsFastSuiteWithoutKernel)
 {
     Model model;
     auto& r_model_part = SetGeometryAndMesh(model);
@@ -177,7 +188,7 @@ KRATOS_TEST_CASE_IN_SUITE(CheckFailureUmatInputsApplyCPhiReductionProcess, Krato
         "Cohesion C out of range: -1e-05")
 }
 
-KRATOS_TEST_CASE_IN_SUITE(CheckFailureEmptyModelPartApplyCPhiReductionProcess, KratosGeoMechanicsFastSuite)
+KRATOS_TEST_CASE_IN_SUITE(CheckFailureEmptyModelPartApplyCPhiReductionProcess, KratosGeoMechanicsFastSuiteWithoutKernel)
 {
     Model model;
     auto& r_modelpart = model.CreateModelPart("dummy");
@@ -185,7 +196,7 @@ KRATOS_TEST_CASE_IN_SUITE(CheckFailureEmptyModelPartApplyCPhiReductionProcess, K
                                       "ApplyCPhiReductionProces has no elements in modelpart dummy")
 }
 
-KRATOS_TEST_CASE_IN_SUITE(CheckReturnsZeroForValidModelPartApplyCPhiReductionProcess, KratosGeoMechanicsFastSuite)
+KRATOS_TEST_CASE_IN_SUITE(CheckReturnsZeroForValidModelPartApplyCPhiReductionProcess, KratosGeoMechanicsFastSuiteWithoutKernel)
 {
     Model                     model;
     auto&                     r_model_part = PrepareCPhiTestModelPart(model);
@@ -193,7 +204,7 @@ KRATOS_TEST_CASE_IN_SUITE(CheckReturnsZeroForValidModelPartApplyCPhiReductionPro
     KRATOS_CHECK_EQUAL(process.Check(), 0);
 }
 
-KRATOS_TEST_CASE_IN_SUITE(CheckFailureNegativeReductionFactorApplyCPhiReductionProcess, KratosGeoMechanicsFastSuite)
+KRATOS_TEST_CASE_IN_SUITE(CheckFailureNegativeReductionFactorApplyCPhiReductionProcess, KratosGeoMechanicsFastSuiteWithoutKernel)
 {
     Model model;
     auto& r_model_part = PrepareCPhiTestModelPart(model);
@@ -208,7 +219,7 @@ KRATOS_TEST_CASE_IN_SUITE(CheckFailureNegativeReductionFactorApplyCPhiReductionP
         "Reduction factor should not drop below 0.01, calculation stopped.");
 }
 
-KRATOS_TEST_CASE_IN_SUITE(CheckFailureTooSmallReductionIncrementApplyCPhiReductionProcess, KratosGeoMechanicsFastSuite)
+KRATOS_TEST_CASE_IN_SUITE(CheckFailureTooSmallReductionIncrementApplyCPhiReductionProcess, KratosGeoMechanicsFastSuiteWithoutKernel)
 {
     Model model;
     auto& r_model_part = PrepareCPhiTestModelPart(model);


### PR DESCRIPTION
**📝 Description**
This PR moves some tests to the faster suite, saving us >1.5 seconds every time we run unit tests. I think the code became a little less clear, but in my opinion the gain is worth it, since we run the unit tests so many times.

Times of these tests before:
![image](https://github.com/user-attachments/assets/6b76a2ac-3a3c-401d-8ad8-346eb1a0c67f)

Times after:
![image](https://github.com/user-attachments/assets/2d294df0-60da-48a6-aeac-39b252371d2d)

