### PR TITLE
[Core][IO] Transition changes and cleaning up `ModelPartIO`

### DIFF
--- a/kratos/includes/model_part_io.h
+++ b/kratos/includes/model_part_io.h
@@ -4,8 +4,8 @@
 //   _|\_\_|  \__,_|\__|\___/ ____/
 //                   Multi-Physics
 //
-//  License:		 BSD License
-//					 Kratos default license: kratos/license.txt
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
 //
 //  Main authors:    Pooyan Dadvand
 //                   Riccardo Rossi
@@ -17,15 +17,11 @@
 // System includes
 #include <filesystem>
 #include <fstream>
-#include <string>
-#include <unordered_set>
 
 // External includes
 
 // Project includes
-#include "includes/define.h"
 #include "includes/io.h"
-#include "containers/flags.h"
 
 namespace Kratos
 {
@@ -52,7 +48,8 @@ namespace Kratos
 /// An IO class for reading and writing a modelpart
 /** This class reads and writes all modelpart data including the meshes.
 */
-class KRATOS_API(KRATOS_CORE) ModelPartIO : public IO
+class KRATOS_API(KRATOS_CORE) ModelPartIO 
+    : public IO
 {
 public:
     ///@name Type Definitions
@@ -61,20 +58,43 @@ public:
     /// Pointer definition of ModelPartIO
     KRATOS_CLASS_POINTER_DEFINITION(ModelPartIO);
 
-    typedef IO                                    BaseType;
+    /// Alias for the base IO type.
+    using BaseType = IO;
 
-    typedef BaseType::NodeType                    NodeType;
-    typedef BaseType::MeshType                    MeshType;
-    typedef BaseType::NodesContainerType          NodesContainerType;
-    typedef BaseType::PropertiesContainerType     PropertiesContainerType;
-    typedef BaseType::ElementsContainerType       ElementsContainerType;
-    typedef BaseType::ConditionsContainerType     ConditionsContainerType;
-    typedef BaseType::ConnectivitiesContainerType ConnectivitiesContainerType;
+    /// Alias for the node type.
+    using NodeType = BaseType::NodeType;
 
-    typedef std::vector<std::ostream*>            OutputFilesContainerType;
-    typedef std::size_t                           SizeType;
+    /// Alias for the mesh type.
+    using MeshType = BaseType::MeshType;
 
-    // Prevents this class from hiding IO::WriteProperties(Properties)
+    /// Alias for the nodes container type.
+    using NodesContainerType = BaseType::NodesContainerType;
+
+    /// Alias for the properties container type.
+    using PropertiesContainerType = BaseType::PropertiesContainerType;
+
+    /// The geometry map type within ModelPart
+    using GeometriesMapType = BaseType::GeometriesMapType;
+
+    /// Alias for the elements container type.
+    using ElementsContainerType = BaseType::ElementsContainerType;
+
+    /// Alias for the conditions container type.
+    using ConditionsContainerType = BaseType::ConditionsContainerType;
+
+    /// Alias for the master-slave constraints container type.
+    using MasterSlaveConstraintContainerType = BaseType::MasterSlaveConstraintContainerType;
+
+    /// Alias for the connectivities container type.
+    using ConnectivitiesContainerType = BaseType::ConnectivitiesContainerType;
+
+    /// Alias for the output files container type.
+    using OutputFilesContainerType = std::vector<std::ostream*>;
+
+    /// Alias for the size type.
+    using SizeType = std::size_t;
+
+    /// Prevents this class from hiding IO::WriteProperties(Properties)
     using BaseType::WriteProperties;
 
     ///@}
@@ -91,22 +111,18 @@ public:
         Kratos::shared_ptr<std::iostream> Stream,
         const Flags Options = IO::IGNORE_VARIABLES_ERROR.AsFalse() | IO::SKIP_TIMER);
 
-
     /// Constructor with filenames.
     // ModelPartIO(std::string const& InputFilename, std::string const& OutputFilename)
     //     : mNumberOfLines(0), mInput(std::ifstream(InputFilename.c_str())), mOutput(std::ofstream(OutputFilename.c_str()))
     // {
     // }
 
-
     /// Destructor.
     ~ModelPartIO() override;
-
 
     ///@}
     ///@name Operators
     ///@{
-
 
     ///@}
     ///@name Operations
@@ -216,7 +232,7 @@ public:
      * @param rElementsConnectivities The elements connectivities
      * @return The number of elements
      */
-    std::size_t  ReadElementsConnectivities(ConnectivitiesContainerType& rElementsConnectivities) override;
+    std::size_t ReadElementsConnectivities(ConnectivitiesContainerType& rElementsConnectivities) override;
 
     /**
      * @brief This method writes an array of elements
@@ -241,7 +257,7 @@ public:
      * @param rConditionsConnectivities The conditions connectivities
      * @return The number of conditions
      */
-    std::size_t  ReadConditionsConnectivities(ConnectivitiesContainerType& rConditionsConnectivities) override;
+    std::size_t ReadConditionsConnectivities(ConnectivitiesContainerType& rConditionsConnectivities) override;
 
     /**
      * @brief This method writes an array of conditions
@@ -313,26 +329,40 @@ public:
 
     void SwapStreamSource(Kratos::shared_ptr<std::iostream> newStream);
 
+    /**
+     * @brief Virtual method to read element and condition IDs from a sub-model part.
+     * @details This method is intended to be overridden by derived classes.
+     * @param rModelPartName The name of the sub-model part to read from.
+     * @param rElementsIds Set to store element IDs.
+     * @param rConditionsIds Set to store condition IDs.
+     */
     void ReadSubModelPartElementsAndConditionsIds(
         std::string const& rModelPartName,
-        std::unordered_set<SizeType> &rElementsIds,
-        std::unordered_set<SizeType> &rConditionsIds) override;
+        std::unordered_set<SizeType>& rElementsIds,
+        std::unordered_set<SizeType>& rConditionsIds
+        ) override;
 
