### PR TITLE
[Core] Missing constraints in `ConnectivityPreserveModeler`

### DIFF
--- a/kratos/modeler/connectivity_preserve_modeler.cpp
+++ b/kratos/modeler/connectivity_preserve_modeler.cpp
@@ -31,12 +31,10 @@ ConnectivityPreserveModeler::ConnectivityPreserveModeler(Model& rModel, Paramete
     mParameters.ValidateAndAssignDefaults(GetDefaultParameters());
 }
 
-
 Modeler::Pointer ConnectivityPreserveModeler::Create(Model& rModel, const Parameters Settings) const
 {
     return Kratos::make_shared<ConnectivityPreserveModeler>(rModel, Settings);
 }
-
 
 void ConnectivityPreserveModeler::GenerateModelPart(
     ModelPart& rOriginModelPart,
@@ -163,7 +161,6 @@ void ConnectivityPreserveModeler::SetupModelPart()
     }
 }
 
-
 const Parameters ConnectivityPreserveModeler::GetDefaultParameters() const
 {
     return Parameters(R"({
@@ -174,12 +171,10 @@ const Parameters ConnectivityPreserveModeler::GetDefaultParameters() const
     })");
 }
 
-
 std::string ConnectivityPreserveModeler::Info() const
 {
     return "ConnectivityPreserveModeler";
 }
-
 
 // Private methods /////////////////////////////////////////////////////////////
 void ConnectivityPreserveModeler::CheckVariableLists(ModelPart& rOriginModelPart, ModelPart& rDestinationModelPart) const
