### PR TITLE
[GeoMechanicsApplication] Fix arrays passed to UDSM

### DIFF
--- a/applications/GeoMechanicsApplication/custom_constitutive/interface_coulomb_with_tension_cut_off.cpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/interface_coulomb_with_tension_cut_off.cpp
@@ -73,12 +73,12 @@ int InterfaceCoulombWithTensionCutOff::Check(const Properties&   rMaterialProper
     // Since `CheckProperty` doesn't accept a custom range yet, we have inlined a modified version
     // of `CheckProperty` to check the friction angle
     KRATOS_ERROR_IF_NOT(rMaterialProperties.Has(GEO_FRICTION_ANGLE))
-        << GEO_FRICTION_ANGLE.Name() << " is not defined for property " << rMaterialProperties.Id() << std::endl;
-    KRATOS_ERROR_IF(rMaterialProperties[GEO_FRICTION_ANGLE] <= 0.0 ||
-                    rMaterialProperties[GEO_FRICTION_ANGLE] >= 90.0)
-        << "value of " << GEO_FRICTION_ANGLE.Name() << " for property " << rMaterialProperties.Id()
-        << " is out of range: " << rMaterialProperties[GEO_FRICTION_ANGLE] << " is not in (0.0, 90.0)"
+        << GEO_FRICTION_ANGLE.Name() << " is not defined for property " << rMaterialProperties.Id()
         << std::endl;
+    KRATOS_ERROR_IF(rMaterialProperties[GEO_FRICTION_ANGLE] <= 0.0 || rMaterialProperties[GEO_FRICTION_ANGLE] >= 90.0)
+        << "value of " << GEO_FRICTION_ANGLE.Name() << " for property " << rMaterialProperties.Id()
+        << " is out of range: " << rMaterialProperties[GEO_FRICTION_ANGLE]
+        << " is not in (0.0, 90.0)" << std::endl;
     ConstitutiveLawUtilities::CheckProperty(rMaterialProperties, GEO_DILATANCY_ANGLE,
                                             rMaterialProperties[GEO_FRICTION_ANGLE]);
     ConstitutiveLawUtilities::CheckProperty(

--- a/applications/GeoMechanicsApplication/custom_constitutive/small_strain_udsm_2D_interface_law.cpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/small_strain_udsm_2D_interface_law.cpp
@@ -40,12 +40,12 @@ void SmallStrainUDSM2DInterfaceLaw::SetExternalStressVector(Vector& rStressVecto
 
 void SmallStrainUDSM2DInterfaceLaw::SetInternalStressVector(const Vector& rStressVector)
 {
-    KRATOS_TRY
-    std::fill(mStressVectorFinalized.begin(), mStressVectorFinalized.end(), 0.0);
+    auto& r_sig0 = GetSig0();
 
-    mStressVectorFinalized[INDEX_3D_ZZ] = rStressVector(INDEX_2D_INTERFACE_ZZ);
-    mStressVectorFinalized[INDEX_3D_XZ] = rStressVector(INDEX_2D_INTERFACE_XZ);
-    KRATOS_CATCH("")
+    std::fill_n(r_sig0.begin(), StressVectorSize, 0.0);
+
+    r_sig0[INDEX_3D_ZZ] = rStressVector(INDEX_2D_INTERFACE_ZZ);
+    r_sig0[INDEX_3D_XZ] = rStressVector(INDEX_2D_INTERFACE_XZ);
 }
 
 void SmallStrainUDSM2DInterfaceLaw::SetInternalStrainVector(const Vector& rStrainVector)
@@ -95,10 +95,11 @@ Vector& SmallStrainUDSM2DInterfaceLaw::GetValue(const Variable<Vector>& rThisVar
     if (rThisVariable == STATE_VARIABLES) {
         SmallStrainUDSM3DLaw::GetValue(rThisVariable, rValue);
     } else if (rThisVariable == CAUCHY_STRESS_VECTOR) {
-        if (rValue.size() != VoigtSize) rValue.resize(VoigtSize);
+        rValue.resize(VoigtSize);
 
-        rValue[INDEX_2D_INTERFACE_ZZ] = mStressVectorFinalized[INDEX_3D_ZZ];
-        rValue[INDEX_2D_INTERFACE_XZ] = mStressVectorFinalized[INDEX_3D_XZ];
+        auto& r_sig0                  = GetSig0();
+        rValue[INDEX_2D_INTERFACE_ZZ] = r_sig0[INDEX_3D_ZZ];
+        rValue[INDEX_2D_INTERFACE_XZ] = r_sig0[INDEX_3D_XZ];
     }
     return rValue;
 }

--- a/applications/GeoMechanicsApplication/custom_constitutive/small_strain_udsm_2D_interface_law.cpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/small_strain_udsm_2D_interface_law.cpp
@@ -26,10 +26,12 @@ ConstitutiveLaw::Pointer SmallStrainUDSM2DInterfaceLaw::Clone() const
 
 void SmallStrainUDSM2DInterfaceLaw::UpdateInternalDeltaStrainVector(ConstitutiveLaw::Parameters& rValues)
 {
-    const Vector& rStrainVector = rValues.GetStrainVector();
+    const auto& r_strain_vector = rValues.GetStrainVector();
 
-    mDeltaStrainVector[INDEX_3D_ZZ] = rStrainVector(INDEX_2D_INTERFACE_ZZ) - mStrainVectorFinalized[INDEX_3D_ZZ];
-    mDeltaStrainVector[INDEX_3D_XZ] = rStrainVector(INDEX_2D_INTERFACE_XZ) - mStrainVectorFinalized[INDEX_3D_XZ];
+    mDeltaStrainVector[INDEX_3D_ZZ] =
+        r_strain_vector[INDEX_2D_INTERFACE_ZZ] - mStrainVectorFinalized[INDEX_3D_ZZ];
+    mDeltaStrainVector[INDEX_3D_XZ] =
+        r_strain_vector[INDEX_2D_INTERFACE_XZ] - mStrainVectorFinalized[INDEX_3D_XZ];
 }
 
 void SmallStrainUDSM2DInterfaceLaw::SetExternalStressVector(Vector& rStressVector)

--- a/applications/GeoMechanicsApplication/custom_constitutive/small_strain_udsm_2D_interface_law.cpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/small_strain_udsm_2D_interface_law.cpp
@@ -46,8 +46,8 @@ void SmallStrainUDSM2DInterfaceLaw::SetInternalStressVector(const Vector& rStres
 
     std::fill_n(r_sig0.begin(), StressVectorSize, 0.0);
 
-    r_sig0[INDEX_3D_ZZ] = rStressVector(INDEX_2D_INTERFACE_ZZ);
-    r_sig0[INDEX_3D_XZ] = rStressVector(INDEX_2D_INTERFACE_XZ);
+    r_sig0[INDEX_3D_ZZ] = rStressVector[INDEX_2D_INTERFACE_ZZ];
+    r_sig0[INDEX_3D_XZ] = rStressVector[INDEX_2D_INTERFACE_XZ];
 }
 
 void SmallStrainUDSM2DInterfaceLaw::SetInternalStrainVector(const Vector& rStrainVector)

--- a/applications/GeoMechanicsApplication/custom_constitutive/small_strain_udsm_2D_plane_strain_law.cpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/small_strain_udsm_2D_plane_strain_law.cpp
@@ -45,11 +45,7 @@ void SmallStrainUDSM2DPlaneStrainLaw::SetExternalStressVector(Vector& rStressVec
 
 void SmallStrainUDSM2DPlaneStrainLaw::SetInternalStressVector(const Vector& rStressVector)
 {
-    KRATOS_TRY
-    for (unsigned int i = 0; i < VoigtSize; ++i) {
-        mStressVectorFinalized[i] = rStressVector(i);
-    }
-    KRATOS_CATCH("")
+    std::copy_n(rStressVector.begin(), VoigtSize, GetSig0().begin());
 }
 
 void SmallStrainUDSM2DPlaneStrainLaw::SetInternalStrainVector(const Vector& rStrainVector)
@@ -89,10 +85,8 @@ Vector& SmallStrainUDSM2DPlaneStrainLaw::GetValue(const Variable<Vector>& rThisV
     if (rThisVariable == STATE_VARIABLES) {
         SmallStrainUDSM3DLaw::GetValue(rThisVariable, rValue);
     } else if (rThisVariable == CAUCHY_STRESS_VECTOR) {
-        if (rValue.size() != VoigtSize) rValue.resize(VoigtSize);
-        for (unsigned int i = 0; i < VoigtSize; ++i) {
-            rValue[i] = mStressVectorFinalized[i];
-        }
+        rValue.resize(VoigtSize);
+        std::copy_n(GetSig0().begin(), VoigtSize, rValue.begin());
     }
     return rValue;
 }

--- a/applications/GeoMechanicsApplication/custom_constitutive/small_strain_udsm_2D_plane_strain_law.cpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/small_strain_udsm_2D_plane_strain_law.cpp
@@ -25,15 +25,6 @@ ConstitutiveLaw::Pointer SmallStrainUDSM2DPlaneStrainLaw::Clone() const
     KRATOS_CATCH("")
 }
 
-void SmallStrainUDSM2DPlaneStrainLaw::UpdateInternalDeltaStrainVector(ConstitutiveLaw::Parameters& rValues)
-{
-    const Vector& rStrainVector = rValues.GetStrainVector();
-
-    for (unsigned int i = 0; i < VoigtSize; ++i) {
-        mDeltaStrainVector[i] = rStrainVector(i) - mStrainVectorFinalized[i];
-    }
-}
-
 void SmallStrainUDSM2DPlaneStrainLaw::SetExternalStressVector(Vector& rStressVector)
 {
     KRATOS_TRY

--- a/applications/GeoMechanicsApplication/custom_constitutive/small_strain_udsm_2D_plane_strain_law.cpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/small_strain_udsm_2D_plane_strain_law.cpp
@@ -34,11 +34,6 @@ void SmallStrainUDSM2DPlaneStrainLaw::SetExternalStressVector(Vector& rStressVec
     KRATOS_CATCH("")
 }
 
-void SmallStrainUDSM2DPlaneStrainLaw::SetInternalStressVector(const Vector& rStressVector)
-{
-    std::copy_n(rStressVector.begin(), VoigtSize, GetSig0().begin());
-}
-
 void SmallStrainUDSM2DPlaneStrainLaw::SetInternalStrainVector(const Vector& rStrainVector)
 {
     KRATOS_TRY

--- a/applications/GeoMechanicsApplication/custom_constitutive/small_strain_udsm_2D_plane_strain_law.hpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/small_strain_udsm_2D_plane_strain_law.hpp
@@ -146,7 +146,6 @@ protected:
     ///@name Protected  Access
     ///@{
     void SetExternalStressVector(Vector& rStressVector) override;
-    void SetInternalStressVector(const Vector& rStressVector) override;
     void SetInternalStrainVector(const Vector& rStrainVector) override;
     void CopyConstitutiveMatrix(ConstitutiveLaw::Parameters& rValues, Matrix& rConstitutiveMatrix) override;
 

--- a/applications/GeoMechanicsApplication/custom_constitutive/small_strain_udsm_2D_plane_strain_law.hpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/small_strain_udsm_2D_plane_strain_law.hpp
@@ -145,7 +145,6 @@ protected:
     ///@}
     ///@name Protected  Access
     ///@{
-    void UpdateInternalDeltaStrainVector(ConstitutiveLaw::Parameters& rValues) override;
     void SetExternalStressVector(Vector& rStressVector) override;
     void SetInternalStressVector(const Vector& rStressVector) override;
     void SetInternalStrainVector(const Vector& rStrainVector) override;

--- a/applications/GeoMechanicsApplication/custom_constitutive/small_strain_udsm_3D_interface_law.cpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/small_strain_udsm_3D_interface_law.cpp
@@ -53,9 +53,9 @@ void SmallStrainUDSM3DInterfaceLaw::SetInternalStressVector(const Vector& rStres
 
     std::fill_n(r_sig0.begin(), StressVectorSize, 0.0);
 
-    r_sig0[INDEX_3D_ZZ] = rStressVector(INDEX_3D_INTERFACE_ZZ);
-    r_sig0[INDEX_3D_YZ] = rStressVector(INDEX_3D_INTERFACE_YZ);
-    r_sig0[INDEX_3D_XZ] = rStressVector(INDEX_3D_INTERFACE_XZ);
+    r_sig0[INDEX_3D_ZZ] = rStressVector[INDEX_3D_INTERFACE_ZZ];
+    r_sig0[INDEX_3D_YZ] = rStressVector[INDEX_3D_INTERFACE_YZ];
+    r_sig0[INDEX_3D_XZ] = rStressVector[INDEX_3D_INTERFACE_XZ];
 }
 
 void SmallStrainUDSM3DInterfaceLaw::SetInternalStrainVector(const Vector& rStrainVector)

--- a/applications/GeoMechanicsApplication/custom_constitutive/small_strain_udsm_3D_interface_law.cpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/small_strain_udsm_3D_interface_law.cpp
@@ -30,11 +30,14 @@ ConstitutiveLaw::Pointer SmallStrainUDSM3DInterfaceLaw::Clone() const
 
 void SmallStrainUDSM3DInterfaceLaw::UpdateInternalDeltaStrainVector(ConstitutiveLaw::Parameters& rValues)
 {
-    const Vector& rStrainVector = rValues.GetStrainVector();
+    const auto& r_strain_vector = rValues.GetStrainVector();
 
-    mDeltaStrainVector[INDEX_3D_ZZ] = rStrainVector(INDEX_3D_INTERFACE_ZZ) - mStrainVectorFinalized[INDEX_3D_ZZ];
-    mDeltaStrainVector[INDEX_3D_YZ] = rStrainVector(INDEX_3D_INTERFACE_YZ) - mStrainVectorFinalized[INDEX_3D_YZ];
-    mDeltaStrainVector[INDEX_3D_XZ] = rStrainVector(INDEX_3D_INTERFACE_XZ) - mStrainVectorFinalized[INDEX_3D_XZ];
+    mDeltaStrainVector[INDEX_3D_ZZ] =
+        r_strain_vector[INDEX_3D_INTERFACE_ZZ] - mStrainVectorFinalized[INDEX_3D_ZZ];
+    mDeltaStrainVector[INDEX_3D_YZ] =
+        r_strain_vector[INDEX_3D_INTERFACE_YZ] - mStrainVectorFinalized[INDEX_3D_YZ];
+    mDeltaStrainVector[INDEX_3D_XZ] =
+        r_strain_vector[INDEX_3D_INTERFACE_XZ] - mStrainVectorFinalized[INDEX_3D_XZ];
 }
 
 void SmallStrainUDSM3DInterfaceLaw::SetExternalStressVector(Vector& rStressVector)

--- a/applications/GeoMechanicsApplication/custom_constitutive/small_strain_udsm_3D_interface_law.cpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/small_strain_udsm_3D_interface_law.cpp
@@ -46,14 +46,13 @@ void SmallStrainUDSM3DInterfaceLaw::SetExternalStressVector(Vector& rStressVecto
 
 void SmallStrainUDSM3DInterfaceLaw::SetInternalStressVector(const Vector& rStressVector)
 {
-    KRATOS_TRY
-    std::fill(mStressVectorFinalized.begin(), mStressVectorFinalized.end(), 0.0);
+    auto& r_sig0 = GetSig0();
 
-    mStressVectorFinalized[INDEX_3D_ZZ] = rStressVector(INDEX_3D_INTERFACE_ZZ);
-    mStressVectorFinalized[INDEX_3D_YZ] = rStressVector(INDEX_3D_INTERFACE_YZ);
-    mStressVectorFinalized[INDEX_3D_XZ] = rStressVector(INDEX_3D_INTERFACE_XZ);
+    std::fill_n(r_sig0.begin(), StressVectorSize, 0.0);
 
-    KRATOS_CATCH("")
+    r_sig0[INDEX_3D_ZZ] = rStressVector(INDEX_3D_INTERFACE_ZZ);
+    r_sig0[INDEX_3D_YZ] = rStressVector(INDEX_3D_INTERFACE_YZ);
+    r_sig0[INDEX_3D_XZ] = rStressVector(INDEX_3D_INTERFACE_XZ);
 }
 
 void SmallStrainUDSM3DInterfaceLaw::SetInternalStrainVector(const Vector& rStrainVector)
@@ -106,11 +105,12 @@ Vector& SmallStrainUDSM3DInterfaceLaw::GetValue(const Variable<Vector>& rVariabl
     if (rVariable == STATE_VARIABLES) {
         SmallStrainUDSM3DLaw::GetValue(rVariable, rValue);
     } else if (rVariable == CAUCHY_STRESS_VECTOR) {
-        if (rValue.size() != VoigtSize) rValue.resize(VoigtSize);
+        rValue.resize(VoigtSize);
 
-        rValue[INDEX_3D_INTERFACE_ZZ] = mStressVectorFinalized[INDEX_3D_ZZ];
-        rValue[INDEX_3D_INTERFACE_YZ] = mStressVectorFinalized[INDEX_3D_YZ];
-        rValue[INDEX_3D_INTERFACE_XZ] = mStressVectorFinalized[INDEX_3D_XZ];
+        auto& r_sig0                  = GetSig0();
+        rValue[INDEX_3D_INTERFACE_ZZ] = r_sig0[INDEX_3D_ZZ];
+        rValue[INDEX_3D_INTERFACE_YZ] = r_sig0[INDEX_3D_YZ];
+        rValue[INDEX_3D_INTERFACE_XZ] = r_sig0[INDEX_3D_XZ];
     }
     return rValue;
 }

--- a/applications/GeoMechanicsApplication/custom_constitutive/small_strain_udsm_3D_law.cpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/small_strain_udsm_3D_law.cpp
@@ -282,7 +282,7 @@ void SmallStrainUDSM3DLaw::ResetMaterial(const Properties&   rMaterialProperties
     mSig0.clear();
 
     // set strain vectors:
-    noalias(mDeltaStrainVector)     = ZeroVector(mDeltaStrainVector.size());
+    mDeltaStrainVector.clear();
     noalias(mStrainVectorFinalized) = ZeroVector(mStrainVectorFinalized.size());
 
     for (unsigned int i = 0; i < VOIGT_SIZE_3D; ++i)
@@ -610,13 +610,11 @@ void SmallStrainUDSM3DLaw::CalculateMaterialResponseCauchy(ConstitutiveLaw::Para
 
 void SmallStrainUDSM3DLaw::UpdateInternalDeltaStrainVector(ConstitutiveLaw::Parameters& rValues)
 {
-    KRATOS_TRY
-    const Vector& r_strain_vector = rValues.GetStrainVector();
+    const auto& r_strain_vector = rValues.GetStrainVector();
 
-    for (unsigned int i = 0; i < mDeltaStrainVector.size(); ++i) {
-        mDeltaStrainVector[i] = r_strain_vector(i) - mStrainVectorFinalized[i];
+    for (unsigned int i = 0; i < GetStrainSize(); ++i) {
+        mDeltaStrainVector[i] = r_strain_vector[i] - mStrainVectorFinalized[i];
     }
-    KRATOS_CATCH("")
 }
 
 void SmallStrainUDSM3DLaw::SetExternalStressVector(Vector& rStressVector)

--- a/applications/GeoMechanicsApplication/custom_constitutive/small_strain_udsm_3D_law.cpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/small_strain_udsm_3D_law.cpp
@@ -122,15 +122,14 @@ using SizeType = std::size_t;
 SmallStrainUDSM3DLaw::SmallStrainUDSM3DLaw(const SmallStrainUDSM3DLaw& rOther)
     : ConstitutiveLaw(rOther),
       mStressVector(rOther.mStressVector),
-      mStressVectorFinalized(rOther.mStressVectorFinalized),
       mDeltaStrainVector(rOther.mDeltaStrainVector),
       mStrainVectorFinalized(rOther.mStrainVectorFinalized),
       mIsModelInitialized(rOther.mIsModelInitialized),
       mIsUDSMLoaded(rOther.mIsUDSMLoaded),
       mAttributes(rOther.mAttributes),
       mStateVariables(rOther.mStateVariables),
-      mStateVariablesFinalized(rOther.mStateVariablesFinalized)
-
+      mStateVariablesFinalized(rOther.mStateVariablesFinalized),
+      mSig0(rOther.mSig0)
 {
     KRATOS_TRY
 
@@ -161,9 +160,9 @@ SmallStrainUDSM3DLaw& SmallStrainUDSM3DLaw::operator=(SmallStrainUDSM3DLaw const
     this->mStateVariables          = rOther.mStateVariables;
     this->mStateVariablesFinalized = rOther.mStateVariablesFinalized;
     this->mStressVector            = rOther.mStressVector;
-    this->mStressVectorFinalized   = rOther.mStressVectorFinalized;
     this->mDeltaStrainVector       = rOther.mDeltaStrainVector;
     this->mStrainVectorFinalized   = rOther.mStrainVectorFinalized;
+    this->mSig0                    = rOther.mSig0;
 
     for (unsigned int i = 0; i < VOIGT_SIZE_3D; ++i)
         for (unsigned int j = 0; j < VOIGT_SIZE_3D; ++j)
@@ -279,8 +278,8 @@ void SmallStrainUDSM3DLaw::ResetMaterial(const Properties&   rMaterialProperties
     ResetStateVariables(rMaterialProperties);
 
     // set stress vectors:
-    noalias(mStressVector)          = ZeroVector(mStressVector.size());
-    noalias(mStressVectorFinalized) = ZeroVector(mStressVectorFinalized.size());
+    noalias(mStressVector) = ZeroVector(mStressVector.size());
+    mSig0.clear();
 
     // set strain vectors:
     noalias(mDeltaStrainVector)     = ZeroVector(mDeltaStrainVector.size());
@@ -338,12 +337,12 @@ void SmallStrainUDSM3DLaw::SetAttributes(const Properties& rMaterialProperties)
     const auto& MaterialParameters = rMaterialProperties[UMAT_PARAMETERS];
     mpUserMod(&IDTask, &modelNumber, &isUndr, &iStep, &iteration, &iElement, &integrationNumber,
               &Xorigin, &Yorigin, &Zorigin, &time, &deltaTime, &(MaterialParameters.data()[0]),
-              &(mStressVectorFinalized.data()[0]), &excessPorePressurePrevious,
-              StateVariablesFinalized.data(), &(mDeltaStrainVector.data()[0]), (double**)mMatrixD,
-              &bulkWater, &(mStressVector.data()[0]), &excessPorePressureCurrent,
-              StateVariables.data(), &iPlastic, &nStateVariables, &mAttributes[IS_NON_SYMMETRIC],
-              &mAttributes[IS_STRESS_DEPENDENT], &mAttributes[IS_TIME_DEPENDENT],
-              &mAttributes[USE_TANGENT_MATRIX], mProjectDirectory.data(), &nSizeProjectDirectory, &iAbort);
+              &(mSig0.data()[0]), &excessPorePressurePrevious, StateVariablesFinalized.data(),
+              &(mDeltaStrainVector.data()[0]), (double**)mMatrixD, &bulkWater,
+              &(mStressVector.data()[0]), &excessPorePressureCurrent, StateVariables.data(), &iPlastic,
+              &nStateVariables, &mAttributes[IS_NON_SYMMETRIC], &mAttributes[IS_STRESS_DEPENDENT],
+              &mAttributes[IS_TIME_DEPENDENT], &mAttributes[USE_TANGENT_MATRIX],
+              mProjectDirectory.data(), &nSizeProjectDirectory, &iAbort);
 
     KRATOS_ERROR_IF_NOT(iAbort == 0)
         << "The specified UDSM returns an error while call UDSM with IDTASK"
@@ -389,12 +388,12 @@ int SmallStrainUDSM3DLaw::GetNumberOfStateVariablesFromUDSM(const Properties& rM
     const auto& MaterialParameters = rMaterialProperties[UMAT_PARAMETERS];
     mpUserMod(&IDTask, &modelNumber, &isUndr, &iStep, &iteration, &iElement, &integrationNumber,
               &Xorigin, &Yorigin, &Zorigin, &time, &deltaTime, &(MaterialParameters.data()[0]),
-              &(mStressVectorFinalized.data()[0]), &excessPorePressurePrevious,
-              StateVariablesFinalized.data(), &(mDeltaStrainVector.data()[0]), (double**)mMatrixD,
-              &bulkWater, &(mStressVector.data()[0]), &excessPorePressureCurrent,
-              StateVariables.data(), &iPlastic, &nStateVariables, &mAttributes[IS_NON_SYMMETRIC],
-              &mAttributes[IS_STRESS_DEPENDENT], &mAttributes[IS_TIME_DEPENDENT],
-              &mAttributes[USE_TANGENT_MATRIX], mProjectDirectory.data(), &nSizeProjectDirectory, &iAbort);
+              &(mSig0.data()[0]), &excessPorePressurePrevious, StateVariablesFinalized.data(),
+              &(mDeltaStrainVector.data()[0]), (double**)mMatrixD, &bulkWater,
+              &(mStressVector.data()[0]), &excessPorePressureCurrent, StateVariables.data(), &iPlastic,
+              &nStateVariables, &mAttributes[IS_NON_SYMMETRIC], &mAttributes[IS_STRESS_DEPENDENT],
+              &mAttributes[IS_TIME_DEPENDENT], &mAttributes[USE_TANGENT_MATRIX],
+              mProjectDirectory.data(), &nSizeProjectDirectory, &iAbort);
 
     KRATOS_ERROR_IF_NOT(iAbort == 0)
         << "The specified UDSM returns an error while call UDSM with IDTASK"
@@ -629,9 +628,7 @@ void SmallStrainUDSM3DLaw::SetExternalStressVector(Vector& rStressVector)
 
 void SmallStrainUDSM3DLaw::SetInternalStressVector(const Vector& rStressVector)
 {
-    KRATOS_TRY
-    std::copy_n(rStressVector.begin(), mStressVectorFinalized.size(), mStressVectorFinalized.begin());
-    KRATOS_CATCH("")
+    std::copy(rStressVector.begin(), rStressVector.end(), mSig0.begin());
 }
 
 void SmallStrainUDSM3DLaw::CopyConstitutiveMatrix(ConstitutiveLaw::Parameters& rValues, Matrix& rConstitutiveMatrix)
@@ -683,6 +680,8 @@ void SmallStrainUDSM3DLaw::CalculateStress(ConstitutiveLaw::Parameters& rValues,
     KRATOS_CATCH("")
 }
 
+array_1d<double, SmallStrainUDSM3DLaw::Sig0Size>& SmallStrainUDSM3DLaw::GetSig0() { return mSig0; }
+
 void SmallStrainUDSM3DLaw::CallUDSM(int* pIDTask, ConstitutiveLaw::Parameters& rValues)
 {
     KRATOS_TRY
@@ -719,10 +718,10 @@ void SmallStrainUDSM3DLaw::CallUDSM(int* pIDTask, ConstitutiveLaw::Parameters& r
     const auto& MaterialParameters = rMaterialProperties[UMAT_PARAMETERS];
     mpUserMod(pIDTask, &modelNumber, &isUndr, &iStep, &iteration, &iElement, &integrationNumber,
               &Xorigin, &Yorigin, &Zorigin, &time, &deltaTime, &(MaterialParameters.data()[0]),
-              &(mStressVectorFinalized.data()[0]), &excessPorePressurePrevious,
-              &(mStateVariablesFinalized.data()[0]), &(mDeltaStrainVector.data()[0]),
-              (double**)mMatrixD, &bulkWater, &(mStressVector.data()[0]), &excessPorePressureCurrent,
-              &(mStateVariables.data()[0]), &iPlastic, &nStateVariables, &mAttributes[IS_NON_SYMMETRIC],
+              &(mSig0.data()[0]), &excessPorePressurePrevious, &(mStateVariablesFinalized.data()[0]),
+              &(mDeltaStrainVector.data()[0]), (double**)mMatrixD, &bulkWater,
+              &(mStressVector.data()[0]), &excessPorePressureCurrent, &(mStateVariables.data()[0]),
+              &iPlastic, &nStateVariables, &mAttributes[IS_NON_SYMMETRIC],
               &mAttributes[IS_STRESS_DEPENDENT], &mAttributes[IS_TIME_DEPENDENT],
               &mAttributes[USE_TANGENT_MATRIX], mProjectDirectory.data(), &nSizeProjectDirectory, &iAbort);
 
@@ -800,7 +799,7 @@ void SmallStrainUDSM3DLaw::FinalizeMaterialResponseCauchy(ConstitutiveLaw::Param
 {
     UpdateInternalStrainVectorFinalized(rValues);
     mStateVariablesFinalized = mStateVariables;
-    mStressVectorFinalized   = mStressVector;
+    std::copy(mStressVector.begin(), mStressVector.end(), mSig0.begin());
 }
 
 void SmallStrainUDSM3DLaw::SetInternalStrainVector(const Vector& rStrainVector)
@@ -877,10 +876,8 @@ Vector& SmallStrainUDSM3DLaw::GetValue(const Variable<Vector>& rThisVariable, Ve
 
         noalias(rValue) = mStateVariablesFinalized;
     } else if (rThisVariable == CAUCHY_STRESS_VECTOR) {
-        if (rValue.size() != mStressVectorFinalized.size())
-            rValue.resize(mStressVectorFinalized.size());
-
-        noalias(rValue) = mStressVectorFinalized;
+        rValue.resize(StressVectorSize);
+        std::copy_n(mSig0.begin(), StressVectorSize, rValue.begin());
     }
     return rValue;
 }
@@ -913,8 +910,11 @@ void SmallStrainUDSM3DLaw::SetValue(const Variable<Vector>& rVariable, const Vec
 {
     if ((rVariable == STATE_VARIABLES) && (rValue.size() == mStateVariablesFinalized.size())) {
         std::copy(rValue.begin(), rValue.end(), mStateVariablesFinalized.begin());
-    } else if ((rVariable == CAUCHY_STRESS_VECTOR) && (rValue.size() == mStressVectorFinalized.size())) {
-        std::copy(rValue.begin(), rValue.end(), mStressVectorFinalized.begin());
+    } else if (rVariable == CAUCHY_STRESS_VECTOR) {
+        KRATOS_ERROR_IF(rValue.size() != StressVectorSize)
+            << "Failed to set stress vector: expected one with " << StressVectorSize
+            << " components, but got one with " << rValue.size() << "components\n";
+        std::copy(rValue.begin(), rValue.end(), mSig0.begin());
     }
 }
 

--- a/applications/GeoMechanicsApplication/custom_constitutive/small_strain_udsm_3D_law.cpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/small_strain_udsm_3D_law.cpp
@@ -713,9 +713,13 @@ void SmallStrainUDSM3DLaw::CallUDSM(int* pIDTask, ConstitutiveLaw::Parameters& r
     int  iAbort                = 0;
     auto nSizeProjectDirectory = static_cast<int>(mProjectDirectory.size());
 
-    const auto& MaterialParameters = rMaterialProperties[UMAT_PARAMETERS];
+    const auto&    r_given_umat_parameters  = rMaterialProperties[UMAT_PARAMETERS];
+    constexpr auto max_umat_parameters_size = SizeType{50};
+    auto umat_parameters = array_1d<double, max_umat_parameters_size>{max_umat_parameters_size, 0.0};
+    std::copy(r_given_umat_parameters.begin(), r_given_umat_parameters.end(), umat_parameters.begin());
+
     mpUserMod(pIDTask, &modelNumber, &isUndr, &iStep, &iteration, &iElement, &integrationNumber,
-              &Xorigin, &Yorigin, &Zorigin, &time, &deltaTime, &(MaterialParameters.data()[0]),
+              &Xorigin, &Yorigin, &Zorigin, &time, &deltaTime, &(umat_parameters.data()[0]),
               &(mSig0.data()[0]), &excessPorePressurePrevious, &(mStateVariablesFinalized.data()[0]),
               &(mDeltaStrainVector.data()[0]), (double**)mMatrixD, &bulkWater,
               &(mStressVector.data()[0]), &excessPorePressureCurrent, &(mStateVariables.data()[0]),
@@ -729,7 +733,7 @@ void SmallStrainUDSM3DLaw::CallUDSM(int* pIDTask, ConstitutiveLaw::Parameters& r
             << std::to_string(*pIDTask) << "."
             << " UDSM: " << rMaterialProperties[UDSM_NAME]
             << " UDSM_NUMBER: " << rMaterialProperties[UDSM_NUMBER]
-            << " Parameters: " << MaterialParameters << std::endl;
+            << " Parameters: " << r_given_umat_parameters << std::endl;
         KRATOS_ERROR << "the specified UDSM returns an error while call UDSM with IDTASK: "
                      << std::to_string(*pIDTask) << ". UDSM: " << rMaterialProperties[UDSM_NAME]
                      << std::endl;

--- a/applications/GeoMechanicsApplication/custom_constitutive/small_strain_udsm_3D_law.hpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/small_strain_udsm_3D_law.hpp
@@ -115,6 +115,9 @@ public:
     /// Static definition of the VoigtSize
     static constexpr SizeType VoigtSize = VOIGT_SIZE_3D;
 
+    static constexpr SizeType Sig0Size         = 20;
+    static constexpr SizeType StressVectorSize = 6;
+
     /// Pointer definition of SmallStrainUDSM3DLaw
     KRATOS_CLASS_POINTER_DEFINITION(SmallStrainUDSM3DLaw);
 
@@ -348,7 +351,6 @@ protected:
     ///@name Protected member Variables
     ///@{
     array_1d<double, VOIGT_SIZE_3D> mStressVector;
-    array_1d<double, VOIGT_SIZE_3D> mStressVectorFinalized;
 
     array_1d<double, VOIGT_SIZE_3D> mDeltaStrainVector;
     array_1d<double, VOIGT_SIZE_3D> mStrainVectorFinalized;
@@ -388,6 +390,8 @@ protected:
     // returns 1 if the stiffness matrix of the material is tangential
     int getUseTangentMatrix() { return mAttributes[USE_TANGENT_MATRIX]; }
 
+    array_1d<double, Sig0Size>& GetSig0();
+
     ///@}
     ///@name Protected Inquiry
     ///@{
@@ -419,6 +423,10 @@ private:
 
     Vector mStateVariables;
     Vector mStateVariablesFinalized;
+
+    // See section 16.2 "Implementation of User Defined (UD) soil Models in calculations program"
+    // of the Plaxis documentation for the array sizes
+    array_1d<double, Sig0Size> mSig0;
 
     ///@}
     ///@name Private Operators
@@ -463,7 +471,7 @@ private:
         KRATOS_SERIALIZE_SAVE_BASE_CLASS(rSerializer, ConstitutiveLaw)
         rSerializer.save("InitializedModel", mIsModelInitialized);
         rSerializer.save("Attributes", mAttributes);
-        rSerializer.save("StressVectorFinalized", mStressVectorFinalized);
+        rSerializer.save("Sig0", mSig0);
         rSerializer.save("StrainVectorFinalized", mStrainVectorFinalized);
         rSerializer.save("StateVariablesFinalized", mStateVariablesFinalized);
     }
@@ -473,7 +481,7 @@ private:
         KRATOS_SERIALIZE_LOAD_BASE_CLASS(rSerializer, ConstitutiveLaw)
         rSerializer.load("InitializedModel", mIsModelInitialized);
         rSerializer.load("Attributes", mAttributes);
-        rSerializer.load("StressVectorFinalized", mStressVectorFinalized);
+        rSerializer.load("Sig0", mSig0);
         rSerializer.load("StrainVectorFinalized", mStrainVectorFinalized);
         rSerializer.load("StateVariablesFinalized", mStateVariablesFinalized);
     }

--- a/applications/GeoMechanicsApplication/custom_constitutive/small_strain_udsm_3D_law.hpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/small_strain_udsm_3D_law.hpp
@@ -115,8 +115,9 @@ public:
     /// Static definition of the VoigtSize
     static constexpr SizeType VoigtSize = VOIGT_SIZE_3D;
 
-    static constexpr SizeType Sig0Size         = 20;
-    static constexpr SizeType StressVectorSize = 6;
+    static constexpr SizeType Sig0Size                  = 20;
+    static constexpr SizeType StressVectorSize          = 6;
+    static constexpr SizeType StrainIncrementVectorSize = 12;
 
     /// Pointer definition of SmallStrainUDSM3DLaw
     KRATOS_CLASS_POINTER_DEFINITION(SmallStrainUDSM3DLaw);
@@ -350,10 +351,10 @@ protected:
     ///@}
     ///@name Protected member Variables
     ///@{
-    array_1d<double, VOIGT_SIZE_3D> mStressVector;
+    array_1d<double, VOIGT_SIZE_3D> mStressVector{VOIGT_SIZE_3D, 0.0};
 
-    array_1d<double, VOIGT_SIZE_3D> mDeltaStrainVector;
-    array_1d<double, VOIGT_SIZE_3D> mStrainVectorFinalized;
+    array_1d<double, StrainIncrementVectorSize> mDeltaStrainVector{StrainIncrementVectorSize, 0.0};
+    array_1d<double, VOIGT_SIZE_3D>             mStrainVectorFinalized{VOIGT_SIZE_3D, 0.0};
 
     double mMatrixD[VOIGT_SIZE_3D][VOIGT_SIZE_3D];
 
@@ -426,7 +427,7 @@ private:
 
     // See section 16.2 "Implementation of User Defined (UD) soil Models in calculations program"
     // of the Plaxis documentation for the array sizes
-    array_1d<double, Sig0Size> mSig0;
+    array_1d<double, Sig0Size> mSig0{Sig0Size, 0.0};
 
     ///@}
     ///@name Private Operators

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_constitutive/test_interface_coulomb_with_tension_cut_off.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_constitutive/test_interface_coulomb_with_tension_cut_off.cpp
@@ -366,8 +366,7 @@ KRATOS_TEST_CASE_IN_SUITE(InterfaceCoulombWithTensionCutOff_Check, KratosGeoMech
         "Error: GEO_FRICTION_ANGLE is not defined for property 3")
     properties.SetValue(GEO_FRICTION_ANGLE, -30.0);
     KRATOS_EXPECT_EXCEPTION_IS_THROWN(
-        [[maybe_unused]] const auto unused = law.Check(properties, element_geometry, process_info),
-        "Error: value of GEO_FRICTION_ANGLE for property 3 is out of range: -30 is not in (0.0, 90.0)")
+        [[maybe_unused]] const auto unused = law.Check(properties, element_geometry, process_info), "Error: value of GEO_FRICTION_ANGLE for property 3 is out of range: -30 is not in (0.0, 90.0)")
     properties.SetValue(GEO_FRICTION_ANGLE, 30.0);
 
     KRATOS_EXPECT_EXCEPTION_IS_THROWN(


### PR DESCRIPTION
**📝 Description**
The sizes of three arrays (i.e. `Sig0`, `dEps`, and `Props`) did not match the expected sizes as written down in the UDSM documentation. With these changes, we now ensure that the arrays have the correct sizes. See Section 16.2 "Implementation of User Defined (UD) soil Models in calculations program" of the Plaxis documentation.

Note that data member `mStressVectorFinalized` has been replaced by data member `mSig0` (which matches the function parameter name adopted by the UDSM), since it contains more than just the stress vector.

**🆕 Changelog**
Other changes include:
- Use subscript operator `[]` rather than `()` to access vector elements.
- Removed an `override` that did effectively the same thing as the base class version.
- Replaced a few raw `for` loops by STL algorithms.
- Changed a few names to comply with the Kratos Style Guide.
- Replaced some explicit type names by `auto`.
- Removed some redundant size checks (member function `resize` already checks whether the new size differs from the current one).
- Removed some `KRATOS_TRY` and `KRATOS_CATCH` constructs.
