### PR TITLE
[Core] Adding process to manually move mesh 

### DIFF
--- a/kratos/python/add_strategies_to_python.cpp
+++ b/kratos/python/add_strategies_to_python.cpp
@@ -74,11 +74,11 @@ namespace Kratos:: Python
 {
     namespace py = pybind11;
 
-    typedef UblasSpace<double, CompressedMatrix, boost::numeric::ublas::vector<double>> SparseSpaceType;
-    typedef UblasSpace<double, Matrix, Vector> LocalSpaceType;
+    using SparseSpaceType = UblasSpace<double, CompressedMatrix, boost::numeric::ublas::vector<double>>;
+    using LocalSpaceType = UblasSpace<double, Matrix, Vector>;
 
-    typedef UblasSpace<std::complex<double>, ComplexCompressedMatrix, boost::numeric::ublas::vector<std::complex<double>>> ComplexSparseSpaceType;
-    typedef UblasSpace<std::complex<double>, ComplexMatrix, ComplexVector> ComplexLocalSpaceType;
+    using ComplexSparseSpaceType = UblasSpace<std::complex<double>, ComplexCompressedMatrix, boost::numeric::ublas::vector<std::complex<double>>>;
+    using ComplexLocalSpaceType = UblasSpace<std::complex<double>, ComplexMatrix, ComplexVector>;
 
     //ADDED BY PAOLO (next two)
 
@@ -541,8 +541,8 @@ namespace Kratos:: Python
         //********************************************************************
         //********************************************************************
 
-        //strategy base class
-        typedef SolvingStrategy< SparseSpaceType, LocalSpaceType > BaseSolvingStrategyType;
+        // Strategy base class
+        using BaseSolvingStrategyType = SolvingStrategy< SparseSpaceType, LocalSpaceType >;
         py::class_< BaseSolvingStrategyType, typename BaseSolvingStrategyType::Pointer >(m,"BaseSolvingStrategy")
             .def(py::init<ModelPart&, Parameters >() )
             .def(py::init < ModelPart&, bool >())
@@ -560,6 +560,7 @@ namespace Kratos:: Python
             .def("MoveMeshFlag", &BaseSolvingStrategyType::GetMoveMeshFlag)
             .def("GetMoveMeshFlag", &BaseSolvingStrategyType::GetMoveMeshFlag)
             .def("MoveMesh", &BaseSolvingStrategyType::MoveMesh)
+            .def_static("SimpleDisplacementMeshMoving", &BaseSolvingStrategyType::SimpleDisplacementMeshMoving)
             .def("Clear", &BaseSolvingStrategyType::Clear)
             .def("Check", &BaseSolvingStrategyType::Check)
             .def("GetDefaultParameters",&BaseSolvingStrategyType::GetDefaultParameters)

--- a/kratos/python_scripts/move_mesh_process.py
+++ b/kratos/python_scripts/move_mesh_process.py
@@ -1,0 +1,65 @@
+# Importing the Kratos Library
+import KratosMultiphysics as KM
+
+# Define the process factory
+def Factory(settings, Model):
+    if not isinstance(settings, KM.Parameters):
+        raise Exception("expected input shall be a Parameters object, encapsulating a json string")
+    return MoveMeshProcess(Model, settings["Parameters"])
+
+class MoveMeshProcess(KM.Process):
+    """
+    This process moves the mesh of a model part using the specified variable.
+    The mesh is moved only if the current time is within the specified interval.
+
+    Only the member variables listed below should be accessed directly.
+
+    Public member variables:
+    Model -- the container of the different model parts.
+    settings -- Kratos parameters containing solver settings.
+    """
+
+    def __init__(self, Model, settings):
+        """ The default constructor of the class
+
+        Keyword arguments:
+        self -- It signifies an instance of a class.
+        Model -- the container of the different model parts.
+        settings -- Kratos parameters containing solver settings.
+        """
+        # call the base class constructor
+        super().__init__()
+
+        # Validate input settings
+        default_settings = KM.Parameters("""
+        {
+            "help"            : "This process moves the mesh of a model part using the specified variable. The mesh is moved only if the current time is within the specified interval.",
+            "model_part_name" : "please_specify_model_part_name",
+            "variable_name"   : "DISPLACEMENT",
+            "interval"        : [0.0, 1e30]
+        }
+        """
+        )
+
+        # Validate and assign
+        settings.ValidateAndAssignDefaults(default_settings)
+
+        # Define member variables of the class
+        self.model_part = Model[settings["model_part_name"].GetString()]
+        self.variable = KM.KratosGlobals.GetVariable(settings["variable_name"].GetString())
+        self.interval = KM.IntervalUtility(settings)
+
+    def ExecuteInitializeSolutionStep(self):
+        """ This method is executed in order to initialize the current step
+
+        Keyword arguments:
+        self -- It signifies an instance of a class.
+        """
+        process_info = self.model_part.ProcessInfo
+        current_time = process_info[KM.TIME]
+
+        # Check if the current time is in the interval
+        if self.interval.IsInInterval(current_time):
+            # If the interval is valid, we apply the mesh moving process
+            KM.BaseSolvingStrategy.SimpleDisplacementMeshMoving(self.model_part, self.variable)
+

--- a/kratos/solving_strategies/strategies/solving_strategy.h
+++ b/kratos/solving_strategies/strategies/solving_strategy.h
@@ -331,16 +331,29 @@ public:
     {
         KRATOS_TRY
 
+        // For the base class we just simply move using the displacements of the nodes
         KRATOS_ERROR_IF_NOT(GetModelPart().HasNodalSolutionStepVariable(DISPLACEMENT_X)) << "It is impossible to move the mesh since the DISPLACEMENT var is not in the Model Part. Either use SetMoveMeshFlag(False) or add DISPLACEMENT to the list of variables" << std::endl;
-
-        block_for_each(GetModelPart().Nodes(), [](Node& rNode){
-            noalias(rNode.Coordinates()) = rNode.GetInitialPosition().Coordinates();
-            noalias(rNode.Coordinates()) += rNode.FastGetSolutionStepValue(DISPLACEMENT);
-        });
+        SimpleDisplacementMeshMoving(GetModelPart(), DISPLACEMENT);
 
         KRATOS_INFO_IF("SolvingStrategy", this->GetEchoLevel() != 0) << " MESH MOVED " << std::endl;
 
         KRATOS_CATCH("")
+    }
+
+    /**
+     * @brief This function is designed to move the mesh using the displacements of the nodes
+     * @param rModelPart The model part to be moved
+     * @param rVariable The variable to be used for the mesh moving
+     */
+    static void SimpleDisplacementMeshMoving(
+        ModelPart& rModelPart,
+        const Variable<array_1d<double, 3>>& rDisplacementVariable = DISPLACEMENT
+        )
+    {
+        block_for_each(rModelPart.Nodes(), [&rDisplacementVariable](Node& rNode){
+            noalias(rNode.Coordinates()) = rNode.GetInitialPosition().Coordinates();
+            noalias(rNode.Coordinates()) += rNode.FastGetSolutionStepValue(rDisplacementVariable);
+        });
     }
 
     /**


### PR DESCRIPTION
**📝 Description**

Related: https://github.com/KratosMultiphysics/Kratos/issues/13350

This PR adds a process in order to move the mesh manually (instead of waiting for the strategy to do it). With the following changes.

1. **Exposing `SimpleDisplacementMeshMoving` to Python:**
   - A new static method `SimpleDisplacementMeshMoving` is added to the `SolvingStrategy` class, which moves the mesh using the displacement of nodes.
   - The function is exposed to Python through the `add_strategies_to_python.cpp` file, enabling its use within Python scripts.

2. **MoveMeshProcess for Mesh Movement:**
   - A new Python process `MoveMeshProcess` is added in the `move_mesh_process.py` file. This process moves the mesh of a model part using a specified variable (e.g., displacement) and applies the mesh movement only if the current time is within the defined interval.

Example of use:

~~~json
{
    "python_module" : "move_mesh_process",
    "kratos_module" : "KratosMultiphysics",
    "process_name"  : "MoveMeshProcess",
    "Parameters"    : {
        "model_part_name" : "Structure",
        "variable_name"   : "DISPLACEMENT",
        "interval"        : [0.0,"End"]
    }
}
~~~

**🆕 Changelog**

- [Add `SimpleDisplacementMeshMoving` function for mesh movement using node displacements](https://github.com/KratosMultiphysics/Kratos/commit/c11ec4b8be9a7490557978f06babfb28a3205efc)
- [Expose SimpleDisplacementMeshMoving to python](https://github.com/KratosMultiphysics/Kratos/commit/e7dddd35c4ade3871fa8fc89b3999c19fe54b752)
- [Add MoveMeshProcess for mesh movement based on specified variable and time interval](https://github.com/KratosMultiphysics/Kratos/commit/e5ad56e487ccbc10ee87f4d9b4d7d4b011554eb2)