@@ -206,10 +201,12 @@ void ConnectivityPreserveModeler::ResetModelPart(ModelPart& rDestinationModelPar
     VariableUtils().SetFlag(TO_ERASE, true, rDestinationModelPart.Nodes());
     VariableUtils().SetFlag(TO_ERASE, true, rDestinationModelPart.Elements());
     VariableUtils().SetFlag(TO_ERASE, true, rDestinationModelPart.Conditions());
+    VariableUtils().SetFlag(TO_ERASE, true, rDestinationModelPart.MasterSlaveConstraints());
 
     rDestinationModelPart.RemoveNodesFromAllLevels(TO_ERASE);
     rDestinationModelPart.RemoveElementsFromAllLevels(TO_ERASE);
     rDestinationModelPart.RemoveConditionsFromAllLevels(TO_ERASE);
+    rDestinationModelPart.RemoveMasterSlaveConstraintsFromAllLevels(TO_ERASE);
 }
 
 void ConnectivityPreserveModeler::CopyCommonData(
@@ -240,6 +237,9 @@ void ConnectivityPreserveModeler::CopyCommonData(
 
     // Assign the geometries to the new model part
     rDestinationModelPart.Geometries() = rOriginModelPart.Geometries();
+
+    // Assign the master slave constraints to the new model part
+    rDestinationModelPart.MasterSlaveConstraints() = rOriginModelPart.MasterSlaveConstraints();
 }
 
 void ConnectivityPreserveModeler::DuplicateElements(
@@ -328,37 +328,37 @@ void ConnectivityPreserveModeler::DuplicateCommunicatorData(
 }
 
 void ConnectivityPreserveModeler::DuplicateSubModelParts(
-ModelPart& rOriginModelPart,
-ModelPart& rDestinationModelPart) const
+    ModelPart& rOriginModelPart,
+    ModelPart& rDestinationModelPart) const
 {
     for (auto i_part = rOriginModelPart.SubModelPartsBegin(); i_part != rOriginModelPart.SubModelPartsEnd(); ++i_part) {
         if(!rDestinationModelPart.HasSubModelPart(i_part->Name())) {
             rDestinationModelPart.CreateSubModelPart(i_part->Name());
         }
 
-        ModelPart& destination_part = rDestinationModelPart.GetSubModelPart(i_part->Name());
+        ModelPart& r_destination_part = rDestinationModelPart.GetSubModelPart(i_part->Name());
 
-        destination_part.AddNodes(i_part->NodesBegin(), i_part->NodesEnd());
+        r_destination_part.AddNodes(i_part->NodesBegin(), i_part->NodesEnd());
 
         std::vector<ModelPart::IndexType> ids;
         ids.reserve(i_part->Elements().size());
 
         // Execute only if we created elements in the destination
-        if (rDestinationModelPart.NumberOfElements() > 0)
-        {
+        if (rDestinationModelPart.NumberOfElements() > 0) {
             //adding by index
-            for(auto it=i_part->ElementsBegin(); it!=i_part->ElementsEnd(); ++it)
+            for(auto it=i_part->ElementsBegin(); it!=i_part->ElementsEnd(); ++it) {
                 ids.push_back(it->Id());
-            destination_part.AddElements(ids, 0); //adding by index
+            }
+            r_destination_part.AddElements(ids, 0); //adding by index
         }
 
         // Execute only if we created conditions in the destination
-        if (rDestinationModelPart.NumberOfConditions() > 0)
-        {
+        if (rDestinationModelPart.NumberOfConditions() > 0) {
             ids.clear();
-            for(auto it=i_part->ConditionsBegin(); it!=i_part->ConditionsEnd(); ++it)
+            for(auto it=i_part->ConditionsBegin(); it!=i_part->ConditionsEnd(); ++it) {
                 ids.push_back(it->Id());
-            destination_part.AddConditions(ids, 0);
+            }
+            r_destination_part.AddConditions(ids, 0);
         }
 
         // Execute only if there are geometries in the destination
@@ -367,14 +367,24 @@ ModelPart& rDestinationModelPart) const
             for (const auto& r_geom : i_part->Geometries()) {
                 ids.push_back(r_geom.Id());
             }
-            destination_part.AddGeometries(ids);
+            r_destination_part.AddGeometries(ids);
+        }
+
+        // Execute only if there are MasterSlaveConstraints in the destination
+        if (rDestinationModelPart.NumberOfMasterSlaveConstraints() > 0) {
+            ids.clear();
+            ids.reserve(i_part->NumberOfMasterSlaveConstraints());
+            for (const auto& r_constraint : i_part->MasterSlaveConstraints()) {
+                ids.push_back(r_constraint.Id());
+            }
+            r_destination_part.AddMasterSlaveConstraints(ids, 0);
         }
 
         // Duplicate the Communicator for this SubModelPart
-        this->DuplicateCommunicatorData(*i_part, destination_part);
+        this->DuplicateCommunicatorData(*i_part, r_destination_part);
 
         // Recursively call this function to duplicate any child SubModelParts
-        this->DuplicateSubModelParts(*i_part, destination_part);
+        this->DuplicateSubModelParts(*i_part, r_destination_part);
     }
 }
 

--- a/kratos/modeler/connectivity_preserve_modeler.h
+++ b/kratos/modeler/connectivity_preserve_modeler.h
@@ -11,33 +11,34 @@
 //
 //
 
-#if !defined( KRATOS_CONNECTIVITY_PRESERVE_MODELER_H )
-#define  KRATOS_CONNECTIVITY_PRESERVE_MODELER_H
-
-
+#pragma once
 
 // System includes
-#include <string>
-#include <iostream>
-#include <algorithm>
 
 // External includes
 
-
 // Project includes
-#include "includes/define.h"
 #include "includes/define_registry.h"
 #include "includes/model_part.h"
 #include "modeler/modeler.h"
 
 namespace Kratos
 {
-///@}
 ///@name Kratos Classes
 ///@{
 
-/// A tool to generate a copy of a ModelPart, sharing the same nodes as the original.
-class KRATOS_API(KRATOS_CORE) ConnectivityPreserveModeler : public Modeler
+/**
+ * @class ConnectivityPreserveModeler
+ * @ingroup KratosCore
+ * @brief This class is used to generate a copy of a ModelPart, sharing the same nodes as the original.
+ * @details The elements and conditions of the new ModelPart will have the same connectivity (and id) as in the original ModelPart,
+ * but their type is determined by the reference element and condition provided during construction.
+ * Note that both ModelParts will share the same nodes, as well as ProcessInfo and tables.
+ * SubModelParts and, in MPI, communicator data will be replicated in the new ModelPart.
+ * @author Riccardo Rossi
+ */
+class KRATOS_API(KRATOS_CORE) ConnectivityPreserveModeler
+    : public Modeler
 {
 public:
     ///@name Type Definitions
@@ -79,26 +80,28 @@ public:
     /// Factory initialization
     Modeler::Pointer Create(Model& rModel, const Parameters Settings) const override;
 
-    /// Generate a copy of rOriginModelPart in rDestinationModelPart, using the given element and condtion types.
-    /** This function fills rDestinationModelPart using data obtained from rOriginModelPart. The elements
+    /**
+     * @brief Generate a copy of rOriginModelPart in rDestinationModelPart, using the given element and condition types.
+     * @details This function fills rDestinationModelPart using data obtained from rOriginModelPart. The elements
      *  and conditions of rDestinationModelPart part use the same connectivity (and id) as in
      *  rOriginModelPart but their type is determined by rReferenceElement and rReferenceBoundaryCondition.
      *  Note that both ModelParts will share the same nodes, as well as ProcessInfo and tables.
      *  SubModelParts and, in MPI, communicator data will be replicated in DestinationModelPart.
-     *  @param rOriginModelPart The source ModelPart.
-     *  @param rDestinationModelPart The ModelPart to be filled by this function.
-     *  @param rReferenceElement The Element type for rDestinationModelPart.
-     *  @param rReferenceBoundaryCondition The Condition type for rDestinationModelPart.
+     * @param rOriginModelPart The source ModelPart.
+     * @param rDestinationModelPart The ModelPart to be filled by this function.
+     * @param rReferenceElement The Element type for rDestinationModelPart.
+     * @param rReferenceBoundaryCondition The Condition type for rDestinationModelPart.
      */
     void GenerateModelPart(
         ModelPart& OriginModelPart,
         ModelPart& DestinationModelPart,
         const Element& rReferenceElement,
         const Condition& rReferenceBoundaryCondition
-    ) override;
+        ) override;
 
-    /// Generate a copy of rOriginModelPart in rDestinationModelPart, using the given element type.
-    /** This function fills rDestinationModelPart using data obtained from
+    /**
+     * @brief Generate a copy of rOriginModelPart in rDestinationModelPart, using the given element type.
+     * @details This function fills rDestinationModelPart using data obtained from
      *  rOriginModelPart. The elements of rDestinationModelPart part use the
      *  same connectivity (and id) as in rOriginModelPart but their type is
      *  determined by rReferenceElement. In this variant, conditions are not
@@ -106,18 +109,19 @@ public:
      *  Note that both ModelParts will share the same nodes, as well as
      *  ProcessInfo and tables. SubModelParts and, in MPI, communicator data
      *  will be replicated in DestinationModelPart.
-     *  @param rOriginModelPart The source ModelPart.
-     *  @param rDestinationModelPart The ModelPart to be filled by this function.
-     *  @param rReferenceElement The Element type for rDestinationModelPart.
+     * @param rOriginModelPart The source ModelPart.
+     * @param rDestinationModelPart The ModelPart to be filled by this function.
+     * @param rReferenceElement The Element type for rDestinationModelPart.
      */
     virtual void GenerateModelPart(
         ModelPart& OriginModelPart,
         ModelPart& DestinationModelPart,
         const Element& rReferenceElement
-    );
+        );
 
-    /// Generate a copy of rOriginModelPart in rDestinationModelPart, using the given condition type.
-    /** This function fills rDestinationModelPart using data obtained from
+    /**
+     * @brief Generate a copy of rOriginModelPart in rDestinationModelPart, using the given condition type.
+     * @details This function fills rDestinationModelPart using data obtained from
      *  rOriginModelPart. The conditions of rDestinationModelPart part use the
      *  same connectivity (and id) as in rOriginModelPart but their type is
      *  determined by rReferenceCondition. In this variant, elements are not
@@ -125,15 +129,15 @@ public:
      *  Note that both ModelParts will share the same nodes, as well as
      *  ProcessInfo and tables. SubModelParts and, in MPI, communicator data
      *  will be replicated in DestinationModelPart.
-     *  @param rOriginModelPart The source ModelPart.
-     *  @param rDestinationModelPart The ModelPart to be filled by this function.
-     *  @param rReferenceCondition The Condition type for rDestinationModelPart.
+     * @param rOriginModelPart The source ModelPart.
+     * @param rDestinationModelPart The ModelPart to be filled by this function.
+     * @param rReferenceCondition The Condition type for rDestinationModelPart.
      */
     virtual void GenerateModelPart(
         ModelPart& OriginModelPart,
         ModelPart& DestinationModelPart,
         const Condition& rReferenceCondition
-    );
+        );
 
     /**
      * @brief Generate a copy of rOriginModelPart in rDestinationModelPart.
@@ -144,16 +148,17 @@ public:
      *  Note that both ModelParts will share the same nodes, geometries, as
      *  well as ProcessInfo and tables. SubModelParts and, in MPI, communicator
      *  data will be replicated in DestinationModelPart.
-     *  @param rOriginModelPart The source ModelPart.
-     *  @param rDestinationModelPart The ModelPart to be filled by this function
+     * @param rOriginModelPart The source ModelPart.
+     * @param rDestinationModelPart The ModelPart to be filled by this function
      */
     virtual void GenerateModelPart(
         ModelPart& OriginModelPart,
         ModelPart& DestinationModelPart
-    );
+        );
 
