### PR TITLE
[Hotfix][Core] Sparse arrays move constructors

### DIFF
--- a/kratos/containers/csr_matrix.h
+++ b/kratos/containers/csr_matrix.h
@@ -173,9 +173,10 @@ public:
         });
     }
 
-    //move constructor
+    /// Move constructor
     CsrMatrix(CsrMatrix<TDataType,TIndexType>&& rOtherMatrix)
     {
+        mpComm = rOtherMatrix.mpComm;
         mIsOwnerOfData=rOtherMatrix.mIsOwnerOfData;
         rOtherMatrix.mIsOwnerOfData=false;
 
@@ -205,7 +206,7 @@ public:
     /// Assignment operator.
     CsrMatrix& operator=(CsrMatrix const& rOtherMatrix) = delete; //i really think this should not be allowed, too risky
 
-    //move assignement operator
+    /// Move assignment operator
     CsrMatrix& operator=(CsrMatrix&& rOtherMatrix)
     {
         mpComm = rOtherMatrix.mpComm;

--- a/kratos/containers/system_vector.h
+++ b/kratos/containers/system_vector.h
@@ -114,6 +114,13 @@ public:
         });
     }
 
+    // Move constructor
+    SystemVector(SystemVector<TDataType,TIndexType>& rOtherVector)
+    {
+        mpComm = rOtherVector.mpComm;
+        mData = rOtherVector.mData;
+    }
+
     /// Destructor.
     ~SystemVector(){}
 
@@ -196,6 +203,13 @@ public:
         return *this;
     }
 
+    /// Move assignment operator
+    SystemVector& operator=(SystemVector&& rOtherVector)
+    {
+        mpComm = rOtherVector.mpComm;
+        mData = rOtherVector.mData;
+        return *this;
+    }
 
     SystemVector& operator+=(const SystemVector& rOtherVector)
     {


### PR DESCRIPTION
**📝 Description**
This PR adds a small fix to the CSR matrix move constructor (the communicator pointer was not set). It also adds the missing move constructor and assignment operators to the system vector.
