### PR TITLE
Fix typos in applications/ContactStructuralMechanicsApplication

### DIFF
--- a/applications/ContactStructuralMechanicsApplication/custom_conditions/ALM_frictional_mortar_contact_axisym_condition.h
+++ b/applications/ContactStructuralMechanicsApplication/custom_conditions/ALM_frictional_mortar_contact_axisym_condition.h
@@ -172,7 +172,7 @@ public:
     ///@{
 
     /**
-     * @brief Creates a new element pointer from an arry of nodes
+     * @brief Creates a new element pointer from an array of nodes
      * @param NewId The ID of the new element
      * @param rThisNodes The nodes of the new element
      * @param pProperties The properties assigned to the new element
@@ -214,7 +214,7 @@ public:
 
 
     /******************************************************************/
-    /********** AUXILLIARY METHODS FOR GENERAL CALCULATIONS ***********/
+    /********** AUXILIARY METHODS FOR GENERAL CALCULATIONS ************/
     /******************************************************************/
 
     /**

--- a/applications/ContactStructuralMechanicsApplication/custom_conditions/ALM_frictional_mortar_contact_condition.h
+++ b/applications/ContactStructuralMechanicsApplication/custom_conditions/ALM_frictional_mortar_contact_condition.h
@@ -219,7 +219,7 @@ public:
     void FinalizeSolutionStep(const ProcessInfo& rCurrentProcessInfo) override;
 
     /**
-     * @brief Creates a new element pointer from an arry of nodes
+     * @brief Creates a new element pointer from an array of nodes
      * @param NewId the ID of the new element
      * @param rThisNodes the nodes of the new element
      * @param pProperties the properties assigned to the new element
@@ -297,7 +297,7 @@ public:
         );
 
     /******************************************************************/
-    /********** AUXILLIARY METHODS FOR GENERAL CALCULATIONS ***********/
+    /********** AUXILIARY METHODS FOR GENERAL CALCULATIONS ************/
     /******************************************************************/
 
     /**
@@ -426,7 +426,7 @@ protected:
         ) override;
 
     /******************************************************************/
-    /********** AUXILLIARY METHODS FOR GENERAL CALCULATIONS ***********/
+    /********** AUXILIARY METHODS FOR GENERAL CALCULATIONS ************/
     /******************************************************************/
 
     /**

--- a/applications/ContactStructuralMechanicsApplication/custom_conditions/ALM_frictionless_components_mortar_contact_condition.h
+++ b/applications/ContactStructuralMechanicsApplication/custom_conditions/ALM_frictionless_components_mortar_contact_condition.h
@@ -189,7 +189,7 @@ public:
     ///@{
 
     /**
-     * @brief Creates a new element pointer from an arry of nodes
+     * @brief Creates a new element pointer from an array of nodes
      * @param NewId the ID of the new element
      * @param rThisNodes the nodes of the new element
      * @param pProperties the properties assigned to the new element
@@ -251,7 +251,7 @@ public:
         );
 
     /******************************************************************/
-    /********** AUXILLIARY METHODS FOR GENERAL CALCULATIONS ***********/
+    /********** AUXILIARY METHODS FOR GENERAL CALCULATIONS ************/
     /******************************************************************/
 
     /**
@@ -374,7 +374,7 @@ protected:
         ) override;
 
     /******************************************************************/
-    /********** AUXILLIARY METHODS FOR GENERAL CALCULATIONS ***********/
+    /********** AUXILIARY METHODS FOR GENERAL CALCULATIONS ************/
     /******************************************************************/
 
     /**

--- a/applications/ContactStructuralMechanicsApplication/custom_conditions/ALM_frictionless_mortar_contact_axisym_condition.h
+++ b/applications/ContactStructuralMechanicsApplication/custom_conditions/ALM_frictionless_mortar_contact_axisym_condition.h
@@ -173,7 +173,7 @@ public:
     ///@{
 
     /**
-     * @brief Creates a new element pointer from an arry of nodes
+     * @brief Creates a new element pointer from an array of nodes
      * @param NewId The ID of the new element
      * @param ThisNodes tThe nodes of the new element
      * @param pProperties The properties assigned to the new element
@@ -214,7 +214,7 @@ public:
         ) const override;
 
     /******************************************************************/
-    /********** AUXILLIARY METHODS FOR GENERAL CALCULATIONS ***********/
+    /********** AUXILIARY METHODS FOR GENERAL CALCULATIONS ************/
     /******************************************************************/
 
     /**

--- a/applications/ContactStructuralMechanicsApplication/custom_conditions/ALM_frictionless_mortar_contact_condition.h
+++ b/applications/ContactStructuralMechanicsApplication/custom_conditions/ALM_frictionless_mortar_contact_condition.h
@@ -189,7 +189,7 @@ public:
     ///@{
 
     /**
-     * @brief Creates a new element pointer from an arry of nodes
+     * @brief Creates a new element pointer from an array of nodes
      * @param NewId the ID of the new element
      * @param rThisNodes the nodes of the new element
      * @param pProperties the properties assigned to the new element
@@ -251,7 +251,7 @@ public:
         );
 
     /******************************************************************/
-    /********** AUXILLIARY METHODS FOR GENERAL CALCULATIONS ***********/
+    /********** AUXILIARY METHODS FOR GENERAL CALCULATIONS ************/
     /******************************************************************/
 
     /**
@@ -374,7 +374,7 @@ protected:
         ) override;
 
     /******************************************************************/
