### PR TITLE
[Tests] Bugfix in SparseContainersTestUtilities

### DIFF
--- a/kratos/tests/test_utilities/sparse_containers_test_utilities.cpp
+++ b/kratos/tests/test_utilities/sparse_containers_test_utilities.cpp
@@ -40,18 +40,16 @@ SparseContainersTestUtilities::ElementConnectivityType SparseContainersTestUtili
     ElementConnectivityType connectivities((IndexEnd-IndexBegin)*BlockSize);
 
     #pragma omp parallel for
-    for(int i=static_cast<int>(IndexBegin); i<static_cast<int>(IndexEnd);++i)
+    for(int i = 0; i < static_cast<int>(IndexEnd - IndexBegin); ++i)
     {
         connectivities[i].resize(NodesInElem*BlockSize);
         std::mt19937 gen(i);
-        //std::uniform_int_distribution<> dis(0,NDof-1);
         std::normal_distribution<> dis{
             static_cast<double>(NDof/(IndexEnd-IndexBegin)*i),
             static_cast<double>(StandardDev)
             };
 
         for(int j = 0; j<static_cast<int>(NodesInElem); ++j){
-            //IndexType eq_id = dis(gen)*BlockSize;
             IndexType eq_id;
             bool acceptable = false;
             while(!acceptable){


### PR DESCRIPTION
The i index is incorrect so I was getting a memory error in the next line (accesing connectivities[i]). You did not see in this CI because the test that exposed the issue (DistributedSparseGraphConstructionBenchmark) only fails if its run with more than 4 cores.