### PR TITLE
[GeoMechanicsApplication] Avoid Derived `LinearSolver` as Template Parameter

### DIFF
--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_strategies/test_geo_mechanics_newton_rapson_erosion_processs_strategy.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_strategies/test_geo_mechanics_newton_rapson_erosion_processs_strategy.cpp
@@ -96,6 +96,7 @@ auto SetupPipingStrategy(Model& rModel)
 {
     using SparseSpaceType          = UblasSpace<double, CompressedMatrix, Vector>;
     using LocalSpaceType           = UblasSpace<double, Matrix, Vector>;
+    using LinearSolverBaseType     = LinearSolver<SparseSpaceType, LocalSpaceType>;
     using LinearSolverType         = SkylineLUFactorizationSolver<SparseSpaceType, LocalSpaceType>;
     using ConvergenceCriteriaType  = ConvergenceCriteria<SparseSpaceType, LocalSpaceType>;
     using MixedGenericCriteriaType = MixedGenericCriteria<SparseSpaceType, LocalSpaceType>;
@@ -154,12 +155,12 @@ auto SetupPipingStrategy(Model& rModel)
     }  )");
 
     const auto p_builder_and_solver =
-        Kratos::make_shared<ResidualBasedBlockBuilderAndSolver<SparseSpaceType, LocalSpaceType, LinearSolverType>>(nullptr);
+        Kratos::make_shared<ResidualBasedBlockBuilderAndSolver<SparseSpaceType, LocalSpaceType, LinearSolverBaseType>>(nullptr);
     const ConvergenceVariableListType      convergence_settings{};
     const ConvergenceCriteriaType::Pointer p_criteria =
         std::make_shared<MixedGenericCriteriaType>(convergence_settings);
 
-    return std::make_unique<MockGeoMechanicsNewtonRaphsonErosionProcessStrategy<SparseSpaceType, LocalSpaceType, LinearSolverType>>(
+    return std::make_unique<MockGeoMechanicsNewtonRaphsonErosionProcessStrategy<SparseSpaceType, LocalSpaceType, LinearSolverBaseType>>(
         r_model_part, nullptr, p_criteria, p_builder_and_solver, p_parameters);
 }
 } // namespace Kratos

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_strategies/test_geo_mechanics_newton_rapson_erosion_processs_strategy.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_strategies/test_geo_mechanics_newton_rapson_erosion_processs_strategy.cpp
@@ -96,8 +96,7 @@ auto SetupPipingStrategy(Model& rModel)
 {
     using SparseSpaceType          = UblasSpace<double, CompressedMatrix, Vector>;
     using LocalSpaceType           = UblasSpace<double, Matrix, Vector>;
-    using LinearSolverBaseType     = LinearSolver<SparseSpaceType, LocalSpaceType>;
-    using LinearSolverType         = SkylineLUFactorizationSolver<SparseSpaceType, LocalSpaceType>;
+    using LinearSolverType         = LinearSolver<SparseSpaceType, LocalSpaceType>;
     using ConvergenceCriteriaType  = ConvergenceCriteria<SparseSpaceType, LocalSpaceType>;
     using MixedGenericCriteriaType = MixedGenericCriteria<SparseSpaceType, LocalSpaceType>;
     using ConvergenceVariableListType = MixedGenericCriteriaType::ConvergenceVariableListType;
@@ -155,12 +154,12 @@ auto SetupPipingStrategy(Model& rModel)
     }  )");
 
     const auto p_builder_and_solver =
-        Kratos::make_shared<ResidualBasedBlockBuilderAndSolver<SparseSpaceType, LocalSpaceType, LinearSolverBaseType>>(nullptr);
+        Kratos::make_shared<ResidualBasedBlockBuilderAndSolver<SparseSpaceType, LocalSpaceType, LinearSolverType>>(nullptr);
     const ConvergenceVariableListType      convergence_settings{};
     const ConvergenceCriteriaType::Pointer p_criteria =
         std::make_shared<MixedGenericCriteriaType>(convergence_settings);
 
-    return std::make_unique<MockGeoMechanicsNewtonRaphsonErosionProcessStrategy<SparseSpaceType, LocalSpaceType, LinearSolverBaseType>>(
+    return std::make_unique<MockGeoMechanicsNewtonRaphsonErosionProcessStrategy<SparseSpaceType, LocalSpaceType, LinearSolverType>>(
         r_model_part, nullptr, p_criteria, p_builder_and_solver, p_parameters);
 }
 } // namespace Kratos


### PR DESCRIPTION
## Changelog

- replace `SkylineLUFactorizationSolver` with its base class `LinearSolver` as a template parameter in an instantiation of `ResidualBasedBlockBuilderAndSolver`.

## Why?

This isn't really an error or a bug, but it would make life hard for someone who wanted to pull definitions from headers into source files.

In more detail, `BuilderAndSolver`s are all class templates, which would normally mean that keeping their definitions in headers is the only option. However, there's only a handful of template parameters we ever expect to instantiate them with (`TUblasSparseSpace` or `KratosSpace` with `double` or `float`, etc). This opens up the possibility of moving their member functions' definitions into source files **and explicitly instantiating the classes with all expected sets of template parameters**.

So far so good, but the unfortunate reality is that `BuilderAndSolver` is also templated on the linear solver type, and as you can see, `LinearSolver` has **many** derived classes. Instantiating `BuilderAndSolver` with different derived classes of the same `LinearSolver` template doesn't (practically) provide any useful features, but it completely breaks the approach based on explicit instantiations described in the paragraph above.
