### PR TITLE
[FastPR][Solid] Moving Gauss-Lobatto line to SolidMechanicsApplication

### DIFF
--- a/applications/SolidMechanicsApplication/custom_geometries/line_gauss_lobatto_3d_2.h
+++ b/applications/SolidMechanicsApplication/custom_geometries/line_gauss_lobatto_3d_2.h
@@ -23,7 +23,7 @@
 
 // Project includes
 #include "geometries/geometry.h"
-#include "integration/line_gauss_lobatto_integration_points.h"
+#include "custom_integration/solid_mechanics_line_gauss_lobatto_integration_points.h"
 
 
 namespace Kratos
@@ -831,16 +831,11 @@ private:
     static const IntegrationPointsContainerType AllIntegrationPoints()
     {
         IntegrationPointsContainerType integration_points = {{
-                Quadrature<LineGaussLobattoIntegrationPoints1, 1, IntegrationPoint<3> >::GenerateIntegrationPoints(),
-                Quadrature<LineGaussLobattoIntegrationPoints2, 1, IntegrationPoint<3> >::GenerateIntegrationPoints(),
-                Quadrature<LineGaussLobattoIntegrationPoints3, 1, IntegrationPoint<3> >::GenerateIntegrationPoints(),
-                Quadrature<LineGaussLobattoIntegrationPoints4, 1, IntegrationPoint<3> >::GenerateIntegrationPoints(),
-                Quadrature<LineGaussLobattoIntegrationPoints5, 1, IntegrationPoint<3> >::GenerateIntegrationPoints(),
-                Quadrature<LineGaussLobattoIntegrationPoints6, 1, IntegrationPoint<3> >::GenerateIntegrationPoints(),
-                Quadrature<LineGaussLobattoIntegrationPoints7, 1, IntegrationPoint<3> >::GenerateIntegrationPoints(),
-                Quadrature<LineGaussLobattoIntegrationPoints8, 1, IntegrationPoint<3> >::GenerateIntegrationPoints(),
-                Quadrature<LineGaussLobattoIntegrationPoints9, 1, IntegrationPoint<3> >::GenerateIntegrationPoints(),
-                Quadrature<LineGaussLobattoIntegrationPoints10,1, IntegrationPoint<3> >::GenerateIntegrationPoints(),
+                Quadrature<SolidMechanicsLineGaussLobattoIntegrationPoints1, 1, IntegrationPoint<3> >::GenerateIntegrationPoints(),
+                Quadrature<SolidMechanicsLineGaussLobattoIntegrationPoints2, 1, IntegrationPoint<3> >::GenerateIntegrationPoints(),
+                Quadrature<SolidMechanicsLineGaussLobattoIntegrationPoints3, 1, IntegrationPoint<3> >::GenerateIntegrationPoints(),
+                Quadrature<SolidMechanicsLineGaussLobattoIntegrationPoints4, 1, IntegrationPoint<3> >::GenerateIntegrationPoints(),
+                Quadrature<SolidMechanicsLineGaussLobattoIntegrationPoints5, 1, IntegrationPoint<3> >::GenerateIntegrationPoints()
             }
         };
         return integration_points;

--- a/applications/SolidMechanicsApplication/custom_integration/solid_mechanics_line_gauss_lobatto_integration_points.h
+++ b/applications/SolidMechanicsApplication/custom_integration/solid_mechanics_line_gauss_lobatto_integration_points.h
@@ -12,8 +12,7 @@
 //
 
 
-#if !defined(KRATOS_LINE_GAUSS_LOBATTO_INTEGRATION_POINTS_H_INCLUDED )
-#define  KRATOS_LINE_GAUSS_LOBATTO_INTEGRATION_POINTS_H_INCLUDED
+#pragma once
 
 
 // System includes
@@ -26,10 +25,10 @@
 
 namespace Kratos
 {
-class LineGaussLobattoIntegrationPoints1
+class SolidMechanicsLineGaussLobattoIntegrationPoints1
 {
 public:
-    KRATOS_CLASS_POINTER_DEFINITION(LineGaussLobattoIntegrationPoints1);
+    KRATOS_CLASS_POINTER_DEFINITION(SolidMechanicsLineGaussLobattoIntegrationPoints1);
     typedef std::size_t SizeType;
 
     static const unsigned int Dimension = 1;
@@ -64,10 +63,10 @@ public:
 };
 
 
-class LineGaussLobattoIntegrationPoints2
+class SolidMechanicsLineGaussLobattoIntegrationPoints2
 {
 public:
-    KRATOS_CLASS_POINTER_DEFINITION(LineGaussLobattoIntegrationPoints2);
+    KRATOS_CLASS_POINTER_DEFINITION(SolidMechanicsLineGaussLobattoIntegrationPoints2);
     typedef std::size_t SizeType;
 
     static const unsigned int Dimension = 1;
@@ -103,10 +102,10 @@ public:
 };
 
 
-class LineGaussLobattoIntegrationPoints3
+class SolidMechanicsLineGaussLobattoIntegrationPoints3
 {
 public:
-    KRATOS_CLASS_POINTER_DEFINITION(LineGaussLobattoIntegrationPoints3);
+    KRATOS_CLASS_POINTER_DEFINITION(SolidMechanicsLineGaussLobattoIntegrationPoints3);
     typedef std::size_t SizeType;
 
     static const unsigned int Dimension = 1;
@@ -140,14 +139,14 @@ public:
     }
 
 
-}; // Class LineGaussLobattoIntegrationPoints3
+}; // Class SolidMechanicsLineGaussLobattoIntegrationPoints3
 
 
 
