### PR TITLE
[GeoMechanicsApplication] Remove redundant overrides geo scheme

### DIFF
--- a/applications/GeoMechanicsApplication/custom_strategies/schemes/geomechanics_time_integration_scheme.hpp
+++ b/applications/GeoMechanicsApplication/custom_strategies/schemes/geomechanics_time_integration_scheme.hpp
@@ -64,7 +64,7 @@ public:
     {
     }
 
-    int Check(const ModelPart& rModelPart) const final
+    [[nodiscard]] int Check(const ModelPart& rModelPart) const final
     {
         KRATOS_TRY
 
@@ -176,11 +176,11 @@ public:
     }
 
     template <typename T>
-    void CalculateSystemContributionsImpl(T&                                rCurrentComponent,
-                                          LocalSystemMatrixType&            LHS_Contribution,
-                                          LocalSystemVectorType&            RHS_Contribution,
-                                          typename T::EquationIdVectorType& EquationId,
-                                          const ProcessInfo&                CurrentProcessInfo)
+    static void CalculateSystemContributionsImpl(T&                     rCurrentComponent,
+                                                 LocalSystemMatrixType& LHS_Contribution,
+                                                 LocalSystemVectorType& RHS_Contribution,
+                                                 typename T::EquationIdVectorType& EquationId,
+                                                 const ProcessInfo& CurrentProcessInfo)
 
     {
         KRATOS_TRY
@@ -208,10 +208,10 @@ public:
     }
 
     template <typename T>
-    void CalculateRHSContributionImpl(T&                                rCurrentComponent,
-                                      LocalSystemVectorType&            RHS_Contribution,
-                                      typename T::EquationIdVectorType& EquationId,
-                                      const ProcessInfo&                CurrentProcessInfo)
+    static void CalculateRHSContributionImpl(T&                                rCurrentComponent,
+                                             LocalSystemVectorType&            RHS_Contribution,
+                                             typename T::EquationIdVectorType& EquationId,
+                                             const ProcessInfo&                CurrentProcessInfo)
     {
         KRATOS_TRY
 
@@ -238,10 +238,10 @@ public:
     }
 
     template <typename T>
-    void CalculateLHSContributionImpl(T&                                rCurrentComponent,
-                                      LocalSystemMatrixType&            LHS_Contribution,
-                                      typename T::EquationIdVectorType& EquationId,
-                                      const ProcessInfo&                CurrentProcessInfo)
+    static void CalculateLHSContributionImpl(T&                                rCurrentComponent,
+                                             LocalSystemMatrixType&            LHS_Contribution,
+                                             typename T::EquationIdVectorType& EquationId,
+                                             const ProcessInfo&                CurrentProcessInfo)
     {
         KRATOS_TRY
 
@@ -317,7 +317,7 @@ private:
         }
     }
 
-    void CheckBufferSize(const ModelPart& rModelPart) const
+    static void CheckBufferSize(const ModelPart& rModelPart)
     {
         constexpr auto minimum_buffer_size = ModelPart::IndexType{2};
         KRATOS_ERROR_IF(rModelPart.GetBufferSize() < minimum_buffer_size)
@@ -327,14 +327,14 @@ private:
     }
 
     template <class T>
-    void CheckSolutionStepsData(const Node& rNode, const Variable<T>& rVariable) const
+    static void CheckSolutionStepsData(const Node& rNode, const Variable<T>& rVariable)
     {
         KRATOS_ERROR_IF_NOT(rNode.SolutionStepsDataHas(rVariable))
             << rVariable.Name() << " variable is not allocated for node " << rNode.Id() << std::endl;
     }
 
     template <class T>
-    void CheckDof(const Node& rNode, const Variable<T>& rVariable) const
+    static void CheckDof(const Node& rNode, const Variable<T>& rVariable)
     {
         KRATOS_ERROR_IF_NOT(rNode.HasDofFor(rVariable))
             << "missing " << rVariable.Name() << " dof on node " << rNode.Id() << std::endl;

--- a/applications/GeoMechanicsApplication/custom_strategies/schemes/geomechanics_time_integration_scheme.hpp
+++ b/applications/GeoMechanicsApplication/custom_strategies/schemes/geomechanics_time_integration_scheme.hpp
@@ -77,24 +77,6 @@ public:
         KRATOS_CATCH("")
     }
 
