### PR TITLE
[GeoMechanicsApplication] Remove unused arc-length control parameters

### DIFF
--- a/applications/GeoMechanicsApplication/custom_strategies/strategies/geo_mechanics_newton_raphson_strategy.hpp
+++ b/applications/GeoMechanicsApplication/custom_strategies/strategies/geo_mechanics_newton_raphson_strategy.hpp
@@ -83,7 +83,6 @@ public:
                     "min_radius_factor": 0.5,
                     "search_neighbours_step": false,
                     "body_domain_sub_model_part_list": [],
-                    "loads_sub_model_part_list": [],
                     "loads_variable_list" : [],
                     "rebuild_level": 2
                 }  )");

--- a/applications/GeoMechanicsApplication/custom_strategies/strategies/geo_mechanics_newton_raphson_strategy.hpp
+++ b/applications/GeoMechanicsApplication/custom_strategies/strategies/geo_mechanics_newton_raphson_strategy.hpp
@@ -83,7 +83,6 @@ public:
                     "min_radius_factor": 0.5,
                     "search_neighbours_step": false,
                     "body_domain_sub_model_part_list": [],
-                    "loads_variable_list" : [],
                     "rebuild_level": 2
                 }  )");
 

--- a/applications/GeoMechanicsApplication/custom_utilities/solving_strategy_factory.hpp
+++ b/applications/GeoMechanicsApplication/custom_utilities/solving_strategy_factory.hpp
@@ -63,9 +63,7 @@ public:
             const auto reform_dof_set_at_each_step = rSolverSettings["reform_dofs_at_each_step"].GetBool();
             const auto move_mesh_flag = rSolverSettings["move_mesh_flag"].GetBool();
 
-            const std::vector<std::string> strategy_entries = {"loads_variable_list"};
-            auto                           strategy_parameters =
-                ParametersUtilities::CopyOptionalParameters(rSolverSettings, strategy_entries);
+            auto strategy_parameters = Parameters{};
             auto result =
                 std::make_unique<GeoMechanicsNewtonRaphsonStrategy<TSparseSpace, TDenseSpace, TLinearSolver>>(
                     rModelPart, scheme, criteria, builder_and_solver, strategy_parameters,

--- a/applications/GeoMechanicsApplication/custom_utilities/solving_strategy_factory.hpp
+++ b/applications/GeoMechanicsApplication/custom_utilities/solving_strategy_factory.hpp
@@ -63,8 +63,7 @@ public:
             const auto reform_dof_set_at_each_step = rSolverSettings["reform_dofs_at_each_step"].GetBool();
             const auto move_mesh_flag = rSolverSettings["move_mesh_flag"].GetBool();
 
-            const std::vector<std::string> strategy_entries = {"loads_sub_model_part_list",
-                                                               "loads_variable_list"};
+            const std::vector<std::string> strategy_entries = {"loads_variable_list"};
             auto                           strategy_parameters =
                 ParametersUtilities::CopyOptionalParameters(rSolverSettings, strategy_entries);
             auto result =

--- a/applications/GeoMechanicsApplication/custom_workflows/dgeoflow.cpp
+++ b/applications/GeoMechanicsApplication/custom_workflows/dgeoflow.cpp
@@ -125,8 +125,7 @@ KratosExecute::GeoMechanicsNewtonRaphsonErosionProcessStrategyType::Pointer Krat
         "max_radius_factor": 10.0,
         "min_radius_factor": 0.1,
         "search_neighbours_step": false,
-        "body_domain_sub_model_part_list": [],
-        "loads_variable_list" : []
+        "body_domain_sub_model_part_list": []
     }  )");
 
     int  MaxIterations          = 15;

--- a/applications/GeoMechanicsApplication/custom_workflows/dgeoflow.cpp
+++ b/applications/GeoMechanicsApplication/custom_workflows/dgeoflow.cpp
@@ -126,7 +126,6 @@ KratosExecute::GeoMechanicsNewtonRaphsonErosionProcessStrategyType::Pointer Krat
         "min_radius_factor": 0.1,
         "search_neighbours_step": false,
         "body_domain_sub_model_part_list": [],
