### PR TITLE
[FastPR][Core] Missing const in transpose CSR

### DIFF
--- a/kratos/utilities/amgcl_csr_conversion_utilities.h
+++ b/kratos/utilities/amgcl_csr_conversion_utilities.h
@@ -84,7 +84,7 @@ public:
     //Note that we deliberately return a unique_ptr as it can be moved to a shared_ptr as needed
     template< class TDataType, class TIndexType >
     static typename CsrMatrix<TDataType, TIndexType>::Pointer Transpose(
-        CsrMatrix<TDataType, TIndexType>& rA
+        const CsrMatrix<TDataType, TIndexType>& rA
     )
     {
         const auto pAamgcl = ConvertToAmgcl<TDataType,TIndexType>(rA);


### PR DESCRIPTION
**📝 Description**
Adds a missing `const` to the provided argument.
