### PR TITLE
[Structural] Add `LinkConstraint`

### DIFF
--- a/applications/StructuralMechanicsApplication/CMakeLists.txt
+++ b/applications/StructuralMechanicsApplication/CMakeLists.txt
@@ -12,6 +12,7 @@ file(GLOB_RECURSE KRATOS_STRUCTURAL_MECHANICS_APPLICATION_CORE
     ${CMAKE_CURRENT_SOURCE_DIR}/structural_mechanics_application.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/structural_mechanics_application_variables.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/custom_conditions/*.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/custom_constraints/*.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/custom_constitutive/*.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/custom_elements/*.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/custom_io/*.cpp

--- a/applications/StructuralMechanicsApplication/custom_constraints/link_constraint.cpp
+++ b/applications/StructuralMechanicsApplication/custom_constraints/link_constraint.cpp
@@ -184,32 +184,6 @@ LinkConstraint::LinkConstraint(const IndexType Id,
 }
 
 
-LinkConstraint::LinkConstraint(LinkConstraint&& rRhs) noexcept
-    : mpImpl(std::move(rRhs.mpImpl))
-{
-}
-
-
-LinkConstraint::LinkConstraint(const LinkConstraint& rRhs)
-    : mpImpl(new Impl(*rRhs.mpImpl))
-{
-}
-
-
-LinkConstraint& LinkConstraint::operator=(LinkConstraint&& rRhs) noexcept
-{
-    mpImpl = std::move(rRhs.mpImpl);
-    return *this;
-}
-
-
-LinkConstraint& LinkConstraint::operator=(const LinkConstraint& rRhs)
-{
-    mpImpl.reset(new Impl(*rRhs.mpImpl));
-    return *this;
-}
-
-
 LinkConstraint::~LinkConstraint() = default;
 
 

--- a/applications/StructuralMechanicsApplication/custom_constraints/link_constraint.cpp
+++ b/applications/StructuralMechanicsApplication/custom_constraints/link_constraint.cpp
@@ -1,0 +1,359 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
+//
+//  Main authors:    Máté Kelemen
+//
+
+// Project includes
+#include "custom_constraints/link_constraint.hpp" // LinkConstraint
+#include "includes/define.h"
+#include "includes/process_info.h"
+#include "includes/variables.h" // DISPLACEMENT_X, DISPLACEMENT_Y, DISPLACEMENT_Z
+#include "includes/serializer.h" // Serializer
+#include "includes/variables.h" // CONSTITUTIVE_MATRIX, INTERNAL_FORCES_VECTOR
+
+// STL includes
+#include <algorithm> // std::max_element, std::equal, std::transform
+
+
+namespace Kratos {
+
+
+struct LinkConstraint::Impl
+{
+    using ValueType = double;
+
+    static void ComputeRelationMatrix(LinkConstraint::MatrixType& rRelationMatrix,
+                                      LinkConstraint::MatrixType& rHessian,
+                                      LinkConstraint::VectorType& rConstraintGaps,
+                                      const std::array<ValueType,6>& rLastPositions,
+                                      const std::array<ValueType,6>& rLastDisplacements,
+                                      const unsigned Dimensions)
+    {
+        // Make sure we don't try to allocate an underflown unsigned integer.
+        KRATOS_ERROR_IF_NOT(Dimensions);
+
+        // Set output sizes.
+        rRelationMatrix.resize(1, 2 * Dimensions);
+        rHessian.resize(2 * Dimensions, 2 * Dimensions);
+        rConstraintGaps.resize(1);
+
+        // Initialize outputs.
+        rConstraintGaps[0] = 0.0;
+        std::fill(rRelationMatrix.data().begin(),
+                  rRelationMatrix.data().end(),
+                  static_cast<ValueType>(0));
+        std::fill(rHessian.data().begin(),
+                  rHessian.data().end(),
+                  static_cast<ValueType>(0));
+
+        // Compute constraint violation.
+        double current_norm = 0.0;
+        for (std::size_t i_component=0ul; i_component<Dimensions; ++i_component) {
+            const auto current_diff = rLastPositions[i_component] - rLastPositions[i_component + Dimensions]
+                                    + rLastDisplacements[i_component] - rLastDisplacements[i_component + Dimensions];
+            current_norm += current_diff * current_diff;
+        } // for i_component in range(Dimensions)
+
+        KRATOS_ERROR_IF_NOT(current_norm) << "degenerate link constraint";
+        const auto current_norm_root = std::sqrt(current_norm);
+
+        // Dof order:
+        // {u^0_x, ..., u^0_w, u^1_x, ..., u^1_w}
+        // Where w is the axis with the highest index for the provided dimensions
+        // (e.g.: z-axis in 3 dimensions).
+
+        for (std::size_t i_component=0u; i_component<Dimensions; ++i_component) {
+            const auto current_diff = rLastPositions[i_component] - rLastPositions[i_component + Dimensions]
+                                    + rLastDisplacements[i_component] - rLastDisplacements[i_component + Dimensions];
+
+            rRelationMatrix(0, i_component) = current_diff / current_norm_root;
+            rRelationMatrix(0, i_component + Dimensions) = -rRelationMatrix(0, i_component);
+
+            const auto hessian_entry = (current_norm_root - current_diff * current_diff / current_norm_root) / current_norm;
+
+            rHessian(i_component, i_component) = hessian_entry;
+            rHessian(i_component, i_component + Dimensions) = -hessian_entry;
+            rHessian(i_component + Dimensions, i_component) = -hessian_entry;
+            rHessian(i_component + Dimensions, i_component + Dimensions) = hessian_entry;
+        } // for i_component in range(mDimensions)
+    }
+
+
+    static LinkConstraint::DofPointerVectorType CollectDofs(Node& rFirst,
+                                                            Node& rSecond,
+                                                            const std::size_t Dimensions)
+    {
+        DofPointerVectorType dofs;
+
+        KRATOS_TRY
+        using ValueType = double;
+
+        const std::array<const Variable<ValueType>*,3> displacement_components {
+            &DISPLACEMENT_X,
+            &DISPLACEMENT_Y,
+            &DISPLACEMENT_Z
+        };
+
+        std::array<Node*, 2> nodes {&rFirst, &rSecond};
+        dofs.resize(2 * Dimensions);
+
+        // Collect dofs from nodes in the following order:
+        // {u^0_x, ..., u^0_w, u^1_x, ..., u^1_w}
+        // Where w is the axis with the highest index for the provided dimensions
+        // (e.g.: z-axis in 3 dimensions).
+        for (std::size_t i_dimension=0ul; i_dimension<Dimensions; ++i_dimension) {
+            const auto component_id = displacement_components[i_dimension]->Key();
+
+            for (std::size_t i_node=0ul; i_node<2; ++i_node) {
+                Node& r_node = *nodes[i_node];
+                const auto it_dof = std::find_if(r_node.GetDofs().begin(),
+                                                 r_node.GetDofs().end(),
+                                                 [component_id](auto& rp_dof){
+                                                         return rp_dof->GetVariable().Key() == component_id;
+                                                 });
+                KRATOS_ERROR_IF(it_dof == r_node.GetDofs().end())
+                    << "cannot find DoF " << displacement_components[i_dimension]->Name()
+                    << " in node " << r_node.Id();
+                dofs[i_node * Dimensions + i_dimension] = it_dof->get();
+            } // for i_node in range(2)
+        } // for i_dimension in range(Dimensions)
+        KRATOS_CATCH("")
+
+        return dofs;
+    }
+
+
+    void FetchNodePositions(std::array<ValueType,6>& rPositions,
+                            std::array<ValueType,6>& rDisplacements) const {
+        KRATOS_TRY
+
+        const std::array<const Variable<Impl::ValueType>*,3> displacement_components {
+            &DISPLACEMENT_X,
+            &DISPLACEMENT_Y,
+            &DISPLACEMENT_Z
+        };
+
+        for (std::size_t i_component=0u; i_component<mDimensions; ++i_component) {
+            for (std::size_t i_node=0u; i_node<2; ++i_node) {
+                const std::size_t i_dof = i_component + (i_node ? mDimensions : 0u);
+                rPositions[i_dof] = mNodePair[i_node]->Coordinates()[i_component];
+                rDisplacements[i_dof] = mNodePair[i_node]->GetSolutionStepValue(*displacement_components[i_component]);
+            } // for i_node in range(2)
+        } // for i_component in range(mDimensions)
+
+        KRATOS_CATCH("")
+    }
+
+
+    std::size_t mDimensions;
+
+    bool mIsMeshMoved;
+
+    /// @details MasterSlaveConstraint::GetSlaveDofsVector and MasterSlaveConstraint::GetMasterDofsVector
+    ///          require arrays of mutable Dof pointers, which are only obtainable from mutable nodes,
+    ///          so the nodes pointers stored here cannot be immutable. Risky business.
+    std::array<Node*,2> mNodePair;
+
+    std::array<ValueType,6> mLastPositions;
+
+    std::array<ValueType,6> mLastDisplacements;
+}; // struct LinkConstraint::Impl
+
+
+LinkConstraint::LinkConstraint(const IndexType Id,
+                               Node& rFirst,
+                               Node& rSecond,
+                               const std::size_t Dimensions,
+                               bool IsMeshMoved)
+    : MultifreedomConstraint(/*Id               : */Id,
+                             /*rDofs            : */Impl::CollectDofs(rFirst, rSecond, Dimensions),
+                             /*rConstraintLabels: */std::vector<std::size_t> {Id}),
+      mpImpl(new Impl{/*mDimensions         : */Dimensions,
+                      /*mIsMeshMoved        : */IsMeshMoved,
+                      /*mNodePair           : */{&rFirst, &rSecond},
+                      /*mLastPositions      : */{0.0, 0.0, 0.0, 0.0, 0.0, 0.0},
+                      /*mLastDisplacements  : */{0.0, 0.0, 0.0, 0.0, 0.0, 0.0}})
+{
+}
+
+
+LinkConstraint::LinkConstraint(LinkConstraint&& rRhs) noexcept
+    : mpImpl(std::move(rRhs.mpImpl))
+{
+}
+
+
+LinkConstraint::LinkConstraint(const LinkConstraint& rRhs)
+    : mpImpl(new Impl(*rRhs.mpImpl))
+{
+}
+
+
+LinkConstraint& LinkConstraint::operator=(LinkConstraint&& rRhs) noexcept
+{
+    mpImpl = std::move(rRhs.mpImpl);
+    return *this;
+}
+
+
+LinkConstraint& LinkConstraint::operator=(const LinkConstraint& rRhs)
+{
+    mpImpl.reset(new Impl(*rRhs.mpImpl));
+    return *this;
+}
+
+
+LinkConstraint::~LinkConstraint() = default;
+
+
+MasterSlaveConstraint::Pointer LinkConstraint::Clone(IndexType NewId) const
+{
+    KRATOS_TRY
+    auto p_other = LinkConstraint::Pointer(
+        new LinkConstraint(NewId,
+                           *mpImpl->mNodePair.front(),
+                           *mpImpl->mNodePair.back(),
+                           mpImpl->mDimensions,
+                           mpImpl->mIsMeshMoved)
+    );
+    return p_other;
+    KRATOS_CATCH("")
+}
+
+
+void LinkConstraint::Initialize([[maybe_unused]] const ProcessInfo&)
+{
+}
+
+
+void LinkConstraint::InitializeSolutionStep(const ProcessInfo&)
+{
+    KRATOS_TRY
+    // Store displacements before nonlinear iterations begin.
+    // At this point, displacements are at their last converged
+    // state, when the constraint is supposed to be still satisfied.
+    mpImpl->FetchNodePositions(mpImpl->mLastPositions,
+                               mpImpl->mLastDisplacements);
+
+    if (!mpImpl->mIsMeshMoved)
+        for (std::size_t i_component=0ul; i_component<mpImpl->mLastPositions.size(); ++i_component)
+            mpImpl->mLastPositions[i_component] += mpImpl->mLastDisplacements[i_component];
+
+    Impl::ComputeRelationMatrix(this->Data().GetValue(CONSTITUTIVE_MATRIX),
+                                this->GetHessian(),
+                                this->Data().GetValue(INTERNAL_FORCES_VECTOR),
+                                mpImpl->mLastPositions,
+                                mpImpl->mLastDisplacements,
+                                mpImpl->mDimensions);
+    KRATOS_CATCH("")
+}
+
+
+void LinkConstraint::InitializeNonLinearIteration(const ProcessInfo&)
+{
+    KRATOS_TRY
+    [[maybe_unused]] std::array<Impl::ValueType,6> dummy;
+    mpImpl->FetchNodePositions(dummy,  mpImpl->mLastDisplacements);
+
+    Impl::ComputeRelationMatrix(this->Data().GetValue(CONSTITUTIVE_MATRIX),
+                                this->GetHessian(),
+                                this->Data().GetValue(INTERNAL_FORCES_VECTOR),
+                                mpImpl->mLastPositions,
+                                mpImpl->mLastDisplacements,
+                                mpImpl->mDimensions);
+    KRATOS_CATCH("")
+}
+
+
+void LinkConstraint::FinalizeNonLinearIteration(const ProcessInfo& rProcessInfo)
+{
+}
+
+
+void LinkConstraint::FinalizeSolutionStep(const ProcessInfo&)
+{
+    this->Data().GetValue(CONSTITUTIVE_MATRIX).clear();
+    this->Data().GetValue(INTERNAL_FORCES_VECTOR).clear();
+}
+
+
+void LinkConstraint::Finalize(const ProcessInfo&)
+{
+}
+
+
+void LinkConstraint::CalculateLocalSystem(MatrixType& rRelationMatrix,
+                                          VectorType& rConstraintGaps,
+                                          [[maybe_unused]] const ProcessInfo& rProcessInfo) const
+{
+    rRelationMatrix = this->GetData().GetValue(CONSTITUTIVE_MATRIX);
+    rConstraintGaps = this->GetData().GetValue(INTERNAL_FORCES_VECTOR);
+}
+
+
+int LinkConstraint::Check(const ProcessInfo& rProcessInfo) const
+{
+    // Check whatever the base class checks.
+    MasterSlaveConstraint::Check(rProcessInfo);
+
+    // Restrict dimensions to 1, 2, or 3.
+    KRATOS_ERROR_IF_NOT(0 < mpImpl->mDimensions || mpImpl->mDimensions <= 3) << "unsupported dimensions (" << mpImpl->mDimensions << ")";
+
+    // Make sure that the nodes have the necessary Dofs.
+    const std::array<const Variable<Impl::ValueType>*,3> displacement_components {
+        &DISPLACEMENT_X,
+        &DISPLACEMENT_Y,
+        &DISPLACEMENT_Z
+    };
+
+    for (unsigned i_component=0u; i_component<mpImpl->mDimensions; ++i_component) {
+        for (unsigned i_node=0u; i_node<2; ++i_node) {
+            KRATOS_ERROR_IF_NOT(mpImpl->mNodePair[i_node]->HasDofFor(*displacement_components[i_component]))
+                << "node " << mpImpl->mNodePair[i_node]->Id()
+                << " has no Dof for " << displacement_components[i_component]->Name();
+        } // for i_node in range(2)
+    } // for i_component in range(mDimensions)
+
+    // Check for overlapping nodes.
+    constexpr Impl::ValueType tolerance = 1e-16;
+    KRATOS_ERROR_IF(norm_2(mpImpl->mNodePair.front()->Coordinates() - mpImpl->mNodePair.back()->Coordinates()) < tolerance)
+        << "coincident nodes in LinkConstraint";
+
+    return 0;
+}
+
+
+void LinkConstraint::save(Serializer& rSerializer) const
+{
+    KRATOS_SERIALIZE_SAVE_BASE_CLASS(rSerializer, MultifreedomConstraint);
+    rSerializer.save("Dimensions", mpImpl->mDimensions);
+    rSerializer.save("Nodes", mpImpl->mNodePair);
+    // The rest of the private members should be computed/cached after restarting.
+}
+
+
+void LinkConstraint::load(Serializer& rDeserializer)
+{
+    KRATOS_SERIALIZE_LOAD_BASE_CLASS(rDeserializer, MultifreedomConstraint);
+    rDeserializer.load("Dimensions", mpImpl->mDimensions);
+    rDeserializer.load("Nodes", mpImpl->mNodePair);
+}
+
+
+std::ostream& operator<<(std::ostream& rStream, const LinkConstraint& rInstance)
+{
+    return rStream << "LinkConstraint between nodes "
+                   << rInstance.mpImpl->mNodePair.front()->Id()
+                   << " and "
+                   << rInstance.mpImpl->mNodePair.back()->Id();
+}
+
+
+} // namespace Kratos