-        "loads_sub_model_part_list": [],
         "loads_variable_list" : []
     }  )");
 

--- a/applications/GeoMechanicsApplication/python_scripts/check_and_prepare_model_process_geo.py
+++ b/applications/GeoMechanicsApplication/python_scripts/check_and_prepare_model_process_geo.py
@@ -1,8 +1,4 @@
-
 import KratosMultiphysics
-
-# Import applications
-import KratosMultiphysics.StructuralMechanicsApplication as SMA
 import KratosMultiphysics.GeoMechanicsApplication
 
 
@@ -22,7 +18,6 @@ class CheckAndPrepareModelProcess(KratosMultiphysics.Process):
         self.processes_sub_model_part_list = Parameters["processes_sub_model_part_list"]
         self.body_domain_sub_model_part_list = Parameters["body_domain_sub_model_part_list"]
         self.body_domain_sub_sub_model_part_list = Parameters["body_domain_sub_sub_model_part_list"]
-        self.loads_sub_model_part_list = Parameters["loads_sub_model_part_list"]
         self.loads_sub_sub_model_part_list = Parameters["loads_sub_sub_model_part_list"]
 
     def Execute(self):
@@ -75,13 +70,3 @@ class CheckAndPrepareModelProcess(KratosMultiphysics.Process):
             for elem in body_sub_model_part.Elements:
                 list_of_ids.add(elem.Id)
             body_sub_sub_model_part.AddElements(list(list_of_ids))
-        # Arc-Length
-        for i in range(self.loads_sub_model_part_list.size()):
-            load_sub_model_part = self.main_model_part.GetSubModelPart(self.loads_sub_model_part_list[i].GetString())
-            if not self.main_model_part.HasSubModelPart(self.loads_sub_sub_model_part_list[i].GetString()):
-                computing_model_part.CreateSubModelPart(self.loads_sub_sub_model_part_list[i].GetString())
-            load_sub_sub_model_part = computing_model_part.GetSubModelPart(self.loads_sub_sub_model_part_list[i].GetString())
-            list_of_ids = set()
-            for node in load_sub_model_part.Nodes:
-                list_of_ids.add(node.Id)
-            load_sub_sub_model_part.AddNodes(list(list_of_ids))

--- a/applications/GeoMechanicsApplication/python_scripts/check_and_prepare_model_process_geo.py
+++ b/applications/GeoMechanicsApplication/python_scripts/check_and_prepare_model_process_geo.py
@@ -18,7 +18,6 @@ class CheckAndPrepareModelProcess(KratosMultiphysics.Process):
         self.processes_sub_model_part_list = Parameters["processes_sub_model_part_list"]
         self.body_domain_sub_model_part_list = Parameters["body_domain_sub_model_part_list"]
         self.body_domain_sub_sub_model_part_list = Parameters["body_domain_sub_sub_model_part_list"]
-        self.loads_sub_sub_model_part_list = Parameters["loads_sub_sub_model_part_list"]
 
     def Execute(self):
         # Construct the computing model part: a model part which contains the mesh to compute

--- a/applications/GeoMechanicsApplication/python_scripts/geomechanics_Pw_solver.py
+++ b/applications/GeoMechanicsApplication/python_scripts/geomechanics_Pw_solver.py
@@ -86,7 +86,6 @@ class PwSolver(GeoSolver):
             "problem_domain_sub_model_part_list": [""],
             "processes_sub_model_part_list": [""],
             "body_domain_sub_model_part_list": [""],
-            "loads_sub_model_part_list": [],
             "loads_variable_list": []
         }""")
 

--- a/applications/GeoMechanicsApplication/python_scripts/geomechanics_Pw_solver.py
+++ b/applications/GeoMechanicsApplication/python_scripts/geomechanics_Pw_solver.py
@@ -85,8 +85,7 @@ class PwSolver(GeoSolver):
             },
             "problem_domain_sub_model_part_list": [""],
             "processes_sub_model_part_list": [""],
-            "body_domain_sub_model_part_list": [""],
-            "loads_variable_list": []
+            "body_domain_sub_model_part_list": [""]
         }""")
 
         this_defaults.AddMissingParameters(super().GetDefaultParameters())

