### PR TITLE
Fix typos in applications/ConstitutiveLawsApplication

### DIFF
--- a/applications/ConstitutiveLawsApplication/custom_constitutive/auxiliary_files/cl_integrators/generic_cl_integrator_kinematic_plasticity.h
+++ b/applications/ConstitutiveLawsApplication/custom_constitutive/auxiliary_files/cl_integrators/generic_cl_integrator_kinematic_plasticity.h
@@ -154,7 +154,7 @@ class GenericConstitutiveLawIntegratorKinematicPlasticity
     ///@{
 
     /**
-     * @brief This method integrates the predictive stress vector with the CL using differents evolution laws using the backward euler scheme
+     * @brief This method integrates the predictive stress vector with the CL using different evolution laws using the backward euler scheme
      * @param rPredictiveStressVector The predictive stress vector S = C:(E-Ep)
      * @param rStrainVector The equivalent strain vector of that integration point
      * @param rUniaxialStress The equivalent uniaxial stress

--- a/applications/ConstitutiveLawsApplication/custom_constitutive/auxiliary_files/cl_integrators/generic_cl_integrator_plasticity.h
+++ b/applications/ConstitutiveLawsApplication/custom_constitutive/auxiliary_files/cl_integrators/generic_cl_integrator_plasticity.h
@@ -142,7 +142,7 @@ class GenericConstitutiveLawIntegratorPlasticity
     ///@{
 
     /**
-     * @brief This method integrates the predictive stress vector with the CL using differents evolution laws using the backward euler scheme
+     * @brief This method integrates the predictive stress vector with the CL using different evolution laws using the backward euler scheme
      * @param rPredictiveStressVector The predictive stress vector S = C:(E-Ep)
      * @param rStrainVector The equivalent strain vector of that integration point
      * @param rUniaxialStress The equivalent uniaxial stress
@@ -736,7 +736,7 @@ class GenericConstitutiveLawIntegratorPlasticity
         if (PlasticDissipation <= segment_threshold) {
             const double Eps = EquivalentPlasticStrain;
 
-            if (EquivalentPlasticStrain < plastic_strain_indicator_1) { // Polinomial region
+            if (EquivalentPlasticStrain < plastic_strain_indicator_1) { // Polynomial region
                 double S_Ep = curve_fitting_parameters[0];
                 double dS_dEp = 0.0;
                 for (IndexType i = 1; i < order_polinomial; ++i) {

--- a/applications/ConstitutiveLawsApplication/custom_constitutive/composites/serial_parallel_rule_of_mixtures_law.h
+++ b/applications/ConstitutiveLawsApplication/custom_constitutive/composites/serial_parallel_rule_of_mixtures_law.h
@@ -508,7 +508,7 @@ class KRATOS_API(CONSTITUTIVE_LAWS_APPLICATION) SerialParallelRuleOfMixturesLaw
         const ConstitutiveLaw::StressMeasure& rStressMeasure);
 
     /**
-     * This method checks wether the serial stresses are in equilibrium
+     * This method checks whether the serial stresses are in equilibrium
      * @param rStrainVector The total strain of the composite
      * @param rSerialProjector The Serial behaviour projector
      * @param rMatrixStressVector  the stress vector of the matrix

--- a/applications/ConstitutiveLawsApplication/custom_constitutive/finite_strains/hyperelasticity/hyper_elastic_isotropic_kirchhoff_3d.h
+++ b/applications/ConstitutiveLawsApplication/custom_constitutive/finite_strains/hyperelasticity/hyper_elastic_isotropic_kirchhoff_3d.h
@@ -136,7 +136,7 @@ public:
     }
 
     /**
-     * @brief Returns the stress measure of this constitutive law (by default 2st Piola-Kirchhoff stress in voigt notation)
+     * @brief Returns the stress measure of this constitutive law (by default 2nd Piola-Kirchhoff stress in voigt notation)
      * @return the expected stress measure
      */
     StressMeasure GetStressMeasure() override

