### PR TITLE
Fix typos in applications/MappingApplication

### DIFF
--- a/applications/MappingApplication/README.md
+++ b/applications/MappingApplication/README.md
@@ -92,7 +92,7 @@ The **Map** function is used to map values from the **Origin** to the **Destinat
 mapper.Map(KM.TEMPERATURE, KM.AMBIENT_TEMPERATURE)
 ```
 
-The **Map** function is overloaded, this means that mapping vector quantities works in the same way as mapping scalar quantites.
+The **Map** function is overloaded, this means that mapping vector quantities works in the same way as mapping scalar quantities.
 
 ```py
 # mapping vector quantities
@@ -135,7 +135,7 @@ The previous section introduced the basics of using the _MappingApplication_. Th
 
 #### Customizing the behavior of the mapping with Flags
 
-By default the mapping functions **Map** and **InverseMap** will overwrite the values where they map to. In order to add instead of overwrite the values the behavior can be customized by using _Kratos::Flags_. Consider in the following example that several forces are acting on a surface. Overwritting the values would cancel the previously applied forces.
+By default the mapping functions **Map** and **InverseMap** will overwrite the values where they map to. In order to add instead of overwrite the values the behavior can be customized by using _Kratos::Flags_. Consider in the following example that several forces are acting on a surface. Overwriting the values would cancel the previously applied forces.
 
 ```py
 # Instead of overwriting, this will add the values to the existing ones
@@ -143,7 +143,7 @@ By default the mapping functions **Map** and **InverseMap** will overwrite the v
 mapper.Map(KM.REACTION, KM.FORCE, KM.Mapper.ADD_VALUES)
 ```
 
