### PR TITLE
[CI] Fix Rocky

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,7 +99,7 @@ jobs:
           export CC=/usr/bin/clang-14
           export CXX=/usr/bin/clang++-14
           export KRATOS_CMAKE_CXX_FLAGS="-Werror -Wno-deprecated-declarations"
-          export KRATOS_CMAKE_OPTIONS_FLAGS="-DMMG_ROOT=/external_libraries/mmg/mmg_5_5_1/" 
+          export KRATOS_CMAKE_OPTIONS_FLAGS="-DMMG_ROOT=/external_libraries/mmg/mmg_5_5_1/"
         else
           echo 'Unsupported compiler: ${{ matrix.compiler }}'
           exit 1
@@ -326,6 +326,7 @@ jobs:
 
     - name: Build
       run: |
+        if [ -f /etc/bashrc ]; then source /etc/bashrc; fi
         export KRATOS_CMAKE_CXX_FLAGS="-Werror -Wno-deprecated-declarations -Wignored-qualifiers"
         cp .github/workflows/rocky_configure.sh rocky_configure.sh
         bash rocky_configure.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -333,12 +333,14 @@ jobs:
 
     - name: Running C++ tests
       run: |
+        if [ -f /etc/bashrc ]; then source /etc/bashrc; fi
         export PYTHONPATH=${GITHUB_WORKSPACE}/bin/Custom
         export LD_LIBRARY_PATH=${GITHUB_WORKSPACE}/bin/Custom/libs
         python3.8 kratos/python_scripts/testing/run_cpp_tests.py
 
     - name: Running python tests
       run: |
+        if [ -f /etc/bashrc ]; then source /etc/bashrc; fi
         export PYTHONPATH=${GITHUB_WORKSPACE}/bin/Custom
         export LD_LIBRARY_PATH=${GITHUB_WORKSPACE}/bin/Custom/libs
         python3.8 kratos/python_scripts/testing/run_python_tests.py -l nightly -c python3.8

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -311,7 +311,7 @@ jobs:
       ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
 
     container:
-      image: kratosmultiphysics/kratos-image-ci-rockylinux-8:latest
+      image: kratosmultiphysics/kratos-image-ci-rocky8:latest
       options: --user 1001
 
     steps:

--- a/scripts/docker_files/docker_file_ci_rockylinux8/DockerFile
+++ b/scripts/docker_files/docker_file_ci_rockylinux8/DockerFile
@@ -8,6 +8,7 @@ ENV HOME /root
 RUN dnf -y install gcc-toolset-11
 
 # Enable devtools 11 every time a shell is started
+# TODO: /etc/bashrc is never executed so this line does not fulfill its purpose => fix it.
 RUN echo "source /opt/rh/gcc-toolset-11/enable" >> /etc/bashrc
 
 # Install python3.8.10


### PR DESCRIPTION
Fix two problems with our Rocky CI.

1) the docker image we push to (`kratosmultiphysics/kratos-image-ci-rocky8`) is not the same image we fetch (`kratosmultiphysics/kratos-image-ci-rockylinux-8`)
   https://github.com/KratosMultiphysics/Kratos/blob/27bf3ea5100fd24f9b641d282b7e34a55e493b7a/.github/workflows/build_docker_images_for_ci.yml#L57
   https://github.com/KratosMultiphysics/Kratos/blob/27bf3ea5100fd24f9b641d282b7e34a55e493b7a/.github/workflows/ci.yml#L314
2) switching the toolchain is handled by a bash script (`/opt/rh/gcc-toolset-11/enable`) that is currently sourced from `/etc/bashrc`. The problem is that `/etc/bashrc` never actually gets executed when running a shell in a docker image, so the new toolchain is never used.
   https://github.com/KratosMultiphysics/Kratos/blob/27bf3ea5100fd24f9b641d282b7e34a55e493b7a/scripts/docker_files/docker_file_ci_rockylinux8/DockerFile#L11

##

This PR is a follow-up on #13224.