--- a/applications/GeoMechanicsApplication/python_scripts/geomechanics_T_solver.py
+++ b/applications/GeoMechanicsApplication/python_scripts/geomechanics_T_solver.py
@@ -78,7 +78,6 @@ class TSolver(GeoSolver):
             "problem_domain_sub_model_part_list": [""],
             "processes_sub_model_part_list": [""],
             "body_domain_sub_model_part_list": [""],
-            "loads_sub_model_part_list": [],
             "loads_variable_list": []
         }""")
 

--- a/applications/GeoMechanicsApplication/python_scripts/geomechanics_T_solver.py
+++ b/applications/GeoMechanicsApplication/python_scripts/geomechanics_T_solver.py
@@ -77,8 +77,7 @@ class TSolver(GeoSolver):
             },
             "problem_domain_sub_model_part_list": [""],
             "processes_sub_model_part_list": [""],
-            "body_domain_sub_model_part_list": [""],
-            "loads_variable_list": []
+            "body_domain_sub_model_part_list": [""]
         }""")
 
         this_defaults.AddMissingParameters(super().GetDefaultParameters())

--- a/applications/GeoMechanicsApplication/python_scripts/geomechanics_U_Pw_solver.py
+++ b/applications/GeoMechanicsApplication/python_scripts/geomechanics_U_Pw_solver.py
@@ -91,8 +91,7 @@ class UPwSolver(GeoSolver):
             },
             "problem_domain_sub_model_part_list": [""],
             "processes_sub_model_part_list": [""],
-            "body_domain_sub_model_part_list": [""],
-            "loads_variable_list": []
+            "body_domain_sub_model_part_list": [""]
         }""")
 
         this_defaults.AddMissingParameters(super().GetDefaultParameters())

--- a/applications/GeoMechanicsApplication/python_scripts/geomechanics_U_Pw_solver.py
+++ b/applications/GeoMechanicsApplication/python_scripts/geomechanics_U_Pw_solver.py
@@ -92,7 +92,6 @@ class UPwSolver(GeoSolver):
             "problem_domain_sub_model_part_list": [""],
             "processes_sub_model_part_list": [""],
             "body_domain_sub_model_part_list": [""],
-            "loads_sub_model_part_list": [],
             "loads_variable_list": []
         }""")
 

--- a/applications/GeoMechanicsApplication/python_scripts/geomechanics_solver.py
+++ b/applications/GeoMechanicsApplication/python_scripts/geomechanics_solver.py
@@ -127,7 +127,6 @@ class GeoMechanicalSolver(PythonSolver):
             "problem_domain_sub_model_part_list": [""],
             "processes_sub_model_part_list": [""],
             "body_domain_sub_model_part_list": [""],
