### PR TITLE
[GeoMechanicsApplication] Fixed several (minor) issues detected by Clang-tidy

### DIFF
--- a/applications/GeoMechanicsApplication/custom_constitutive/small_strain_udsm_2D_interface_law.cpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/small_strain_udsm_2D_interface_law.cpp
@@ -103,13 +103,13 @@ Vector& SmallStrainUDSM2DInterfaceLaw::GetValue(const Variable<Vector>& rThisVar
     return rValue;
 }
 
-void SmallStrainUDSM2DInterfaceLaw::SetValue(const Variable<Vector>& rThisVariable,
+void SmallStrainUDSM2DInterfaceLaw::SetValue(const Variable<Vector>& rVariable,
                                              const Vector&           rValue,
                                              const ProcessInfo&      rCurrentProcessInfo)
 {
-    if (rThisVariable == STATE_VARIABLES) {
-        SmallStrainUDSM3DLaw::SetValue(rThisVariable, rValue, rCurrentProcessInfo);
-    } else if ((rThisVariable == CAUCHY_STRESS_VECTOR) && (rValue.size() == VoigtSize)) {
+    if (rVariable == STATE_VARIABLES) {
+        SmallStrainUDSM3DLaw::SetValue(rVariable, rValue, rCurrentProcessInfo);
+    } else if ((rVariable == CAUCHY_STRESS_VECTOR) && (rValue.size() == VoigtSize)) {
         this->SetInternalStressVector(rValue);
     }
 }

--- a/applications/GeoMechanicsApplication/custom_constitutive/small_strain_udsm_2D_plane_strain_law.cpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/small_strain_udsm_2D_plane_strain_law.cpp
@@ -97,13 +97,13 @@ Vector& SmallStrainUDSM2DPlaneStrainLaw::GetValue(const Variable<Vector>& rThisV
     return rValue;
 }
 
-void SmallStrainUDSM2DPlaneStrainLaw::SetValue(const Variable<Vector>& rThisVariable,
+void SmallStrainUDSM2DPlaneStrainLaw::SetValue(const Variable<Vector>& rVariable,
                                                const Vector&           rValue,
                                                const ProcessInfo&      rCurrentProcessInfo)
 {
-    if (rThisVariable == STATE_VARIABLES) {
-        SmallStrainUDSM3DLaw::SetValue(rThisVariable, rValue, rCurrentProcessInfo);
-    } else if ((rThisVariable == CAUCHY_STRESS_VECTOR) && (rValue.size() == VoigtSize)) {
+    if (rVariable == STATE_VARIABLES) {
+        SmallStrainUDSM3DLaw::SetValue(rVariable, rValue, rCurrentProcessInfo);
+    } else if ((rVariable == CAUCHY_STRESS_VECTOR) && (rValue.size() == VoigtSize)) {
         this->SetInternalStressVector(rValue);
     }
 }

--- a/applications/GeoMechanicsApplication/custom_constitutive/small_strain_udsm_3D_interface_law.cpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/small_strain_udsm_3D_interface_law.cpp
@@ -101,11 +101,11 @@ indexStress3D SmallStrainUDSM3DInterfaceLaw::getIndex3D(const indexStress3DInter
     }
 }
 
-Vector& SmallStrainUDSM3DInterfaceLaw::GetValue(const Variable<Vector>& rThisVariable, Vector& rValue)
+Vector& SmallStrainUDSM3DInterfaceLaw::GetValue(const Variable<Vector>& rVariable, Vector& rValue)
 {
-    if (rThisVariable == STATE_VARIABLES) {
-        SmallStrainUDSM3DLaw::GetValue(rThisVariable, rValue);
-    } else if (rThisVariable == CAUCHY_STRESS_VECTOR) {
+    if (rVariable == STATE_VARIABLES) {
+        SmallStrainUDSM3DLaw::GetValue(rVariable, rValue);
+    } else if (rVariable == CAUCHY_STRESS_VECTOR) {
         if (rValue.size() != VoigtSize) rValue.resize(VoigtSize);
 
         rValue[INDEX_3D_INTERFACE_ZZ] = mStressVectorFinalized[INDEX_3D_ZZ];

--- a/applications/GeoMechanicsApplication/custom_constitutive/small_strain_udsm_3D_interface_law.hpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/small_strain_udsm_3D_interface_law.hpp
@@ -72,7 +72,7 @@ public:
      */
     ConstitutiveLaw::Pointer Clone() const override;
 
-    Vector& GetValue(const Variable<Vector>& rThisVariable, Vector& rValue) override;
+    Vector& GetValue(const Variable<Vector>& rVariable, Vector& rValue) override;
     using SmallStrainUDSM3DLaw::GetValue;
 
     void SetValue(const Variable<Vector>& rVariable, const Vector& rValue, const ProcessInfo& rCurrentProcessInfo) override;

--- a/applications/GeoMechanicsApplication/custom_constitutive/small_strain_udsm_3D_law.cpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/small_strain_udsm_3D_law.cpp
@@ -898,26 +898,22 @@ double& SmallStrainUDSM3DLaw::GetValue(const Variable<double>& rThisVariable, do
     return rValue;
 }
 
-void SmallStrainUDSM3DLaw::SetValue(const Variable<double>& rThisVariable,
-                                    const double&           rValue,
-                                    const ProcessInfo&      rCurrentProcessInfo)
+void SmallStrainUDSM3DLaw::SetValue(const Variable<double>& rVariable, const double& rValue, const ProcessInfo& rCurrentProcessInfo)
 {
-    const int index = ConstitutiveLawUtilities::GetStateVariableIndex(rThisVariable);
+    const int index = ConstitutiveLawUtilities::GetStateVariableIndex(rVariable);
 
     KRATOS_DEBUG_ERROR_IF(index < 0 || index > (static_cast<int>(mStateVariablesFinalized.size()) - 1))
-        << "GetValue: Variable: " << rThisVariable
+        << "GetValue: Variable: " << rVariable
         << " does not exist in UDSM. Requested index: " << index << std::endl;
 
     mStateVariablesFinalized[index] = rValue;
 }
 
-void SmallStrainUDSM3DLaw::SetValue(const Variable<Vector>& rThisVariable,
-                                    const Vector&           rValue,
-                                    const ProcessInfo&      rCurrentProcessInfo)
+void SmallStrainUDSM3DLaw::SetValue(const Variable<Vector>& rVariable, const Vector& rValue, const ProcessInfo& rCurrentProcessInfo)
 {
-    if ((rThisVariable == STATE_VARIABLES) && (rValue.size() == mStateVariablesFinalized.size())) {
+    if ((rVariable == STATE_VARIABLES) && (rValue.size() == mStateVariablesFinalized.size())) {
         std::copy(rValue.begin(), rValue.end(), mStateVariablesFinalized.begin());
-    } else if ((rThisVariable == CAUCHY_STRESS_VECTOR) && (rValue.size() == mStressVectorFinalized.size())) {
+    } else if ((rVariable == CAUCHY_STRESS_VECTOR) && (rValue.size() == mStressVectorFinalized.size())) {
         std::copy(rValue.begin(), rValue.end(), mStressVectorFinalized.begin());
     }
 }

--- a/applications/GeoMechanicsApplication/custom_constitutive/small_strain_umat_2D_interface_law.cpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/small_strain_umat_2D_interface_law.cpp
@@ -99,13 +99,13 @@ Vector& SmallStrainUMAT2DInterfaceLaw::GetValue(const Variable<Vector>& rThisVar
     return rValue;
 }
 
-void SmallStrainUMAT2DInterfaceLaw::SetValue(const Variable<Vector>& rThisVariable,
+void SmallStrainUMAT2DInterfaceLaw::SetValue(const Variable<Vector>& rVariable,
                                              const Vector&           rValue,
                                              const ProcessInfo&      rCurrentProcessInfo)
 {
-    if (rThisVariable == STATE_VARIABLES) {
-        SmallStrainUMAT3DLaw::SetValue(rThisVariable, rValue, rCurrentProcessInfo);
-    } else if ((rThisVariable == CAUCHY_STRESS_VECTOR) && (rValue.size() == VoigtSize)) {
+    if (rVariable == STATE_VARIABLES) {
+        SmallStrainUMAT3DLaw::SetValue(rVariable, rValue, rCurrentProcessInfo);
+    } else if ((rVariable == CAUCHY_STRESS_VECTOR) && (rValue.size() == VoigtSize)) {
         this->SetInternalStressVector(rValue);
     }
 }

--- a/applications/GeoMechanicsApplication/custom_constitutive/small_strain_umat_2D_plane_strain_law.cpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/small_strain_umat_2D_plane_strain_law.cpp
@@ -90,13 +90,13 @@ Vector& SmallStrainUMAT2DPlaneStrainLaw::GetValue(const Variable<Vector>& rThisV
     return rValue;
 }
 
-void SmallStrainUMAT2DPlaneStrainLaw::SetValue(const Variable<Vector>& rThisVariable,
+void SmallStrainUMAT2DPlaneStrainLaw::SetValue(const Variable<Vector>& rVariable,
                                                const Vector&           rValue,
                                                const ProcessInfo&      rCurrentProcessInfo)
 {
-    if (rThisVariable == STATE_VARIABLES) {
-        SmallStrainUMAT3DLaw::SetValue(rThisVariable, rValue, rCurrentProcessInfo);
-    } else if ((rThisVariable == CAUCHY_STRESS_VECTOR) && (rValue.size() == VoigtSize)) {
+    if (rVariable == STATE_VARIABLES) {
+        SmallStrainUMAT3DLaw::SetValue(rVariable, rValue, rCurrentProcessInfo);
+    } else if ((rVariable == CAUCHY_STRESS_VECTOR) && (rValue.size() == VoigtSize)) {
         this->SetInternalStressVector(rValue);
     }
 }

--- a/applications/GeoMechanicsApplication/custom_constitutive/small_strain_umat_3D_interface_law.cpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/small_strain_umat_3D_interface_law.cpp
@@ -108,13 +108,13 @@ Vector& SmallStrainUMAT3DInterfaceLaw::GetValue(const Variable<Vector>& rThisVar
     return rValue;
 }
 
-void SmallStrainUMAT3DInterfaceLaw::SetValue(const Variable<Vector>& rThisVariable,
+void SmallStrainUMAT3DInterfaceLaw::SetValue(const Variable<Vector>& rVariable,
                                              const Vector&           rValue,
                                              const ProcessInfo&      rCurrentProcessInfo)
 {
-    if (rThisVariable == STATE_VARIABLES) {
-        SmallStrainUMAT3DLaw::SetValue(rThisVariable, rValue, rCurrentProcessInfo);
-    } else if ((rThisVariable == CAUCHY_STRESS_VECTOR) && (rValue.size() == VoigtSize)) {
+    if (rVariable == STATE_VARIABLES) {
+        SmallStrainUMAT3DLaw::SetValue(rVariable, rValue, rCurrentProcessInfo);
+    } else if ((rVariable == CAUCHY_STRESS_VECTOR) && (rValue.size() == VoigtSize)) {
         this->SetInternalStressVector(rValue);
     }
 }

--- a/applications/GeoMechanicsApplication/custom_constitutive/small_strain_umat_3D_law.cpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/small_strain_umat_3D_law.cpp
@@ -672,11 +672,9 @@ double& SmallStrainUMAT3DLaw::GetValue(const Variable<double>& rThisVariable, do
     return rValue;
 }
 
-void SmallStrainUMAT3DLaw::SetValue(const Variable<double>& rThisVariable,
-                                    const double&           rValue,
-                                    const ProcessInfo&      rCurrentProcessInfo)
+void SmallStrainUMAT3DLaw::SetValue(const Variable<double>& rVariable, const double& rValue, const ProcessInfo& rCurrentProcessInfo)
 {
-    const int index = ConstitutiveLawUtilities::GetStateVariableIndex(rThisVariable);
+    const int index = ConstitutiveLawUtilities::GetStateVariableIndex(rVariable);
 
     KRATOS_DEBUG_ERROR_IF(index < 0 || index > (static_cast<int>(mStateVariablesFinalized.size()) - 1))
         << "SetValue: State variable does not exist in UDSM. Requested index: " << index << std::endl;
@@ -684,13 +682,11 @@ void SmallStrainUMAT3DLaw::SetValue(const Variable<double>& rThisVariable,
     mStateVariablesFinalized[index] = rValue;
 }
 
-void SmallStrainUMAT3DLaw::SetValue(const Variable<Vector>& rThisVariable,
-                                    const Vector&           rValue,
-                                    const ProcessInfo&      rCurrentProcessInfo)
+void SmallStrainUMAT3DLaw::SetValue(const Variable<Vector>& rVariable, const Vector& rValue, const ProcessInfo& rCurrentProcessInfo)
 {
-    if ((rThisVariable == STATE_VARIABLES) && (rValue.size() == mStateVariablesFinalized.size())) {
+    if ((rVariable == STATE_VARIABLES) && (rValue.size() == mStateVariablesFinalized.size())) {
         std::copy(rValue.begin(), rValue.end(), mStateVariablesFinalized.begin());
-    } else if ((rThisVariable == CAUCHY_STRESS_VECTOR) && (rValue.size() == mStressVectorFinalized.size())) {
+    } else if ((rVariable == CAUCHY_STRESS_VECTOR) && (rValue.size() == mStressVectorFinalized.size())) {
         std::copy(rValue.begin(), rValue.end(), mStressVectorFinalized.begin());
     }
 }

--- a/applications/GeoMechanicsApplication/custom_elements/U_Pw_base_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/U_Pw_base_element.cpp
@@ -415,14 +415,13 @@ void UPwBaseElement::CalculateDerivativesOnInitialConfiguration(
 {
     KRATOS_TRY
 
-    const GeometryType&                             rGeom = this->GetGeometry();
-    const GeometryType::IntegrationPointsArrayType& IntegrationPoints =
-        rGeom.IntegrationPoints(mThisIntegrationMethod);
+    const auto& r_geometry           = this->GetGeometry();
+    const auto& r_integration_points = r_geometry.IntegrationPoints(mThisIntegrationMethod);
 
-    GeometryUtils::JacobianOnInitialConfiguration(rGeom, IntegrationPoints[IntegrationPointIndex], rJ0);
-    const Matrix& DN_De = rGeom.ShapeFunctionsLocalGradients(mThisIntegrationMethod)[IntegrationPointIndex];
-    MathUtils<double>::InvertMatrix(rJ0, rInvJ0, rDetJ);
-    GeometryUtils::ShapeFunctionsGradients(DN_De, rInvJ0, rDNu_DX0);
+    GeometryUtils::JacobianOnInitialConfiguration(r_geometry, r_integration_points[IntegrationPointIndex], rJ0);
+    const auto& r_dn_de = r_geometry.ShapeFunctionsLocalGradients(mThisIntegrationMethod)[IntegrationPointIndex];
+    MathUtils<>::InvertMatrix(rJ0, rInvJ0, rDetJ);
+    GeometryUtils::ShapeFunctionsGradients(r_dn_de, rInvJ0, rDNu_DX0);
 
     KRATOS_CATCH("")
 }

--- a/applications/GeoMechanicsApplication/custom_elements/U_Pw_base_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/U_Pw_base_element.cpp
@@ -411,7 +411,7 @@ std::vector<double> UPwBaseElement::CalculateIntegrationCoefficients(
 }
 
 void UPwBaseElement::CalculateDerivativesOnInitialConfiguration(
-    double& detJ, Matrix& J0, Matrix& InvJ0, Matrix& DNu_DX0, unsigned int IntegrationPointIndex) const
+    double& rDetJ, Matrix& rJ0, Matrix& rInvJ0, Matrix& rDNu_DX0, unsigned int IntegrationPointIndex) const
 {
     KRATOS_TRY
 
@@ -419,10 +419,10 @@ void UPwBaseElement::CalculateDerivativesOnInitialConfiguration(
     const GeometryType::IntegrationPointsArrayType& IntegrationPoints =
         rGeom.IntegrationPoints(mThisIntegrationMethod);
 
-    GeometryUtils::JacobianOnInitialConfiguration(rGeom, IntegrationPoints[IntegrationPointIndex], J0);
+    GeometryUtils::JacobianOnInitialConfiguration(rGeom, IntegrationPoints[IntegrationPointIndex], rJ0);
     const Matrix& DN_De = rGeom.ShapeFunctionsLocalGradients(mThisIntegrationMethod)[IntegrationPointIndex];
-    MathUtils<double>::InvertMatrix(J0, InvJ0, detJ);
-    GeometryUtils::ShapeFunctionsGradients(DN_De, InvJ0, DNu_DX0);
+    MathUtils<double>::InvertMatrix(rJ0, rInvJ0, rDetJ);
+    GeometryUtils::ShapeFunctionsGradients(DN_De, rInvJ0, rDNu_DX0);
 
     KRATOS_CATCH("")
 }

--- a/applications/GeoMechanicsApplication/custom_elements/U_Pw_base_element.hpp
+++ b/applications/GeoMechanicsApplication/custom_elements/U_Pw_base_element.hpp
@@ -166,8 +166,11 @@ protected:
     std::vector<double> CalculateIntegrationCoefficients(const GeometryType::IntegrationPointsArrayType& rIntegrationPoints,
                                                          const Vector& rDetJs) const;
 
-    void CalculateDerivativesOnInitialConfiguration(
-        double& detJ, Matrix& J0, Matrix& InvJ0, Matrix& DN_DX, unsigned int IntegrationPointIndex) const;
+    void CalculateDerivativesOnInitialConfiguration(double&      rDetJ,
+                                                    Matrix&      rJ0,
+                                                    Matrix&      rInvJ0,
+                                                    Matrix&      rDNu_DX0,
+                                                    unsigned int IntegrationPointIndex) const;
 
     void CalculateJacobianOnCurrentConfiguration(double& detJ, Matrix& rJ, Matrix& rInvJ, unsigned int GPoint) const;
 

--- a/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_interface_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_interface_element.cpp
@@ -884,7 +884,7 @@ void UPwSmallStrainInterfaceElement<TDim, TNumNodes>::CalculateOnLobattoIntegrat
 
 template <unsigned int TDim, unsigned int TNumNodes>
 void UPwSmallStrainInterfaceElement<TDim, TNumNodes>::CalculateOnLobattoIntegrationPoints(
-    const Variable<Vector>& rVariable, std::vector<Vector>& rValues, const ProcessInfo& rCurrentProcessInfo)
+    const Variable<Vector>& rVariable, std::vector<Vector>& rOutput, const ProcessInfo& rCurrentProcessInfo)
 {
     KRATOS_TRY
 
@@ -893,7 +893,7 @@ void UPwSmallStrainInterfaceElement<TDim, TNumNodes>::CalculateOnLobattoIntegrat
     const IndexType     NumGPoints = rGeom.IntegrationPointsNumber(mThisIntegrationMethod);
 
     // calculated on Lobatto points
-    if (rValues.size() != NumGPoints) rValues.resize(NumGPoints);
+    rOutput.resize(NumGPoints);
 
     if (rVariable == TOTAL_STRESS_VECTOR) {
         // Defining necessary variables
@@ -963,11 +963,7 @@ void UPwSmallStrainInterfaceElement<TDim, TNumNodes>::CalculateOnLobattoIntegrat
             noalias(TotalStressVector) += PORE_PRESSURE_SIGN_FACTOR * Variables.BiotCoefficient *
                                           Variables.BishopCoefficient * Variables.FluidPressure * VoigtVector;
 
-            // calculate on Lobatto integration points
-            if (rValues[GPoint].size() != TotalStressVector.size())
-                rValues[GPoint].resize(TotalStressVector.size(), false);
-
-            rValues[GPoint] = TotalStressVector;
+            rOutput[GPoint] = TotalStressVector;
         }
     }
     KRATOS_CATCH("")

--- a/applications/GeoMechanicsApplication/custom_elements/steady_state_Pw_piping_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/steady_state_Pw_piping_element.cpp
@@ -283,25 +283,24 @@ double SteadyStatePwPipingElement<3, 8>::CalculateHeadGradient(const PropertiesT
 /// <summary>
 /// Calculates the equilibrium pipe height of a piping element according to Sellmeijers rule
 /// </summary>
-/// <param name="Prop"></param>
-/// <param name="Geom"></param>
+/// <param name="rProperties"></param>
+/// <param name="rGeometry"></param>
 /// <returns></returns>
 template <unsigned int TDim, unsigned int TNumNodes>
-double SteadyStatePwPipingElement<TDim, TNumNodes>::CalculateEquilibriumPipeHeight(const PropertiesType& Prop,
-                                                                                   const GeometryType& Geom,
-                                                                                   double pipe_length)
+double SteadyStatePwPipingElement<TDim, TNumNodes>::CalculateEquilibriumPipeHeight(
+    const PropertiesType& rProperties, const GeometryType& rGeometry, double PipeLength)
 {
-    const double modelFactor  = Prop[PIPE_MODEL_FACTOR];
-    const double eta          = Prop[PIPE_ETA];
-    const double theta        = Prop[PIPE_THETA];
-    const double SolidDensity = Prop[DENSITY_SOLID];
-    const double FluidDensity = Prop[DENSITY_WATER];
+    const double modelFactor  = rProperties[PIPE_MODEL_FACTOR];
+    const double eta          = rProperties[PIPE_ETA];
+    const double theta        = rProperties[PIPE_THETA];
+    const double SolidDensity = rProperties[DENSITY_SOLID];
+    const double FluidDensity = rProperties[DENSITY_WATER];
 
     // calculate head gradient over element
-    double dhdx = CalculateHeadGradient(Prop, Geom, pipe_length);
+    double dhdx = CalculateHeadGradient(rProperties, rGeometry, PipeLength);
 
     // calculate particle diameter
-    double particle_d = GeoTransportEquationUtilities::CalculateParticleDiameter(Prop);
+    double particle_d = GeoTransportEquationUtilities::CalculateParticleDiameter(rProperties);
 
     // todo calculate slope of pipe, currently pipe is assumed to be horizontal
     const double pipeSlope = 0;

--- a/applications/GeoMechanicsApplication/custom_elements/steady_state_Pw_piping_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/steady_state_Pw_piping_element.cpp
@@ -290,29 +290,20 @@ template <unsigned int TDim, unsigned int TNumNodes>
 double SteadyStatePwPipingElement<TDim, TNumNodes>::CalculateEquilibriumPipeHeight(
     const PropertiesType& rProperties, const GeometryType& rGeometry, double PipeLength)
 {
-    const double modelFactor  = rProperties[PIPE_MODEL_FACTOR];
-    const double eta          = rProperties[PIPE_ETA];
-    const double theta        = rProperties[PIPE_THETA];
-    const double SolidDensity = rProperties[DENSITY_SOLID];
-    const double FluidDensity = rProperties[DENSITY_WATER];
-
     // calculate head gradient over element
-    double dhdx = CalculateHeadGradient(rProperties, rGeometry, PipeLength);
-
-    // calculate particle diameter
-    double particle_d = GeoTransportEquationUtilities::CalculateParticleDiameter(rProperties);
-
-    // todo calculate slope of pipe, currently pipe is assumed to be horizontal
-    const double pipeSlope = 0;
+    const auto dhdx = CalculateHeadGradient(rProperties, rGeometry, PipeLength);
 
     // return infinite when dhdx is 0
-    if (dhdx < std::numeric_limits<double>::epsilon()) {
-        return 1e10;
-    }
+    if (dhdx < std::numeric_limits<double>::epsilon()) return 1e10;
 
-    return modelFactor * Globals::Pi / 3.0 * particle_d * (SolidDensity / FluidDensity - 1) * eta *
-           std::sin(MathUtils<>::DegreesToRadians(theta + pipeSlope)) /
-           std::cos(MathUtils<>::DegreesToRadians(theta)) / dhdx;
+    // todo calculate slope of pipe, currently pipe is assumed to be horizontal
+    constexpr auto pipe_slope = 0.0;
+
+    return rProperties[PIPE_MODEL_FACTOR] * Globals::Pi / 3.0 *
+           GeoTransportEquationUtilities::CalculateParticleDiameter(rProperties) *
+           (rProperties[DENSITY_SOLID] / rProperties[DENSITY_WATER] - 1) * rProperties[PIPE_ETA] *
+           std::sin(MathUtils<>::DegreesToRadians(rProperties[PIPE_THETA] + pipe_slope)) /
+           std::cos(MathUtils<>::DegreesToRadians(rProperties[PIPE_THETA])) / dhdx;
 }
 
 template <unsigned int TDim, unsigned int TNumNodes>

--- a/applications/GeoMechanicsApplication/custom_elements/steady_state_Pw_piping_element.hpp
+++ b/applications/GeoMechanicsApplication/custom_elements/steady_state_Pw_piping_element.hpp
@@ -101,7 +101,9 @@ public:
 
     double CalculateHeadGradient(const PropertiesType& Prop, const GeometryType& Geom, double pipe_length);
 
-    double CalculateEquilibriumPipeHeight(const PropertiesType& Prop, const GeometryType& Geom, double dx);
+    double CalculateEquilibriumPipeHeight(const PropertiesType& rProperties,
+                                          const GeometryType&   rGeometry,
+                                          double                PipeLength);
 
     void CalculateLength(const GeometryType& Geom);
 

--- a/applications/GeoMechanicsApplication/custom_elements/transient_Pw_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/transient_Pw_element.cpp
@@ -498,7 +498,7 @@ void TransientPwElement<TDim, TNumNodes>::CalculateAndAddCompressibilityMatrix(M
 template <unsigned int TDim, unsigned int TNumNodes>
 void TransientPwElement<TDim, TNumNodes>::CalculateAndAddRHS(VectorType&       rRightHandSideVector,
                                                              ElementVariables& rVariables,
-                                                             unsigned int      integration_point)
+                                                             unsigned int)
 {
     KRATOS_TRY
 

--- a/applications/GeoMechanicsApplication/custom_elements/transient_Pw_element.hpp
+++ b/applications/GeoMechanicsApplication/custom_elements/transient_Pw_element.hpp
@@ -135,7 +135,7 @@ protected:
 
     void CalculateAndAddLHS(MatrixType& rLeftHandSideMatrix, ElementVariables& rVariables) override;
 
-    void CalculateAndAddRHS(VectorType& rRightHandSideVector, ElementVariables& rVariables, unsigned int GPoint) override;
+    void CalculateAndAddRHS(VectorType& rRightHandSideVector, ElementVariables& rVariables, unsigned int) override;
 
     void CalculateKinematics(ElementVariables& rVariables, unsigned int IntegrationPointIndex) override;
 

--- a/applications/GeoMechanicsApplication/custom_elements/updated_lagrangian_U_Pw_diff_order_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/updated_lagrangian_U_Pw_diff_order_element.cpp
@@ -25,16 +25,15 @@ Element::Pointer UpdatedLagrangianUPwDiffOrderElement::Create(IndexType         
                                                               NodesArrayType const& ThisNodes,
                                                               PropertiesType::Pointer pProperties) const
 {
-    return Element::Pointer(new UpdatedLagrangianUPwDiffOrderElement(
-        NewId, this->GetGeometry().Create(ThisNodes), pProperties, this->GetStressStatePolicy().Clone()));
+    return Create(NewId, this->GetGeometry().Create(ThisNodes), pProperties);
 }
 
 Element::Pointer UpdatedLagrangianUPwDiffOrderElement::Create(IndexType             NewId,
                                                               GeometryType::Pointer pGeom,
                                                               PropertiesType::Pointer pProperties) const
 {
-    return Element::Pointer(new UpdatedLagrangianUPwDiffOrderElement(
-        NewId, pGeom, pProperties, this->GetStressStatePolicy().Clone()));
+    return make_intrusive<UpdatedLagrangianUPwDiffOrderElement>(
+        NewId, pGeom, pProperties, this->GetStressStatePolicy().Clone());
 }
 
 void UpdatedLagrangianUPwDiffOrderElement::CalculateAll(MatrixType&        rLeftHandSideMatrix,

--- a/applications/GeoMechanicsApplication/custom_elements/updated_lagrangian_U_Pw_diff_order_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/updated_lagrangian_U_Pw_diff_order_element.cpp
@@ -22,10 +22,10 @@ namespace Kratos
 {
 
 Element::Pointer UpdatedLagrangianUPwDiffOrderElement::Create(IndexType             NewId,
-                                                              NodesArrayType const& ThisNodes,
+                                                              const NodesArrayType& rNodes,
                                                               PropertiesType::Pointer pProperties) const
 {
-    return Create(NewId, this->GetGeometry().Create(ThisNodes), pProperties);
+    return Create(NewId, this->GetGeometry().Create(rNodes), pProperties);
 }
 
 Element::Pointer UpdatedLagrangianUPwDiffOrderElement::Create(IndexType             NewId,

--- a/applications/GeoMechanicsApplication/custom_elements/updated_lagrangian_U_Pw_diff_order_element.hpp
+++ b/applications/GeoMechanicsApplication/custom_elements/updated_lagrangian_U_Pw_diff_order_element.hpp
@@ -98,6 +98,7 @@ public:
     {
     }
 
+    /// Destructor
     ~UpdatedLagrangianUPwDiffOrderElement() override = default;
 
     /**
@@ -112,11 +113,13 @@ public:
     /**
      * @brief Creates a new element
      * @param NewId The Id of the new created element
-     * @param rNodes The array containing nodes
+     * @param ThisNodes The array containing nodes
      * @param pProperties The pointer to property
      * @return The pointer to the created element
      */
-    Element::Pointer Create(IndexType NewId, const NodesArrayType& rNodes, PropertiesType::Pointer pProperties) const override;
+    Element::Pointer Create(IndexType               NewId,
+                            NodesArrayType const&   ThisNodes,
+                            PropertiesType::Pointer pProperties) const override;
 
     /**
      * @brief Calculate a double Variable on the Element Constitutive Law

--- a/applications/GeoMechanicsApplication/custom_elements/updated_lagrangian_U_Pw_diff_order_element.hpp
+++ b/applications/GeoMechanicsApplication/custom_elements/updated_lagrangian_U_Pw_diff_order_element.hpp
@@ -113,13 +113,11 @@ public:
     /**
      * @brief Creates a new element
      * @param NewId The Id of the new created element
-     * @param ThisNodes The array containing nodes
+     * @param rNodes The array containing nodes
      * @param pProperties The pointer to property
      * @return The pointer to the created element
      */
-    Element::Pointer Create(IndexType               NewId,
-                            NodesArrayType const&   ThisNodes,
-                            PropertiesType::Pointer pProperties) const override;
+    Element::Pointer Create(IndexType NewId, const NodesArrayType& rNodes, PropertiesType::Pointer pProperties) const override;
 
     /**
      * @brief Calculate a double Variable on the Element Constitutive Law

--- a/applications/GeoMechanicsApplication/custom_elements/updated_lagrangian_U_Pw_diff_order_element.hpp
+++ b/applications/GeoMechanicsApplication/custom_elements/updated_lagrangian_U_Pw_diff_order_element.hpp
@@ -98,7 +98,6 @@ public:
     {
     }
 
-    /// Destructor
     ~UpdatedLagrangianUPwDiffOrderElement() override = default;
 
     /**

--- a/applications/GeoMechanicsApplication/custom_elements/updated_lagrangian_U_Pw_diff_order_element.hpp
+++ b/applications/GeoMechanicsApplication/custom_elements/updated_lagrangian_U_Pw_diff_order_element.hpp
@@ -13,10 +13,6 @@
 #if !defined(KRATOS_GEO_UPDATED_LAGRANGIAN_U_PW_DIFF_ORDER_ELEMENT_H_INCLUDED)
 #define KRATOS_GEO_UPDATED_LAGRANGIAN_U_PW_DIFF_ORDER_ELEMENT_H_INCLUDED
 
-// System includes
-
-// External includes
-
 // Project includes
 #include "custom_elements/small_strain_U_Pw_diff_order_element.hpp"
 #include "custom_utilities/element_utilities.hpp"

--- a/applications/GeoMechanicsApplication/custom_operations/activate_model_part_operation.h
+++ b/applications/GeoMechanicsApplication/custom_operations/activate_model_part_operation.h
@@ -80,7 +80,7 @@ public:
     ///@name Operations
     ///@{
 
-    Operation::Pointer Create(Model& rModel, Parameters ThisParameters) const override;
+    Operation::Pointer Create(Model& rModel, Parameters Settings) const override;
 
     void Execute() override;
 

--- a/applications/GeoMechanicsApplication/custom_operations/deactivate_model_part_operation.h
+++ b/applications/GeoMechanicsApplication/custom_operations/deactivate_model_part_operation.h
@@ -80,7 +80,7 @@ public:
     ///@name Operations
     ///@{
 
-    Operation::Pointer Create(Model& rModel, Parameters ThisParameters) const override;
+    Operation::Pointer Create(Model& rModel, Parameters Settings) const override;
 
     void Execute() override;
 

--- a/applications/GeoMechanicsApplication/custom_processes/apply_excavation_process.cpp
+++ b/applications/GeoMechanicsApplication/custom_processes/apply_excavation_process.cpp
@@ -22,10 +22,10 @@
 namespace Kratos
 {
 
-ApplyExcavationProcess::ApplyExcavationProcess(ModelPart& rModelPart, const Parameters& rSettings)
+ApplyExcavationProcess::ApplyExcavationProcess(ModelPart& rModelPart, const Parameters& rProcessSettings)
     : Process(Flags()),
       mrModelPart{rModelPart},
-      mDeactivateSoilPart{rSettings["deactivate_soil_part"].GetBool()}
+      mDeactivateSoilPart{rProcessSettings["deactivate_soil_part"].GetBool()}
 {
 }
 

--- a/applications/GeoMechanicsApplication/custom_processes/apply_excavation_process.cpp
+++ b/applications/GeoMechanicsApplication/custom_processes/apply_excavation_process.cpp
@@ -22,10 +22,10 @@
 namespace Kratos
 {
 
-ApplyExcavationProcess::ApplyExcavationProcess(ModelPart& rModelPart, const Parameters& rProcessSettings)
+ApplyExcavationProcess::ApplyExcavationProcess(ModelPart& rModelPart, const Parameters& rSettings)
     : Process(Flags()),
       mrModelPart{rModelPart},
-      mDeactivateSoilPart{rProcessSettings["deactivate_soil_part"].GetBool()}
+      mDeactivateSoilPart{rSettings["deactivate_soil_part"].GetBool()}
 {
 }
 

--- a/applications/GeoMechanicsApplication/custom_processes/apply_excavation_process.h
+++ b/applications/GeoMechanicsApplication/custom_processes/apply_excavation_process.h
@@ -24,7 +24,7 @@ class KRATOS_API(GEO_MECHANICS_APPLICATION) ApplyExcavationProcess : public Proc
 public:
     KRATOS_CLASS_POINTER_DEFINITION(ApplyExcavationProcess);
 
-    ApplyExcavationProcess(ModelPart& rModelPart, const Parameters& rSettings);
+    ApplyExcavationProcess(ModelPart& rModelPart, const Parameters& rProcessSettings);
 
     ~ApplyExcavationProcess() override;
 

--- a/applications/GeoMechanicsApplication/custom_processes/set_multiple_moving_loads.cpp
+++ b/applications/GeoMechanicsApplication/custom_processes/set_multiple_moving_loads.cpp
@@ -14,8 +14,8 @@
 
 namespace Kratos
 {
-SetMultipleMovingLoadsProcess::SetMultipleMovingLoadsProcess(ModelPart& rModelPart, const Parameters& rSettings)
-    : mrModelPart(rModelPart), mParameters(rSettings)
+SetMultipleMovingLoadsProcess::SetMultipleMovingLoadsProcess(ModelPart& rModelPart, const Parameters& rProcessSettings)
+    : mrModelPart(rModelPart), mParameters(rProcessSettings)
 {
     Parameters default_parameters(R"(
         {

--- a/applications/GeoMechanicsApplication/custom_processes/set_multiple_moving_loads.h
+++ b/applications/GeoMechanicsApplication/custom_processes/set_multiple_moving_loads.h
@@ -48,7 +48,7 @@ public:
     ///@name Life Cycle
     ///@{
 
-    SetMultipleMovingLoadsProcess(ModelPart& rModelPart, const Parameters& rSettings);
+    SetMultipleMovingLoadsProcess(ModelPart& rModelPart, const Parameters& rProcessSettings);
 
     SetMultipleMovingLoadsProcess(const SetMultipleMovingLoadsProcess&)            = delete;
     SetMultipleMovingLoadsProcess& operator=(const SetMultipleMovingLoadsProcess&) = delete;

--- a/applications/GeoMechanicsApplication/custom_processes/set_multiple_moving_loads.h
+++ b/applications/GeoMechanicsApplication/custom_processes/set_multiple_moving_loads.h
@@ -48,7 +48,7 @@ public:
     ///@name Life Cycle
     ///@{
 
-    SetMultipleMovingLoadsProcess(ModelPart& rModelPart, const Parameters& rParameters);
+    SetMultipleMovingLoadsProcess(ModelPart& rModelPart, const Parameters& rSettings);
 
     SetMultipleMovingLoadsProcess(const SetMultipleMovingLoadsProcess&)            = delete;
     SetMultipleMovingLoadsProcess& operator=(const SetMultipleMovingLoadsProcess&) = delete;

--- a/applications/GeoMechanicsApplication/custom_processes/set_parameter_field_process.hpp
+++ b/applications/GeoMechanicsApplication/custom_processes/set_parameter_field_process.hpp
@@ -59,7 +59,7 @@ public:
     ///@name Life Cycle
     ///@{
 
-    SetParameterFieldProcess(ModelPart& rModelPart, const Parameters& rParameters);
+    SetParameterFieldProcess(ModelPart& rModelPart, const Parameters& rSettings);
 
     ///@}
     ///@name Operations

--- a/applications/GeoMechanicsApplication/custom_strategies/builder_and_solvers/residualbased_block_builder_and_solver_with_mass_and_damping.h
+++ b/applications/GeoMechanicsApplication/custom_strategies/builder_and_solvers/residualbased_block_builder_and_solver_with_mass_and_damping.h
@@ -107,7 +107,7 @@ public:
     using ConditionsArrayType   = typename BaseType::ConditionsArrayType;
 
     /// Additional definitions
-    using EquationIdVectorType  = Element::EquationIdVectorType;
+    using EquationIdVectorType = Element::EquationIdVectorType;
 
     ///@}
     ///@name Life Cycle

--- a/applications/GeoMechanicsApplication/custom_workflows/dgeosettlement.h
+++ b/applications/GeoMechanicsApplication/custom_workflows/dgeosettlement.h
@@ -48,7 +48,7 @@ public:
     int RunStage(const std::filesystem::path&            rWorkingDirectory,
                  const std::filesystem::path&            rProjectParametersFile,
                  const std::function<void(const char*)>& rLogCallback,
-                 const std::function<void(double)>&      rReportProgress,
+                 const std::function<void(double)>&      rProgressDelegate,
                  const std::function<void(const char*)>& rReportTextualProgress,
                  const std::function<bool()>&            rShouldCancel);
 

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_strategies/test_newmark_dynamic_U_Pw_scheme.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_strategies/test_newmark_dynamic_U_Pw_scheme.cpp
@@ -34,7 +34,7 @@ public:
 
     NewmarkDynamicUPwScheme<SparseSpaceType, LocalSpaceType> CreateValidScheme() const
     {
-        return NewmarkDynamicUPwScheme<SparseSpaceType, LocalSpaceType>(0.25, 0.5, 0.75);
+        return {0.25, 0.5, 0.75};
     }
 
     void CreateValidModelPart(const bool Add3DDofs)


### PR DESCRIPTION
**📝 Description**
Fixed several (minor) issues detected by Clang-tidy.

**🆕 Changelog**
- Make sure that parameter names are declared consistently.
- Made an unused function parameter "unnamed".
- Applied the Kratos Style Guide to a few parameter names.
- Removed some redundant size checks.
- Avoid repeating the return type from the declaration; use a braced initializer list instead.
- Formatted the C++ code using Clang-format.