-class LineGaussLobattoIntegrationPoints4
+class SolidMechanicsLineGaussLobattoIntegrationPoints4
 {
 public:
-    KRATOS_CLASS_POINTER_DEFINITION(LineGaussLobattoIntegrationPoints4);
+    KRATOS_CLASS_POINTER_DEFINITION(SolidMechanicsLineGaussLobattoIntegrationPoints4);
     typedef std::size_t SizeType;
 
     static const unsigned int Dimension = 1;
@@ -182,14 +181,14 @@ public:
     }
 
 
-}; // Class LineGaussLobattoIntegrationPoints4
+}; // Class SolidMechanicsLineGaussLobattoIntegrationPoints4
 
 
 
-class LineGaussLobattoIntegrationPoints5
+class SolidMechanicsLineGaussLobattoIntegrationPoints5
 {
 public:
-    KRATOS_CLASS_POINTER_DEFINITION(LineGaussLobattoIntegrationPoints5);
+    KRATOS_CLASS_POINTER_DEFINITION(SolidMechanicsLineGaussLobattoIntegrationPoints5);
     typedef std::size_t SizeType;
 
     static const unsigned int Dimension = 1;
@@ -225,14 +224,14 @@ public:
     }
 
 
-}; // Class LineGaussLobattoIntegrationPoints5
+}; // Class SolidMechanicsLineGaussLobattoIntegrationPoints5
 
 
 
-class LineGaussLobattoIntegrationPoints6
+class SolidMechanicsLineGaussLobattoIntegrationPoints6
 {
 public:
-    KRATOS_CLASS_POINTER_DEFINITION(LineGaussLobattoIntegrationPoints6);
+    KRATOS_CLASS_POINTER_DEFINITION(SolidMechanicsLineGaussLobattoIntegrationPoints6);
     typedef std::size_t SizeType;
 
     static const unsigned int Dimension = 1;
@@ -269,14 +268,14 @@ public:
     }
 
 
-}; // Class LineGaussLobattoIntegrationPoints6
+}; // Class SolidMechanicsLineGaussLobattoIntegrationPoints6
 
 
 
-class LineGaussLobattoIntegrationPoints7
+class SolidMechanicsLineGaussLobattoIntegrationPoints7
 {
 public:
-    KRATOS_CLASS_POINTER_DEFINITION(LineGaussLobattoIntegrationPoints7);
+    KRATOS_CLASS_POINTER_DEFINITION(SolidMechanicsLineGaussLobattoIntegrationPoints7);
     typedef std::size_t SizeType;
 
     static const unsigned int Dimension = 1;
@@ -314,14 +313,14 @@ public:
     }
 
 
-}; // Class LineGaussLobattoIntegrationPoints7
+}; // Class SolidMechanicsLineGaussLobattoIntegrationPoints7
 
 
 
-class LineGaussLobattoIntegrationPoints8
+class SolidMechanicsLineGaussLobattoIntegrationPoints8
 {
 public:
-    KRATOS_CLASS_POINTER_DEFINITION(LineGaussLobattoIntegrationPoints8);
+    KRATOS_CLASS_POINTER_DEFINITION(SolidMechanicsLineGaussLobattoIntegrationPoints8);
     typedef std::size_t SizeType;
 
     static const unsigned int Dimension = 1;
@@ -360,14 +359,14 @@ public:
     }
 
 
