### PR TITLE
[Core] Enhance `CompareElementsAndConditionsUtility` to support `MasterSlaveConstraint` name retrieval

### DIFF
--- a/kratos/tests/cpp_tests/sources/test_compare_elements_and_conditions_utility.cpp
+++ b/kratos/tests/cpp_tests/sources/test_compare_elements_and_conditions_utility.cpp
@@ -4,11 +4,11 @@
 //   _|\_\_|  \__,_|\__|\___/ ____/
 //                   Multi-Physics
 //
-//  License:		 BSD License
-//					 Kratos default license: kratos/license.txt
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
 //
-//  Main authors:    
-//
+//  Main author:     Carlos Roig
+//                   Vicente Mataix Ferrandiz
 //
 
 // System includes
@@ -18,15 +18,14 @@
 // Project includes
 #include "testing/testing.h"
 #include "utilities/compare_elements_and_conditions_utility.h"
-
 #include "includes/element.h"
 #include "includes/condition.h"
+#include "includes/master_slave_constraint.h"
 #include "includes/kratos_components.h"
 #include "geometries/triangle_2d_3.h"
 #include "geometries/quadrilateral_2d_4.h"
 
-namespace Kratos {
-namespace Testing {
+namespace Kratos::Testing {
 
 class CustomElement : public Element
 {
@@ -148,5 +147,19 @@ KRATOS_TEST_CASE_IN_SUITE(GetRegisteredNameCondition, KratosCoreFastSuite)
     KRATOS_EXPECT_NE(component_name, "Condition");
 }
 
-}  // namespace Testing.
-}  // namespace Kratos.
+KRATOS_TEST_CASE_IN_SUITE(GetRegisteredNameMasterSlaveConstraint, KratosCoreFastSuite)
+{
+    // MasterSlaveConstraint name
+    const MasterSlaveConstraint& r_master_slave_constraint = KratosComponents<MasterSlaveConstraint>::Get("LinearMasterSlaveConstraint");
+    std::string component_name;
+    CompareElementsAndConditionsUtility::GetRegisteredName(r_master_slave_constraint, component_name);
+    KRATOS_EXPECT_EQ(component_name, "LinearMasterSlaveConstraint");
+    CompareElementsAndConditionsUtility::GetRegisteredName(&r_master_slave_constraint, component_name);
+    KRATOS_EXPECT_EQ(component_name, "LinearMasterSlaveConstraint");
+    CompareElementsAndConditionsUtility::GetRegisteredName(r_master_slave_constraint, component_name);
+    KRATOS_EXPECT_NE(component_name, "MasterSlaveConstraint");
+    CompareElementsAndConditionsUtility::GetRegisteredName(&r_master_slave_constraint, component_name);
+    KRATOS_EXPECT_NE(component_name, "MasterSlaveConstraint");
+}
+
+}  // namespace Kratos::Testing.

--- a/kratos/utilities/compare_elements_and_conditions_utility.cpp
+++ b/kratos/utilities/compare_elements_and_conditions_utility.cpp
@@ -4,11 +4,11 @@
 //   _|\_\_|  \__,_|\__|\___/ ____/
 //                   Multi-Physics
 //
-//  License:		 BSD License
-//					 Kratos default license: kratos/license.txt
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
 //
-//  Main author: Carlos Roig
-//               Vicente Mataix Ferrandiz
+//  Main author:     Carlos Roig
+//                   Vicente Mataix Ferrandiz
 //
 
 
