### PR TITLE
[Core] Add `SetMasterSlaveConstraints` method and update Python bindings for `MasterSlaveConstraints`

### DIFF
--- a/kratos/includes/mesh.h
+++ b/kratos/includes/mesh.h
@@ -822,6 +822,11 @@ public:
         return mpMasterSlaveConstraints;
     }
 
+    void SetMasterSlaveConstraints(typename MasterSlaveConstraintContainerType::Pointer pOtherMasterSlaveConstraints)
+    {
+        mpMasterSlaveConstraints = pOtherMasterSlaveConstraints;
+    }
+
     typename MasterSlaveConstraintContainerType::ContainerType& MasterSlaveConstraintsArray()
     {
         return mpMasterSlaveConstraints->GetContainer();

--- a/kratos/python/add_mesh_to_python.cpp
+++ b/kratos/python/add_mesh_to_python.cpp
@@ -694,10 +694,6 @@ void  AddMeshToPython(pybind11::module& m)
     .def("ConditionsArray", &MeshType::ConditionsArray, py::return_value_policy::reference_internal)
     .def("NumberOfConditions", &MeshType::NumberOfConditions)
 
-    .def_property("Conditions", &MeshType::pConditions,&MeshType::SetConditions)
-    .def("ConditionsArray", &MeshType::ConditionsArray, py::return_value_policy::reference_internal)
-    .def("NumberOfConditions", &MeshType::NumberOfConditions)
-
     .def_property("MasterSlaveConstraints", &MeshType::pMasterSlaveConstraints,&MeshType::SetMasterSlaveConstraints)
     .def("MasterSlaveConstraintsArray", &MeshType::MasterSlaveConstraintsArray, py::return_value_policy::reference_internal)
     .def("NumberOfMasterSlaveConstraints", &MeshType::NumberOfMasterSlaveConstraints)

--- a/kratos/python/add_mesh_to_python.cpp
+++ b/kratos/python/add_mesh_to_python.cpp
@@ -47,13 +47,13 @@ typename TVariableType::Type GetValueHelperFunction(TContainerType& el, const TV
     return el.GetValue(rVar);
 }
 
-typedef Mesh<Node, Properties, Element, Condition> MeshType;
-typedef MeshType::NodeType NodeType;
-typedef MeshType::NodesContainerType NodesContainerType;
-typedef Geometry<Node > GeometryType;
-typedef GeometryType::PointsArrayType NodesArrayType;
-typedef GeometryType::IntegrationPointsArrayType IntegrationPointsArrayType;
-typedef Point::CoordinatesArrayType CoordinatesArrayType;
+using MeshType = Mesh<Node, Properties, Element, Condition>;
+using NodeType = MeshType::NodeType;
+using NodesContainerType = MeshType::NodesContainerType;
+using GeometryType = Geometry<Node>;
+using NodesArrayType = GeometryType::PointsArrayType;
+using IntegrationPointsArrayType = GeometryType::IntegrationPointsArrayType;
+using CoordinatesArrayType = Point::CoordinatesArrayType;
 
 Properties::Pointer GetPropertiesFromElement( Element& pelem )
 {
@@ -693,6 +693,14 @@ void  AddMeshToPython(pybind11::module& m)
     .def_property("Conditions", &MeshType::pConditions,&MeshType::SetConditions)
     .def("ConditionsArray", &MeshType::ConditionsArray, py::return_value_policy::reference_internal)
     .def("NumberOfConditions", &MeshType::NumberOfConditions)
+
+    .def_property("Conditions", &MeshType::pConditions,&MeshType::SetConditions)
+    .def("ConditionsArray", &MeshType::ConditionsArray, py::return_value_policy::reference_internal)
+    .def("NumberOfConditions", &MeshType::NumberOfConditions)
+
+    .def_property("MasterSlaveConstraints", &MeshType::pMasterSlaveConstraints,&MeshType::SetMasterSlaveConstraints)
+    .def("MasterSlaveConstraintsArray", &MeshType::MasterSlaveConstraintsArray, py::return_value_policy::reference_internal)
+    .def("NumberOfMasterSlaveConstraints", &MeshType::NumberOfMasterSlaveConstraints)
 
     .def_property("Properties", &MeshType::pProperties,&MeshType::SetProperties)
     .def("PropertiesArray", &MeshType::PropertiesArray, py::return_value_policy::reference_internal)


### PR DESCRIPTION
**📝 Description**

This PR introduces the following changes:

1. **In `mesh.h`:** 
   - Added a new setter function `SetMasterSlaveConstraints` to assign a new value to the `mpMasterSlaveConstraints` member.

2. **In `add_mesh_to_python.cpp`:**
   - Updated Python bindings for the `Mesh` class:
     - Added properties and methods related to `MasterSlaveConstraints`, including:
       - A property for `MasterSlaveConstraints` with getter and setter (`pMasterSlaveConstraints` and `SetMasterSlaveConstraints`).
       - A method to access the `MasterSlaveConstraints` array (`MasterSlaveConstraintsArray`).
       - A method to get the number of master-slave constraints (`NumberOfMasterSlaveConstraints`).
   - Introduced new `using` declarations for clearer and more concise type aliases in the code.

**🆕 Changelog**

- [Add `SetMasterSlaveConstraints` method and update Python bindings for `MasterSlaveConstraints`](https://github.com/KratosMultiphysics/Kratos/commit/72ac0b8d543ee8cec4ac926342ea019fd46a7624)
