### PR TITLE
[GeoMechanicsApplication] Avoid slicing of class `StressStatePolicy`

### DIFF
--- a/applications/GeoMechanicsApplication/custom_elements/axisymmetric_stress_state.h
+++ b/applications/GeoMechanicsApplication/custom_elements/axisymmetric_stress_state.h
@@ -18,25 +18,25 @@
 namespace Kratos
 {
 
-class KRATOS_API(GEO_MECHANICS_APPLICATION) AxisymmetricStressState : public StressStatePolicy
+class KRATOS_API(GEO_MECHANICS_APPLICATION) AxisymmetricStressState final : public StressStatePolicy
 {
 public:
     [[nodiscard]] double CalculateIntegrationCoefficient(const Geometry<Node>::IntegrationPointType& rIntegrationPoint,
                                                          double DetJ,
-                                                         const Geometry<Node>& rGeometry) const final;
+                                                         const Geometry<Node>& rGeometry) const override;
     [[nodiscard]] Matrix CalculateBMatrix(const Matrix&         rDN_DX,
                                           const Vector&         rN,
-                                          const Geometry<Node>& rGeometry) const final;
-    [[nodiscard]] Vector CalculateGreenLagrangeStrain(const Matrix& rDeformationGradient) const final;
-    [[nodiscard]] std::unique_ptr<StressStatePolicy> Clone() const final;
-    [[nodiscard]] const Vector&                      GetVoigtVector() const final;
-    [[nodiscard]] SizeType                           GetVoigtSize() const final;
-    [[nodiscard]] SizeType                           GetStressTensorSize() const final;
+                                          const Geometry<Node>& rGeometry) const override;
+    [[nodiscard]] Vector CalculateGreenLagrangeStrain(const Matrix& rDeformationGradient) const override;
+    [[nodiscard]] std::unique_ptr<StressStatePolicy> Clone() const override;
+    [[nodiscard]] const Vector&                      GetVoigtVector() const override;
+    [[nodiscard]] SizeType                           GetVoigtSize() const override;
+    [[nodiscard]] SizeType                           GetStressTensorSize() const override;
 
 private:
     friend class Serializer;
-    void save(Serializer&) const final;
-    void load(Serializer&) final;
+    void save(Serializer&) const override;
+    void load(Serializer&) override;
 };
 
 } // namespace Kratos

--- a/applications/GeoMechanicsApplication/custom_elements/axisymmetric_stress_state.h
+++ b/applications/GeoMechanicsApplication/custom_elements/axisymmetric_stress_state.h
@@ -23,20 +23,20 @@ class KRATOS_API(GEO_MECHANICS_APPLICATION) AxisymmetricStressState : public Str
 public:
     [[nodiscard]] double CalculateIntegrationCoefficient(const Geometry<Node>::IntegrationPointType& rIntegrationPoint,
                                                          double DetJ,
-                                                         const Geometry<Node>& rGeometry) const override;
+                                                         const Geometry<Node>& rGeometry) const final;
     [[nodiscard]] Matrix CalculateBMatrix(const Matrix&         rDN_DX,
                                           const Vector&         rN,
-                                          const Geometry<Node>& rGeometry) const override;
-    [[nodiscard]] Vector CalculateGreenLagrangeStrain(const Matrix& rDeformationGradient) const override;
-    [[nodiscard]] std::unique_ptr<StressStatePolicy> Clone() const override;
-    [[nodiscard]] const Vector&                      GetVoigtVector() const override;
-    [[nodiscard]] SizeType                           GetVoigtSize() const override;
-    [[nodiscard]] SizeType                           GetStressTensorSize() const override;
+                                          const Geometry<Node>& rGeometry) const final;
+    [[nodiscard]] Vector CalculateGreenLagrangeStrain(const Matrix& rDeformationGradient) const final;
+    [[nodiscard]] std::unique_ptr<StressStatePolicy> Clone() const final;
+    [[nodiscard]] const Vector&                      GetVoigtVector() const final;
+    [[nodiscard]] SizeType                           GetVoigtSize() const final;
+    [[nodiscard]] SizeType                           GetStressTensorSize() const final;
 
 private:
     friend class Serializer;
-    void save(Serializer&) const override;
-    void load(Serializer&) override;
+    void save(Serializer&) const final;
+    void load(Serializer&) final;
 };
 
 } // namespace Kratos