-    void InitializeElements(ModelPart& rModelPart) override
-    {
-        const ProcessInfo& r_current_process_info = rModelPart.GetProcessInfo();
-        block_for_each(rModelPart.Elements(), [&r_current_process_info](auto& rElement) {
-            rElement.Initialize(r_current_process_info);
-        });
-        this->SetElementsAreInitialized();
-    }
-
-    void InitializeConditions(ModelPart& rModelPart) override
-    {
-        const ProcessInfo& r_current_process_info = rModelPart.GetProcessInfo();
-        block_for_each(rModelPart.Conditions(), [r_current_process_info](auto& rCondition) {
-            rCondition.Initialize(r_current_process_info);
-        });
-        this->SetConditionsAreInitialized();
-    }
-
     void Predict(ModelPart& rModelPart, DofsArrayType&, TSystemMatrixType&, TSystemVectorType&, TSystemVectorType&) override
     {
         this->UpdateVariablesDerivatives(rModelPart);

--- a/applications/GeoMechanicsApplication/custom_strategies/schemes/geomechanics_time_integration_scheme.hpp
+++ b/applications/GeoMechanicsApplication/custom_strategies/schemes/geomechanics_time_integration_scheme.hpp
@@ -64,7 +64,7 @@ public:
     {
     }
 
-    [[nodiscard]] int Check(const ModelPart& rModelPart) const final
+    int Check(const ModelPart& rModelPart) const final
     {
         KRATOS_TRY
 

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_strategies/test_geomechanics_time_integration_scheme.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_strategies/test_geomechanics_time_integration_scheme.cpp
@@ -194,21 +194,16 @@ KRATOS_TEST_CASE_IN_SUITE(FunctionCallsOnAllConditions_AreOnlyCalledForActiveCon
     tester.TestFunctionCallOnAllComponents_AreOnlyCalledForActiveComponents<SpyCondition>();
 }
 
-KRATOS_TEST_CASE_IN_SUITE(FunctionCalledOnCondition_IsCalledOnActiveAndInactiveConditions,
+KRATOS_TEST_CASE_IN_SUITE(FunctionCalledOnElement_IsCalledOnActiveAndInactiveElementsAndConditions,
                           KratosGeoMechanicsFastSuiteWithoutKernel)
-{
-    GeoMechanicsSchemeTester tester;
-    tester.TestFunctionCalledOnComponent_IsCalledOnActiveAndInactiveComponents<SpyCondition>(
-        [](auto& rModelPart, auto& rCondition) { rModelPart.AddCondition(rCondition); },
-        [](auto& rScheme, auto& rModelPart) { rScheme.InitializeConditions(rModelPart); });
-}
-
-KRATOS_TEST_CASE_IN_SUITE(FunctionCalledOnElement_IsCalledOnActiveAndInactiveElements, KratosGeoMechanicsFastSuiteWithoutKernel)
 {
     GeoMechanicsSchemeTester tester;
     tester.TestFunctionCalledOnComponent_IsCalledOnActiveAndInactiveComponents<SpyElement>(
         [](auto& rModelPart, auto& rElement) { rModelPart.AddElement(rElement); },
         [](auto& rScheme, auto& rModelPart) { rScheme.InitializeElements(rModelPart); });
+    tester.TestFunctionCalledOnComponent_IsCalledOnActiveAndInactiveComponents<SpyCondition>(
+        [](auto& rModelPart, auto& rCondition) { rModelPart.AddCondition(rCondition); },
+        [](auto& rScheme, auto& rModelPart) { rScheme.InitializeConditions(rModelPart); });
 }
 
 KRATOS_TEST_CASE_IN_SUITE(ForInvalidBufferSize_CheckGeoMechanicsTimeIntegrationScheme_Throws,

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_strategies/test_geomechanics_time_integration_scheme.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_strategies/test_geomechanics_time_integration_scheme.cpp
@@ -194,16 +194,32 @@ KRATOS_TEST_CASE_IN_SUITE(FunctionCallsOnAllConditions_AreOnlyCalledForActiveCon
     tester.TestFunctionCallOnAllComponents_AreOnlyCalledForActiveComponents<SpyCondition>();
 }
 
-KRATOS_TEST_CASE_IN_SUITE(FunctionCalledOnElement_IsCalledOnActiveAndInactiveElementsAndConditions,
-                          KratosGeoMechanicsFastSuiteWithoutKernel)
+KRATOS_TEST_CASE_IN_SUITE(FunctionCalledOnElement_IsCalledOnActiveAndInactiveElements, KratosGeoMechanicsFastSuiteWithoutKernel)
 {
     GeoMechanicsSchemeTester tester;
     tester.TestFunctionCalledOnComponent_IsCalledOnActiveAndInactiveComponents<SpyElement>(
         [](auto& rModelPart, auto& rElement) { rModelPart.AddElement(rElement); },
         [](auto& rScheme, auto& rModelPart) { rScheme.InitializeElements(rModelPart); });
+}
+
+KRATOS_TEST_CASE_IN_SUITE(FunctionCalledOnCondition_IsCalledOnActiveAndInactiveConditions,
+                          KratosGeoMechanicsFastSuiteWithoutKernel)
+{
+    GeoMechanicsSchemeTester tester;
     tester.TestFunctionCalledOnComponent_IsCalledOnActiveAndInactiveComponents<SpyCondition>(
         [](auto& rModelPart, auto& rCondition) { rModelPart.AddCondition(rCondition); },
-        [](auto& rScheme, auto& rModelPart) { rScheme.InitializeConditions(rModelPart); });
+        [](auto& rScheme, auto& rModelPart) {
+        rScheme.SetElementsAreInitialized(); // Precondition for initializing the conditions
+        rScheme.InitializeConditions(rModelPart);
+    });
+}
+
+KRATOS_TEST_CASE_IN_SUITE(InitializeConditions_Throws_IfElementsNotInitialized, KratosGeoMechanicsFastSuiteWithoutKernel)
+{
+    GeoMechanicsSchemeTester tester;
+    tester.Setup();
+    auto& model_part = tester.GetModelPart();
+    EXPECT_THROW(tester.mScheme.InitializeConditions(model_part), Kratos::Exception);
 }
 
 KRATOS_TEST_CASE_IN_SUITE(ForInvalidBufferSize_CheckGeoMechanicsTimeIntegrationScheme_Throws,


### PR DESCRIPTION
**📝 Description**
Since #13119 got merged, we no longer need these functions in the geomechanics scheme, since the base functions now have exactly the same behavior.

There is one exception, which is that the `InitializeConditions` function checks if the elements have already been initialized, which is why we had to combine two unit tests into one.

I also did some minor clean-up while I was here anyway