--- a/applications/StructuralMechanicsApplication/custom_constraints/link_constraint.hpp
+++ b/applications/StructuralMechanicsApplication/custom_constraints/link_constraint.hpp
@@ -27,17 +27,13 @@ namespace Kratos {
  *           @f$ n^0 @f$ and @f$ n^1 @f$ that get displaced by @f$ u^0_i @f$ and @f$ u^1_i @f$ respectively.
  *           @p LinkConstraint then represents the following constraint equation:
  *           @f[
- *              \sum_i \left( (n^0_i + u^0_i) - (n^1_i + u^1_i) \right)^2
+ *              \sqrt{
+ *                  \sum_i \left( (n^0_i + u^0_i) - (n^1_i + u^1_i) \right)^2
+ *              }
  *              -
- *              \sum_i \left( n^0_i - n^1_i \right)^2
- *              = 0
- *           @f]
- *
- *           The constraint equation above is linearized in each nonlinear iteration @f$ k @f$
- *           to the following form:
- *           @f[
- *              \sum_i \left( (2 n^0_i + u^0_{i,k-1}) -  (2 n^1_i + u^1_{i,k-1}) \right)
- *              \left( u^0_{i,k} - u^1_{i,k} \right)
+ *              \sqrt{
+ *                  \sum_i \left( n^0_i - n^1_i \right)^2
+ *              }
  *              = 0
  *           @f]
  *

--- a/applications/StructuralMechanicsApplication/custom_constraints/link_constraint.hpp
+++ b/applications/StructuralMechanicsApplication/custom_constraints/link_constraint.hpp
@@ -1,0 +1,144 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:         BSD License
+//                   license: StructuralMechanicsApplication/license.txt
+//
+//  Main authors:    Máté Kelemen
+//
+
+// Project includes
+#include "solving_strategies/builder_and_solvers/p_multigrid/multifreedom_constraint.hpp" // MultifreedomConstraint
+#include "includes/code_location.h" // KRATOS_CODE_LOCATION
+
+// STL includes
+#include <memory> // std::unique_ptr
+#include <iosfwd> // std::ostream
+
+
+namespace Kratos {
+
+
+/** @brief A constraint enforcing the distance between two @ref Node "nodes" to remain constant.
+ *  @details Let @f$ n^0_i @f$ and @f$ n^1_i @f$ denote the coordinates of the initial positions of @ref Node "node"
+ *           @f$ n^0 @f$ and @f$ n^1 @f$ that get displaced by @f$ u^0_i @f$ and @f$ u^1_i @f$ respectively.
+ *           @p LinkConstraint then represents the following constraint equation:
+ *           @f[
+ *              \sum_i \left( (n^0_i + u^0_i) - (n^1_i + u^1_i) \right)^2
+ *              -
+ *              \sum_i \left( n^0_i - n^1_i \right)^2
+ *              = 0
+ *           @f]
+ *
+ *           The constraint equation above is linearized in each nonlinear iteration @f$ k @f$
+ *           to the following form:
+ *           @f[
+ *              \sum_i \left( (2 n^0_i + u^0_{i,k-1}) -  (2 n^1_i + u^1_{i,k-1}) \right)
+ *              \left( u^0_{i,k} - u^1_{i,k} \right)
+ *              = 0
+ *           @f]
+ *
+ *  @note @p LinkConstraint is nonlinear and as such, should not be imposed via master-slave elimination (the slave
+ *        DoF's coefficient may vanish). Consider using the @ref AugmentedLagrangeConstraintAssembler "penalty method",
+ *        the method of Lagrange multipliers, or @ref AugmentedLagrangeConstraintAssembler "augmented lagrange" multipliers.
+ */
+class KRATOS_API(STRUCTURAL_MECHANICS_APPLICATION) LinkConstraint final
+    : public MultifreedomConstraint
+{
+public:
+    KRATOS_CLASS_POINTER_DEFINITION(LinkConstraint);
+
+    LinkConstraint() noexcept = default;
+
+    LinkConstraint(const IndexType Id,
+                   Node& rFirst,
+                   Node& rSecond,
+                   const std::size_t Dimensions,
+                   bool IsMeshMoved);
+
+    LinkConstraint(LinkConstraint&& rRhs) noexcept;
+
+    LinkConstraint(const LinkConstraint& rRhs);
+
+    LinkConstraint& operator=(LinkConstraint&& rRhs) noexcept;
+
+    LinkConstraint& operator=(const LinkConstraint& rRhs);
+
+    /// @internal
+    ~LinkConstraint();
+
+    MasterSlaveConstraint::Pointer Clone(IndexType NewId) const override;
+
+    void Initialize(const ProcessInfo& rProcessInfo) override;
+
+    void InitializeSolutionStep(const ProcessInfo& rProcessInfo) override;
+
+    void InitializeNonLinearIteration(const ProcessInfo& rProcessInfo) override;
+
+    void FinalizeNonLinearIteration(const ProcessInfo& rProcessInfo) override;
+
+    void FinalizeSolutionStep(const ProcessInfo& rProcessInfo) override;
+
+    void Finalize(const ProcessInfo& rProcessInfo) override;
+
+    void CalculateLocalSystem(MatrixType& rRelationMatrix,
+                              VectorType& rConstraintGaps,
+                              const ProcessInfo& rProcessInfo) const override;
+
+    int Check(const ProcessInfo& rProcessInfo) const override;
+
+    friend std::ostream& operator<<(std::ostream& rStream, const LinkConstraint& rInstance);
+
+    /// @name Unsupported Interface
+    /// @{
+
+    MasterSlaveConstraint::Pointer Create(IndexType,
+                                          DofPointerVectorType&,
+                                          DofPointerVectorType&,
+                                          const MatrixType&,
+                                          const VectorType&) const override
+    {KRATOS_ERROR << KRATOS_CODE_LOCATION.CleanFunctionName() << " is not supported by LinkConstraint.";}
+
+    MasterSlaveConstraint::Pointer Create(IndexType,
+                                          NodeType&,
+                                          const VariableType&,
+                                          NodeType&,
+                                          const VariableType&,
+                                          const double,
+                                          const double) const override
+    {KRATOS_ERROR << KRATOS_CODE_LOCATION.CleanFunctionName() << " is not supported by LinkConstraint.";}
+
+    void SetDofList(const DofPointerVectorType&,
+                    const DofPointerVectorType&,
+                    const ProcessInfo&) override
+    {KRATOS_ERROR << KRATOS_CODE_LOCATION.CleanFunctionName() << " is not supported by LinkConstraint.";}
+
+    void SetSlaveDofsVector(const DofPointerVectorType&) override
+    {KRATOS_ERROR << KRATOS_CODE_LOCATION.CleanFunctionName() << " is not supported by LinkConstraint.";}
+
+    void SetMasterDofsVector(const DofPointerVectorType&) override
+    {KRATOS_ERROR << KRATOS_CODE_LOCATION.CleanFunctionName() << " is not supported by LinkConstraint.";}
+
+    void SetLocalSystem(const MatrixType&,
+                        const VectorType&,
+                        const ProcessInfo&) override
+    {KRATOS_ERROR << KRATOS_CODE_LOCATION.CleanFunctionName() << " is not supported by LinkConstraint.";}
+
+    /// @}
+
+private:
+    friend class Serializer;
+
+    void save(Serializer& rSerializer) const override;
+
+    void load(Serializer& rDeserializer) override;
+
+    struct Impl;
+    std::unique_ptr<Impl> mpImpl;
+}; // class LinkConstraint
+
+
+} // namespace Kratos

--- a/applications/StructuralMechanicsApplication/custom_constraints/link_constraint.hpp
+++ b/applications/StructuralMechanicsApplication/custom_constraints/link_constraint.hpp
@@ -55,14 +55,6 @@ public:
                    const std::size_t Dimensions,
                    bool IsMeshMoved);
 