-            "loads_sub_model_part_list": [],
             "loads_variable_list": []
         }""")
 
@@ -209,9 +208,6 @@ class GeoMechanicalSolver(PythonSolver):
 
         sub_model_part_names = [f"sub_{name.GetString()}" for name in self.settings["body_domain_sub_model_part_list"].values()]
         self.body_domain_sub_sub_model_part_list = KratosMultiphysics.Parameters(json.dumps(sub_model_part_names))
-
-        sub_model_part_names = [f"sub_{name.GetString()}" for name in self.settings["loads_sub_model_part_list"].values()]
-        self.loads_sub_sub_model_part_list = KratosMultiphysics.Parameters(json.dumps(sub_model_part_names))
 
         if not self.main_model_part.ProcessInfo[KratosMultiphysics.IS_RESTARTED]:
             ## Executes the check and prepare model process (Create computing_model_part and set constitutive law)
@@ -410,8 +406,6 @@ class GeoMechanicalSolver(PythonSolver):
         params.AddValue("processes_sub_model_part_list",self.settings["processes_sub_model_part_list"])
         params.AddValue("body_domain_sub_model_part_list",self.settings["body_domain_sub_model_part_list"])
         params.AddValue("body_domain_sub_sub_model_part_list",self.body_domain_sub_sub_model_part_list)
-        params.AddValue("loads_sub_model_part_list",self.settings["loads_sub_model_part_list"])
-        params.AddValue("loads_sub_sub_model_part_list",self.loads_sub_sub_model_part_list)
         # CheckAndPrepareModelProcess creates the porous_computational_model_part
         from KratosMultiphysics.GeoMechanicsApplication import check_and_prepare_model_process_geo
         check_and_prepare_model_process_geo.CheckAndPrepareModelProcess(self.main_model_part, params).Execute()
@@ -470,7 +464,6 @@ class GeoMechanicalSolver(PythonSolver):
 
         if strategy_type.lower() == "newton_raphson":
             self.strategy_params = KratosMultiphysics.Parameters("{}")
-            self.strategy_params.AddValue("loads_sub_model_part_list",self.loads_sub_sub_model_part_list)
             self.strategy_params.AddValue("loads_variable_list",self.settings["loads_variable_list"])
             solving_strategy = GeoMechanicsApplication.GeoMechanicsNewtonRaphsonStrategy(self.computing_model_part,
                                                                                          self.scheme,
@@ -483,7 +476,6 @@ class GeoMechanicalSolver(PythonSolver):
                                                                                          move_mesh_flag)
         elif strategy_type.lower() == "newton_raphson_with_piping":
             self.strategy_params = KratosMultiphysics.Parameters("{}")
-            self.strategy_params.AddValue("loads_sub_model_part_list",self.loads_sub_sub_model_part_list)
             self.strategy_params.AddValue("loads_variable_list",self.settings["loads_variable_list"])
             self.strategy_params.AddValue("max_piping_iterations", self.settings["max_piping_iterations"])
             solving_strategy = GeoMechanicsApplication.GeoMechanicsNewtonRaphsonErosionProcessStrategy(self.computing_model_part,

--- a/applications/GeoMechanicsApplication/python_scripts/geomechanics_solver.py
+++ b/applications/GeoMechanicsApplication/python_scripts/geomechanics_solver.py
@@ -126,8 +126,7 @@ class GeoMechanicalSolver(PythonSolver):
             },
             "problem_domain_sub_model_part_list": [""],
             "processes_sub_model_part_list": [""],
-            "body_domain_sub_model_part_list": [""],
-            "loads_variable_list": []
+            "body_domain_sub_model_part_list": [""]
         }""")
 
         this_defaults.AddMissingParameters(super().GetDefaultParameters())
@@ -464,7 +463,6 @@ class GeoMechanicalSolver(PythonSolver):
 
         if strategy_type.lower() == "newton_raphson":
             self.strategy_params = KratosMultiphysics.Parameters("{}")
-            self.strategy_params.AddValue("loads_variable_list",self.settings["loads_variable_list"])
             solving_strategy = GeoMechanicsApplication.GeoMechanicsNewtonRaphsonStrategy(self.computing_model_part,
                                                                                          self.scheme,
                                                                                          self.convergence_criterion,
@@ -476,7 +474,6 @@ class GeoMechanicalSolver(PythonSolver):
                                                                                          move_mesh_flag)
         elif strategy_type.lower() == "newton_raphson_with_piping":
             self.strategy_params = KratosMultiphysics.Parameters("{}")
-            self.strategy_params.AddValue("loads_variable_list",self.settings["loads_variable_list"])
             self.strategy_params.AddValue("max_piping_iterations", self.settings["max_piping_iterations"])
             solving_strategy = GeoMechanicsApplication.GeoMechanicsNewtonRaphsonErosionProcessStrategy(self.computing_model_part,
                                                                                                        self.scheme,


### PR DESCRIPTION
**📝 Description**
Remove unused arc-length control parameters.

**🆕 Changelog**
- Removed handling of input lists `"loads_sub_model_part_list"`, `"loads_sub_sub_model_part_list"`, and `"loads_variable_list"`. Note that these input parameters were not used by any of the geomechanics tests.
- Removed an unused `import` of StructuralMechanicsApplication.