-    /********** AUXILLIARY METHODS FOR GENERAL CALCULATIONS ***********/
+    /********** AUXILIARY METHODS FOR GENERAL CALCULATIONS ************/
     /******************************************************************/
 
     /**

--- a/applications/ContactStructuralMechanicsApplication/custom_conditions/mesh_tying_mortar_condition.cpp
+++ b/applications/ContactStructuralMechanicsApplication/custom_conditions/mesh_tying_mortar_condition.cpp
@@ -405,7 +405,7 @@ bool MeshTyingMortarCondition<TDim,TNumNodes, TNumNodesMaster>::CalculateAe(
     const IntegrationMethod ThisIntegrationMethod
     )
 {
-    // We initilize the Ae components
+    // We initialize the Ae components
     AeData rAeData;
     rAeData.Initialize();
 
@@ -560,7 +560,7 @@ void MeshTyingMortarCondition<TDim,TNumNodes, TNumNodesMaster>::CalculateLocalLH
         }
     }
     
-    // Update intial index
+    // Update initial index
     initial_row_index = dof_size * TNumNodesMaster;
 
     // Iterate over the number of dofs on slave side

--- a/applications/ContactStructuralMechanicsApplication/custom_conditions/mesh_tying_mortar_condition.h
+++ b/applications/ContactStructuralMechanicsApplication/custom_conditions/mesh_tying_mortar_condition.h
@@ -232,7 +232,7 @@ public:
         ) override;
 
     /**
-     * @brief Creates a new element pointer from an arry of nodes
+     * @brief Creates a new element pointer from an array of nodes
      * @param NewId the ID of the new element
      * @param rThisNodes the nodes of the new element
      * @param pProperties the properties assigned to the new element
@@ -273,7 +273,7 @@ public:
         ) const override;
 
     /******************************************************************/
-    /********** AUXILLIARY METHODS FOR GENERAL CALCULATIONS ***********/
+    /********** AUXILIARY METHODS FOR GENERAL CALCULATIONS ************/
     /******************************************************************/
 
     /**
@@ -384,7 +384,7 @@ protected:
     ///@{
 
     /**
-     * This data will be used to compute teh derivatives
+     * This data will be used to compute the derivatives
      */
     struct DofData
     {
@@ -609,7 +609,7 @@ protected:
         );
 
     /***********************************************************************************/
-    /**************** AUXILLIARY METHODS FOR CONDITION LHS CONTRIBUTION ****************/
+    /**************** AUXILIARY METHODS FOR CONDITION LHS CONTRIBUTION *****************/
     /***********************************************************************************/
 
     /**
@@ -625,7 +625,7 @@ protected:
         );
 
     /******************************************************************/
-    /********** AUXILLIARY METHODS FOR GENERAL CALCULATIONS ***********/
+    /********** AUXILIARY METHODS FOR GENERAL CALCULATIONS ************/
     /******************************************************************/
 
     /**

--- a/applications/ContactStructuralMechanicsApplication/custom_conditions/mortar_contact_condition.h
+++ b/applications/ContactStructuralMechanicsApplication/custom_conditions/mortar_contact_condition.h
@@ -264,7 +264,7 @@ public:
         ) override;
 
     /**
-     * @brief Creates a new element pointer from an arry of nodes
+     * @brief Creates a new element pointer from an array of nodes
      * @param NewId the ID of the new element
      * @param rThisNodes the nodes of the new element
      * @param pProperties the properties assigned to the new element
@@ -342,7 +342,7 @@ public:
         ) override;
 
     /******************************************************************/
-    /********** AUXILLIARY METHODS FOR GENERAL CALCULATIONS ***********/
+    /********** AUXILIARY METHODS FOR GENERAL CALCULATIONS ************/
     /******************************************************************/
 
     /**
@@ -552,7 +552,7 @@ protected:
         );
 
     /******************************************************************/
-    /********** AUXILLIARY METHODS FOR GENERAL CALCULATIONS ***********/
+    /********** AUXILIARY METHODS FOR GENERAL CALCULATIONS ************/
     /******************************************************************/
 
     /**

--- a/applications/ContactStructuralMechanicsApplication/custom_conditions/mpc_mortar_contact_condition.h
+++ b/applications/ContactStructuralMechanicsApplication/custom_conditions/mpc_mortar_contact_condition.h
@@ -191,7 +191,7 @@ public:
     ///@{
 
     /**
-     * @brief Creates a new element pointer from an arry of nodes
+     * @brief Creates a new element pointer from an array of nodes
      * @param NewId the ID of the new element
      * @param rThisNodes the nodes of the new element
      * @param pProperties the properties assigned to the new element
@@ -310,7 +310,7 @@ public:
     void AddExplicitContribution(const ProcessInfo& rCurrentProcessInfo) override;
 
     /******************************************************************/
-    /********** AUXILLIARY METHODS FOR GENERAL CALCULATIONS ***********/
+    /********** AUXILIARY METHODS FOR GENERAL CALCULATIONS ************/
     /******************************************************************/
 
     /**

--- a/applications/ContactStructuralMechanicsApplication/custom_conditions/paired_condition.h
+++ b/applications/ContactStructuralMechanicsApplication/custom_conditions/paired_condition.h
@@ -45,7 +45,7 @@ namespace Kratos
  * @ingroup ContactStructuralMechanicsApplication
  * @class PairedCondition
  * @brief This is a base class for the conditions paired
- * @details This is a base class for the conditions paired, it is basically equal to the base condition, with a pointer to the paired geoemtry
+ * @details This is a base class for the conditions paired, it is basically equal to the base condition, with a pointer to the paired geometry
  * @author Vicente Mataix Ferrandiz
  */
 class KRATOS_API(CONTACT_STRUCTURAL_MECHANICS_APPLICATION) PairedCondition
