### PR TITLE
[GeoMechanicsApplication] Convert the reordering of Mohr-Coulomb principal stresses to averaging

### DIFF
--- a/applications/GeoMechanicsApplication/custom_constitutive/mohr_coulomb_with_tension_cutoff.cpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/mohr_coulomb_with_tension_cutoff.cpp
@@ -260,13 +260,29 @@ void MohrCoulombWithTensionCutOff::CalculateMaterialResponseCauchy(ConstitutiveL
                 MathUtils<>::DegreesToRadians(r_prop[GEO_FRICTION_ANGLE]), r_prop[GEO_COHESION]);
         }
 
-        StressStrainUtilities::ReorderEigenValuesAndVectors(principal_trial_stress_vector, rotation_matrix);
+        principal_trial_stress_vector = this->RearrangeEigenValuesAndVectors(principal_trial_stress_vector);
     }
 
     mStressVector = StressStrainUtilities::RotatePrincipalStresses(
         principal_trial_stress_vector, rotation_matrix, mpConstitutiveDimension->GetStrainSize());
 
     rParameters.GetStressVector() = mStressVector;
+}
+
+Vector MohrCoulombWithTensionCutOff::RearrangeEigenValuesAndVectors(const Vector& rPrincipalStressVector)
+{
+    auto result = rPrincipalStressVector;
+    if (result[0] < result[1]) {
+        double average = (result[0] + result[1]) * 0.5;
+        result[0] = average;
+        result[1] = average;
+    }
+    else if(result[1] < result[2]) {
+        double average = (result[1] + result[2]) * 0.5;
+        result[1] = average;
+        result[2] = average;
+    }
+    return result;
 }
 
 bool MohrCoulombWithTensionCutOff::IsAdmissiblePrincipalStressState(const Vector& rPrincipalStresses) const

--- a/applications/GeoMechanicsApplication/custom_constitutive/mohr_coulomb_with_tension_cutoff.h
+++ b/applications/GeoMechanicsApplication/custom_constitutive/mohr_coulomb_with_tension_cutoff.h
@@ -88,6 +88,7 @@ private:
     [[nodiscard]] static bool IsStressAtCornerReturnZone(const Vector& rTrialSigmaTau,
                                                          double        DilatancyAngle,
                                                          const Vector& rCornerPoint);
+    Vector RearrangeEigenValuesAndVectors(const Vector& rPrincipalStressVector);
 
     friend class Serializer;
     void save(Serializer& rSerializer) const override;

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_constitutive/test_mohr_coulomb_with_tension_cutoff.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_constitutive/test_mohr_coulomb_with_tension_cutoff.cpp
@@ -202,7 +202,7 @@ KRATOS_TEST_CASE_IN_SUITE(MohrCoulombWithTensionCutOff_CalculateMaterialResponse
                               expected_cauchy_stress_vector, Defaults::absolute_tolerance);
 
     cauchy_stress_vector <<= 12.0, 10.0, -16.0, 0.0;
-    expected_cauchy_stress_vector <<= 7.338673315592010089, 7.90609951999166506, -9.24477283558367515, 0.0;
+    expected_cauchy_stress_vector <<= 7.806379130008, 7.806379130008, -9.61275826001616129, 0.0;
     KRATOS_EXPECT_VECTOR_NEAR(CalculateMappedStressVector(cauchy_stress_vector, parameters, law),
                               expected_cauchy_stress_vector, Defaults::absolute_tolerance);
 }
@@ -239,7 +239,7 @@ KRATOS_TEST_CASE_IN_SUITE(MohrCoulombWithTensionCutOff_CalculateMaterialResponse
     cauchy_stress_vector <<= 24.0, 22.0, -8.0, 0.0;
     expected_cauchy_stress_vector <<= 10.0, 10.0, -1.5179192179966735, 0.0;
     KRATOS_EXPECT_VECTOR_NEAR(CalculateMappedStressVector(cauchy_stress_vector, parameters, law),
-                              expected_cauchy_stress_vector, Defaults::absolute_tolerance);
+                              expected_cauchy_stress_vector, 1.0e-10);
 }
 
 KRATOS_TEST_CASE_IN_SUITE(MohrCoulombWithTensionCutOff_CalculateMaterialResponseCauchyAtTensionCutoffReturnZone,
@@ -274,7 +274,7 @@ KRATOS_TEST_CASE_IN_SUITE(MohrCoulombWithTensionCutOff_CalculateMaterialResponse
     cauchy_stress_vector <<= 14.0, 12.0, 6.0, 0.0;
     expected_cauchy_stress_vector <<= 10.0, 10.0, 6.0, 0.0;
     KRATOS_EXPECT_VECTOR_NEAR(CalculateMappedStressVector(cauchy_stress_vector, parameters, law),
-                              expected_cauchy_stress_vector, Defaults::absolute_tolerance);
+                              expected_cauchy_stress_vector, 1.0e-10);
 }
 
 KRATOS_TEST_CASE_IN_SUITE(MohrCoulombWithTensionCutOff_CalculateMaterialResponseCauchyAtTensionApexReturnZone,
@@ -299,12 +299,12 @@ KRATOS_TEST_CASE_IN_SUITE(MohrCoulombWithTensionCutOff_CalculateMaterialResponse
     Vector expected_cauchy_stress_vector(4);
     expected_cauchy_stress_vector <<= 10.0, 10.0, 10.0, 0.0;
     KRATOS_EXPECT_VECTOR_NEAR(CalculateMappedStressVector(cauchy_stress_vector, parameters, law),
-                              expected_cauchy_stress_vector, Defaults::absolute_tolerance);
+                              expected_cauchy_stress_vector, 1.0e-10);
 
     cauchy_stress_vector <<= 11.5, 10.0, 10.5, 0.0;
     expected_cauchy_stress_vector <<= 10.0, 10.0, 10.0, 0.0;
     KRATOS_EXPECT_VECTOR_NEAR(CalculateMappedStressVector(cauchy_stress_vector, parameters, law),
-                              expected_cauchy_stress_vector, Defaults::absolute_tolerance);
+                              expected_cauchy_stress_vector, 1.0e-10);
 }
 
 KRATOS_TEST_CASE_IN_SUITE(MohrCoulombWithTensionCutOff_CalculateMaterialResponseCauchyWithLargeTensileStrength,
@@ -329,7 +329,7 @@ KRATOS_TEST_CASE_IN_SUITE(MohrCoulombWithTensionCutOff_CalculateMaterialResponse
     Vector expected_cauchy_stress_vector(4);
     expected_cauchy_stress_vector <<= 14.2814800674211450, 14.2814800674211450, 14.2814800674211450, 0.0;
     KRATOS_EXPECT_VECTOR_NEAR(CalculateMappedStressVector(cauchy_stress_vector, parameters, law),
-                              expected_cauchy_stress_vector, Defaults::absolute_tolerance);
+                              expected_cauchy_stress_vector, 1.0e-10);
 }
 
 KRATOS_TEST_CASE_IN_SUITE(MohrCoulombWithTensionCutOff_Serialization, KratosGeoMechanicsFastSuiteWithoutKernel)


### PR DESCRIPTION
**📝 Description**
In order to make the currently implemented Mohr-Coulomb consistent to UDSM of Plaxis, we need to change the reordering of the principal stresse to averaging type.

**🆕 Changelog**
- Added averaging replacing of reordering
- Fixed the unit tests