--- a/applications/GeoMechanicsApplication/custom_elements/interface_stress_state.h
+++ b/applications/GeoMechanicsApplication/custom_elements/interface_stress_state.h
@@ -20,23 +20,23 @@ namespace Kratos
 class KRATOS_API(GEO_MECHANICS_APPLICATION) InterfaceStressState : public StressStatePolicy
 {
 public:
-    [[nodiscard]] Matrix CalculateBMatrix(const Matrix&, const Vector& rN, const Geometry<Node>& rGeometry) const override;
+    [[nodiscard]] Matrix CalculateBMatrix(const Matrix&, const Vector& rN, const Geometry<Node>& rGeometry) const final;
     [[nodiscard]] double CalculateIntegrationCoefficient(const Geometry<Node>::IntegrationPointType& rIntegrationPoint,
                                                          double DetJ,
-                                                         const Geometry<Node>& rGeometry) const override;
-    [[nodiscard]] Vector CalculateGreenLagrangeStrain(const Matrix& rDeformationGradient) const override;
-    [[nodiscard]] std::unique_ptr<StressStatePolicy> Clone() const override;
-    [[nodiscard]] const Vector&                      GetVoigtVector() const override;
-    [[nodiscard]] SizeType                           GetVoigtSize() const override;
-    [[nodiscard]] SizeType                           GetStressTensorSize() const override;
+                                                         const Geometry<Node>& rGeometry) const final;
+    [[nodiscard]] Vector CalculateGreenLagrangeStrain(const Matrix& rDeformationGradient) const final;
+    [[nodiscard]] std::unique_ptr<StressStatePolicy> Clone() const final;
+    [[nodiscard]] const Vector&                      GetVoigtVector() const final;
+    [[nodiscard]] SizeType                           GetVoigtSize() const final;
+    [[nodiscard]] SizeType                           GetStressTensorSize() const final;
 
 private:
     static const Vector VoigtVectorInterface2D;
     static Vector       DefineInterfaceVoigtVector();
 
     friend class Serializer;
-    void save(Serializer&) const override;
-    void load(Serializer&) override;
+    void save(Serializer&) const final;
+    void load(Serializer&) final;
 };
 
 } // namespace Kratos

--- a/applications/GeoMechanicsApplication/custom_elements/interface_stress_state.h
+++ b/applications/GeoMechanicsApplication/custom_elements/interface_stress_state.h
@@ -17,26 +17,26 @@
 namespace Kratos
 {
 
-class KRATOS_API(GEO_MECHANICS_APPLICATION) InterfaceStressState : public StressStatePolicy
+class KRATOS_API(GEO_MECHANICS_APPLICATION) InterfaceStressState final : public StressStatePolicy
 {
 public:
-    [[nodiscard]] Matrix CalculateBMatrix(const Matrix&, const Vector& rN, const Geometry<Node>& rGeometry) const final;
+    [[nodiscard]] Matrix CalculateBMatrix(const Matrix&, const Vector& rN, const Geometry<Node>& rGeometry) const override;
     [[nodiscard]] double CalculateIntegrationCoefficient(const Geometry<Node>::IntegrationPointType& rIntegrationPoint,
                                                          double DetJ,
-                                                         const Geometry<Node>& rGeometry) const final;
-    [[nodiscard]] Vector CalculateGreenLagrangeStrain(const Matrix& rDeformationGradient) const final;
-    [[nodiscard]] std::unique_ptr<StressStatePolicy> Clone() const final;
-    [[nodiscard]] const Vector&                      GetVoigtVector() const final;
-    [[nodiscard]] SizeType                           GetVoigtSize() const final;
-    [[nodiscard]] SizeType                           GetStressTensorSize() const final;
+                                                         const Geometry<Node>& rGeometry) const override;
+    [[nodiscard]] Vector CalculateGreenLagrangeStrain(const Matrix& rDeformationGradient) const override;
+    [[nodiscard]] std::unique_ptr<StressStatePolicy> Clone() const override;
+    [[nodiscard]] const Vector&                      GetVoigtVector() const override;
+    [[nodiscard]] SizeType                           GetVoigtSize() const override;
+    [[nodiscard]] SizeType                           GetStressTensorSize() const override;
 
 private:
     static const Vector VoigtVectorInterface2D;
     static Vector       DefineInterfaceVoigtVector();
 
     friend class Serializer;
-    void save(Serializer&) const final;
-    void load(Serializer&) final;
+    void save(Serializer&) const override;
+    void load(Serializer&) override;
 };
 
 } // namespace Kratos