@@ -160,7 +160,7 @@ public:
     void InitializeNonLinearIteration(const ProcessInfo& rCurrentProcessInfo) override;
 
     /**
-     * @brief Creates a new element pointer from an arry of nodes
+     * @brief Creates a new element pointer from an array of nodes
      * @param NewId the ID of the new element
      * @param rThisNodes the nodes of the new element
      * @param pProperties the properties assigned to the new element

--- a/applications/ContactStructuralMechanicsApplication/custom_conditions/penalty_frictional_mortar_contact_axisym_condition.h
+++ b/applications/ContactStructuralMechanicsApplication/custom_conditions/penalty_frictional_mortar_contact_axisym_condition.h
@@ -173,7 +173,7 @@ public:
     ///@{
 
     /**
-     * @brief Creates a new element pointer from an arry of nodes
+     * @brief Creates a new element pointer from an array of nodes
      * @param NewId The ID of the new element
      * @param rThisNodes The nodes of the new element
      * @param pProperties The properties assigned to the new element
@@ -214,7 +214,7 @@ public:
         ) const override;
 
     /******************************************************************/
-    /********** AUXILLIARY METHODS FOR GENERAL CALCULATIONS ***********/
+    /********** AUXILIARY METHODS FOR GENERAL CALCULATIONS ************/
     /******************************************************************/
 
     /**

--- a/applications/ContactStructuralMechanicsApplication/custom_conditions/penalty_frictional_mortar_contact_condition.h
+++ b/applications/ContactStructuralMechanicsApplication/custom_conditions/penalty_frictional_mortar_contact_condition.h
@@ -220,7 +220,7 @@ public:
     void FinalizeSolutionStep(const ProcessInfo& rCurrentProcessInfo) override;
 
     /**
-     * @brief Creates a new element pointer from an arry of nodes
+     * @brief Creates a new element pointer from an array of nodes
      * @param NewId the ID of the new element
      * @param rThisNodes the nodes of the new element
      * @param pProperties the properties assigned to the new element
@@ -329,7 +329,7 @@ public:
         );
 
     /******************************************************************/
-    /********** AUXILLIARY METHODS FOR GENERAL CALCULATIONS ***********/
+    /********** AUXILIARY METHODS FOR GENERAL CALCULATIONS ************/
     /******************************************************************/
 
     /**
@@ -460,7 +460,7 @@ protected:
         ) override;
 
     /******************************************************************/
-    /********** AUXILLIARY METHODS FOR GENERAL CALCULATIONS ***********/
+    /********** AUXILIARY METHODS FOR GENERAL CALCULATIONS ************/
     /******************************************************************/
 
     /**

--- a/applications/ContactStructuralMechanicsApplication/custom_conditions/penalty_frictionless_mortar_contact_axisym_condition.h
+++ b/applications/ContactStructuralMechanicsApplication/custom_conditions/penalty_frictionless_mortar_contact_axisym_condition.h
@@ -173,7 +173,7 @@ public:
     ///@{
 
     /**
-     * @brief Creates a new element pointer from an arry of nodes
+     * @brief Creates a new element pointer from an array of nodes
      * @param NewId The ID of the new element
      * @param ThisNodes tThe nodes of the new element
      * @param pProperties The properties assigned to the new element
@@ -214,7 +214,7 @@ public:
         ) const override;
 
     /******************************************************************/
-    /********** AUXILLIARY METHODS FOR GENERAL CALCULATIONS ***********/
+    /********** AUXILIARY METHODS FOR GENERAL CALCULATIONS ************/
     /******************************************************************/
 
     /**

--- a/applications/ContactStructuralMechanicsApplication/custom_conditions/penalty_frictionless_mortar_contact_condition.h
+++ b/applications/ContactStructuralMechanicsApplication/custom_conditions/penalty_frictionless_mortar_contact_condition.h
@@ -200,7 +200,7 @@ public:
     ///@{
 
     /**
-     * @brief Creates a new element pointer from an arry of nodes
+     * @brief Creates a new element pointer from an array of nodes
      * @param NewId the ID of the new element
      * @param rThisNodes the nodes of the new element
      * @param pProperties the properties assigned to the new element
@@ -305,7 +305,7 @@ public:
         );
 
     /******************************************************************/
-    /********** AUXILLIARY METHODS FOR GENERAL CALCULATIONS ***********/
+    /********** AUXILIARY METHODS FOR GENERAL CALCULATIONS ************/
     /******************************************************************/
 
     /**
@@ -428,7 +428,7 @@ protected:
         ) override;
 
     /******************************************************************/
-    /********** AUXILLIARY METHODS FOR GENERAL CALCULATIONS ***********/
+    /********** AUXILIARY METHODS FOR GENERAL CALCULATIONS ************/
     /******************************************************************/
 
     /**

--- a/applications/ContactStructuralMechanicsApplication/custom_linear_solvers/mixedulm_linear_solver.h
+++ b/applications/ContactStructuralMechanicsApplication/custom_linear_solvers/mixedulm_linear_solver.h
@@ -179,7 +179,7 @@ public:
     {
         KRATOS_TRY
 
-        // Now validate agains defaults -- this also ensures no type mismatch
+        // Now validate against defaults -- this also ensures no type mismatch
         Parameters default_parameters = GetDefaultParameters();
         ThisParameters.ValidateAndAssignDefaults(default_parameters);
 
@@ -264,7 +264,7 @@ public:
             mpSolverDispBlock->Initialize(mKDispModified, mDisp, mResidualDisp);
             mOptions.Set(IS_INITIALIZED, true);
         } else
-            KRATOS_DETAIL("MixedULM Initialize") << "Linear solver intialization is deferred to the moment at which blocks are available" << std::endl;
+            KRATOS_DETAIL("MixedULM Initialize") << "Linear solver initialization is deferred to the moment at which blocks are available" << std::endl;
     }
 
     /**

--- a/applications/ContactStructuralMechanicsApplication/custom_master_slave_constraints/contact_master_slave_constraint.h
+++ b/applications/ContactStructuralMechanicsApplication/custom_master_slave_constraints/contact_master_slave_constraint.h
@@ -202,7 +202,7 @@ public:
 
     /**
      * @brief Returns the string containing a detailed description of this object.
-     * @return the string with informations
+     * @return the string with information
      */
     std::string GetInfo() const override;
 