-    /// Generate a copy of rOriginModelPart in rDestinationModelPart.
-    /** This function fills rDestinationModelPart using data obtained from
+    /**
+     * @brief Generate a copy of rOriginModelPart in rDestinationModelPart.
+     * @details This function fills rDestinationModelPart using data obtained from
      *  rOriginModelPart. It is equivalent to one of the GenerateModelPart
      *  functions, depending on whether an element and/or a condition
      *  have been defined in the Parameters during construction.
@@ -171,46 +176,99 @@ public:
     std::string Info() const override;
 
     ///@}
-
 private:
     ///@name Private Operations
     ///@{
 
+    /**
+     * @brief Checks if the variable lists between the origin and destination ModelParts match.
+     * @details This function checks if the list of solution step variables in the destination ModelPart
+     * matches with those in the origin ModelPart, and logs warnings if there are any mismatches.
+     * @param rOriginModelPart The origin ModelPart.
+     * @param rDestinationModelPart The destination ModelPart.
+     */
     void CheckVariableLists(ModelPart& rOriginModelPart, ModelPart& rDestinationModelPart) const;
 
+    /**
+     * @brief Resets the destination ModelPart by setting the TO_ERASE flag for nodes, elements, and conditions.
+     * @details This function marks all nodes, elements, and conditions in the destination ModelPart with the
+     * TO_ERASE flag and removes them from all levels.
+     * @param rDestinationModelPart The destination ModelPart to reset.
+     */
     void ResetModelPart(ModelPart& rDestinationModelPart) const;
 
