### PR TITLE
[Core] CUSTOM integration method in QuadratureMethod enum

### DIFF
--- a/applications/IgaApplication/custom_processes/assign_integration_points_to_background_elements_process.cpp
+++ b/applications/IgaApplication/custom_processes/assign_integration_points_to_background_elements_process.cpp
@@ -68,10 +68,10 @@ namespace Kratos
             }
             IntegrationInfo integration_info = p_geometry->GetDefaultIntegrationInfo();
             GeometriesArrayType geometry_list;
-            // Make sure one qudrature point geometry is created for each integration point.
-            integration_info.SetQuadratureMethod(0, IntegrationInfo::QuadratureMethod::EXTENDED_GAUSS);
-            integration_info.SetQuadratureMethod(1, IntegrationInfo::QuadratureMethod::EXTENDED_GAUSS);
-            integration_info.SetQuadratureMethod(2, IntegrationInfo::QuadratureMethod::EXTENDED_GAUSS);
+            // Make sure one quadrature point geometry is created for each integration point.
+            integration_info.SetQuadratureMethod(0, IntegrationInfo::QuadratureMethod::CUSTOM);
+            integration_info.SetQuadratureMethod(1, IntegrationInfo::QuadratureMethod::CUSTOM);
+            integration_info.SetQuadratureMethod(2, IntegrationInfo::QuadratureMethod::CUSTOM);
             p_geometry->CreateQuadraturePointGeometries(geometry_list, 2, integration_points, integration_info);
 
             // Get properties from main model part

--- a/applications/IgaApplication/custom_processes/map_nurbs_volume_results_to_embedded_geometry_process.cpp
+++ b/applications/IgaApplication/custom_processes/map_nurbs_volume_results_to_embedded_geometry_process.cpp
@@ -89,10 +89,10 @@ namespace Kratos
 
         IntegrationInfo integration_info = p_geometry->GetDefaultIntegrationInfo();
         GeometriesArrayType geometry_list;
-        // Make sure one qudrature point geometry is created for each integration point.
-        integration_info.SetQuadratureMethod(0, IntegrationInfo::QuadratureMethod::EXTENDED_GAUSS);
-        integration_info.SetQuadratureMethod(1, IntegrationInfo::QuadratureMethod::EXTENDED_GAUSS);
-        integration_info.SetQuadratureMethod(2, IntegrationInfo::QuadratureMethod::EXTENDED_GAUSS);
+        // Make sure one quadrature point geometry is created for each integration point.
+        integration_info.SetQuadratureMethod(0, IntegrationInfo::QuadratureMethod::CUSTOM);
+        integration_info.SetQuadratureMethod(1, IntegrationInfo::QuadratureMethod::CUSTOM);
+        integration_info.SetQuadratureMethod(2, IntegrationInfo::QuadratureMethod::CUSTOM);
         p_geometry->CreateQuadraturePointGeometries(geometry_list, 2, integration_points, integration_info);
 
         const auto p_properties = main_model_part.pGetProperties(1);

--- a/applications/IgaApplication/tests/iga_test_factory.py
+++ b/applications/IgaApplication/tests/iga_test_factory.py
@@ -50,6 +50,7 @@ class MembraneSinglePatchFourPointSailImplicitDynamic(IgaTestFactory):
     file_name = "membrane_test/Membrane_single_patch_four_point_sail_implicit_dynamic"
 
 # 3p Kirchhoff-Love Shell
+@KratosUnittest.skipIfApplicationsNotAvailable("LinearSolversApplication")
 class ScordelisRoofShell3pTest(IgaTestFactory):
     file_name = "scordelis_roof_test/scordelis_roof_shell_3p"
 
@@ -74,9 +75,11 @@ class ScordelisRoofShell5pTest(IgaTestFactory):
     file_name = "scordelis_roof_test/scordelis_roof_shell_5p"
 
 # Weak support
+@KratosUnittest.skipIfApplicationsNotAvailable("LinearSolversApplication")
 class SinglePatchRefinedSupportPenaltyTest(IgaTestFactory):
     file_name = "weak_support_tests/single_patch_refined_test/single_patch_refined_test_penalty"
 
+@KratosUnittest.skipIfApplicationsNotAvailable("LinearSolversApplication")
 class SinglePatchRefinedSupportLagrangeTest(IgaTestFactory):
     file_name = "weak_support_tests/single_patch_refined_test/single_patch_refined_test_lagrange"
 
@@ -84,18 +87,22 @@ class SinglePatchRefinedSupportNitscheTest(IgaTestFactory):
     file_name = "weak_support_tests/single_patch_refined_test/single_patch_refined_test_nitsche"
 
 # Coupling C_0
+@KratosUnittest.skipIfApplicationsNotAvailable("LinearSolversApplication")
 class TwoPatchCouplingPenaltyShell3pTest(IgaTestFactory):
     file_name = "coupling_condition_tests/two_patch_test/two_patch_test_penalty_shell_3p"
 