--- a/applications/ContactStructuralMechanicsApplication/custom_processes/advanced_contact_search_process.h
+++ b/applications/ContactStructuralMechanicsApplication/custom_processes/advanced_contact_search_process.h
@@ -46,7 +46,7 @@ namespace Kratos
 /**
  * @class AdvancedContactSearchProcess
  * @ingroup ContactStructuralMechanicsApplication
- * @brief This utilitiy has as objective to create the contact conditions.
+ * @brief This utility has as objective to create the contact conditions.
  * @details The conditions that can be created are Mortar conditions (or segment to segment) conditions: The created conditions will be between two segments
  * The utility employs the projection.h from MeshingApplication, which works internally using a kd-tree
  * @author Vicente Mataix Ferrandiz

--- a/applications/ContactStructuralMechanicsApplication/custom_processes/alm_variables_calculation_process.h
+++ b/applications/ContactStructuralMechanicsApplication/custom_processes/alm_variables_calculation_process.h
@@ -185,7 +185,7 @@ private:
     ///@{
 
     ModelPart& mrThisModelPart;              /// The main model part
-    Variable<double>& mrNodalLengthVariable; /// The variable used to messure the lenght of the element
+    Variable<double>& mrNodalLengthVariable; /// The variable used to messure the length of the element
     double mFactorStiffness;                 /// The proportion between stiffness and penalty/scale factor
     double mPenaltyScale;                    /// The penalty/scale factor proportion
     bool mComputeScaleFactor;                /// If compute the scale factor

--- a/applications/ContactStructuralMechanicsApplication/custom_processes/base_contact_search_process.cpp
+++ b/applications/ContactStructuralMechanicsApplication/custom_processes/base_contact_search_process.cpp
@@ -69,7 +69,7 @@ BaseContactSearchProcess<TDim, TNumNodes, TNumNodesMaster>::BaseContactSearchPro
     this->Set(BaseContactSearchProcess::PREDEFINE_MASTER_SLAVE, mThisParameters["predefined_master_slave"].GetBool());
     this->Set(BaseContactSearchProcess::PURE_SLIP, mThisParameters["pure_slip"].GetBool());
 
-    // If we are going to consider multple searchs
+    // If we are going to consider multple searches
     const std::string& id_name = mThisParameters["id_name"].GetString();
     const bool multiple_searchs = id_name == "" ? false : true;
     this->Set(BaseContactSearchProcess::MULTIPLE_SEARCHS, multiple_searchs);

--- a/applications/ContactStructuralMechanicsApplication/custom_processes/base_contact_search_process.h
+++ b/applications/ContactStructuralMechanicsApplication/custom_processes/base_contact_search_process.h
@@ -412,14 +412,14 @@ protected:
     bool IsNotPureSlip();
 
     /**
-     * @brief This returns if we consider multiple searchs
-     * @return True if we consider multiple searchs
+     * @brief This returns if we consider multiple searches
+     * @return True if we consider multiple searches
      */
     bool IsMultipleSearchs();
 
     /**
-     * @brief This returns if we do not consider multiple searchs
-     * @return True if we do not consider multiple searchs
+     * @brief This returns if we do not consider multiple searches
+     * @return True if we do not consider multiple searches
      */
     bool IsNotMultipleSearchs();
 
@@ -462,7 +462,7 @@ private:
     ///@{
 
     /**
-     * @brief This auxiliary method performs the seach using a KDTree
+     * @brief This auxiliary method performs the search using a KDTree
      * @param rSubContactModelPart The submodel part studied
      * @param rSubComputingContactModelPart The computing contact submodel part
      */
@@ -472,7 +472,7 @@ private:
         );
 
     /**
-     * @brief This auxiliary method performs the seach using a Octree
+     * @brief This auxiliary method performs the search using a Octree
      * @param rSubContactModelPart The submodel part studied
      * @param rSubComputingContactModelPart The computing contact submodel part
      */