+    /**
+     * @brief Copies common data (such as solution step variables, process info, nodes, and geometries) 
+     * from the origin ModelPart to the destination ModelPart.
+     * @details This function handles copying essential data from the origin to the destination ModelPart. It 
+     * performs checks to ensure the destination ModelPart is not a SubModelPart and raises errors 
+     * if any attempts are made to modify attributes that would break the parent ModelPart.
+     * @param rOriginModelPart The origin ModelPart to copy data from.
+     * @param rDestinationModelPart The destination ModelPart to copy data to.
+     */
     void CopyCommonData(
         ModelPart& rOriginModelPart,
         ModelPart& rDestinationModelPart
-    ) const;
+        ) const;
 
+    /**
+     * @brief Duplicates elements from the origin ModelPart to the destination ModelPart using a reference element.
+     * @details This function duplicates elements from the origin to the destination ModelPart, reusing the 
+     * geometry of the reference element for memory efficiency.
+     * @param rOriginModelPart The origin ModelPart containing elements to duplicate.
+     * @param rDestinationModelPart The destination ModelPart where the elements will be copied to.
+     * @param rReferenceElement The reference element used for creating new elements.
+     */
     void DuplicateElements(
         ModelPart& rOriginModelPart,
         ModelPart& rDestinationModelPart,
         const Element& rReferenceElement
-    ) const;
+        ) const;
 