+    /**
+     * @brief Virtual method to read nodal graph from entities list.
+     * @details This method is intended to be overridden by derived classes.
+     * @param rAuxConnectivities Container of connectivities.
+     * @param rElementsIds Set of element IDs.
+     * @param rConditionsIds Set of condition IDs.
+     * @return The size of the nodal graph.
+     */
     std::size_t ReadNodalGraphFromEntitiesList(
         ConnectivitiesContainerType& rAuxConnectivities,
-        std::unordered_set<SizeType> &rElementsIds,
-        std::unordered_set<SizeType> &rConditionsIds) override;
-
+        std::unordered_set<SizeType>& rElementsIds,
+        std::unordered_set<SizeType>& rConditionsIds
+        ) override;
 
     ///@}
     ///@name Access
     ///@{
 
-
     ///@}
     ///@name Inquiry
     ///@{
-
 
     ///@}
     ///@name Input and output
@@ -359,54 +389,67 @@ public:
     ///@name Friends
     ///@{
 
-
     ///@}
-
 protected:
     ///@name Protected static Member Variables
     ///@{
-
 
     ///@}
     ///@name Protected member Variables
     ///@{
 
-
     ///@}
     ///@name Protected Operators
     ///@{
-
 
     ///@}
     ///@name Protected Operations
     ///@{
 
-  	virtual ModelPartIO::SizeType ReorderedNodeId(ModelPartIO::SizeType NodeId);
-  	virtual ModelPartIO::SizeType ReorderedGeometryId(ModelPartIO::SizeType GeometryId);
-  	virtual ModelPartIO::SizeType ReorderedElementId(ModelPartIO::SizeType ElementId);
-  	virtual ModelPartIO::SizeType ReorderedConditionId(ModelPartIO::SizeType ConditionId);
+    /**
+     * @brief Returns the reordered node ID.
+     * @param NodeId The original node ID.
+     * @return The reordered node ID (same as input in this base class).
+     */
+    virtual ModelPartIO::SizeType ReorderedNodeId(ModelPartIO::SizeType NodeId);
+
+    /**
+     * @brief Returns the reordered geometry ID.
+     * @param GeometryId The original geometry ID.
+     * @return The reordered geometry ID (same as input in this base class).
+     */
+    virtual ModelPartIO::SizeType ReorderedGeometryId(ModelPartIO::SizeType GeometryId);
+
+    /**
+     * @brief Returns the reordered element ID.
+     * @param ElementId The original element ID.
+     * @return The reordered element ID (same as input in this base class).
+     */
+    virtual ModelPartIO::SizeType ReorderedElementId(ModelPartIO::SizeType ElementId);
+
+    /**
+     * @brief Returns the reordered condition ID.
+     * @param ConditionId The original condition ID.
+     * @return The reordered condition ID (same as input in this base class).
+     */
+    virtual ModelPartIO::SizeType ReorderedConditionId(ModelPartIO::SizeType ConditionId);
 
     ///@}
     ///@name Protected  Access
     ///@{
 