--- a/applications/ContactStructuralMechanicsApplication/custom_processes/mpc_contact_search_process.cpp
+++ b/applications/ContactStructuralMechanicsApplication/custom_processes/mpc_contact_search_process.cpp
@@ -29,7 +29,7 @@ MPCContactSearchProcess<TDim, TNumNodes, TNumNodesMaster>::MPCContactSearchProce
     Properties::Pointer pPairedProperties
     ) : BaseType(rMainModelPart, ThisParameters, pPairedProperties)
 {
-    // If we are going to consider multple searchs
+    // If we are going to consider multple searches
     const std::string& id_name = BaseType::mThisParameters["id_name"].GetString();
 
     // We get the contact model part

--- a/applications/ContactStructuralMechanicsApplication/custom_processes/mpc_contact_search_process.h
+++ b/applications/ContactStructuralMechanicsApplication/custom_processes/mpc_contact_search_process.h
@@ -43,7 +43,7 @@ namespace Kratos
 /**
  * @class MPCContactSearchProcess
  * @ingroup ContactStructuralMechanicsApplication
- * @brief This utilitiy has as objective to create the contact constraints
+ * @brief This utility has as objective to create the contact constraints
  * @details It uses a KDtree for performing the search
  * @author Vicente Mataix Ferrandiz
  * @tparam TDim The dimension of work

--- a/applications/ContactStructuralMechanicsApplication/custom_processes/simple_contact_search_process.h
+++ b/applications/ContactStructuralMechanicsApplication/custom_processes/simple_contact_search_process.h
@@ -46,7 +46,7 @@ namespace Kratos
 /**
  * @class SimpleContactSearchProcess
  * @ingroup ContactStructuralMechanicsApplication
- * @brief This utilitiy has as objective to create the contact conditions.
+ * @brief This utility has as objective to create the contact conditions.
  * @details The conditions that can be created are Mortar conditions (or segment to segment) conditions: The created conditions will be between two segments
  * The utility employs the projection.h from MeshingApplication, which works internally using a kd-tree
  * @author Vicente Mataix Ferrandiz

--- a/applications/ContactStructuralMechanicsApplication/custom_strategies/custom_builder_and_solvers/contact_residualbased_block_builder_and_solver.h
+++ b/applications/ContactStructuralMechanicsApplication/custom_strategies/custom_builder_and_solvers/contact_residualbased_block_builder_and_solver.h
@@ -47,7 +47,7 @@ namespace Kratos
  * @ingroup ContactStructuralMechanicsApplication
  * @brief Current class provides an implementation for contact builder and solving operations.
  * @details The RHS is constituted by the unbalanced loads (residual). Degrees of freedom are reordered putting the restrained degrees of freedom at the end of the system ordered in reverse order with respect to the DofSet. Imposition of the dirichlet conditions is naturally dealt with as the residual already contains
-this information. Calculation of the reactions involves a cost very similiar to the calculation of the total residual
+this information. Calculation of the reactions involves a cost very similar to the calculation of the total residual
  * @author Vicente Mataix Ferrandiz
  * @tparam TSparseSpace The sparse matrix system considered
  * @tparam TDenseSpace The dense matrix system

--- a/applications/ContactStructuralMechanicsApplication/custom_strategies/custom_builder_and_solvers/contact_residualbased_elimination_builder_and_solver.h
+++ b/applications/ContactStructuralMechanicsApplication/custom_strategies/custom_builder_and_solvers/contact_residualbased_elimination_builder_and_solver.h
@@ -48,7 +48,7 @@ namespace Kratos
  * @class ContactResidualBasedEliminationBuilderAndSolver
  * @ingroup ContactStructuralMechanicsApplication
  * @brief Current class provides an implementation for contact builder and solving operations. (elimination)
- * @details The RHS is constituted by the unbalanced loads (residual). Degrees of freedom are reordered putting the restrained degrees of freedom at the end of the system ordered in reverse order with respect to the DofSet and not considered the inactive ones. Imposition of the dirichlet conditions is naturally dealt with as the residual already contains this information. Calculation of the reactions involves a cost very similiar to the calculation of the total residual
+ * @details The RHS is constituted by the unbalanced loads (residual). Degrees of freedom are reordered putting the restrained degrees of freedom at the end of the system ordered in reverse order with respect to the DofSet and not considered the inactive ones. Imposition of the dirichlet conditions is naturally dealt with as the residual already contains this information. Calculation of the reactions involves a cost very similar to the calculation of the total residual
  * @author Vicente Mataix Ferrandiz
  * @tparam TSparseSpace The sparse matrix system considered
  * @tparam TDenseSpace The dense matrix system

--- a/applications/ContactStructuralMechanicsApplication/custom_strategies/custom_builder_and_solvers/contact_residualbased_elimination_builder_and_solver_with_constraints.h
+++ b/applications/ContactStructuralMechanicsApplication/custom_strategies/custom_builder_and_solvers/contact_residualbased_elimination_builder_and_solver_with_constraints.h
@@ -48,7 +48,7 @@ namespace Kratos
  * @class ContactResidualBasedEliminationBuilderAndSolverWithConstraints
  * @ingroup ContactStructuralMechanicsApplication
  * @brief Current class provides an implementation for contact builder and solving operations. (elimination)
- * @details The RHS is constituted by the unbalanced loads (residual). Degrees of freedom are reordered putting the restrained degrees of freedom at the end of the system ordered in reverse order with respect to the DofSet and not considered the inactive ones. Imposition of the dirichlet conditions is naturally dealt with as the residual already contains this information. Calculation of the reactions involves a cost very similiar to the calculation of the total residual
+ * @details The RHS is constituted by the unbalanced loads (residual). Degrees of freedom are reordered putting the restrained degrees of freedom at the end of the system ordered in reverse order with respect to the DofSet and not considered the inactive ones. Imposition of the dirichlet conditions is naturally dealt with as the residual already contains this information. Calculation of the reactions involves a cost very similar to the calculation of the total residual
  * @author Vicente Mataix Ferrandiz
  * @tparam TSparseSpace The sparse matrix system considered
  * @tparam TDenseSpace The dense matrix system
@@ -195,7 +195,7 @@ public:
     /**
      * @brief Builds the list of the DofSets involved in the problem by "asking" to each element
      * and condition its Dofs.
-     * @details The list of dofs is stores insde the BuilderAndSolver as it is closely connected to the
+     * @details The list of dofs is stores inside the BuilderAndSolver as it is closely connected to the
      * way the matrix and RHS are built
      * @param pScheme The integration scheme considered
      * @param rModelPart The model part of the problem to solve
@@ -269,7 +269,7 @@ protected:
 
     /**
      * @brief Builds the list of the DofSets involved in the problem by "asking" to each element and condition its Dofs.
-     * @details Equivalent to the ResidualBasedEliminationBuilderAndSolver but with constraints. The list of dofs is stores insde the BuilderAndSolver as it is closely connected to the way the matrix and RHS are built
+     * @details Equivalent to the ResidualBasedEliminationBuilderAndSolver but with constraints. The list of dofs is stores inside the BuilderAndSolver as it is closely connected to the way the matrix and RHS are built
      * @param pScheme The integration scheme considered
      * @param rModelPart The model part of the problem to solve
      */

--- a/applications/ContactStructuralMechanicsApplication/custom_strategies/custom_strategies/residualbased_newton_raphson_contact_strategy.h
+++ b/applications/ContactStructuralMechanicsApplication/custom_strategies/custom_strategies/residualbased_newton_raphson_contact_strategy.h
@@ -628,7 +628,7 @@ protected:
         TSystemVectorType& rDx = *BaseType::mpDx;
         TSystemVectorType& rb = *BaseType::mpb;
 
-        // Initializing the parameters of the Newton-Raphson cicle
+        // Initializing the parameters of the Newton-Raphson cycle
         IndexType iteration_number = 1;
         r_process_info[NL_ITERATION_NUMBER] = iteration_number;
 
@@ -692,7 +692,7 @@ protected:
             is_converged = BaseType::mpConvergenceCriteria->PostCriteria(r_model_part, r_dof_set, rA, rDx, rb);
         }
 
