### PR TITLE
[GeoMechanicsApplication] Settlement workflow - Fix uninitialized value issue

### DIFF
--- a/applications/GeoMechanicsApplication/custom_processes/apply_component_table_process.cpp
+++ b/applications/GeoMechanicsApplication/custom_processes/apply_component_table_process.cpp
@@ -51,7 +51,9 @@ ApplyComponentTableProcess::ApplyComponentTableProcess(ModelPart& rModelPart, Pa
 
     unsigned int TableId = ProcessSettings["table"].GetInt();
     mpTable              = rModelPart.pGetTable(TableId);
-    mTimeUnitConverter   = rModelPart.GetProcessInfo()[TIME_UNIT_CONVERTER];
+    KRATOS_ERROR_IF_NOT(rModelPart.GetProcessInfo().Has(TIME_UNIT_CONVERTER))
+        << "TIME_UNIT_CONVERTER not found in ProcessInfo for the ApplyComponentTableProcess" << std::endl;
+    mTimeUnitConverter = rModelPart.GetProcessInfo()[TIME_UNIT_CONVERTER];
 
     KRATOS_CATCH("")
 }

--- a/applications/GeoMechanicsApplication/custom_workflows/dgeosettlement.cpp
+++ b/applications/GeoMechanicsApplication/custom_workflows/dgeosettlement.cpp
@@ -367,6 +367,8 @@ std::shared_ptr<StrategyWrapper> KratosGeoSettlement::MakeStrategyWrapper(const 
 void KratosGeoSettlement::PrepareModelPart(const Parameters& rSolverSettings)
 {
     auto& main_model_part = GetMainModelPart();
+    main_model_part.GetProcessInfo().SetValue(TIME_UNIT_CONVERTER, 1.0);
+
     if (!main_model_part.HasSubModelPart(mComputationalSubModelPartName)) {
         main_model_part.CreateSubModelPart(mComputationalSubModelPartName);
     }


### PR DESCRIPTION
**📝 Description**
This PR fixes an issue with the settlement workflow, when using a time-dependent (i.e. table) process. As seen [here](https://github.com/KratosMultiphysics/Kratos/blob/master/applications/GeoMechanicsApplication/custom_processes/apply_component_table_process.cpp#L54) and [here](https://github.com/KratosMultiphysics/Kratos/blob/master/applications/GeoMechanicsApplication/custom_processes/apply_component_table_process.cpp#L100) the `TIME_UNIT_CONVERTER` variable in the process info is used to apply a value to a certain variable. If it's not initialized, it's 0.0, or something random, leading to undefined behavior.

Similar to the [python workflow](https://github.com/KratosMultiphysics/Kratos/blob/master/applications/GeoMechanicsApplication/python_scripts/geomechanics_solver.py#L199-L205), it is now set to 1.0.