-
     ///@}
     ///@name Protected Inquiry
     ///@{
-
 
     ///@}
     ///@name Protected LifeCycle
     ///@{
 
-
     ///@}
-
 private:
     ///@name Static Member Variables
     ///@{
-
 
     ///@}
     ///@name Member Variables
@@ -419,11 +462,9 @@ private:
 
     Kratos::shared_ptr<std::iostream> mpStream;
 
-
     ///@}
     ///@name Private Operators
     ///@{
-
 
     ///@}
     ///@name Private Operations
@@ -435,9 +476,9 @@ private:
 
     bool CheckEndBlock(std::string const& BlockName, std::string& rWord);
 
-    void ReadModelPartDataBlock(ModelPart& rModelPart, const bool is_submodelpart=false);
+    void ReadModelPartDataBlock(ModelPart& rModelPart, const bool IsSubmodelpart=false);
 
-    void WriteModelPartDataBlock(ModelPart& rModelPart, const bool is_submodelpart=false);
+    void WriteModelPartDataBlock(ModelPart& rModelPart, const bool IsSubmodelpart=false);
 
     template<class TablesContainerType>
     void ReadTableBlock(TablesContainerType& rTables);
@@ -567,12 +608,32 @@ private:
 
     void ReadSubModelPartPropertiesBlock(ModelPart& rMainModelPart, ModelPart& rSubModelPart);
 
+    /**
+     * @brief Reads the nodes block of a submodelpart.
+     * @param rMainModelPart Reference to the main model part.
+     * @param rSubModelPart Reference to the submodelpart where the nodes will be added.
+     */
     void ReadSubModelPartNodesBlock(ModelPart& rMainModelPart, ModelPart& rSubModelPart);
 
+    /**
+     * @brief Reads the elements block of a submodelpart.
+     * @param rMainModelPart Reference to the main model part.
+     * @param rSubModelPart Reference to the submodelpart where the elements will be added.
+     */
     void ReadSubModelPartElementsBlock(ModelPart& rMainModelPart, ModelPart& rSubModelPart);
 
+    /**
+     * @brief Reads the conditions block of a submodelpart.
+     * @param rMainModelPart Reference to the main model part.
+     * @param rSubModelPart Reference to the submodelpart where the conditions will be added.
+     */
     void ReadSubModelPartConditionsBlock(ModelPart& rMainModelPart, ModelPart& rSubModelPart);
 
+    /**
+     * @brief Reads the geometries block of a submodelpart.
+     * @param rMainModelPart Reference to the main model part.
+     * @param rSubModelPart Reference to the submodelpart where the geometries will be added.
+     */
     void ReadSubModelPartGeometriesBlock(
         ModelPart &rMainModelPart,
         ModelPart &rSubModelPart);

--- a/kratos/includes/model_part_io.h
+++ b/kratos/includes/model_part_io.h
@@ -82,9 +82,6 @@ public:
     /// Alias for the conditions container type.
     using ConditionsContainerType = BaseType::ConditionsContainerType;
 
-    /// Alias for the master-slave constraints container type.
-    using MasterSlaveConstraintContainerType = BaseType::MasterSlaveConstraintContainerType;
-
     /// Alias for the connectivities container type.
     using ConnectivitiesContainerType = BaseType::ConnectivitiesContainerType;
 

--- a/kratos/includes/model_part_io.h
+++ b/kratos/includes/model_part_io.h
@@ -73,9 +73,6 @@ public:
     /// Alias for the properties container type.
     using PropertiesContainerType = BaseType::PropertiesContainerType;
 
-    /// The geometry map type within ModelPart
-    using GeometriesMapType = BaseType::GeometriesMapType;
-
     /// Alias for the elements container type.
     using ElementsContainerType = BaseType::ElementsContainerType;
 