-    LinkConstraint(LinkConstraint&& rRhs) noexcept;
-
-    LinkConstraint(const LinkConstraint& rRhs);
-
-    LinkConstraint& operator=(LinkConstraint&& rRhs) noexcept;
-
-    LinkConstraint& operator=(const LinkConstraint& rRhs);
-
     /// @internal
     ~LinkConstraint();
 
@@ -126,6 +118,14 @@ public:
     /// @}
 
 private:
+    LinkConstraint(LinkConstraint&& rRhs) = delete;
+
+    LinkConstraint(const LinkConstraint& rRhs) = delete;
+
+    LinkConstraint& operator=(LinkConstraint&& rRhs) = delete;
+
+    LinkConstraint& operator=(const LinkConstraint& rRhs) = delete;
+
     friend class Serializer;
 
     void save(Serializer& rSerializer) const override;

--- a/applications/StructuralMechanicsApplication/custom_python/add_custom_constraints_to_python.cpp
+++ b/applications/StructuralMechanicsApplication/custom_python/add_custom_constraints_to_python.cpp
@@ -1,0 +1,28 @@
+// KRATOS  ___|  |                   |                   |
+//       \___ \  __|  __| |   |  __| __| |   |  __| _` | |
+//             | |   |    |   | (    |   |   | |   (   | |
+//       _____/ \__|_|   \__,_|\___|\__|\__,_|_|  \__,_|_| MECHANICS
+//
+//  License:         BSD License
+//                   license: StructuralMechanicsApplication/license.txt
+//
+//  Main authors:    Mate Kelemen
+//
+
+// Project includes
+#include "custom_python/add_custom_constraints_to_python.hpp" // AddCustomConstraintsToPython
+#include "custom_constraints/link_constraint.hpp" // LinkConstraint
+
+
+namespace Kratos::Python {
+
+
+void AddCustomConstraintsToPython(pybind11::module& rModule)
+{
+    pybind11::class_<LinkConstraint, LinkConstraint::Pointer, MasterSlaveConstraint>(rModule, "LinkConstraint")
+        .def(pybind11::init<const LinkConstraint::IndexType,Node&,Node&,const std::size_t,bool>())
+        ;
+}
+
+
+} // namespace Kratos::Python