-Sometimes it can be necessary to swap the signs of quantites that are to be mapped. This can be done with the following:
+Sometimes it can be necessary to swap the signs of quantities that are to be mapped. This can be done with the following:
 
 ```py
 # Swapping the sign, i.e. multiplying the values with (-1)
@@ -248,17 +248,17 @@ The _NearestNeighborMapper_ is a very simple/basic _Mapper_. Searches its closes
 
 This mapper is best suited for problems where both interfaces have a similar discretization. Furthermore it is very robust and can be used for setting up problems when one does not (yet) want to deal with mapping.
 
-Internally it constructs the mapping matrix, hence it offers the usage of the transposed mapping matrix. When using this, for very inhomogenous interface discretizations it can come to oscillations in the mapped quantities.
+Internally it constructs the mapping matrix, hence it offers the usage of the transposed mapping matrix. When using this, for very inhomogeneous interface discretizations it can come to oscillations in the mapped quantities.
 
 **Supported mesh topologies**: This mapper only works with nodes and hence supports any mesh topology
 
 #### Nearest Element
 
-The _NearestElementMapper_ projects nodes to the elements( or conditions) on other side of the inteface. Mapping is then done by interpolating the values of the nodes of the elements by using the shape functions at the projected position.
+The _NearestElementMapper_ projects nodes to the elements( or conditions) on other side of the interface. Mapping is then done by interpolating the values of the nodes of the elements by using the shape functions at the projected position.
 
 This mapper is best suited for problems where the _NearestNeighborMapper_ cannot be used, i.e. for cases where the discretization on the interfaces is different. Note that it is less robust than the _NearestNeighborMapper_ due to the projections it performs. In case a projection fails, it uses an approximation that is similar to the approach of the _NearestNeighborMapper_. This can be disabled by setting `use_approximation` to `false` in the mapper-settings.
 
-Internally it constructs the mapping matrix, hence it offers the usage of the transposed mapping matrix. When using this, for very inhomogenous interface discretizations it can come to oscillations in the mapped quantities.
+Internally it constructs the mapping matrix, hence it offers the usage of the transposed mapping matrix. When using this, for very inhomogeneous interface discretizations it can come to oscillations in the mapped quantities.
 
 **Supported mesh topologies**: Any mesh topology available in Kratos, which includes the most common linear and quadratic geometries, see [here](../../kratos/geometries).
 
@@ -270,7 +270,7 @@ This mapper can be used when no geometries are available and interpolative prope
 
 Furthermore, the geometry type for the reconstruction/interpolation has to be chosen with the `interpolation_type` setting. The following types are available: `line`, `triangle` and `tetrahedra`
 
-Internally it constructs the mapping matrix, hence it offers the usage of the transposed mapping matrix. When using this, for very inhomogenous interface discretizations it can come to oscillations in the mapped quantities.
+Internally it constructs the mapping matrix, hence it offers the usage of the transposed mapping matrix. When using this, for very inhomogeneous interface discretizations it can come to oscillations in the mapped quantities.
 
 **Supported mesh topologies**: This mapper only works with nodes and hence supports any mesh topology
 

--- a/applications/MappingApplication/custom_mappers/barycentric_mapper.cpp
+++ b/applications/MappingApplication/custom_mappers/barycentric_mapper.cpp
@@ -262,7 +262,7 @@ void BarycentricLocalSystem::CalculateAll(MatrixType& rLocalMappingMatrix,
 {
     KRATOS_TRY
 
-    KRATOS_DEBUG_ERROR_IF_NOT(mpNode) << "Members are not intitialized!" << std::endl;
+    KRATOS_DEBUG_ERROR_IF_NOT(mpNode) << "Members are not initialized!" << std::endl;
 
     if (mInterfaceInfos.size() < 1) {
         ResizeToZero(rLocalMappingMatrix, rOriginIds, rDestinationIds, rPairingStatus);
@@ -332,7 +332,7 @@ void BarycentricLocalSystem::CalculateAll(MatrixType& rLocalMappingMatrix,
 
 void BarycentricLocalSystem::PairingInfo(std::ostream& rOStream, const int EchoLevel) const
 {
-    KRATOS_DEBUG_ERROR_IF_NOT(mpNode) << "Members are not intitialized!" << std::endl;
+    KRATOS_DEBUG_ERROR_IF_NOT(mpNode) << "Members are not initialized!" << std::endl;
 
     rOStream << "BarycentricLocalSystem based on " << mpNode->Info();
     if (EchoLevel > 3) {

--- a/applications/MappingApplication/custom_mappers/barycentric_mapper.h
+++ b/applications/MappingApplication/custom_mappers/barycentric_mapper.h
@@ -83,7 +83,7 @@ public:
 
     CoordinatesArrayType& Coordinates() const override
     {
-        KRATOS_DEBUG_ERROR_IF_NOT(mpNode) << "Members are not intitialized!" << std::endl;
+        KRATOS_DEBUG_ERROR_IF_NOT(mpNode) << "Members are not initialized!" << std::endl;
         return mpNode->Coordinates();
     }
 

--- a/applications/MappingApplication/custom_mappers/coupling_geometry_mapper.cpp
+++ b/applications/MappingApplication/custom_mappers/coupling_geometry_mapper.cpp
@@ -178,7 +178,7 @@ void CouplingGeometryMapper<TSparseSpace, TDenseSpace>::InitializeInterface(Krat
         mpInterfaceVectorContainerSlave->GetModelPart(),
         mpInterfaceVectorContainerSlave->GetModelPart(),
         mMapperLocalSystemsSlave,
-        0); // The echo-level is no longer neeed here, refactor in separate PR
+        0); // The echo-level is no longer needed here, refactor in separate PR
 
     MappingMatrixUtilities<TSparseSpace, TDenseSpace>::BuildMappingMatrix(
         mpMappingMatrixProjector,
@@ -187,7 +187,7 @@ void CouplingGeometryMapper<TSparseSpace, TDenseSpace>::InitializeInterface(Krat
         mpInterfaceVectorContainerMaster->GetModelPart(),
         mpInterfaceVectorContainerSlave->GetModelPart(),
         mMapperLocalSystemsProjector,
-        0); // The echo-level is no longer neeed here, refactor in separate PR
+        0); // The echo-level is no longer needed here, refactor in separate PR
 
     // Perform consistency scaling if requested
     if (mMapperSettings["consistency_scaling"].GetBool()) {

--- a/applications/MappingApplication/custom_mappers/coupling_geometry_mapper.h
+++ b/applications/MappingApplication/custom_mappers/coupling_geometry_mapper.h
@@ -55,7 +55,7 @@ public:
 
     CoordinatesArrayType& Coordinates() const override
     {
-        KRATOS_DEBUG_ERROR_IF_NOT(mpGeom) << "Members are not intitialized!" << std::endl;
+        KRATOS_DEBUG_ERROR_IF_NOT(mpGeom) << "Members are not initialized!" << std::endl;
         // return mpGeom->Center(); // check why not compiling...
         KRATOS_ERROR << "not implemented, needs checking" << std::endl;
     }

--- a/applications/MappingApplication/custom_mappers/interpolative_mapper_base.h
+++ b/applications/MappingApplication/custom_mappers/interpolative_mapper_base.h
@@ -276,7 +276,7 @@ protected:
             const double search_radius = mMapperSettings["search_radius"].GetDouble();
 
             if (mMapperSettings.Has("search_settings")) {
-                KRATOS_ERROR_IF(mMapperSettings["search_settings"].Has("search_radius")) << "\"search_radius\" specified twice, please only speficy it in \"search_settings\"!" << std::endl;
+                KRATOS_ERROR_IF(mMapperSettings["search_settings"].Has("search_radius")) << "\"search_radius\" specified twice, please only specify it in \"search_settings\"!" << std::endl;
             } else {
                 mMapperSettings.AddValue("search_settings", Parameters());
             }
@@ -290,7 +290,7 @@ protected:
             const int search_iterations = mMapperSettings["search_iterations"].GetInt();
 
             if (mMapperSettings.Has("search_settings")) {
-                KRATOS_ERROR_IF(mMapperSettings["search_settings"].Has("max_num_search_iterations")) << "\"search_iterations\" specified twice, please only speficy it in \"search_settings\" (as \"max_num_search_iterations\")!" << std::endl;
+                KRATOS_ERROR_IF(mMapperSettings["search_settings"].Has("max_num_search_iterations")) << "\"search_iterations\" specified twice, please only specify it in \"search_settings\" (as \"max_num_search_iterations\")!" << std::endl;
             } else {
                 mMapperSettings.AddValue("search_settings", Parameters());
             }

--- a/applications/MappingApplication/custom_mappers/nearest_element_mapper.cpp
+++ b/applications/MappingApplication/custom_mappers/nearest_element_mapper.cpp
@@ -139,7 +139,7 @@ void NearestElementLocalSystem::CalculateAll(MatrixType& rLocalMappingMatrix,
 
         mInterfaceInfos[found_idx]->GetValue(rOriginIds, MapperInterfaceInfo::InfoType::Dummy);
 
-        KRATOS_DEBUG_ERROR_IF_NOT(mpNode) << "Members are not intitialized!" << std::endl;
+        KRATOS_DEBUG_ERROR_IF_NOT(mpNode) << "Members are not initialized!" << std::endl;
 
         if (rDestinationIds.size() != 1) rDestinationIds.resize(1);
         rDestinationIds[0] = mpNode->GetValue(INTERFACE_EQUATION_ID);
@@ -149,7 +149,7 @@ void NearestElementLocalSystem::CalculateAll(MatrixType& rLocalMappingMatrix,
 
 void NearestElementLocalSystem::PairingInfo(std::ostream& rOStream, const int EchoLevel) const
 {
-    KRATOS_DEBUG_ERROR_IF_NOT(mpNode) << "Members are not intitialized!" << std::endl;
+    KRATOS_DEBUG_ERROR_IF_NOT(mpNode) << "Members are not initialized!" << std::endl;
 
     rOStream << "NearestElementLocalSystem based on " << mpNode->Info();
     if (EchoLevel > 3) {

--- a/applications/MappingApplication/custom_mappers/nearest_element_mapper.h
+++ b/applications/MappingApplication/custom_mappers/nearest_element_mapper.h
@@ -150,7 +150,7 @@ public:
 
     CoordinatesArrayType& Coordinates() const override
     {
-        KRATOS_DEBUG_ERROR_IF_NOT(mpNode) << "Members are not intitialized!" << std::endl;
+        KRATOS_DEBUG_ERROR_IF_NOT(mpNode) << "Members are not initialized!" << std::endl;
         return mpNode->Coordinates();
     }
 
@@ -176,7 +176,7 @@ private:
 * Each node on the destination side gets assigned is's closest condition or element (distance to center)
 * on the other side of the interface.
 * In the mapping phase every node gets assigned the interpolated value of the condition/element.
-* The interpolation is done with the shape funcitons
+* The interpolation is done with the shape functions
 * For information abt the available echo_levels and the JSON default-parameters
 * look into the class description of the MapperCommunicator
 */

--- a/applications/MappingApplication/custom_mappers/nearest_neighbor_mapper.cpp
+++ b/applications/MappingApplication/custom_mappers/nearest_neighbor_mapper.cpp
@@ -78,7 +78,7 @@ void NearestNeighborLocalSystem::CalculateAll(MatrixType& rLocalMappingMatrix,
             rLocalMappingMatrix(0,i) = mapping_weight;
         }
 
-        KRATOS_DEBUG_ERROR_IF_NOT(mpNode) << "Members are not intitialized!" << std::endl;
+        KRATOS_DEBUG_ERROR_IF_NOT(mpNode) << "Members are not initialized!" << std::endl;
         rDestinationIds[0] = mpNode->GetValue(INTERFACE_EQUATION_ID);
     } else {
         ResizeToZero(rLocalMappingMatrix, rOriginIds, rDestinationIds, rPairingStatus);
@@ -87,7 +87,7 @@ void NearestNeighborLocalSystem::CalculateAll(MatrixType& rLocalMappingMatrix,
 
 void NearestNeighborLocalSystem::PairingInfo(std::ostream& rOStream, const int EchoLevel) const
 {
-    KRATOS_DEBUG_ERROR_IF_NOT(mpNode) << "Members are not intitialized!" << std::endl;
+    KRATOS_DEBUG_ERROR_IF_NOT(mpNode) << "Members are not initialized!" << std::endl;
 
     rOStream << "NearestNeighborLocalSystem based on " << mpNode->Info();
     if (EchoLevel > 3) {

--- a/applications/MappingApplication/custom_mappers/nearest_neighbor_mapper.h
+++ b/applications/MappingApplication/custom_mappers/nearest_neighbor_mapper.h
@@ -108,7 +108,7 @@ public:
 
     CoordinatesArrayType& Coordinates() const override
     {
-        KRATOS_DEBUG_ERROR_IF_NOT(mpNode) << "Members are not intitialized!" << std::endl;
+        KRATOS_DEBUG_ERROR_IF_NOT(mpNode) << "Members are not initialized!" << std::endl;
         return mpNode->Coordinates();
     }
 

--- a/applications/MappingApplication/custom_searching/custom_configures/interface_object_configure.h
+++ b/applications/MappingApplication/custom_searching/custom_configures/interface_object_configure.h
@@ -81,7 +81,7 @@ public:
     ///@name Life Cycle
     ///@{
 
-    /// Default consturctor
+    /// Default constructor
     InterfaceObjectConfigure() {};
 
     /// Default destructor
@@ -92,7 +92,7 @@ public:
     ///@{
 
     /** Calculates the bounding box for the given object.
-     * For this configuation file, the bounding box is the equal to the point given in 'rObject'.
+     * For this configuration file, the bounding box is the equal to the point given in 'rObject'.
      * @param rObject    Point for which the bounding box will be calculated.
      * @param rLowPoint  Lower point of the boundingbox.
      * @param rHighPoint Higher point of the boundingbox.
@@ -103,7 +103,7 @@ public:
     }
 
     /** Calculates the bounding box for the given object extended with a Radius.
-     * For this configuation file, the bounding box is the equal to the point given in 'rObject' + - a radius.
+     * For this configuration file, the bounding box is the equal to the point given in 'rObject' + - a radius.
      * @param rObject    Point for which the bounding box will be calculated.
      * @param rLowPoint  Lower point of the boundingbox.
      * @param rHighPoint Higher point of the boundingbox.
@@ -127,7 +127,7 @@ public:
     }
 
     /** Tests the intersection of two objects
-     * For this configuation file, tests if the two points are the same within a Epsilon tolerance range.
+     * For this configuration file, tests if the two points are the same within a Epsilon tolerance range.
      * @param  rObj_1 First point of the tests
      * @param  rObj_2 Second point of the tests
      * @return        Boolean indicating the result of the intersection test described.
@@ -146,7 +146,7 @@ public:
     }
 
     /** Tests the intersection of two objects extended with a given radius.
-     * For this configuation file, tests if the two points extended with a radius
+     * For this configuration file, tests if the two points extended with a radius
      * are the same within a Epsilon tolerance range.
      * @param  rObj_1 First point of the tests
      * @param  rObj_2 Second point of the tests
@@ -182,7 +182,7 @@ public:
     }
 
     /** Tests the intersection of one object with a boundingbox described by 'rLowPoint' and 'rHighPoint'.
-     * For this configuation file, tests if one point is inside the boundingbox
+     * For this configuration file, tests if one point is inside the boundingbox
      * described by 'rLowPoint' and 'rHighPoint' within a Epsilon tolerance range.
      * @param  rObject    Point of the tests.
      * @param  rLowPoint  Lower point of the boundingbox.
@@ -203,7 +203,7 @@ public:
     }
 
     /** Tests the intersection of one object with a boundingbox described by 'rLowPoint' and 'rHighPoint'.
-     * For this configuation file, tests if one point extended by radius is inside the boundingbox
+     * For this configuration file, tests if one point extended by radius is inside the boundingbox
      * described by 'rLowPoint' and 'rHighPoint' within a Epsilon tolerance range.
      * @param  rObject    Point of the tests.
      * @param  rLowPoint  Lower point of the boundingbox.
@@ -224,8 +224,8 @@ public:
         return true;
     }
 
-    /** Calculates the distance betwen two objects.
-     * For this configuation file, calculates the euclidean distance between 'rObj_1' and 'rObj_2'.
+    /** Calculates the distance between two objects.
+     * For this configuration file, calculates the euclidean distance between 'rObj_1' and 'rObj_2'.
      * # Performance
      * In C++11 'std::pow(T, int)' provides the optimal solution in terms of speed.
      * # References

--- a/applications/MappingApplication/custom_utilities/mapper_local_system.h
+++ b/applications/MappingApplication/custom_utilities/mapper_local_system.h
@@ -94,14 +94,14 @@ public:
                               EquationIdVectorType& rDestinationIds) const
     {
         if (mIsComputed) {
-            // This will be called if the EquationIdVectors have been querried before
+            // This will be called if the EquationIdVectors have been queried before
             // i.e. matrix-based mapping
             rLocalMappingMatrix = mLocalMappingMatrix;
             rOriginIds      = mOriginIds;
             rDestinationIds = mDestinationIds;
         }
         else {
-            // This will be called if the EquationIdVectors have NOT been querried before
+            // This will be called if the EquationIdVectors have NOT been queried before
             // i.e. matrix-free mapping
             CalculateAll(rLocalMappingMatrix, rOriginIds, rDestinationIds, mPairingStatus);
         }
@@ -111,7 +111,7 @@ public:
     * @brief Resizing the output if no InterfaceInfo is available
     * This function resizes the system vectors to zero and also sets that no valid
     * Information from the other side could be found to compute the local system
-    * @param rLocalMappingMatrix The vector conatining the mapping weights
+    * @param rLocalMappingMatrix The vector containing the mapping weights
     * @param rOriginIds The vector containing the ids on the origin
     * @param rDestinationIds The vector containing the ids on the destination
     * @param rPairingStatus The pairingstatus of the MapperLocalSystem

--- a/applications/MappingApplication/custom_utilities/mapper_utilities.cpp
+++ b/applications/MappingApplication/custom_utilities/mapper_utilities.cpp
@@ -385,7 +385,7 @@ void CreateMapperInterfaceInfosFromBuffer(const std::vector<std::vector<double>>
                 << ") that was not casted from an int, i.e. it contains a "
                 << "fractional part of " << std::abs(fract_part-0.1) << "!" << std::endl;
 #endif
-            // retrive data from buffer
+            // retrieve data from buffer
             const int local_sys_idx = static_cast<IndexType>(r_rank_buffer[j*4]+0.1);
             // 0.1 is added to prevent truncation errors like (int)1.9999 = 1
             coords[0] = r_rank_buffer[j*4 + 1];
@@ -418,7 +418,7 @@ void FillBufferAfterLocalSearch(MapperInterfaceInfoPointerVectorType& rMapperInt
             const auto p_serializer_buffer = dynamic_cast<std::stringstream*>(serializer.pGetBuffer());
             const std::string& stream_str = p_serializer_buffer->str();
 
-            const SizeType send_size = sizeof(char) * (stream_str.size()+1); // +1 fof Null-terminated string
+            const SizeType send_size = sizeof(char) * (stream_str.size()+1); // +1 for Null-terminated string
 
             rSendSizes[i_rank] = send_size;
 

--- a/applications/MappingApplication/custom_utilities/mapper_utilities.h
+++ b/applications/MappingApplication/custom_utilities/mapper_utilities.h
@@ -310,7 +310,7 @@ private:
     std::vector<MapperInterfaceInfoPointerType>& mrInterfaceInfos;
     MapperInterfaceInfoPointerType mrpRefInterfaceInfo;
 
-    friend class Kratos::Serializer; // Adding "Kratos::" is nedded bcs of the "MapperUtilities"-namespace
+    friend class Kratos::Serializer; // Adding "Kratos::" is needed bcs of the "MapperUtilities"-namespace
 
     virtual void save(Kratos::Serializer& rSerializer) const;
     virtual void load(Kratos::Serializer& rSerializer);

--- a/applications/MappingApplication/custom_utilities/projection_utilities.cpp
+++ b/applications/MappingApplication/custom_utilities/projection_utilities.cpp
@@ -97,7 +97,7 @@ PairingIndex ProjectOnLine(const GeometryType& rGeometry,
         FillEquationIdVector(rGeometry, rEquationIds);
 
     } else {
-        // projection is ouside the line, searching the closest point
+        // projection is outside the line, searching the closest point
         pairing_index = PairingIndex::Closest_Point;
         const double dist_1 = rPointToProject.Distance(rGeometry[0]);
         const double dist_2 = rPointToProject.Distance(rGeometry[1]);

--- a/applications/MappingApplication/mapping_application.cpp
+++ b/applications/MappingApplication/mapping_application.cpp
@@ -39,7 +39,7 @@
 #include "custom_mappers/coupling_geometry_mapper.h"
 
 // Macros for registering mappers
-// wil be removed once using the core factories
+// will be removed once using the core factories
 #define KRATOS_REGISTER_MAPPER(MapperType, MapperName)                                                \
     {                                                                                                 \
     Model current_model;                                                                              \

--- a/applications/MappingApplication/mpi_extension/custom_python/mapping_mpi_extension.cpp
+++ b/applications/MappingApplication/mpi_extension/custom_python/mapping_mpi_extension.cpp
@@ -33,7 +33,7 @@ PYBIND11_MODULE(KratosMappingMPIExtension,m)
     AddMappingToPython<MPIMapperDefinitions::SparseSpaceType, MPIMapperDefinitions::DenseSpaceType>(m);
 
     // Macros for registering mappers
-    // wil be removed once using the core factories
+    // will be removed once using the core factories
     #define KRATOS_REGISTER_MAPPER(MapperType, MapperName)                                                   \
         {                                                                                                    \
         Model current_model;                                                                                 \

--- a/applications/MappingApplication/python_scripts/empire_mortar_mapper.py
+++ b/applications/MappingApplication/python_scripts/empire_mortar_mapper.py
@@ -63,7 +63,7 @@ class EmpireMortarMapper(PythonMapper):
             EmpireMortarMapper.mapper_lib.deleteMesh(ConvertToChar(self.mesh_name_destination))
 
         EmpireMortarMapper.instances -= 1
-        if EmpireMortarMapper.instances == 0: # last mapper was destoyed
+        if EmpireMortarMapper.instances == 0: # last mapper was destroyed
             if self.echo_level > 1:
                 KM.Logger.PrintInfo('EmpireMortarMapper', 'Destroying last instance, deleting all meshes & mappers')
             #  delete everything to make sure nothing is left

--- a/applications/MappingApplication/python_scripts/python_mapper.py
+++ b/applications/MappingApplication/python_scripts/python_mapper.py
@@ -6,7 +6,7 @@ from abc import ABCMeta, abstractmethod
 
 class PythonMapper(metaclass=ABCMeta):
     """Baseclass for python based mappers in Kratos
-    The inteface matches the C++ version ("custom_mappers/mapper.h")
+    The interface matches the C++ version ("custom_mappers/mapper.h")
     The py-mappers are intentionally NOT derived from the c++ version.
     Reasons:
     - Doing so would require some special treatment of the pure virtual functions exposed to python

--- a/applications/MappingApplication/tests/cpp_tests/test_mapper_utilities.cpp
+++ b/applications/MappingApplication/tests/cpp_tests/test_mapper_utilities.cpp
@@ -383,7 +383,7 @@ KRATOS_TEST_CASE_IN_SUITE(MapperUtilities_MapperInterfaceInfoSerializer, KratosM
     // serializes/deserializes the MapperInterfaceInfos works correctly
     // => this is needed to transfer the data btw the ranks in MPI
     // The test is rather large, this is needed to cover a complete example
-    // Note that the same checks are performed before and after ther serialization
+    // Note that the same checks are performed before and after the serialization
     // to make sure that the objects are properly initialized
 
     typedef Kratos::shared_ptr<MapperInterfaceInfo> MapperInterfaceInfoPointerType;
@@ -464,7 +464,7 @@ KRATOS_TEST_CASE_IN_SUITE(MapperUtilities_MapperInterfaceInfoSerializer, KratosM
     // Now finally we can construct the container
     MapperInterfaceInfoPointerVectorType interface_info_container(2);
 
-    // Note: the order is choosen intentionally
+    // Note: the order is chosen intentionally
     interface_info_container[0].push_back(p_nearest_neighbor_info_3);
     interface_info_container[1].push_back(p_nearest_neighbor_info_1);
     interface_info_container[1].push_back(p_nearest_neighbor_info_2);

--- a/applications/MappingApplication/tests/cpp_tests/test_nearest_element_aux_classes.cpp
+++ b/applications/MappingApplication/tests/cpp_tests/test_nearest_element_aux_classes.cpp
@@ -317,7 +317,7 @@ KRATOS_TEST_CASE_IN_SUITE(NearestElementInterfaceInfo_WithoutApproximation, Krat
 
 KRATOS_TEST_CASE_IN_SUITE(NearestElementInterfaceInfo_NothingFound, KratosMappingApplicationSerialTestSuite)
 {
-    // here no search-results are being processed, therfore nothing is found
+    // here no search-results are being processed, therefore nothing is found
     const Point coords(1.0, 2.45, -23.8);
 
     const std::size_t source_local_sys_idx = 123;

--- a/applications/MappingApplication/tests/mapper_test_case.py
+++ b/applications/MappingApplication/tests/mapper_test_case.py
@@ -50,7 +50,7 @@ class MapperTestCase(KratosUnittest.TestCase):
 
     def setUp(self):
         # reset the ModelPart
-        # initialize it with random values, such that I am not accidentially
+        # initialize it with random values, such that I am not accidentally
         # checking against 0.0
         default_scalar = -12345.6789
         default_vector = KM.Vector([111.222, -222.999, 333.444])

--- a/applications/MappingApplication/tests/runscript_test_MappingApplication.py
+++ b/applications/MappingApplication/tests/runscript_test_MappingApplication.py
@@ -70,4 +70,4 @@ tests_success = CheckOutputFile(tests_output_file, keyword_array, tests_success)
 tests_success = CheckOutputFile(kratos_output_file, keyword_array, tests_success)
 
 test_runtime = datetime.timedelta(seconds=int((time() - start_time)))
-print("\nTests Sucessful: " + str(tests_success) + ", Runtime: " + str(test_runtime))
+print("\nTests Successful: " + str(tests_success) + ", Runtime: " + str(test_runtime))

--- a/applications/MappingApplication/tests/test_MappingApplication.py
+++ b/applications/MappingApplication/tests/test_MappingApplication.py
@@ -17,8 +17,8 @@ from test_patch_test_mappers import TestPatchTestMappers
 def AssembleTestSuites():
     ''' Populates the test suites to run.
 
-    Populates the test suites to run. At least, it should pupulate the suites:
-    "small", "nighlty" and "all"
+    Populates the test suites to run. At least, it should populate the suites:
+    "small", "nightly" and "all"
 
     Return
     ------

--- a/applications/MappingApplication/tests/test_MappingApplication_mpi.py
+++ b/applications/MappingApplication/tests/test_MappingApplication_mpi.py
@@ -15,8 +15,8 @@ import test_projection_3d_2d_mapper
 def AssembleTestSuites():
     ''' Populates the test suites to run.
 
-    Populates the test suites to run. At least, it should pupulate the suites:
-    "small", "nighlty" and "all"
+    Populates the test suites to run. At least, it should populate the suites:
+    "small", "nightly" and "all"
 
     Return
     ------


### PR DESCRIPTION
**📝 Description**
Fixes source comments and doxygen typos.
Found via codespell

**🆕 Changelog**
- Fixes source comments and doxygen typos within application/MappingApplication