--- a/applications/GeoMechanicsApplication/custom_elements/plane_strain_stress_state.h
+++ b/applications/GeoMechanicsApplication/custom_elements/plane_strain_stress_state.h
@@ -17,27 +17,27 @@
 namespace Kratos
 {
 
-class KRATOS_API(GEO_MECHANICS_APPLICATION) PlaneStrainStressState : public StressStatePolicy
+class KRATOS_API(GEO_MECHANICS_APPLICATION) PlaneStrainStressState final : public StressStatePolicy
 {
 public:
     [[nodiscard]] Matrix CalculateBMatrix(const Matrix&         rDN_DX,
                                           const Vector&         rN,
-                                          const Geometry<Node>& rGeometry) const final;
+                                          const Geometry<Node>& rGeometry) const override;
     [[nodiscard]] double CalculateIntegrationCoefficient(const Geometry<Node>::IntegrationPointType& rIntegrationPoint,
                                                          double DetJ,
-                                                         const Geometry<Node>& rGeometry) const final;
-    [[nodiscard]] Vector CalculateGreenLagrangeStrain(const Matrix& rDeformationGradient) const final;
-    [[nodiscard]] std::unique_ptr<StressStatePolicy> Clone() const final;
-    [[nodiscard]] const Vector&                      GetVoigtVector() const final;
-    [[nodiscard]] SizeType                           GetVoigtSize() const final;
-    [[nodiscard]] SizeType                           GetStressTensorSize() const final;
+                                                         const Geometry<Node>& rGeometry) const override;
+    [[nodiscard]] Vector CalculateGreenLagrangeStrain(const Matrix& rDeformationGradient) const override;
+    [[nodiscard]] std::unique_ptr<StressStatePolicy> Clone() const override;
+    [[nodiscard]] const Vector&                      GetVoigtVector() const override;
+    [[nodiscard]] SizeType                           GetVoigtSize() const override;
+    [[nodiscard]] SizeType                           GetStressTensorSize() const override;
 
 private:
     [[nodiscard]] static Vector ConvertStrainTensorToVector(const Matrix& rStrainTensor);
 
     friend class Serializer;
-    void save(Serializer&) const final;
-    void load(Serializer&) final;
+    void save(Serializer&) const override;
+    void load(Serializer&) override;
 };
 
 } // namespace Kratos

--- a/applications/GeoMechanicsApplication/custom_elements/plane_strain_stress_state.h
+++ b/applications/GeoMechanicsApplication/custom_elements/plane_strain_stress_state.h
@@ -22,22 +22,22 @@ class KRATOS_API(GEO_MECHANICS_APPLICATION) PlaneStrainStressState : public Stre
 public:
     [[nodiscard]] Matrix CalculateBMatrix(const Matrix&         rDN_DX,
                                           const Vector&         rN,
-                                          const Geometry<Node>& rGeometry) const override;
+                                          const Geometry<Node>& rGeometry) const final;
     [[nodiscard]] double CalculateIntegrationCoefficient(const Geometry<Node>::IntegrationPointType& rIntegrationPoint,
                                                          double DetJ,
-                                                         const Geometry<Node>& rGeometry) const override;
-    [[nodiscard]] Vector CalculateGreenLagrangeStrain(const Matrix& rDeformationGradient) const override;
-    [[nodiscard]] std::unique_ptr<StressStatePolicy> Clone() const override;
-    [[nodiscard]] const Vector&                      GetVoigtVector() const override;
-    [[nodiscard]] SizeType                           GetVoigtSize() const override;
-    [[nodiscard]] SizeType                           GetStressTensorSize() const override;
+                                                         const Geometry<Node>& rGeometry) const final;
+    [[nodiscard]] Vector CalculateGreenLagrangeStrain(const Matrix& rDeformationGradient) const final;
+    [[nodiscard]] std::unique_ptr<StressStatePolicy> Clone() const final;
+    [[nodiscard]] const Vector&                      GetVoigtVector() const final;
+    [[nodiscard]] SizeType                           GetVoigtSize() const final;
+    [[nodiscard]] SizeType                           GetStressTensorSize() const final;
 
 private:
     [[nodiscard]] static Vector ConvertStrainTensorToVector(const Matrix& rStrainTensor);
 
     friend class Serializer;
-    void save(Serializer&) const override;
-    void load(Serializer&) override;
+    void save(Serializer&) const final;
+    void load(Serializer&) final;
 };
 
 } // namespace Kratos