--- a/applications/StructuralMechanicsApplication/custom_python/add_custom_constraints_to_python.hpp
+++ b/applications/StructuralMechanicsApplication/custom_python/add_custom_constraints_to_python.hpp
@@ -1,0 +1,20 @@
+// KRATOS  ___|  |                   |                   |
+//       \___ \  __|  __| |   |  __| __| |   |  __| _` | |
+//             | |   |    |   | (    |   |   | |   (   | |
+//       _____/ \__|_|   \__,_|\___|\__|\__,_|_|  \__,_|_| MECHANICS
+//
+//  License:         BSD License
+//                   license: StructuralMechanicsApplication/license.txt
+//
+//  Main authors:    Mate Kelemen
+//
+
+#pragma once
+
+// External includes
+#include <pybind11/pybind11.h>
+
+namespace Kratos::Python
+{
+    void AddCustomConstraintsToPython(pybind11::module& rModule);
+}  // namespace Kratos::Python.

--- a/applications/StructuralMechanicsApplication/custom_python/structural_mechanics_python_application.cpp
+++ b/applications/StructuralMechanicsApplication/custom_python/structural_mechanics_python_application.cpp
@@ -23,6 +23,7 @@
 #include "custom_python/add_custom_processes_to_python.h"
 #include "custom_python/add_custom_utilities_to_python.h"
 #include "custom_python/add_custom_constitutive_laws_to_python.h"