+@KratosUnittest.skipIfApplicationsNotAvailable("LinearSolversApplication")
 class TwoPatchCouplingLagrangeShell3pTest(IgaTestFactory):
     file_name = "coupling_condition_tests/two_patch_test/two_patch_test_lagrange_shell_3p"
 
 class TwoPatchCouplingNitscheShell3pTest(IgaTestFactory):
     file_name = "coupling_condition_tests/two_patch_test/two_patch_test_nitsche_shell_3p"
 
+@KratosUnittest.skipIfApplicationsNotAvailable("LinearSolversApplication")
 class TwoPatchRefinedCouplingPenaltyMembraneTest(IgaTestFactory):
     file_name = "coupling_condition_tests/two_patch_refined_test/two_patch_refined_test_penalty_membrane"
 
+@KratosUnittest.skipIfApplicationsNotAvailable("LinearSolversApplication")
 class TwoPatchRefinedCouplingLagrangeMembraneTest(IgaTestFactory):
     file_name = "coupling_condition_tests/two_patch_refined_test/two_patch_refined_test_lagrange_membrane"
 

--- a/applications/IgaApplication/tests/shell_3p_element_tests.py
+++ b/applications/IgaApplication/tests/shell_3p_element_tests.py
@@ -15,7 +15,7 @@ import os
 def GetFilePath(fileName):
     return os.path.dirname(__file__) + "/" + fileName
 
-
+@KratosUnittest.skipIfApplicationsNotAvailable("LinearSolversApplication")
 class Shell3pElementTests(KratosUnittest.TestCase):
 
     def solve_cantilever(create_geometry):

--- a/kratos/geometries/nurbs_volume_geometry.h
+++ b/kratos/geometries/nurbs_volume_geometry.h
@@ -709,7 +709,7 @@ public:
         // Makes sure we use assembly Option 2 in CreateQuadraturePointGeometries().
         IntegrationInfo integration_info(
             { PolynomialDegreeU() + 1, PolynomialDegreeV() + 1, PolynomialDegreeW() + 1 },
-            { IntegrationInfo::QuadratureMethod::EXTENDED_GAUSS, IntegrationInfo::QuadratureMethod::EXTENDED_GAUSS, IntegrationInfo::QuadratureMethod::EXTENDED_GAUSS });
+            { IntegrationInfo::QuadratureMethod::CUSTOM, IntegrationInfo::QuadratureMethod::CUSTOM, IntegrationInfo::QuadratureMethod::CUSTOM });
 
         this->CreateQuadraturePointGeometries(
             rResultGeometries,
@@ -817,7 +817,7 @@ public:
                 this->WorkingSpaceDimension(), 3, data_container, nonzero_control_points, this);
         }
         // Option 2: A list of QuadraturePointGeometry is created, one for each integration points.
-        else if ( IntegrationInfo::QuadratureMethod::EXTENDED_GAUSS == rIntegrationInfo.GetQuadratureMethod(0) ) {
+        else if ( IntegrationInfo::QuadratureMethod::CUSTOM == rIntegrationInfo.GetQuadratureMethod(0) ) {
             // Shape function container.
             NurbsVolumeShapeFunction shape_function_container(
                 mPolynomialDegreeU, mPolynomialDegreeV, mPolynomialDegreeW, NumberOfShapeFunctionDerivatives);

--- a/kratos/integration/integration_info.h
+++ b/kratos/integration/integration_info.h
@@ -58,11 +58,12 @@ public:
 
     enum class QuadratureMethod
     {
-        Default,
-        GAUSS,
-        EXTENDED_GAUSS,
-        LOBATTO,
-        GRID
+        Default, // Default do nothing integration rule
+        GAUSS, // Standard Gauss integration rule
+        EXTENDED_GAUSS, //FIXME: Messy and misleading stuff to be removed in an upcoming PR
+        LOBATTO, // Standard Lobatto integration rule
+        GRID, // Equally-spaced integration points rule (not suitable for all geometries)
+        CUSTOM // Custom integration rule (e.g., integration points coming from QuESo)
     };
 
     ///@}
@@ -116,7 +117,7 @@ public:
     IntegrationMethod GetIntegrationMethod(
         IndexType DimensionIndex) const;
 
-    /* Evaluates the corresponding IntegrationMethod to 
+    /* Evaluates the corresponding IntegrationMethod to
      * the number of points and the quadrature method.
      */
     static IntegrationMethod GetIntegrationMethod(


### PR DESCRIPTION
**📝 Description**
This creates a `CUSTOM` entry in the `QuadratureMethod` enum to indicate custom integration rules.

An example of usage could be the integration points distribution coming from QuESo library. Note this was exactly a misuse of the `EXTENDED_GAUSS`, which is also amend in this PR.

(#13438 needs to be merged first).