--- a/applications/ConstitutiveLawsApplication/custom_constitutive/finite_strains/hyperelasticity/hyper_elastic_isotropic_neo_hookean_3d.h
+++ b/applications/ConstitutiveLawsApplication/custom_constitutive/finite_strains/hyperelasticity/hyper_elastic_isotropic_neo_hookean_3d.h
@@ -140,7 +140,7 @@ public:
     }
 
     /**
-     * @brief Returns the stress measure of this constitutive law (by default 2st Piola-Kirchhoff stress in voigt notation)
+     * @brief Returns the stress measure of this constitutive law (by default 2nd Piola-Kirchhoff stress in voigt notation)
      * @return the expected stress measure
      */
     StressMeasure GetStressMeasure() override

--- a/applications/ConstitutiveLawsApplication/custom_constitutive/finite_strains/hyperelasticity/hyper_elastic_isotropic_q_incomp_isoch_neo_hook_3d.h
+++ b/applications/ConstitutiveLawsApplication/custom_constitutive/finite_strains/hyperelasticity/hyper_elastic_isotropic_q_incomp_isoch_neo_hook_3d.h
@@ -140,7 +140,7 @@ public:
     }
 
     /**
-     * @brief Returns the stress measure of this constitutive law (by default 2st Piola-Kirchhoff stress in voigt notation)
+     * @brief Returns the stress measure of this constitutive law (by default 2nd Piola-Kirchhoff stress in voigt notation)
      * @return the expected stress measure
      */
     StressMeasure GetStressMeasure() override

--- a/applications/ConstitutiveLawsApplication/custom_constitutive/finite_strains/hyperelasticity/hyper_elastic_simo_taylor_neo_hookean_3d.h
+++ b/applications/ConstitutiveLawsApplication/custom_constitutive/finite_strains/hyperelasticity/hyper_elastic_simo_taylor_neo_hookean_3d.h
@@ -141,7 +141,7 @@ public:
     }
 
     /**
-     * @brief Returns the stress measure of this constitutive law (by default 2st Piola-Kirchhoff stress in voigt notation)
+     * @brief Returns the stress measure of this constitutive law (by default 2nd Piola-Kirchhoff stress in voigt notation)
      * @return the expected stress measure
      */
     StressMeasure GetStressMeasure() override

