### PR TITLE
[RuntimeDocs] Include `pybind11` Docstrings in Stubgen

### DIFF
--- a/scripts/post_install/stub_generation.py
+++ b/scripts/post_install/stub_generation.py
@@ -211,6 +211,7 @@ def Main():
     args: 'list[str]' = ["-o", str(kratos_library_path)]
     for k in list_of_cpp_libs:
         args.extend(["-p", k.GetCppLibModule()])
+    args.append("--include-docstrings")
     options = parse_options(args)
     generate_stubs(options)
 
@@ -228,7 +229,10 @@ if __name__ == "__main__":
     error_and_warning_outut_file = f"{sys.argv[1]}/stub_generation_errors_and_warnings.txt"
     if "--quiet" in sys.argv: # suppress output from Kratos imports
         args = [arg for arg in sys.argv if arg != "--quiet"]
-        subprocess.run([sys.executable] + args, stdout = subprocess.PIPE, stderr = sys.stderr, check=True)
+        proc = subprocess.run([sys.executable] + args, stdout = subprocess.PIPE, stderr = sys.stderr, check=True)
+        if proc.stderr is not None:
+            print(proc.stderr)
+
     else:
         Main()
         PostProcessGeneratedStubFiles()


### PR DESCRIPTION
At the expense of a bit of extra junk, `--include-docstrings` includes function docstrings and resolves function argument types regardless of stubgen's execution order.