-}; // Class LineGaussLobattoIntegrationPoints8
+}; // Class SolidMechanicsLineGaussLobattoIntegrationPoints8
 
 
 
-class LineGaussLobattoIntegrationPoints9
+class SolidMechanicsLineGaussLobattoIntegrationPoints9
 {
 public:
-    KRATOS_CLASS_POINTER_DEFINITION(LineGaussLobattoIntegrationPoints9);
+    KRATOS_CLASS_POINTER_DEFINITION(SolidMechanicsLineGaussLobattoIntegrationPoints9);
     typedef std::size_t SizeType;
 
     static const unsigned int Dimension = 1;
@@ -407,14 +406,14 @@ public:
     }
 
 
-}; // Class LineGaussLobattoIntegrationPoints9
+}; // Class SolidMechanicsLineGaussLobattoIntegrationPoints9
 
 
 
-class LineGaussLobattoIntegrationPoints10
+class SolidMechanicsLineGaussLobattoIntegrationPoints10
 {
 public:
-    KRATOS_CLASS_POINTER_DEFINITION(LineGaussLobattoIntegrationPoints10);
+    KRATOS_CLASS_POINTER_DEFINITION(SolidMechanicsLineGaussLobattoIntegrationPoints10);
     typedef std::size_t SizeType;
 
     static const unsigned int Dimension = 1;
@@ -455,7 +454,7 @@ public:
     }
 
 
-}; // Class LineGaussLobattoIntegrationPoints10
+}; // Class SolidMechanicsLineGaussLobattoIntegrationPoints10
 
 
 ///@}
@@ -473,6 +472,5 @@ public:
 
 }  // namespace Kratos.
 
-#endif // KRATOS_LINE_GAUSS_LOBATTO_INTEGRATION_POINTS_H_INCLUDED  defined
 
 

--- a/applications/SolidMechanicsApplication/solid_mechanics_application.cpp
+++ b/applications/SolidMechanicsApplication/solid_mechanics_application.cpp
@@ -38,7 +38,7 @@
 #include "geometries/line_2d_2.h"
 #include "geometries/line_3d_2.h"
 #include "geometries/line_3d_3.h"
-#include "geometries/line_gauss_lobatto_3d_2.h"
+#include "custom_geometries/line_gauss_lobatto_3d_2.h"
 
 #include "geometries/point_2d.h"
 #include "geometries/point_3d.h"
@@ -321,7 +321,7 @@ KratosSolidMechanicsApplication::KratosSolidMechanicsApplication()
                  Element::GeometryType::PointsArrayType(3))),
       mLargeDisplacementBeamSEMCElement3D2N(
           0, Kratos::make_shared< LineGaussLobatto3D2<Node > >(
-                 Element::GeometryType::PointsArrayType(2))), 
+                 Element::GeometryType::PointsArrayType(2))),
       mGeometricallyExactRodElement3D2N(
           0, Kratos::make_shared< Line3D2<Node > >(
                  Element::GeometryType::PointsArrayType(2))),


### PR DESCRIPTION
**📝 Description**
In line to what has been discussed in https://github.com/KratosMultiphysics/Kratos/issues/13085, this PR targets arranging the KratosCore integration rules.

Specifically, this PR moves the `line_gauss_lobatto_3d_2.h` geometry from the core to the `SolidMechanicsApplication`.  The rationale is that this geometry duplicates the `line_3d_2.h` and all across Kratos is only used by one element in this application.

Together with the geometry above, it also moves the `line_gauss_lobatto_integration_points.h` to the same application to avoid breaking any current workflow. Note that this does not follow the standard as the expected `GAUSS_LOBATTO_1` (the two endpoints) is named as `GAUSS_LOBATTO_2` while `GAUSS_LOBATTO_1` returns a one point Gauss integration rule. To avoid clashing with the core implementation the file has been renamed to `solid_mechanics_line_gauss_lobatto_integration_points.h`.

Furthermore, I required to remove the order 6 to 10 rules as these were leveraging the misused `EXTENDED_GAUSS_*` enum. I believe you don't require such high order integration rule.

I tried to compile the application to run the tests but it doesn't compile because other reasons related to the testing. Until that  point, includes seemed to be OK.
