### PR TITLE
[Core] Fixed issue with uninitialized boolean member of Scheme

### DIFF
--- a/kratos/solving_strategies/schemes/scheme.h
+++ b/kratos/solving_strategies/schemes/scheme.h
@@ -760,7 +760,7 @@ protected:
     bool mSchemeIsInitialized = false;      /// Flag to be used in controlling if the Scheme has been initialized or not
     bool mElementsAreInitialized = false;   /// Flag taking in account if the elements were initialized correctly or not
     bool mConditionsAreInitialized = false; /// Flag taking in account if the conditions were initialized correctly or not
-    bool mConstraintsAreInitialized = false; /// Flag taking in account if the constraintswere initialized correctly or not
+    bool mConstraintsAreInitialized = false; /// Flag taking in account if the constraints were initialized correctly or not
 
     ///@}
     ///@name Protected Operators

--- a/kratos/solving_strategies/schemes/scheme.h
+++ b/kratos/solving_strategies/schemes/scheme.h
@@ -760,7 +760,7 @@ protected:
     bool mSchemeIsInitialized = false;      /// Flag to be used in controlling if the Scheme has been initialized or not
     bool mElementsAreInitialized = false;   /// Flag taking in account if the elements were initialized correctly or not
     bool mConditionsAreInitialized = false; /// Flag taking in account if the conditions were initialized correctly or not
-    bool mConstraintsAreInitialized = false;
+    bool mConstraintsAreInitialized = false; /// Flag taking in account if the constraintswere initialized correctly or not
 
     ///@}
     ///@name Protected Operators

--- a/kratos/solving_strategies/schemes/scheme.h
+++ b/kratos/solving_strategies/schemes/scheme.h
@@ -97,14 +97,9 @@ public:
 
     /**
      * @brief Default Constructor
-     * @details Initializes the flags
      */
-    explicit Scheme()
-    {
-        mSchemeIsInitialized = false;
-        mElementsAreInitialized = false;
-        mConditionsAreInitialized = false;
-    }
+    Scheme() = default;
+
     /**
      * @brief Constructor with Parameters
      */
@@ -113,26 +108,15 @@ public:
         // Validate default parameters
         ThisParameters = this->ValidateAndAssignParameters(ThisParameters, this->GetDefaultParameters());
         this->AssignSettings(ThisParameters);
-
-        mSchemeIsInitialized = false;
-        mElementsAreInitialized = false;
-        mConditionsAreInitialized = false;
     }
 
     /** Copy Constructor.
      */
-    explicit Scheme(Scheme& rOther)
-      :mSchemeIsInitialized(rOther.mSchemeIsInitialized)
-      ,mElementsAreInitialized(rOther.mElementsAreInitialized)
-      ,mConditionsAreInitialized(rOther.mConditionsAreInitialized)
-    {
-    }
+    Scheme(Scheme& rOther) = default;
 
     /** Destructor.
      */
-    virtual ~Scheme()
-    {
-    }
+    virtual ~Scheme() = default;
 
     ///@}
     ///@name Operators
@@ -773,10 +757,10 @@ protected:
     ///@name Protected member Variables
     ///@{
 
-    bool mSchemeIsInitialized;      /// Flag to be used in controlling if the Scheme has been initialized or not
-    bool mElementsAreInitialized;   /// Flag taking in account if the elements were initialized correctly or not
-    bool mConditionsAreInitialized; /// Flag taking in account if the conditions were initialized correctly or not
-    bool mConstraintsAreInitialized;
+    bool mSchemeIsInitialized = false;      /// Flag to be used in controlling if the Scheme has been initialized or not
+    bool mElementsAreInitialized = false;   /// Flag taking in account if the elements were initialized correctly or not
+    bool mConditionsAreInitialized = false; /// Flag taking in account if the conditions were initialized correctly or not
+    bool mConstraintsAreInitialized = false;
 
     ///@}
     ///@name Protected Operators


### PR DESCRIPTION
**📝 Description**
This PR makes sure the `mConstraintsAreInitialized` member of the `Scheme` is initialized. Right now it's not, which could lead to undefined behavior (this was flagged by our static analysis of our derived classes in Geo). 

Next to that, this PR makes the constructors/destructors default, such that this cannot happen in a similar fashion in the future to when adding new data members to the `Scheme`. Note that in general it's good practice to have default compiler-generated (copy/move)constructors, destructors whenever possible etc to avoid these kinds of issues. For further reference, see:
- https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#c20-if-you-can-avoid-defining-default-operations-do
- https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#c45-dont-define-a-default-constructor-that-only-initializes-data-members-use-default-member-initializers-instead