### PR TITLE
[StructuralMechachanicsApplication] removed (invisible) symbol from README.md

### DIFF
--- a/applications/StructuralMechanicsApplication/README.md
+++ b/applications/StructuralMechanicsApplication/README.md
@@ -79,6 +79,6 @@ The application includes tests to check the proper functioning of the applicatio
 
 - **+100 Python unittest, including Validation tests, and several cpp tests**
 
-## ️ Examples:
+## Examples:
 
 Examples can be found [here](https://github.com/KratosMultiphysics/Examples/tree/master/structural_mechanics).


### PR DESCRIPTION
struct mechanics wheel could not be build since there was an (invisible) symbol in the readme