--- a/applications/ConstitutiveLawsApplication/custom_constitutive/small_strains/damage/d_plus_d_minus_damage_masonry_3d.h
+++ b/applications/ConstitutiveLawsApplication/custom_constitutive/small_strains/damage/d_plus_d_minus_damage_masonry_3d.h
@@ -677,7 +677,7 @@ private:
 
     /**
      * @brief This method regulates the four bezier control strains to avoid a constitutive snap-back (fracture energy considerations)
-     * @param specific_dissipated_fracture_energy FRACTURE_ENERGY_CMOPRESSION devided by CharacteristicLength
+     * @param specific_dissipated_fracture_energy FRACTURE_ENERGY_CMOPRESSION divided by CharacteristicLength
      *        sp, sk, sr stress Values to control the bezier curves
      *        ep strain pproperty to control the bezier curve
      *        ej, ek, er, eu strain properties to be regulated in method

--- a/applications/ConstitutiveLawsApplication/custom_constitutive/small_strains/damage/small_strain_isotropic_damage_implex_3d.h
+++ b/applications/ConstitutiveLawsApplication/custom_constitutive/small_strains/damage/small_strain_isotropic_damage_implex_3d.h
@@ -242,7 +242,7 @@ public:
 
     /// Print object's data.
     void PrintData(std::ostream& rOStream) const override {
-        rOStream << "Small Strain Isotropic Damage 3D constitutive law with Implex intergration scheme\n";
+        rOStream << "Small Strain Isotropic Damage 3D constitutive law with Implex integration scheme\n";
     };
 
 protected:

--- a/applications/ConstitutiveLawsApplication/custom_constitutive/small_strains/linear/wrinkling_linear_2d_law.cpp
+++ b/applications/ConstitutiveLawsApplication/custom_constitutive/small_strains/linear/wrinkling_linear_2d_law.cpp
@@ -211,7 +211,7 @@ void WrinklingLinear2DLaw::CheckWrinklingState(WrinklingType& rWrinklingState, c
     Vector principal_strains = ZeroVector(2);
     Vector temp_strains = ZeroVector(3);
     temp_strains = rStrain;
-    temp_strains[2] /= 2.0; // Adjust voigt strain vector to calcualte principal strains
+    temp_strains[2] /= 2.0; // Adjust voigt strain vector to calculate principal strains
     PrincipalVector(principal_strains,temp_strains);
 
     Vector principal_stresses = ZeroVector(2);

--- a/applications/ConstitutiveLawsApplication/custom_constitutive/small_strains/plastic_damage/associative_plastic_damage_model.h
+++ b/applications/ConstitutiveLawsApplication/custom_constitutive/small_strains/plastic_damage/associative_plastic_damage_model.h
@@ -50,7 +50,7 @@ namespace Kratos
  * @class AssociativePlasticDamageModel
  * @ingroup StructuralMechanicsApplication
  * @brief This law defines a parallel rule of mixture (classic law of mixture)
- * @details This constitutive law unifies the High cycle, Ultra Low cycle and Low cicle fatigue processes
+ * @details This constitutive law unifies the High cycle, Ultra Low cycle and Low cycle fatigue processes
  * by means of a plastic damage model. Source: A thermodynamically consistent plastic-damage framework for
 localized failure in quasi-brittle solids: Material model and strain
 localization analysis (Wu and Cervera https://doi.org/10.1016/j.ijsolstr.2016.03.005)

--- a/applications/ConstitutiveLawsApplication/custom_utilities/tangent_operator_calculator_utility.h
+++ b/applications/ConstitutiveLawsApplication/custom_utilities/tangent_operator_calculator_utility.h
@@ -608,7 +608,7 @@ private:
     }
 
     /**
-     * @brief This method computes the maximum absolut value (Vector)
+     * @brief This method computes the maximum absolute value (Vector)
      * @param rArrayValues The array containing the values
      * @param rMaxValue The value to be computed
      */
@@ -630,7 +630,7 @@ private:
     }
 
     /**
-     * @brief This method computes the maximum absolut value (Matrix)
+     * @brief This method computes the maximum absolute value (Matrix)
      * @param rArrayValues The array containing the values
      * @param rMaxValue The value to be computed
      */
@@ -659,7 +659,7 @@ private:
     }
 
     /**
-     * @brief This method computes the minimim absolut value (Vector)
+     * @brief This method computes the minimim absolute value (Vector)
      * @param rArrayValues The array containing the values
      * @param rMinValue The value to be computed
      */
@@ -681,7 +681,7 @@ private:
     }
 
     /**
-     * @brief This method computes the minimim absolut value (Matrix)
+     * @brief This method computes the minimim absolute value (Matrix)
      * @param rArrayValues The array containing the values
      * @param rMinValue The value to be computed
      */

--- a/applications/ConstitutiveLawsApplication/tests/test_ConstitutiveLawsApplication.py
+++ b/applications/ConstitutiveLawsApplication/tests/test_ConstitutiveLawsApplication.py
@@ -78,7 +78,7 @@ def AssembleTestSuites():
     nightSuite.addTest(PlasticDamageTest('test_execution'))
 
     ### Adding Validation Tests
-    # For very long tests that should not be in nighly and you can use to validate
+    # For very long tests that should not be in nightly and you can use to validate
     validationSuite = suites['validation']
     validationSuite.addTest(TensileTestStructuralTest('test_execution'))
 


### PR DESCRIPTION
**📝 Description**
Fixes source comments and doxygen typos.
Found via codespell

**🆕 Changelog**
- Fixes source comments and doxygen typos within application/ConstitutiveLawsApplication