+    /**
+     * @brief Duplicates conditions from the origin ModelPart to the destination ModelPart using a reference condition.
+     * @details This function duplicates conditions from the origin to the destination ModelPart, reusing the 
+     * geometry of the reference condition for memory efficiency.
+     * @param rOriginModelPart The origin ModelPart containing conditions to duplicate.
+     * @param rDestinationModelPart The destination ModelPart where the conditions will be copied to.
+     * @param rReferenceBoundaryCondition The reference condition used for creating new conditions.
+     */
     void DuplicateConditions(
         ModelPart& rOriginModelPart,
         ModelPart& rDestinationModelPart,
         const Condition& rReferenceBoundaryCondition
-    ) const;
+        ) const;
 
+    /**
+     * @brief Duplicates communicator data from the origin ModelPart to the destination ModelPart.
+     * @details This function duplicates communicator data, including information about the mesh, colors, 
+     * and node lists for parallel computing scenarios. The elements and conditions will be added 
+     * later using the new elements.
+     * @param rOriginModelPart The origin ModelPart from which communicator data will be copied.
+     * @param rDestinationModelPart The destination ModelPart to which communicator data will be copied.
+     */
     void DuplicateCommunicatorData(
         ModelPart& rOriginModelPart,
         ModelPart& rDestinationModelPart
-    ) const;
+        ) const;
 
+    /**
+     * @brief Duplicates sub-model parts recursively from the origin ModelPart to the destination ModelPart.
+     * @details This function copies all sub-model parts, including nodes, elements, conditions, geometries, constraints,
+     * and communicator data, ensuring that all child sub-model parts are duplicated as well.
+     * @param rOriginModelPart The origin ModelPart containing sub-model parts to duplicate.
+     * @param rDestinationModelPart The destination ModelPart to which the sub-model parts will be copied.
+     */
     void DuplicateSubModelParts(
         ModelPart& rOriginModelPart,
         ModelPart& rDestinationModelPart
-    ) const;
+        ) const;
 
     ///@}
     ///@name Private members
     ///@{
 
+    /// The pointer to the Model object.
     Model* mpModel = nullptr;
 
     ///@}
@@ -219,5 +277,3 @@ private:
 ///@}
 
 } // namespace Kratos.
-
-#endif //KRATOS_GENERATE_MODEL_PART_MODELER_INCLUDED  defined


### PR DESCRIPTION
**📝 Description**

This PR refactors the `ConnectivityPreserveModeler` class, which is responsible for preserving the connectivity between model parts. The changes include:

1. **Missing constraints in `ConnectivityPreserveModeler`**: 
   - Added master-slave constraints into the model part preservation.

2. **Code Cleanup**: Removal of redundant spaces, unnecessary newlines, and minor formatting improvements to enhance readability and maintain consistency.
   
3. **Added Detailed Documentation**: 
   - Included more comprehensive comments throughout the code, explaining the functionality and parameters of key methods, especially for `GenerateModelPart`, `DuplicateElements`, and `DuplicateConditions`.

**🆕 Changelog**

- [Missing constraints in `ConnectivityPreserveModeler`](https://github.com/KratosMultiphysics/Kratos/commit/e856245107d2b5b958390eb451532702731b10d8)