+#include "custom_python/add_custom_constraints_to_python.hpp"
 #include "custom_python/add_custom_response_functions_to_python.h"
 
 namespace Kratos::Python {
@@ -41,6 +42,7 @@ PYBIND11_MODULE(KratosStructuralMechanicsApplication,m)
     AddCustomProcessesToPython(m);
     AddCustomUtilitiesToPython(m);
     AddCustomConstitutiveLawsToPython(m);
+    AddCustomConstraintsToPython(m);
     AddCustomResponseFunctionUtilitiesToPython(m);
 
     py::class_<Variable<ShellCrossSection::Pointer>,VariableData >(m,"ShellCrossSectionVariable");

--- a/applications/StructuralMechanicsApplication/python_scripts/link_constraint_process.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/link_constraint_process.py
@@ -1,0 +1,80 @@
+# --- Kratos Imports ---
+import KratosMultiphysics
+import KratosMultiphysics.StructuralMechanicsApplication
+
+# --- STD Imports ---
+import typing
+
+
+class LinkConstraintProcess(KratosMultiphysics.Process):
+    """@brief Create and manage @ref LinkConstraint "constraints" between pairs of @ref Node "nodes" that force them to keep the distance between each other constant."""
+
+
+    def __init__(self,
+                 model: KratosMultiphysics.Model,
+                 parameters: KratosMultiphysics.Parameters):
+        super().__init__()
+        parameters.ValidateAndAssignDefaults(self.GetDefaultParameters())
+        self.__model_part: KratosMultiphysics.ModelPart = model.GetModelPart(parameters["model_part_name"].GetString())
+        self.__node_pairs: "list[tuple[int,int]]" = []
+        self.__dimensions: int = parameters["dimensions"].GetInt()
+        self.__is_mesh_moved: bool = parameters["move_mesh_flag"].GetBool()
+        self.__interval: KratosMultiphysics.IntervalUtility = KratosMultiphysics.IntervalUtility(parameters)
+        self.__is_active: bool = False
+        self.__constraints: "list[KratosMultiphysics.StructuralMechanicsApplication.LinkConstraint]" = []
+
+        pair: KratosMultiphysics.Parameters
+        for pair in parameters["node_pairs"].values():
+            self.__node_pairs.append((pair[0].GetInt(), pair[1].GetInt()))
+
+
+    @classmethod
+    def GetDefaultParameters(cls: "typing.Type[LinkConstraintProcess]") -> KratosMultiphysics.Parameters:
+        return KratosMultiphysics.Parameters(R"""{
+            "model_part_name" : "",
+            "node_pairs" : [],
+            "dimensions" : 3,
+            "move_mesh_flag" : false,
+            "interval" : [0, "End"]
+        }""")
+
+
+    def ExecuteBeforeSolutionLoop(self) -> None:
+        self.__is_active = self.__interval.IsInInterval(self.__model_part.ProcessInfo[KratosMultiphysics.TIME])
+
+        id: int = self.__GetLastConstraintId() + 1
+        for id_first, id_second in self.__node_pairs:
+            constraint = KratosMultiphysics.StructuralMechanicsApplication.LinkConstraint(
+                id,
+                self.__model_part.GetNode(id_first),
+                self.__model_part.GetNode(id_second),
+                self.__dimensions,
+                self.__is_mesh_moved)
+
+            if not self.__is_active:
+                constraint.Set(KratosMultiphysics.ACTIVE, False)
+
+            self.__constraints.append(constraint)
+            self.__model_part.AddMasterSlaveConstraint(constraint)
+            id += 1
+
+
+    def ExecuteInitializeSolutionStep(self) -> None:
+        is_active: bool = self.__interval.IsInInterval(self.__model_part.ProcessInfo[KratosMultiphysics.TIME])
+        if is_active != self.__is_active:
+            self.__is_active = is_active
+            for constraint in self.__constraints:
+                constraint.Set(KratosMultiphysics.ACTIVE, self.__is_active)
+
+
+    def __GetLastConstraintId(self) -> int:
+        constraint_count: int = len(self.__model_part.MasterSlaveConstraints)
+        if constraint_count:
+            return self.__model_part.MasterSlaveConstraints[constraint_count - 1]
+        else:
+            return 0
+
+
+def Factory(parameters: KratosMultiphysics.Parameters,
+            model: KratosMultiphysics.Model) -> LinkConstraintProcess:
+    return LinkConstraintProcess(model, parameters["Parameters"])

--- a/applications/StructuralMechanicsApplication/tests/constraints/link_constraint_2d.json
+++ b/applications/StructuralMechanicsApplication/tests/constraints/link_constraint_2d.json
@@ -1,0 +1,92 @@
+{
+    "analysis_stage": "KratosMultiphysics.StructuralMechanicsApplication.structural_mechanics_analysis",
+    "problem_data": {
+        "problem_name": "test_link_constraint_2d",
+        "parallel_type": "OpenMP",
+        "echo_level": 1,
+        "start_time": 0,
+        "end_time": 1
+    },
+    "solver_settings": {
+        "time_stepping": {
+            "time_step": 0.5
+        },
+        "solver_type": "Static",
+        "model_part_name": "root",
+        "domain_size": 2,
+        "echo_level": 0,
+        "analysis_type": "non_linear",
+        "reform_dofs_at_each_step" : false,
+        "move_mesh_flag" : false,
+        "max_iteration" : 1e2,
+        "model_import_settings": {
+            "input_type": "mdpa",
+            "input_filename" : "link_constraint_2d"
+        },
+        "material_import_settings": {
+            "materials_filename": "link_constraint_2d_materials.json"
+        },
+        "convergence_criterion": "displacement_criterion",
+        "displacement_relative_tolerance": 1e-4,
+        "displacement_absolute_tolerance": 1e-9,
+        "builder_and_solver_settings" : {
+            "type" : "p_multigrid",
+            "advanced_settings" : {
+                "max_iterations" : 1,
+                "verbosity" : 1,
+                "smoother_settings" : {"solver_type" : "skyline_lu_factorization"},
+                "constraint_imposition_settings" : {
+                    "method" : "augmented_lagrange",
+                    "penalty_factor" : "1e6 * max",
+                    "max_iterations" : 2e1,
+                    "tolerance" : 1e-9,
+                    "verbosity" : 1
+                }
+            }
+        }
+    },
+    "processes": {
+        "constraints_process_list": [
+            {
+                "python_module": "assign_vector_variable_process",
+                "kratos_module": "KratosMultiphysics",
+                "process_name": "AssignVectorVariableProcess",
+                "Parameters": {
+                    "model_part_name": "root.dirichlet",
+                    "variable_name": "DISPLACEMENT",
+                    "interval": [0, "End"],
+                    "constrained": [true, true, false],
+                    "value": [0, 0, 0]
+                }
+            },
+            {
+                "kratos_module" : "KratosMultiphysics.StructuralMechanicsApplication",
+                "python_module" : "link_constraint_process",
+                "process_name" : "LinkConstraintProcess",
+                "Parameters" : {
+                    "model_part_name" : "root",
+                    "node_pairs" : [[2, 3]],
+                    "dimensions" : 2,
+                    "move_mesh_flag" : false,
+                    "interval" : [0, 0.6]
+                }
+            }
+        ],
+        "loads_process_list": [
+            {
+                "python_module": "assign_vector_by_direction_to_condition_process",
+                "kratos_module": "KratosMultiphysics",
+                "process_name": "AssignVectorByDirectionToConditionProcess",
+                "Parameters": {
+                    "model_part_name": "root.neumann",
+                    "variable_name": "POINT_LOAD",
+                    "interval": [
+                        0, "End"
+                    ],
+                    "modulus": "t",
+                    "direction": [-2, 7, 0]
+                }
+            }
+        ]
+    }
+}

--- a/applications/StructuralMechanicsApplication/tests/constraints/link_constraint_2d.json
+++ b/applications/StructuralMechanicsApplication/tests/constraints/link_constraint_2d.json
@@ -34,7 +34,7 @@
             "advanced_settings" : {
                 "max_iterations" : 1,
                 "verbosity" : 1,
-                "smoother_settings" : {"solver_type" : "skyline_lu_factorization"},
+                "linear_solver_settings" : {"solver_type" : "skyline_lu_factorization"},
                 "constraint_imposition_settings" : {
                     "method" : "augmented_lagrange",
                     "penalty_factor" : "1e6 * max",

--- a/applications/StructuralMechanicsApplication/tests/constraints/link_constraint_2d.mdpa
+++ b/applications/StructuralMechanicsApplication/tests/constraints/link_constraint_2d.mdpa
@@ -1,0 +1,31 @@
+Begin Properties 0
+End Properties
+
+Begin Nodes
+    1 0 0 0
+    2 1 0 0
+    3 0 1 0
+    4 1 1 0
+End Nodes
+
+Begin Elements SmallDisplacementElement2D3N
+    1 0 1 2 3
+    2 0 3 2 4
+End Elements
+
+Begin Conditions PointLoadCondition2D1N
+    1 0 3
+End Conditions
+
+Begin SubModelPart neumann
+    Begin SubModelPartConditions
+        1
+    End SubModelPartConditions
+End SubModelPart
+
+Begin SubModelPart dirichlet
+    Begin SubModelPartNodes
+        1
+        4
+    End SubModelPartNodes
+End SubModelPart

--- a/applications/StructuralMechanicsApplication/tests/constraints/link_constraint_2d_materials.json
+++ b/applications/StructuralMechanicsApplication/tests/constraints/link_constraint_2d_materials.json
@@ -1,0 +1,19 @@
+{
+    "properties": [
+        {
+            "model_part_name": "root",
+            "properties_id": 1,
+            "Material": {
+                "constitutive_law": {
+                    "name": "LinearElasticPlaneStress2DLaw"
+                },
+                "Variables": {
+                    "DENSITY": 1.0,
+                    "YOUNG_MODULUS": 1.0,
+                    "POISSON_RATIO": 0.3
+                },
+                "Tables": null
+            }
+        }
+    ]
+}

--- a/applications/StructuralMechanicsApplication/tests/constraints/link_constraint_3d.json
+++ b/applications/StructuralMechanicsApplication/tests/constraints/link_constraint_3d.json
@@ -1,0 +1,93 @@
+{
+    "analysis_stage": "KratosMultiphysics.StructuralMechanicsApplication.structural_mechanics_analysis",
+    "problem_data": {
+        "problem_name": "test_link_constraint_3d",
+        "parallel_type": "OpenMP",
+        "echo_level": 1,
+        "start_time": 0.0,
+        "end_time": 1.0
+    },
+    "solver_settings": {
+        "time_stepping": {
+            "time_step": 0.5
+        },
+        "solver_type": "Static",
+        "model_part_name": "root",
+        "domain_size": 3,
+        "echo_level": 0,
+        "analysis_type": "non_linear",
+        "move_mesh_flag" : true,
+        "max_iteration" : 1e1,
+        "model_import_settings": {
+            "input_type": "mdpa",
+            "input_filename" : "link_constraint_3d"
+        },
+        "material_import_settings": {
+            "materials_filename": "link_constraint_3d_materials.json"
+        },
+        "convergence_criterion": "displacement_criterion",
+        "displacement_relative_tolerance": 1e-4,
+        "displacement_absolute_tolerance": 1e-9,
+        "builder_and_solver_settings" : {
+            "type" : "p_multigrid",
+            "advanced_settings" : {
+                "max_iterations" : 1,
+                "verbosity" : 1,
+                "smoother_settings" : {"solver_type" : "skyline_lu_factorization"},
+                "constraint_imposition_settings" : {
+                    "method" : "augmented_lagrange",
+                    "penalty_factor" : "1e6 * max",
+                    "max_iterations" : 5e1,
+                    "tolerance" : 1e-9,
+                    "verbosity" : 1
+                }
+            }
+        }
+    },
+    "processes": {
+        "constraints_process_list": [
+            {
+                "python_module": "assign_vector_variable_process",
+                "kratos_module": "KratosMultiphysics",
+                "process_name": "AssignVectorVariableProcess",
+                "Parameters": {
+                    "model_part_name": "root.dirichlet",
+                    "variable_name": "DISPLACEMENT",
+                    "interval": [0.0, "End"],
+                    "constrained": [true, true, true],
+                    "value": [0.0, 0.0, 0.0]
+                }
+            },
+            {
+                "kratos_module" : "KratosMultiphysics.StructuralMechanicsApplication",
+                "python_module" : "link_constraint_process",
+                "process_name" : "LinkConstraintProcess",
+                "Parameters" : {
+                    "model_part_name" : "root",
+                    "node_pairs" : [[2, 3]],
+                    "dimensions" : 3,
+                    "interval" : [0, 2],
+                    "move_mesh_flag" : true
+                }
+            }
+        ],
+        "loads_process_list": [
+            {
+                "python_module": "assign_vector_by_direction_to_condition_process",
+                "kratos_module": "KratosMultiphysics",
+                "process_name": "AssignVectorByDirectionToConditionProcess",
+                "Parameters": {
+                    "model_part_name": "root.neumann",
+                    "variable_name": "POINT_LOAD",
+                    "interval": [
+                        0.0, "End"
+                    ],
+                    "modulus": "3e-1 * t",
+                    "direction": [1, 3, 2]
+                }
+            }
+        ],
+        "list_other_processes": []
+    },
+    "output_processes": {}
+}

--- a/applications/StructuralMechanicsApplication/tests/constraints/link_constraint_3d.json
+++ b/applications/StructuralMechanicsApplication/tests/constraints/link_constraint_3d.json
@@ -33,7 +33,7 @@
             "advanced_settings" : {
                 "max_iterations" : 1,
                 "verbosity" : 1,
-                "smoother_settings" : {"solver_type" : "skyline_lu_factorization"},
+                "linear_solver_settings" : {"solver_type" : "skyline_lu_factorization"},
                 "constraint_imposition_settings" : {
                     "method" : "augmented_lagrange",
                     "penalty_factor" : "1e6 * max",

--- a/applications/StructuralMechanicsApplication/tests/constraints/link_constraint_3d.mdpa
+++ b/applications/StructuralMechanicsApplication/tests/constraints/link_constraint_3d.mdpa
@@ -1,0 +1,30 @@
+Begin Properties 0
+End Properties
+
+Begin Nodes
+    1 0 0 0
+    2 1 0 0
+    3 0 1 0
+    4 0 0 1
+End Nodes
+
+Begin Elements SmallDisplacementElement3D4N
+    1 0 1 2 3 4
+End Elements
+
+Begin Conditions PointLoadCondition3D1N
+    1 0 2
+End Conditions
+
+Begin SubModelPart neumann
+    Begin SubModelPartConditions
+        1
+    End SubModelPartConditions
+End SubModelPart
+
+Begin SubModelPart dirichlet
+    Begin SubModelPartNodes
+        1
+        4
+    End SubModelPartNodes
+End SubModelPart

--- a/applications/StructuralMechanicsApplication/tests/constraints/link_constraint_3d_materials.json
+++ b/applications/StructuralMechanicsApplication/tests/constraints/link_constraint_3d_materials.json
@@ -1,0 +1,19 @@
+{
+    "properties": [
+        {
+            "model_part_name": "root",
+            "properties_id": 1,
+            "Material": {
+                "constitutive_law": {
+                    "name": "LinearElastic3DLaw"
+                },
+                "Variables": {
+                    "DENSITY": 1.0,
+                    "YOUNG_MODULUS": 1.0,
+                    "POISSON_RATIO": 0.3
+                },
+                "Tables": null
+            }
+        }
+    ]
+}

--- a/applications/StructuralMechanicsApplication/tests/test_StructuralMechanicsApplication.py
+++ b/applications/StructuralMechanicsApplication/tests/test_StructuralMechanicsApplication.py
@@ -15,6 +15,8 @@ has_linear_solvers_application = kratos_utilities.CheckIfApplicationsAvailable("
 ##### SELF-CONTAINED TESTS #####
 # CL tests
 from test_constitutive_law import TestConstitutiveLaw as TTestConstitutiveLaw
+# Constraint tests
+from test_link_constraint import TestLinkConstraint
 # Processes test
 from test_mass_calculation import TestMassCalculation as TTestMassCalculation
 from test_compute_center_of_gravity import TestComputeCenterOfGravity as TTestComputeCenterOfGravity
@@ -274,6 +276,8 @@ def AssembleTestSuites():
     smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([TTestConstitutiveLaw]))
     nightSuite.addTest(TInitialStateElasticityTest('test_execution'))
     nightSuite.addTest(TInitialStrainShellQ4ThickTest('test_execution'))
+    # Constraint tests
+    smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCase(TestLinkConstraint))
     # Mass calculation tests
     smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([TTestMassCalculation]))
     smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([TTestComputeCenterOfGravity]))

--- a/applications/StructuralMechanicsApplication/tests/test_link_constraint.py
+++ b/applications/StructuralMechanicsApplication/tests/test_link_constraint.py
@@ -1,0 +1,148 @@
+# --- Kratos Imports ---
+import KratosMultiphysics
+import KratosMultiphysics.KratosUnittest
+from KratosMultiphysics.StructuralMechanicsApplication.structural_mechanics_analysis import StructuralMechanicsAnalysis
+
+# --- STD Imports ---
+import pathlib
+import contextlib
+import os
+from typing import Generator
+import math
+
+import KratosMultiphysics.analysis_stage
+
+
+@contextlib.contextmanager
+def CaseWorkingDirectory(case_directory: pathlib.Path) -> Generator[None, None, None]:
+    original_directory = pathlib.Path(os.getcwd())
+    os.chdir(case_directory)
+    try:
+        yield
+    finally:
+        os.chdir(original_directory)
+
+
+class TestLinkConstraint(KratosMultiphysics.KratosUnittest.TestCase):
+
+    def test_LinkConstraint2DWithoutMovedMesh(self) -> None:
+        self.__Run2D(False)
+
+    def test_LinkConstraint2DWithMovedMesh(self) -> None:
+        self.__Run2D(True)
+
+    def test_LinkConstraint3DWithoutMovedMesh(self) -> None:
+        self.__Run3D(False)
+
+    def test_LinkConstraint3DWithMovedMesh(self) -> None:
+        self.__Run3D(True)
+
+    @staticmethod
+    def __GetNodeDistance(first: KratosMultiphysics.Node,
+                          second: KratosMultiphysics.Node,
+                          dimensions: int,
+                          initial_configuration: bool = False) -> float:
+        initial_positions: "list[list[float]]" = [[first.X0, first.Y0, first.Z0],
+                                                  [second.X0, second.Y0, second.Z0]]
+        displacements: "list[list[float]]" = [[first.GetSolutionStepValue(KratosMultiphysics.DISPLACEMENT_X),
+                                               first.GetSolutionStepValue(KratosMultiphysics.DISPLACEMENT_Y),
+                                               first.GetSolutionStepValue(KratosMultiphysics.DISPLACEMENT_Z)],
+                                              [second.GetSolutionStepValue(KratosMultiphysics.DISPLACEMENT_X),
+                                               second.GetSolutionStepValue(KratosMultiphysics.DISPLACEMENT_Y),
+                                               second.GetSolutionStepValue(KratosMultiphysics.DISPLACEMENT_Z)]]
+        distance: float = 0.0
+        for i_component in range(dimensions):
+            diff: float = initial_positions[0][i_component] - initial_positions[1][i_component]
+            if not initial_configuration:
+                diff += displacements[0][i_component] - displacements[1][i_component]
+            distance += diff * diff
+        return math.sqrt(distance)
+
+
+    def __Run2D(self, move_mesh_flag: bool) -> None:
+        script_directory = pathlib.Path(__file__).absolute().parent
+        dimensions = 2
+
+        with CaseWorkingDirectory(script_directory / "constraints"):
+            # Load config.
+            with open("link_constraint_2d.json") as project_parameters_file:
+                parameters = KratosMultiphysics.Parameters(project_parameters_file.read())
+
+            parameters["solver_settings"]["move_mesh_flag"].SetBool(move_mesh_flag)
+            parameters["processes"]["constraints_process_list"][1]["Parameters"]["move_mesh_flag"].SetBool(move_mesh_flag)
+
+            # The test is set up such that 2 pseudo time steps are taken.
+            #
+            # At the end of the first one, the constraint is supposed to
+            # be active so distance between the constrained nodes is supposed
+            # to remain constant.
+            #
+            # At the end of the second step, the constraint is supposed to be
+            # inactive, allowing the distance between the constrained nodes to
+            # change.
+
+            # Run the analysis until the first step and check whether constraints are satisfied.
+            parameters["problem_data"]["end_time"].SetDouble(0.5)
+            model = KratosMultiphysics.Model()
+            self.__Run(model, parameters, move_mesh_flag = move_mesh_flag)
+            root_model_part = model.GetModelPart("root")
+
+            constrained_node_ids: "tuple[int,int]" = (2, 3)
+            first: KratosMultiphysics.Node = root_model_part.GetNode(constrained_node_ids[0])
+            second: KratosMultiphysics.Node = root_model_part.GetNode(constrained_node_ids[1])
+            initial_distance: float = self.__GetNodeDistance(first, second, 2, initial_configuration = True)
+            distance: float = self.__GetNodeDistance(first, second, dimensions)
+            self.assertAlmostEqual(distance, initial_distance, places = 3)
+
+            # Run the analysis until the first step and check whether constraints are not satisfied.
+            parameters["problem_data"]["end_time"].SetDouble(1.0)
+            model = KratosMultiphysics.Model()
+            self.__Run(model, parameters, move_mesh_flag = move_mesh_flag)
+            root_model_part = model.GetModelPart("root")
+
+            constrained_node_ids: "tuple[int,int]" = (2, 3)
+            first: KratosMultiphysics.Node = root_model_part.GetNode(constrained_node_ids[0])
+            second: KratosMultiphysics.Node = root_model_part.GetNode(constrained_node_ids[1])
+            initial_distance: float = self.__GetNodeDistance(first, second, 2, initial_configuration = True)
+            distance: float = self.__GetNodeDistance(first, second, dimensions)
+            self.assertNotAlmostEqual(distance, initial_distance, places = 0)
+
+
+    def __Run3D(self, move_mesh_flag: bool) -> None:
+        script_directory = pathlib.Path(__file__).absolute().parent
+        dimensions = 3
+
+        with CaseWorkingDirectory(script_directory / "constraints"):
+            # Load config.
+            with open("link_constraint_3d.json") as project_parameters_file:
+                parameters = KratosMultiphysics.Parameters(project_parameters_file.read())
+
+            parameters["solver_settings"]["move_mesh_flag"].SetBool(move_mesh_flag)
+            parameters["processes"]["constraints_process_list"][1]["Parameters"]["move_mesh_flag"].SetBool(move_mesh_flag)
+
+            model = KratosMultiphysics.Model()
+            self.__Run(model, parameters, move_mesh_flag = move_mesh_flag)
+            root_model_part = model.GetModelPart("root")
+
+            constrained_node_ids: "tuple[int,int]" = (2, 3)
+            first: KratosMultiphysics.Node = root_model_part.GetNode(constrained_node_ids[0])
+            second: KratosMultiphysics.Node = root_model_part.GetNode(constrained_node_ids[1])
+            initial_distance: float = self.__GetNodeDistance(first, second, 2, initial_configuration = True)
+            distance: float = self.__GetNodeDistance(first, second, dimensions)
+            self.assertAlmostEqual(distance, initial_distance, places = 3)
+
+
+    def __Run(self,
+              model: KratosMultiphysics.Model,
+              project_parameters: KratosMultiphysics.Parameters,
+              move_mesh_flag: bool):
+        project_parameters["solver_settings"]["move_mesh_flag"].SetBool(move_mesh_flag)
+        project_parameters["processes"]["constraints_process_list"][1]["Parameters"]["move_mesh_flag"].SetBool(move_mesh_flag)
+
+        KratosMultiphysics.ModelPart = model.CreateModelPart("root")
+        analysis_stage = StructuralMechanicsAnalysis(model, project_parameters)
+        analysis_stage.Run()
+
+
+if __name__ == "__main__":
+    KratosMultiphysics.KratosUnittest.main()


### PR DESCRIPTION
Add `LinkConstraint` and a factory process. This nonlinear constraint forces two nodes to maintain the original distance between each other after deformation.

![link2D](https://github.com/user-attachments/assets/373e92ce-7f9d-407b-8a3d-3d743c309c21)

##

This constraint can be used as an example for future nonlinear constraints.

##

**Since `LinkConstraint` is nonlinear, it can only be used with `PMultigridBuilderAndSolver` and must not be assembled with `MasterSlaveConstraintAssembler`.**