--- a/kratos/sources/model_part_io.cpp
+++ b/kratos/sources/model_part_io.cpp
@@ -5,7 +5,7 @@
 //                   Multi-Physics
 //
 //  License:         BSD License
-//                     Kratos default license: kratos/license.txt
+//                   Kratos default license: kratos/license.txt
 //
 //  Main authors:    Pooyan Dadvand
 //                   Riccardo Rossi
@@ -437,10 +437,10 @@ void ModelPartIO::ReadConditions(NodesContainerType& rThisNodes, PropertiesConta
     KRATOS_CATCH("")
 }
 
-std::size_t  ModelPartIO::ReadConditionsConnectivities(ConnectivitiesContainerType& rConditionsConnectivities)
+std::size_t ModelPartIO::ReadConditionsConnectivities(ConnectivitiesContainerType& rConditionsConnectivities)
 {
     KRATOS_TRY
-    std::size_t number_of_elements = 0;
+    std::size_t number_of_conditions = 0;
     ResetInput();
     std::string word;
     while(true)
@@ -450,11 +450,11 @@ std::size_t  ModelPartIO::ReadConditionsConnectivities(ConnectivitiesContainerTy
             break;
         ReadBlockName(word);
         if(word == "Conditions")
-            number_of_elements += ReadConditionsConnectivitiesBlock(rConditionsConnectivities);
+            number_of_conditions += ReadConditionsConnectivitiesBlock(rConditionsConnectivities);
         else
             SkipBlock(word);
     }
-    return number_of_elements;
+    return number_of_conditions;
     KRATOS_CATCH("")
 }
 
@@ -803,7 +803,6 @@ void ModelPartIO::FillNodalConnectivitiesFromGeometryBlockInList(
             break;
 
         ExtractValue(word,id);
-        ReadWord(word); // Reading the properties id;
         temp_geometry_nodes.clear();
         for(SizeType i = 0 ; i < n_nodes_in_elem ; i++) {
             ReadWord(word); // Reading the node id;
@@ -1049,7 +1048,8 @@ void ModelPartIO::DivideInputToPartitions(
 void ModelPartIO::DivideInputToPartitionsImpl(
     OutputFilesContainerType& rOutputFiles,
     SizeType NumberOfPartitions,
-    const PartitioningInfo& rPartitioningInfo)
+    const PartitioningInfo& rPartitioningInfo
+    )
 {
     KRATOS_TRY
 
@@ -1160,7 +1160,7 @@ void ModelPartIO::ReadSubModelPartDataBlock(ModelPart& rModelPart)
     KRATOS_CATCH("")
 }
 
-void ModelPartIO::ReadModelPartDataBlock(ModelPart& rModelPart, const bool is_submodelpart)
+void ModelPartIO::ReadModelPartDataBlock(ModelPart& rModelPart, const bool IsSubmodelpart)
 {
     KRATOS_TRY
 
@@ -1169,7 +1169,7 @@ void ModelPartIO::ReadModelPartDataBlock(ModelPart& rModelPart, const bool is_su
     while(!mpStream->eof())
     {
         ReadWord(variable_name);
-        if(!is_submodelpart){
+        if(!IsSubmodelpart){
             if(CheckEndBlock("ModelPartData", variable_name))
                 break;
         }
@@ -1242,7 +1242,7 @@ void ModelPartIO::ReadModelPartDataBlock(ModelPart& rModelPart, const bool is_su
     KRATOS_CATCH("")
 }
 
-void ModelPartIO::WriteModelPartDataBlock(ModelPart& rModelPart, const bool is_submodelpart)
+void ModelPartIO::WriteModelPartDataBlock(ModelPart& rModelPart, const bool IsSubmodelpart)
 {
     KRATOS_TRY;
 


### PR DESCRIPTION
**📝 Description**

Transition minor changes and cleaning up `ModelPartIO`.

1. **Alias definitions**: Replace `typedef` with `alias`.

2. **Code cleanup**

3. **Some documentation definition**

**🆕 Changelog**

- [Transition changes and cleaning up `ModelPartIO`](https://github.com/KratosMultiphysics/Kratos/commit/541c9089dbb160ae16719344256a96954e58bfa9)