--- a/applications/GeoMechanicsApplication/custom_elements/stress_state_policy.h
+++ b/applications/GeoMechanicsApplication/custom_elements/stress_state_policy.h
@@ -25,7 +25,16 @@ class Serializer;
 class KRATOS_API(GEO_MECHANICS_APPLICATION) StressStatePolicy
 {
 public:
+    StressStatePolicy() = default;
     virtual ~StressStatePolicy() = default;
+
+    // To avoid the slicing problem, copying this class has been prohibited.
+    // Use member `Clone` to make deep copies.
+    StressStatePolicy(const StressStatePolicy&) = delete;
+    StressStatePolicy& operator=(const StressStatePolicy&) = delete;
+
+    StressStatePolicy(StressStatePolicy&&) noexcept = default;
+    StressStatePolicy& operator=(StressStatePolicy&&) noexcept = default;
 
     [[nodiscard]] virtual Matrix CalculateBMatrix(const Matrix&         rDN_DX,
                                                   const Vector&         rN,

--- a/applications/GeoMechanicsApplication/custom_elements/stress_state_policy.h
+++ b/applications/GeoMechanicsApplication/custom_elements/stress_state_policy.h
@@ -25,15 +25,15 @@ class Serializer;
 class KRATOS_API(GEO_MECHANICS_APPLICATION) StressStatePolicy
 {
 public:
-    StressStatePolicy() = default;
+    StressStatePolicy()          = default;
     virtual ~StressStatePolicy() = default;
 
     // To avoid the slicing problem, copying this class has been prohibited.
     // Use member `Clone` to make deep copies.
-    StressStatePolicy(const StressStatePolicy&) = delete;
+    StressStatePolicy(const StressStatePolicy&)            = delete;
     StressStatePolicy& operator=(const StressStatePolicy&) = delete;
 
-    StressStatePolicy(StressStatePolicy&&) noexcept = default;
+    StressStatePolicy(StressStatePolicy&&) noexcept            = default;
     StressStatePolicy& operator=(StressStatePolicy&&) noexcept = default;
 
     [[nodiscard]] virtual Matrix CalculateBMatrix(const Matrix&         rDN_DX,

--- a/applications/GeoMechanicsApplication/custom_elements/three_dimensional_stress_state.h
+++ b/applications/GeoMechanicsApplication/custom_elements/three_dimensional_stress_state.h
@@ -18,23 +18,23 @@
 namespace Kratos
 {
 
-class KRATOS_API(GEO_MECHANICS_APPLICATION) ThreeDimensionalStressState : public StressStatePolicy
+class KRATOS_API(GEO_MECHANICS_APPLICATION) ThreeDimensionalStressState final : public StressStatePolicy
 {
 public:
-    [[nodiscard]] Matrix CalculateBMatrix(const Matrix& rDN_DX, const Vector&, const Geometry<Node>& rGeometry) const final;
+    [[nodiscard]] Matrix CalculateBMatrix(const Matrix& rDN_DX, const Vector&, const Geometry<Node>& rGeometry) const override;
     [[nodiscard]] double CalculateIntegrationCoefficient(const Geometry<Node>::IntegrationPointType& rIntegrationPoint,
                                                          double DetJ,
-                                                         const Geometry<Node>& rGeometry) const final;
-    [[nodiscard]] Vector CalculateGreenLagrangeStrain(const Matrix& rDeformationGradient) const final;
-    [[nodiscard]] std::unique_ptr<StressStatePolicy> Clone() const final;
-    [[nodiscard]] const Vector&                      GetVoigtVector() const final;
-    [[nodiscard]] SizeType                           GetVoigtSize() const final;
-    [[nodiscard]] SizeType                           GetStressTensorSize() const final;
+                                                         const Geometry<Node>& rGeometry) const override;
+    [[nodiscard]] Vector CalculateGreenLagrangeStrain(const Matrix& rDeformationGradient) const override;
+    [[nodiscard]] std::unique_ptr<StressStatePolicy> Clone() const override;
+    [[nodiscard]] const Vector&                      GetVoigtVector() const override;
+    [[nodiscard]] SizeType                           GetVoigtSize() const override;
+    [[nodiscard]] SizeType                           GetStressTensorSize() const override;
 
 private:
     friend class Serializer;
-    void save(Serializer&) const final;
-    void load(Serializer&) final;
+    void save(Serializer&) const override;
+    void load(Serializer&) override;
 };
 
 } // namespace Kratos

--- a/applications/GeoMechanicsApplication/custom_elements/three_dimensional_stress_state.h
+++ b/applications/GeoMechanicsApplication/custom_elements/three_dimensional_stress_state.h
@@ -21,20 +21,20 @@ namespace Kratos
 class KRATOS_API(GEO_MECHANICS_APPLICATION) ThreeDimensionalStressState : public StressStatePolicy
 {
 public:
-    [[nodiscard]] Matrix CalculateBMatrix(const Matrix& rDN_DX, const Vector&, const Geometry<Node>& rGeometry) const override;
+    [[nodiscard]] Matrix CalculateBMatrix(const Matrix& rDN_DX, const Vector&, const Geometry<Node>& rGeometry) const final;
     [[nodiscard]] double CalculateIntegrationCoefficient(const Geometry<Node>::IntegrationPointType& rIntegrationPoint,
                                                          double DetJ,
-                                                         const Geometry<Node>& rGeometry) const override;
-    [[nodiscard]] Vector CalculateGreenLagrangeStrain(const Matrix& rDeformationGradient) const override;
-    [[nodiscard]] std::unique_ptr<StressStatePolicy> Clone() const override;
-    [[nodiscard]] const Vector&                      GetVoigtVector() const override;
-    [[nodiscard]] SizeType                           GetVoigtSize() const override;
-    [[nodiscard]] SizeType                           GetStressTensorSize() const override;
+                                                         const Geometry<Node>& rGeometry) const final;
+    [[nodiscard]] Vector CalculateGreenLagrangeStrain(const Matrix& rDeformationGradient) const final;
+    [[nodiscard]] std::unique_ptr<StressStatePolicy> Clone() const final;
+    [[nodiscard]] const Vector&                      GetVoigtVector() const final;
+    [[nodiscard]] SizeType                           GetVoigtSize() const final;
+    [[nodiscard]] SizeType                           GetStressTensorSize() const final;
 
 private:
     friend class Serializer;
-    void save(Serializer&) const override;
-    void load(Serializer&) override;
+    void save(Serializer&) const final;
+    void load(Serializer&) final;
 };
 
 } // namespace Kratos

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_elements/test_axisymmetric_stress_state.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_elements/test_axisymmetric_stress_state.cpp
@@ -78,12 +78,13 @@ KRATOS_TEST_CASE_IN_SUITE(ReturnCorrectIntegrationCoefficient, KratosGeoMechanic
     KRATOS_EXPECT_NEAR(calculated_coefficient, 5.02655, 1e-5);
 }
 
-KRATOS_TEST_CASE_IN_SUITE(AxisymmetricStressState_CannotBeCopiedButItCanBeMoved,
-                          KratosGeoMechanicsFastSuiteWithoutKernel){
-    KRATOS_EXPECT_FALSE(std::is_copy_constructible_v<AxisymmetricStressState>)
-        KRATOS_EXPECT_FALSE(std::is_copy_assignable_v<AxisymmetricStressState>)
-            KRATOS_EXPECT_TRUE(std::is_move_constructible_v<AxisymmetricStressState>)
-                KRATOS_EXPECT_TRUE(std::is_move_assignable_v<AxisymmetricStressState>)}
+KRATOS_TEST_CASE_IN_SUITE(AxisymmetricStressState_CannotBeCopiedButItCanBeMoved, KratosGeoMechanicsFastSuiteWithoutKernel)
+{
+    EXPECT_FALSE(std::is_copy_constructible_v<AxisymmetricStressState>);
+    EXPECT_FALSE(std::is_copy_assignable_v<AxisymmetricStressState>);
+    EXPECT_TRUE(std::is_move_constructible_v<AxisymmetricStressState>);
+    EXPECT_TRUE(std::is_move_assignable_v<AxisymmetricStressState>);
+}
 
 KRATOS_TEST_CASE_IN_SUITE(TestCloneReturnsCorrectType, KratosGeoMechanicsFastSuiteWithoutKernel)
 {

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_elements/test_axisymmetric_stress_state.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_elements/test_axisymmetric_stress_state.cpp
@@ -24,6 +24,7 @@
 
 #include <boost/numeric/ublas/assignment.hpp>
 #include <string>
+#include <type_traits>
 
 using namespace Kratos;
 using namespace std::string_literals;
@@ -77,6 +78,13 @@ KRATOS_TEST_CASE_IN_SUITE(ReturnCorrectIntegrationCoefficient, KratosGeoMechanic
     KRATOS_EXPECT_NEAR(calculated_coefficient, 5.02655, 1e-5);
 }
 
+KRATOS_TEST_CASE_IN_SUITE(AxisymmetricStressState_CannotBeCopiedButItCanBeMoved,
+                          KratosGeoMechanicsFastSuiteWithoutKernel){
+    KRATOS_EXPECT_FALSE(std::is_copy_constructible_v<AxisymmetricStressState>)
+        KRATOS_EXPECT_FALSE(std::is_copy_assignable_v<AxisymmetricStressState>)
+            KRATOS_EXPECT_TRUE(std::is_move_constructible_v<AxisymmetricStressState>)
+                KRATOS_EXPECT_TRUE(std::is_move_assignable_v<AxisymmetricStressState>)}
+
 KRATOS_TEST_CASE_IN_SUITE(TestCloneReturnsCorrectType, KratosGeoMechanicsFastSuiteWithoutKernel)
 {
     const std::unique_ptr<StressStatePolicy> p_stress_state_policy =
@@ -84,6 +92,7 @@ KRATOS_TEST_CASE_IN_SUITE(TestCloneReturnsCorrectType, KratosGeoMechanicsFastSui
     const auto p_cloned_stress_state_policy = p_stress_state_policy->Clone();
 
     KRATOS_EXPECT_NE(dynamic_cast<AxisymmetricStressState*>(p_cloned_stress_state_policy.get()), nullptr);
+    KRATOS_EXPECT_NE(p_cloned_stress_state_policy.get(), p_stress_state_policy.get());
 }
 
 KRATOS_TEST_CASE_IN_SUITE(TestCalculateGreenLagrangeStrainThrows, KratosGeoMechanicsFastSuiteWithoutKernel)

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_elements/test_interface_stress_state_policy.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_elements/test_interface_stress_state_policy.cpp
@@ -44,12 +44,13 @@ auto CreateThreePlusThree2DLineInterfaceGeometry()
 namespace Kratos::Testing
 {
 
-KRATOS_TEST_CASE_IN_SUITE(InterfaceStressState_CannotBeCopiedButItCanBeMoved,
-                          KratosGeoMechanicsFastSuiteWithoutKernel){
-    KRATOS_EXPECT_FALSE(std::is_copy_constructible_v<InterfaceStressState>)
-        KRATOS_EXPECT_FALSE(std::is_copy_assignable_v<InterfaceStressState>)
-            KRATOS_EXPECT_TRUE(std::is_move_constructible_v<InterfaceStressState>)
-                KRATOS_EXPECT_TRUE(std::is_move_assignable_v<InterfaceStressState>)}
+KRATOS_TEST_CASE_IN_SUITE(InterfaceStressState_CannotBeCopiedButItCanBeMoved, KratosGeoMechanicsFastSuiteWithoutKernel)
+{
+    EXPECT_FALSE(std::is_copy_constructible_v<InterfaceStressState>);
+    EXPECT_FALSE(std::is_copy_assignable_v<InterfaceStressState>);
+    EXPECT_TRUE(std::is_move_constructible_v<InterfaceStressState>);
+    EXPECT_TRUE(std::is_move_assignable_v<InterfaceStressState>);
+}
 
 KRATOS_TEST_CASE_IN_SUITE(InterfaceStressState_CloneCreatesCorrectInstance, KratosGeoMechanicsFastSuiteWithoutKernel)
 {

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_elements/test_interface_stress_state_policy.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_elements/test_interface_stress_state_policy.cpp
@@ -19,6 +19,7 @@
 
 #include <boost/numeric/ublas/assignment.hpp>
 #include <string>
+#include <type_traits>
 
 using namespace Kratos;
 using namespace std::string_literals;
@@ -42,6 +43,13 @@ auto CreateThreePlusThree2DLineInterfaceGeometry()
 
 namespace Kratos::Testing
 {
+
+KRATOS_TEST_CASE_IN_SUITE(InterfaceStressState_CannotBeCopiedButItCanBeMoved,
+                          KratosGeoMechanicsFastSuiteWithoutKernel){
+    KRATOS_EXPECT_FALSE(std::is_copy_constructible_v<InterfaceStressState>)
+        KRATOS_EXPECT_FALSE(std::is_copy_assignable_v<InterfaceStressState>)
+            KRATOS_EXPECT_TRUE(std::is_move_constructible_v<InterfaceStressState>)
+                KRATOS_EXPECT_TRUE(std::is_move_assignable_v<InterfaceStressState>)}
 
 KRATOS_TEST_CASE_IN_SUITE(InterfaceStressState_CloneCreatesCorrectInstance, KratosGeoMechanicsFastSuiteWithoutKernel)
 {

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_elements/test_plane_strain_stress_state.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_elements/test_plane_strain_stress_state.cpp
@@ -21,6 +21,7 @@
 
 #include <boost/numeric/ublas/assignment.hpp>
 #include <string>
+#include <type_traits>
 
 using namespace Kratos;
 using namespace std::string_literals;
@@ -92,6 +93,13 @@ KRATOS_TEST_CASE_IN_SUITE(PlaneStrainStressState_ReturnsCorrectGreenLagrangeStra
     KRATOS_CHECK_VECTOR_NEAR(calculated_strain, expected_vector, 1e-12)
 }
 
+KRATOS_TEST_CASE_IN_SUITE(PlaneStrainStressState_CannotBeCopiedButItCanBeMoved,
+                          KratosGeoMechanicsFastSuiteWithoutKernel){
+    KRATOS_EXPECT_FALSE(std::is_copy_constructible_v<PlaneStrainStressState>)
+        KRATOS_EXPECT_FALSE(std::is_copy_assignable_v<PlaneStrainStressState>)
+            KRATOS_EXPECT_TRUE(std::is_move_constructible_v<PlaneStrainStressState>)
+                KRATOS_EXPECT_TRUE(std::is_move_assignable_v<PlaneStrainStressState>)}
+
 KRATOS_TEST_CASE_IN_SUITE(PlaneStrainStressState_GivesCorrectClone, KratosGeoMechanicsFastSuiteWithoutKernel)
 {
     const std::unique_ptr<StressStatePolicy> p_stress_state_policy =
@@ -99,6 +107,7 @@ KRATOS_TEST_CASE_IN_SUITE(PlaneStrainStressState_GivesCorrectClone, KratosGeoMec
     const auto p_clone = p_stress_state_policy->Clone();
 
     KRATOS_EXPECT_NE(dynamic_cast<PlaneStrainStressState*>(p_clone.get()), nullptr);
+    KRATOS_EXPECT_NE(p_clone.get(), p_stress_state_policy.get());
 }
 
 KRATOS_TEST_CASE_IN_SUITE(PlaneStrainStressState_GivesCorrectVoigtVector, KratosGeoMechanicsFastSuiteWithoutKernel)

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_elements/test_plane_strain_stress_state.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_elements/test_plane_strain_stress_state.cpp
@@ -93,12 +93,13 @@ KRATOS_TEST_CASE_IN_SUITE(PlaneStrainStressState_ReturnsCorrectGreenLagrangeStra
     KRATOS_CHECK_VECTOR_NEAR(calculated_strain, expected_vector, 1e-12)
 }
 
-KRATOS_TEST_CASE_IN_SUITE(PlaneStrainStressState_CannotBeCopiedButItCanBeMoved,
-                          KratosGeoMechanicsFastSuiteWithoutKernel){
-    KRATOS_EXPECT_FALSE(std::is_copy_constructible_v<PlaneStrainStressState>)
-        KRATOS_EXPECT_FALSE(std::is_copy_assignable_v<PlaneStrainStressState>)
-            KRATOS_EXPECT_TRUE(std::is_move_constructible_v<PlaneStrainStressState>)
-                KRATOS_EXPECT_TRUE(std::is_move_assignable_v<PlaneStrainStressState>)}
+KRATOS_TEST_CASE_IN_SUITE(PlaneStrainStressState_CannotBeCopiedButItCanBeMoved, KratosGeoMechanicsFastSuiteWithoutKernel)
+{
+    EXPECT_FALSE(std::is_copy_constructible_v<PlaneStrainStressState>);
+    EXPECT_FALSE(std::is_copy_assignable_v<PlaneStrainStressState>);
+    EXPECT_TRUE(std::is_move_constructible_v<PlaneStrainStressState>);
+    EXPECT_TRUE(std::is_move_assignable_v<PlaneStrainStressState>);
+}
 
 KRATOS_TEST_CASE_IN_SUITE(PlaneStrainStressState_GivesCorrectClone, KratosGeoMechanicsFastSuiteWithoutKernel)
 {

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_elements/test_three_dimensional_stress_state.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_elements/test_three_dimensional_stress_state.cpp
@@ -84,12 +84,13 @@ KRATOS_TEST_CASE_IN_SUITE(ThreeDimensionalStressState_ReturnsCorrectIntegrationC
     KRATOS_EXPECT_NEAR(calculated_coefficient, 1.0, 1e-5);
 }
 
-KRATOS_TEST_CASE_IN_SUITE(ThreeDimensionalStressState_CannotBeCopiedButItCanBeMoved,
-                          KratosGeoMechanicsFastSuiteWithoutKernel){
-    KRATOS_EXPECT_FALSE(std::is_copy_constructible_v<ThreeDimensionalStressState>)
-        KRATOS_EXPECT_FALSE(std::is_copy_assignable_v<ThreeDimensionalStressState>)
-            KRATOS_EXPECT_TRUE(std::is_move_constructible_v<ThreeDimensionalStressState>)
-                KRATOS_EXPECT_TRUE(std::is_move_assignable_v<ThreeDimensionalStressState>)}
+KRATOS_TEST_CASE_IN_SUITE(ThreeDimensionalStressState_CannotBeCopiedButItCanBeMoved, KratosGeoMechanicsFastSuiteWithoutKernel)
+{
+    EXPECT_FALSE(std::is_copy_constructible_v<ThreeDimensionalStressState>);
+    EXPECT_FALSE(std::is_copy_assignable_v<ThreeDimensionalStressState>);
+    EXPECT_TRUE(std::is_move_constructible_v<ThreeDimensionalStressState>);
+    EXPECT_TRUE(std::is_move_assignable_v<ThreeDimensionalStressState>);
+}
 
 KRATOS_TEST_CASE_IN_SUITE(ThreeDimensionalStressState_GivesCorrectClone, KratosGeoMechanicsFastSuiteWithoutKernel)
 {

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_elements/test_three_dimensional_stress_state.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_elements/test_three_dimensional_stress_state.cpp
@@ -21,6 +21,7 @@
 
 #include <boost/numeric/ublas/assignment.hpp>
 #include <string>
+#include <type_traits>
 
 using namespace Kratos;
 using namespace std::string_literals;
@@ -83,6 +84,13 @@ KRATOS_TEST_CASE_IN_SUITE(ThreeDimensionalStressState_ReturnsCorrectIntegrationC
     KRATOS_EXPECT_NEAR(calculated_coefficient, 1.0, 1e-5);
 }
 
+KRATOS_TEST_CASE_IN_SUITE(ThreeDimensionalStressState_CannotBeCopiedButItCanBeMoved,
+                          KratosGeoMechanicsFastSuiteWithoutKernel){
+    KRATOS_EXPECT_FALSE(std::is_copy_constructible_v<ThreeDimensionalStressState>)
+        KRATOS_EXPECT_FALSE(std::is_copy_assignable_v<ThreeDimensionalStressState>)
+            KRATOS_EXPECT_TRUE(std::is_move_constructible_v<ThreeDimensionalStressState>)
+                KRATOS_EXPECT_TRUE(std::is_move_assignable_v<ThreeDimensionalStressState>)}
+
 KRATOS_TEST_CASE_IN_SUITE(ThreeDimensionalStressState_GivesCorrectClone, KratosGeoMechanicsFastSuiteWithoutKernel)
 {
     const std::unique_ptr<StressStatePolicy> p_stress_state_policy =
@@ -90,6 +98,7 @@ KRATOS_TEST_CASE_IN_SUITE(ThreeDimensionalStressState_GivesCorrectClone, KratosG
     const auto p_clone = p_stress_state_policy->Clone();
 
     KRATOS_EXPECT_NE(dynamic_cast<ThreeDimensionalStressState*>(p_clone.get()), nullptr);
+    KRATOS_EXPECT_NE(p_clone.get(), p_stress_state_policy.get());
 }
 
 KRATOS_TEST_CASE_IN_SUITE(ThreeDimensionalStressState_CalculateGreenLagrangeStrainReturnsCorrectResults,

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_workflows/test_GeoMechanicsNewtonRaphsonErosionProcessStrategy.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_workflows/test_GeoMechanicsNewtonRaphsonErosionProcessStrategy.cpp
@@ -52,7 +52,7 @@ TEST_P(ParametrizedDGeoFlowTests, ErosionProcessStrategy)
 
     // Act
     const auto status = execute.ExecuteFlowAnalysis(working_directory, project_file, critical_head_info,
-                                                   "PorousDomain.Left_head", call_back_functions);
+                                                    "PorousDomain.Left_head", call_back_functions);
 
     // Assert
     KRATOS_EXPECT_EQ(status, 0);


### PR DESCRIPTION
**📝 Description**
Be more explicit about the intended design of stress state policies. Each policy instance can be moved, but it cannot be copied. To make a deep copy of a stress state policy instance, use member function `Clone`. Unit tests now cover these type traits.