@@ -24,8 +24,9 @@
 namespace Kratos
 {
 void CompareElementsAndConditionsUtility::GetRegisteredName(
-    const Geometry<Node>& rGeometry, 
-    std::string& rName)
+    const Geometry<Node>& rGeometry,
+    std::string& rName
+    )
 {
     KRATOS_TRY;
 
@@ -46,7 +47,9 @@ void CompareElementsAndConditionsUtility::GetRegisteredName(
 
 void CompareElementsAndConditionsUtility::GetRegisteredName(
     const Element& rElement,
-    std::string& rName) {
+    std::string& rName
+    )
+{
     KRATOS_TRY;
 
     for(auto const& component: KratosComponents<Element>::GetComponents()) {
@@ -66,7 +69,8 @@ void CompareElementsAndConditionsUtility::GetRegisteredName(
 
 void CompareElementsAndConditionsUtility::GetRegisteredName(
     const Condition& rCondition,
-    std::string& rName)
+    std::string& rName
+    )
 {
     KRATOS_TRY;
 
@@ -81,6 +85,29 @@ void CompareElementsAndConditionsUtility::GetRegisteredName(
 
     KRATOS_CATCH("");
 }
+
+/***********************************************************************************/
+/***********************************************************************************/
+
+void CompareElementsAndConditionsUtility::GetRegisteredName(
+    const MasterSlaveConstraint& rMasterSlaveConstraint,
+    std::string& rName
+    )
+{
+    KRATOS_TRY;
+
+    for (const auto& r_component : KratosComponents<MasterSlaveConstraint>::GetComponents()) {
+        if (typeid(*(r_component.second)) == typeid(rMasterSlaveConstraint)) {
+            rName = r_component.first;
+            return;
+        }
+    }
+
+    KRATOS_ERROR << "MasterSlaveConstraint \"" << typeid(rMasterSlaveConstraint).name() << "\" not found!" << std::endl;
+
+    KRATOS_CATCH("");
+}
+
 
 } // namespace Kratos.
 

--- a/kratos/utilities/compare_elements_and_conditions_utility.h
+++ b/kratos/utilities/compare_elements_and_conditions_utility.h
@@ -4,44 +4,60 @@
 //   _|\_\_|  \__,_|\__|\___/ ____/
 //                   Multi-Physics
 //
-//  License:		 BSD License
-//					 Kratos default license: kratos/license.txt
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
 //
-//  Main author: Carlos Roig
-//               Vicente Mataix Ferrandiz
+//  Main author:     Carlos Roig
+//                   Vicente Mataix Ferrandiz
 //
 
-#if !defined(KRATOS_COMPARE_ELEMENTS_AND_CONDITIONS_UTILITY_H_INCLUDED)
-#define KRATOS_COMPARE_ELEMENTS_AND_CONDITIONS_UTILITY_H_INCLUDED
+#pragma once
 
 // System includes
 
 // External includes
 
 // Project includes
-#include "includes/define.h"
 #include "includes/element.h"
 #include "includes/condition.h"
-#include "includes/geometrical_object.h"
+#include "includes/master_slave_constraint.h"
 
 namespace Kratos
 {
 ///@name Kratos Classes
 ///@{
-// A utility for comparison of dynamic types of elements and conditions.
+
+/**
+ * @ingroup KratosCore
+ * @class CompareElementsAndConditionsUtility
+ * @brief Utility class to compare elements and conditions in Kratos.
+ * @details This utility provides static methods to retrieve the registered names of geometries,
+ * elements, and conditions. It supports both direct references and pointer-based access.
+ * @author Carlos Roig and Vicente Mataix Ferrandiz
+ */
 class CompareElementsAndConditionsUtility
 {
 public:
-    ///@name Type Definitions
-    ///@{
-    ///@}
     ///@name Operations
     ///@{
 
+    /**
+     * @brief Retrieves the registered name of a geometry.
+     * @details This method retrieves the registered name associated with the given geometry object.
+     * @param rGeometry The geometry object whose registered name is to be retrieved.
+     * @param rName A reference to a string where the registered name will be stored.
+     */
     static void KRATOS_API(KRATOS_CORE) GetRegisteredName(
         const Geometry<Node>& rGeometry,
-        std::string& rName);
+        std::string& rName
+        );
 
+    /**
+     * @brief Retrieves the registered name of a geometry pointer.
+     * @details This method retrieves the registered name associated with the given geometry pointer.
+     * @param pGeometry A pointer to the geometry object whose registered name is to be retrieved.
+     * @param rName A reference to a string where the registered name will be stored.
+     */
     static void GetRegisteredName(
         const Geometry<Node>* pGeometry,
         std::string& rName)
@@ -51,28 +67,79 @@ public:
 
     static void KRATOS_API(KRATOS_CORE) GetRegisteredName(
         const Element& rElement,
-        std::string& rName);
+        std::string& rName
+        );
 
-    static void GetRegisteredName(const Element* pElement, std::string& rName) {
+    /**
+     * @brief Retrieves the registered name of an element pointer.
+     * @details This method retrieves the registered name associated with the given element pointer.
+     * @param pElement A pointer to the element object whose registered name is to be retrieved.
+     * @param rName A reference to a string where the registered name will be stored.
+     */
+    static void GetRegisteredName(
+        const Element* pElement,
+        std::string& rName
+        )
+    {
         CompareElementsAndConditionsUtility::GetRegisteredName(*pElement, rName);
     }
 
+    /**
+     * @brief Retrieves the registered name of a condition.
+     * @details This method retrieves the registered name associated with the given condition object.
+     * @param rCondition The condition object whose registered name is to be retrieved.
+     * @param rName A reference to a string where the registered name will be stored.
+     */
     static void KRATOS_API(KRATOS_CORE) GetRegisteredName(
         const Condition& rCondition,
-        std::string& rName);
+        std::string& rName
+        );
 
-    static void GetRegisteredName(const Condition* pCondition, std::string& rName) {
+    /**
+     * @brief Retrieves the registered name of a condition pointer.
+     * @details This method retrieves the registered name associated with the given condition pointer.
+     * @param pCondition A pointer to the condition object whose registered name is to be retrieved.
+     * @param rName A reference to a string where the registered name will be stored.
+     */
+    static void GetRegisteredName(
+        const Condition* pCondition,
+        std::string& rName
+        )
+    {
         CompareElementsAndConditionsUtility::GetRegisteredName(*pCondition, rName);
     }
 
-    ///@}
+    /**
+     * @brief Retrieves the registered name of a master-slave constraint.
+     * @details This method retrieves the registered name associated with the given master-slave constraint object.
+     * @param rConstraint The master-slave constraint object whose registered name is to be retrieved.
+     * @param rName A reference to a string where the registered name will be stored.
+     */
+     static void KRATOS_API(KRATOS_CORE) GetRegisteredName(
+        const MasterSlaveConstraint& rConstraint,
+        std::string& rName
+        );
 
+    /**
+     * @brief Retrieves the registered name of a master-slave constraint pointer.
+     * @details This method retrieves the registered name associated with the given master-slave constraint pointer.
+     * @param pConstraint A pointer to the master-slave constraint object whose registered name is to be retrieved.
+     * @param rName A reference to a string where the registered name will be stored.
+     */
+    static void GetRegisteredName(
+        const MasterSlaveConstraint* pConstraint,
+        std::string& rName
+        )
+    {
+        CompareElementsAndConditionsUtility::GetRegisteredName(*pConstraint, rName);
+    }
+
+    ///@}
 private:
     ///@name Private Operations
     ///@{
+
     ///@}
 };
 ///@} // Kratos Classes
 } // namespace Kratos.
-
-#endif // KRATOS_COMPARE_ELEMENTS_AND_CONDITIONS_UTILITY_H_INCLUDED defined


### PR DESCRIPTION
# **📝 Description**

This PR introduces modifications to the `CompareElementsAndConditionsUtility` class. The changes include the addition of a method to retrieve the registered name of `MasterSlaveConstraint` objects. 

Additionally, the commit adds a unit test for the `CompareElementsAndConditionsUtility` to validate the name retrieval functionality for `MasterSlaveConstraint` objects.

## Changes

1. In `compare_elements_and_conditions_utility.cpp`:
   - The `GetRegisteredName` method was extended to handle `MasterSlaveConstraint` objects.
   - Formatting and structural changes to improve readability and consistency.

2. In `compare_elements_and_conditions_utility.h`:
   - New function declarations to handle `MasterSlaveConstraint` in the header file.
   - Documentation improvements for the methods to clarify the intended functionality.

3. In `test_compare_elements_and_conditions_utility.cpp`:
   - A new unit test was added to check the correct retrieval of the registered name for `MasterSlaveConstraint`.

# **🆕 Changelog**

- [Enhance `CompareElementsAndConditionsUtility` to support `MasterSlaveConstraint` name retrieval](https://github.com/KratosMultiphysics/Kratos/commit/cf0adbaba53a5d92d4c2cf0e15f6f373800721ca)
- [Add unit test for `CompareElementsAndConditionsUtility`](https://github.com/KratosMultiphysics/Kratos/commit/ca85018caeb0d381ec6f03ba415696635b543a74)