-        // Iteration Cicle... performed only for NonLinearProblems
+        // Iteration Cycle... performed only for NonLinearProblems
         while (is_converged == false && iteration_number++<BaseType::mMaxIterationNumber) {
             //setting the number of iteration
             r_process_info[NL_ITERATION_NUMBER] = iteration_number;

--- a/applications/ContactStructuralMechanicsApplication/custom_utilities/derivatives_utilities.cpp
+++ b/applications/ContactStructuralMechanicsApplication/custom_utilities/derivatives_utilities.cpp
@@ -924,7 +924,7 @@ bool DerivativesUtilities<TDim, TNumNodes, TFrictional, TNormalVariation, TNumNo
 {
     KRATOS_TRY
 
-    // We initilize the Ae components
+    // We initialize the Ae components
     AeData ae_data;
     ae_data.Initialize();
 

--- a/applications/ContactStructuralMechanicsApplication/custom_utilities/interface_preprocess.h
+++ b/applications/ContactStructuralMechanicsApplication/custom_utilities/interface_preprocess.h
@@ -174,7 +174,7 @@ private:
         );
 
     /**
-     * @brief Creates a new properties (contaning just values related with contact)
+     * @brief Creates a new properties (containing just values related with contact)
      * @details These values are removed from the original property (in order to reduce overload of properties on the original elements)
      * @return A map containing new properties
      */

--- a/applications/ContactStructuralMechanicsApplication/custom_utilities/mortar_explicit_contribution_utilities.cpp
+++ b/applications/ContactStructuralMechanicsApplication/custom_utilities/mortar_explicit_contribution_utilities.cpp
@@ -508,7 +508,7 @@ bool MortarExplicitContributionUtilities<TDim,TNumNodes,TFrictional, TNormalVari
     // Initialize general variables for the current master element
     rVariables.Initialize();
 
-    // We initilize the Ae components
+    // We initialize the Ae components
     AeData Ae_data;
     Ae_data.Initialize();
 

--- a/applications/ContactStructuralMechanicsApplication/custom_utilities/self_contact_utilities.cpp
+++ b/applications/ContactStructuralMechanicsApplication/custom_utilities/self_contact_utilities.cpp
@@ -139,7 +139,7 @@ void ComputeSelfContactPairing(
 
     // First loop over the conditions to check the pairs
     for(auto& p_cond : ordered_conditions) {
-        // The slave geoemtry
+        // The slave geometry
         auto& r_slave_geometry = p_cond->GetGeometry();
 
         // Checking if already set

--- a/applications/ContactStructuralMechanicsApplication/python_scripts/adaptative_remeshing_contact_structural_mechanics_analysis.py
+++ b/applications/ContactStructuralMechanicsApplication/python_scripts/adaptative_remeshing_contact_structural_mechanics_analysis.py
@@ -204,7 +204,7 @@ class AdaptativeRemeshingContactStructuralMechanicsAnalysis(BaseClass):
             else: # Processes are given in the new format
                 for process_name in processes_block_names:
                     if (self.project_parameters.Has(process_name) is True):
-                        raise Exception("Mixing of process initialization is not alowed!")
+                        raise Exception("Mixing of process initialization is not allowed!")
         elif parameter_name == "output_processes":
             pass # Already added
         else:

--- a/applications/ContactStructuralMechanicsApplication/python_scripts/alm_contact_process.py
+++ b/applications/ContactStructuralMechanicsApplication/python_scripts/alm_contact_process.py
@@ -493,6 +493,6 @@ class ALMContactProcess(search_base_process.SearchBaseProcess):
                     if self.slip_step_reset_counter >= self.slip_step_reset_frequency:
                         KM.VariableUtils().SetFlag(KM.SLIP, False, self._get_process_model_part().Nodes)
                         self.slip_step_reset_counter = 0
-                else: # If zero never reseted, if negative will consider the direction of the WEIGHTED_SLIP
+                else: # If zero never reset, if negative will consider the direction of the WEIGHTED_SLIP
                     if self.slip_step_reset_frequency < 0: # Update using the slip direction directly (a la PureSlip style)
                         KM.MortarUtilities.ComputeNodesTangentModelPart(self._get_process_model_part(), CSMA.WEIGHTED_SLIP, 1.0, True)

--- a/applications/ContactStructuralMechanicsApplication/python_scripts/contact_remesh_mmg_process.py
+++ b/applications/ContactStructuralMechanicsApplication/python_scripts/contact_remesh_mmg_process.py
@@ -401,7 +401,7 @@ class ContactRemeshMmgProcess(MmgProcess):
         KratosMultiphysics.FastTransferBetweenModelPartsProcess(self.main_model_part, self.main_model_part.GetParentModelPart()).Execute()
 
     def _GenerateErrorProcess(self):
-        """ This method creates an erro process to compute the metric
+        """ This method creates an error process to compute the metric
 
         Keyword arguments:
         self -- It signifies an instance of a class.

--- a/applications/ContactStructuralMechanicsApplication/python_scripts/replace_properties_process.py
+++ b/applications/ContactStructuralMechanicsApplication/python_scripts/replace_properties_process.py
@@ -78,7 +78,7 @@ class ReplacePropertiesProcess(KratosMultiphysics.Process):
                 material_settings["Parameters"]["materials_filename"].SetString(self.materials_filename)
                 KratosMultiphysics.ReadMaterialsUtility(material_settings, self.model)
 
-                # Reinitilize elements and conditions
+                # Reinitialize elements and conditions
                 if self.reinitialize_entities:
                     for elem in self.model_part.Elements:
                         elem.Initialize(process_info)

--- a/applications/ContactStructuralMechanicsApplication/symbolic_generation/ALM_frictionless_components_mortar_condition/alm_frictionlesscomponents_mortar_contact_condition.tex
+++ b/applications/ContactStructuralMechanicsApplication/symbolic_generation/ALM_frictionless_components_mortar_condition/alm_frictionlesscomponents_mortar_contact_condition.tex
@@ -177,9 +177,9 @@ Where $g_n$ is the continuous normal gap, that can be defined as \eqref{eq:eqgap
  \end{align}
 \end{subequations}
 
-Herein, the kinetic contribution $\delta \mathcal{W}_{kin}$ , the internal and external contributions $\delta \mathcal{W}_{int,ext}$ and the unilateral contact contribution $\delta\mathcal{W}_{co}$ to the overall virtual work on the two subdomains, as well as the weak form of the unilateral contact constraint $\delta\mathcal{W}_{\lambda}($, have been abbreviated as \eqref{eq:constributions}.
+Herein, the kinetic contribution $\delta \mathcal{W}_{kin}$ , the internal and external contributions $\delta \mathcal{W}_{int,ext}$ and the unilateral contact contribution $\delta\mathcal{W}_{co}$ to the overall virtual work on the two subdomains, as well as the weak form of the unilateral contact constraint $\delta\mathcal{W}_{\lambda}($, have been abbreviated as \eqref{eq:contributions}.
 
-\begin{subequations}\label{eq:constributions}
+\begin{subequations}\label{eq:contributions}
  \begin{align}
   & -\delta \mathcal{W}_{kin} = \sum_{i = 1}^2 \left[\int_{\Omega_0^{(i)}} \rho_0^{(i)} \ddot{\mathbf{u}}^{(i)} \cdot \delta \mathbf{u}^{(i)} \text{d}V\right] \label{eq:subeq10} \\
  & -\delta \mathcal{W}_{int,ext} = \sum_{i = 1}^2 \left[\int_{\Omega_0^{(i)}} \left(\mathbf{S}^{(i)} : \delta \mathbf{E}^{(i)} - \hat{\mathbf{b}}\cdot \delta\mathbf{u}^{(i)} \right) \text{d}V - \int_{\Gamma_\sigma^{(i)}} \hat{\mathbf{t}}_0^{(i)}\cdot\delta\mathbf{u}^{(i)} \text{d}A \right] \label{eq:subeq11} \\

--- a/applications/ContactStructuralMechanicsApplication/symbolic_generation/ALM_frictionless_mortar_condition/alm_frictionless_mortar_contact_condition.tex
+++ b/applications/ContactStructuralMechanicsApplication/symbolic_generation/ALM_frictionless_mortar_condition/alm_frictionless_mortar_contact_condition.tex
@@ -177,9 +177,9 @@ Where $g_n$ is the continuous normal gap, that can be defined as \eqref{eq:eqgap
  \end{align}
 \end{subequations}
 
-Herein, the kinetic contribution $\delta \mathcal{W}_{kin}$ , the internal and external contributions $\delta \mathcal{W}_{int,ext}$ and the unilateral contact contribution $\delta\mathcal{W}_{co}$ to the overall virtual work on the two subdomains, as well as the weak form of the unilateral contact constraint $\delta\mathcal{W}_{\lambda}($, have been abbreviated as \eqref{eq:constributions}.
+Herein, the kinetic contribution $\delta \mathcal{W}_{kin}$ , the internal and external contributions $\delta \mathcal{W}_{int,ext}$ and the unilateral contact contribution $\delta\mathcal{W}_{co}$ to the overall virtual work on the two subdomains, as well as the weak form of the unilateral contact constraint $\delta\mathcal{W}_{\lambda}($, have been abbreviated as \eqref{eq:contributions}.
 
-\begin{subequations}\label{eq:constributions}
+\begin{subequations}\label{eq:contributions}
  \begin{align}
   & -\delta \mathcal{W}_{kin} = \sum_{i = 1}^2 \left[\int_{\Omega_0^{(i)}} \rho_0^{(i)} \ddot{\mathbf{u}}^{(i)} \cdot \delta \mathbf{u}^{(i)} \text{d}V\right] \label{eq:subeq10} \\
  & -\delta \mathcal{W}_{int,ext} = \sum_{i = 1}^2 \left[\int_{\Omega_0^{(i)}} \left(\mathbf{S}^{(i)} : \delta \mathbf{E}^{(i)} - \hat{\mathbf{b}}\cdot \delta\mathbf{u}^{(i)} \right) \text{d}V - \int_{\Gamma_\sigma^{(i)}} \hat{\mathbf{t}}_0^{(i)}\cdot\delta\mathbf{u}^{(i)} \text{d}A \right] \label{eq:subeq11} \\

--- a/applications/ContactStructuralMechanicsApplication/symbolic_generation/mesh_tying_mortar_condition/mesh_tying_mortar_condition.tex
+++ b/applications/ContactStructuralMechanicsApplication/symbolic_generation/mesh_tying_mortar_condition/mesh_tying_mortar_condition.tex
@@ -129,9 +129,9 @@ Based on these considerations, a saddle point type weak formulation is derived n
  \end{align}
 \end{subequations}
 
-Herein, the kinetic contribution $\delta \mathcal{W}_{kin}$ , the internal and external contributions $\delta \mathcal{W}_{int,ext}$ and the mesh tying interface contribution $\delta\mathcal{W}_{mnt}$ to the overall virtual work on the two subdomains, as well as the weak form of the mesh tying constraint $\delta\mathcal{W}_{\lambda}($, have been abbreviated as \eqref{eq:constributions}.
+Herein, the kinetic contribution $\delta \mathcal{W}_{kin}$ , the internal and external contributions $\delta \mathcal{W}_{int,ext}$ and the mesh tying interface contribution $\delta\mathcal{W}_{mnt}$ to the overall virtual work on the two subdomains, as well as the weak form of the mesh tying constraint $\delta\mathcal{W}_{\lambda}($, have been abbreviated as \eqref{eq:contributions}.
 
-\begin{subequations}\label{eq:constributions}
+\begin{subequations}\label{eq:contributions}
  \begin{align}
   & -\delta \mathcal{W}_{kin} = \sum_{i = 1}^2 \left[\int_{\Omega_0^{(i)}} \rho_0^{(i)} \ddot{\mathbf{u}}^{(i)} \cdot \delta \mathbf{u}^{(i)} \text{d}V_0\right] \label{eq:subeq10} \\
  & -\delta \mathcal{W}_{int,ext} = \sum_{i = 1}^2 \left[\int_{\Omega_0^{(i)}} \left(\mathbf{S}^{(i)} : \delta \mathbf{E}^{(i)} - \hat{\mathbf{b}}\cdot \delta\mathbf{u}^{(i)} \right) \text{d}V_0 - \int_{\Gamma_\sigma^{(i)}} \hat{\mathbf{t}}_0^{(i)}\cdot\delta\mathbf{u}^{(i)} \text{d}A_0 \right] \label{eq:subeq11} \\

--- a/applications/ContactStructuralMechanicsApplication/tests/test_ContactStructuralMechanicsApplication.py
+++ b/applications/ContactStructuralMechanicsApplication/tests/test_ContactStructuralMechanicsApplication.py
@@ -69,7 +69,7 @@ from SmallTests import TwoDSimplestWithFrictionPatchMatchingTestContact   as TTw
 from SmallTests import ThreeDSimplestPatchMatchingTestContact             as TThreeDSimplestPatchMatchingTestContact
 from SmallTests import ThreeDSimplestWithFrictionPatchMatchingTestContact as TThreeDSimplestWithFrictionPatchMatchingTestContact
 
-## NIGTHLY TESTS
+## NIGHTLY TESTS
 # Mesh tying tests
 from NightlyTests import SimplestPatchTestThreeDTriQuadMeshTying as TSimplestPatchTestThreeDTriQuadMeshTying
 from NightlyTests import SimplestPatchTestThreeDQuadTriMeshTying as TSimplestPatchTestThreeDQuadTriMeshTying
@@ -335,7 +335,7 @@ def AssembleTestSuites():
 
         ### BEGIN VALIDATION SUITE ###
 
-        # For very long tests that should not be in nighly and you can use to validate
+        # For very long tests that should not be in nightly and you can use to validate
         validationSuite = suites['validation']
         validationSuite.addTests(nightlySuite)
 
@@ -487,9 +487,9 @@ def AssembleTestSuites():
               TThreeDSimplestPatchMatchingSlopeTestContact,
               TThreeDPatchMatchingTestContact,
               TThreeDPatchNotMatchingTestContact,
-              #### NIGTHLY
+              #### NIGHTLY
               TALMTaylorPatchTestContact,
-              #####TALMHertzSphereTestContact,  # FIXME: This test requieres the axisymmetric to work (memmory error, correct it)
+              #####TALMHertzSphereTestContact,  # FIXME: This test requieres the axisymmetric to work (memory error, correct it)
               TALMHertzSimpleSphereTestContact,
               TComponentsALMTaylorPatchTestContact,
               TALMPureFrictionalTestContact,
@@ -504,7 +504,7 @@ def AssembleTestSuites():
               TBeamContactWithFrictionTest,
               TPlateTest,  # TODO: Fix this
               ### VALIDATION
-              #####TComponentsALMHertzSphereTestContact,  # FIXME: This test requieres the axisymmetric to work (memmory error, correct it)
+              #####TComponentsALMHertzSphereTestContact,  # FIXME: This test requieres the axisymmetric to work (memory error, correct it)
               TALMHertzSimpleTestContact,
               TALMHertzCompleteTestContact,
               TALMBeamsTestContact,


### PR DESCRIPTION
**📝 Description**
Fixes source comments and doxygen typos.
Found via codespell

**🆕 Changelog**
- Fixes source comments and doxygen typos within application/ContactStructuralMechanicsApplication