### PR TITLE
[StructuralMechanicsApplication] changed serialization set_moving_load_process

### DIFF
--- a/applications/StructuralMechanicsApplication/custom_processes/set_moving_load_process.h
+++ b/applications/StructuralMechanicsApplication/custom_processes/set_moving_load_process.h
@@ -116,8 +116,11 @@ private:
     // vector of sorted conditions
     std::vector<Condition> mSortedConditions;
 
-    // vector of booleans which indicate if the nodes in the condition are in reversed order with respect to the direction of the moving load
-    std::vector<bool> mIsCondReversedVector;
+    // vector of the ids of the sorted conditions
+    std::vector<IndexType> mSortedConditionsIds;
+
+    // vector of integers (casted to booleans) which indicate if the nodes in the condition are in reversed order with respect to the direction of the moving load
+    std::vector<int> mIsCondReversedVector;
 
     // point of origin of the moving load
     array_1d<double, 3> mOriginPoint;

--- a/applications/StructuralMechanicsApplication/custom_processes/set_moving_load_process.h
+++ b/applications/StructuralMechanicsApplication/custom_processes/set_moving_load_process.h
@@ -113,9 +113,6 @@ private:
     ModelPart& mrModelPart;
     Parameters mParameters;
 
-    // vector of sorted conditions
-    std::vector<Condition> mSortedConditions;
-
     // vector of the ids of the sorted conditions
     std::vector<IndexType> mSortedConditionsIds;
 
@@ -160,13 +157,11 @@ private:
     std::vector<Condition> FindEndConditions();
 
     /**
-     * \brief Sorts conditions vector. Sorts conditions in the direction of the moving load. The sorting starts from the first condition. Repeated nodes
-     * ares searched in the conditions vector. If a node is repeated, it means the condition is connected to the previous condition. 
-     * \param rUnsortedConditions container of the unsorted conditions within the model part
-     * \param rFirstCondition first condition in the to be sorted conditions vector
-     * \return vector of sorted conditions
+     * \brief Sorts condition ids vector. Sorts the condition ids in the direction of the moving load. The sorting starts from the first condition. 
+     * Repeated nodes are searched in the conditions vector. If a node is repeated, it means the condition is connected to the previous condition. 
+     * \param rFirstCondition first condition in the to be sorted condition ids vector
      */
-    std::vector<Condition> SortConditions(ModelPart::ConditionsContainerType& rUnsortedConditions, Condition& rFirstCondition);
+    void SortConditionIds(Condition& rFirstCondition);
 
     /**
      * \brief Check if conditions points are to be flipped in the direction of the moving load. The points are sorted based on the x-coordinates; if the x-coordinates are equal,

--- a/applications/StructuralMechanicsApplication/tests/test_set_moving_load_process.py
+++ b/applications/StructuralMechanicsApplication/tests/test_set_moving_load_process.py
@@ -618,11 +618,14 @@ class TestSetMovingLoadProcess(KratosUnittest.TestCase):
         serializer_type = KratosMultiphysics.SerializerTraceType.SERIALIZER_NO_TRACE
         save_serializer = KratosMultiphysics.FileSerializer(restart_file_name, serializer_type)
         save_serializer.Save(f"set_moving_load_process_{mp.Name}", process)
+        del save_serializer
 
         load_serializer = KratosMultiphysics.FileSerializer(restart_file_name, serializer_type)
 
         loaded_process = SMA.SetMovingLoadProcess(mp, parameters)
         load_serializer.Load(f"set_moving_load_process_{mp.Name}", loaded_process)
+        del load_serializer
+
         mp.ProcessInfo[KratosMultiphysics.IS_RESTARTED] = True
 
         loaded_process.ExecuteInitialize()
@@ -2001,26 +2004,26 @@ class TestSetMovingLoadProcess(KratosUnittest.TestCase):
         self.checkRHS(rhs, [0.0, -2.0, 0.0, 0.0])
 
 
-    def test_SetMovingLoad(self):
-        self._TestSetMovingLoad()
-
-    def test_SetMovingLoadOffsetPositive(self):
-        self._TestSetMovingLoadOffsetPositive()
-
-    def test_SetMovingLoadOffsetNegative(self):
-        self._TestSetMovingLoadOffsetNegative()
-
-    def test_SetMovingLoadReverseGeom(self):
-        self._TestSetMovingLoadReverseGeom()
-
-    def test_SetMovingLoadReverseGeomOffsetPositive(self):
-        self._TestSetMovingLoadReverseGeomOffsetPositive()
-
-    def test_SetMovingLoadReverseGeomOffsetNegative(self):
-        self._TestSetMovingLoadReverseGeomOffsetNegative()
-
-    def test_SetMovingLoadMultipleConditions(self):
-        self._TestSetMovingLoadMultipleConditions()
+    # def test_SetMovingLoad(self):
+    #     self._TestSetMovingLoad()
+    #
+    # def test_SetMovingLoadOffsetPositive(self):
+    #     self._TestSetMovingLoadOffsetPositive()
+    #
+    # def test_SetMovingLoadOffsetNegative(self):
+    #     self._TestSetMovingLoadOffsetNegative()
+    #
+    # def test_SetMovingLoadReverseGeom(self):
+    #     self._TestSetMovingLoadReverseGeom()
+    #
+    # def test_SetMovingLoadReverseGeomOffsetPositive(self):
+    #     self._TestSetMovingLoadReverseGeomOffsetPositive()
+    #
+    # def test_SetMovingLoadReverseGeomOffsetNegative(self):
+    #     self._TestSetMovingLoadReverseGeomOffsetNegative()
+    #
+    # def test_SetMovingLoadMultipleConditions(self):
+    #     self._TestSetMovingLoadMultipleConditions()
 
     def test_SetMovingLoadMultipleConditionsRestart(self):
         self._TestSetMovingLoadMultipleConditionsRestart()

--- a/applications/StructuralMechanicsApplication/tests/test_set_moving_load_process.py
+++ b/applications/StructuralMechanicsApplication/tests/test_set_moving_load_process.py
@@ -550,6 +550,121 @@ class TestSetMovingLoadProcess(KratosUnittest.TestCase):
         self.checkRHS(all_rhs[0], [0.0, 0.0, 0.0, 0.0])
         self.checkRHS(all_rhs[1], [0.0, -1.0, 0.0, -1.0])
 
+    def _TestSetMovingLoadMultipleConditionsRestart(self):
+        """
+        Tests a moving load on 2 condition elements, where the order of the elements is sorted in the direction of the
+        moving load. After the load is moved, the process is restarted and the load is moved again.
+
+        """
+
+        current_model = KratosMultiphysics.Model()
+        mp = current_model.CreateModelPart("solid_part")
+        mp.AddNodalSolutionStepVariable(KratosMultiphysics.DISPLACEMENT)
+
+        #create nodes
+        second_coord = [1.0, 0.0, 0.0]
+        third_coord = [2.0, 0.0, 0.0]
+        mp.CreateNewNode(4, 0.0, 0.0, 0.0)
+        mp.CreateNewNode(2, second_coord[0],second_coord[1],second_coord[2])
+        mp.CreateNewNode(3, third_coord[0], third_coord[1], third_coord[2])
+
+        strategy = self.setup_strategy(mp)
+
+        # create condition
+        conditions = []
+        conditions.append(mp.CreateNewCondition("MovingLoadCondition2D2N", 1, [4, 2], mp.GetProperties()[1]))
+        conditions.append(mp.CreateNewCondition("MovingLoadCondition2D2N", 2, [2, 3], mp.GetProperties()[1]))
+
+        parameters = KratosMultiphysics.Parameters("""
+                {
+                    "help"            : "This process applies a moving load condition belonging to a modelpart. The load moves over line elements.",
+                    "model_part_name" : "please_specify_model_part_name",
+                    "variable_name"   : "POINT_LOAD",
+                    "load"            : [0.0, -2.0, 0.0],
+                    "direction"       : [1,1,1],
+                    "velocity"        : 1,
+                    "origin"          : [0,0,0]
+                }
+                """
+                                                         )
+        mp.ProcessInfo.SetValue(KratosMultiphysics.TIME, 0)
+        mp.ProcessInfo.SetValue(KratosMultiphysics.DELTA_TIME, 0.5)
+        process = SMA.SetMovingLoadProcess(mp, parameters)
+
+        # initialize and set load
+        process.ExecuteInitialize()
+        process.ExecuteInitializeSolutionStep()
+
+        # initialise matrices
+        lhs = KratosMultiphysics.Matrix(0,0)
+        rhs = KratosMultiphysics.Vector(0)
+
+        # set load on node
+        strategy.InitializeSolutionStep()
+
+        all_rhs = []
+        for cond in conditions:
+            cond.CalculateLocalSystem(lhs, rhs, mp.ProcessInfo)
+            all_rhs.append(list(rhs))
+
+        self.checkRHS(all_rhs[0], [0.0, -2.0, 0.0, 0.0])
+        self.checkRHS(all_rhs[1], [0.0, 0.0, 0.0, 0.0])
+
+        # move load within first element
+        process.ExecuteFinalizeSolutionStep()
+
+        # save and load process and check if moving load is still in the same position
+        restart_file_name = "test_load_set_moving_load_process"
+        serializer_type = KratosMultiphysics.SerializerTraceType.SERIALIZER_NO_TRACE
+        save_serializer = KratosMultiphysics.FileSerializer(restart_file_name, serializer_type)
+        save_serializer.Save(f"set_moving_load_process_{mp.Name}", process)
+
+        load_serializer = KratosMultiphysics.FileSerializer(restart_file_name, serializer_type)
+
+        loaded_process = SMA.SetMovingLoadProcess(mp, parameters)
+        load_serializer.Load(f"set_moving_load_process_{mp.Name}", loaded_process)
+        mp.ProcessInfo[KratosMultiphysics.IS_RESTARTED] = True
+
+        loaded_process.ExecuteInitialize()
+        loaded_process.ExecuteInitializeSolutionStep()
+
+        # check if interpolation is done correctly
+        strategy.InitializeSolutionStep()
+
+        all_rhs = []
+        for cond in conditions:
+            cond.CalculateLocalSystem(lhs, rhs, mp.ProcessInfo)
+            all_rhs.append(list(rhs))
+
+        self.checkRHS(all_rhs[0], [0.0, -1.0, 0.0, -1.0])
+        self.checkRHS(all_rhs[1], [0.0, 0.0, 0.0, 0.0])
+
+        # move load to element connection element
+        loaded_process.ExecuteFinalizeSolutionStep()
+        loaded_process.ExecuteInitializeSolutionStep()
+
+        strategy.InitializeSolutionStep()
+        all_rhs = []
+        for cond in conditions:
+            cond.CalculateLocalSystem(lhs, rhs, mp.ProcessInfo)
+            all_rhs.append(list(rhs))
+
+        self.checkRHS(all_rhs[0], [0.0, 0.0, 0.0, -2.0])
+        self.checkRHS(all_rhs[1], [0.0, 0.0, 0.0, 0.0])
+
+        # move load to next element
+        loaded_process.ExecuteFinalizeSolutionStep()
+        loaded_process.ExecuteInitializeSolutionStep()
+
+        strategy.InitializeSolutionStep()
+        all_rhs = []
+        for cond in conditions:
+            cond.CalculateLocalSystem(lhs, rhs, mp.ProcessInfo)
+            all_rhs.append(list(rhs))
+
+        self.checkRHS(all_rhs[0], [0.0, 0.0, 0.0, 0.0])
+        self.checkRHS(all_rhs[1], [0.0, -1.0, 0.0, -1.0])
+
     def _TestSetMovingLoadMultipleConditionsOffSetPositive(self):
         """
         Tests a moving load on 2 condition elements, where the order of the elements is sorted in the direction of the
@@ -1906,6 +2021,9 @@ class TestSetMovingLoadProcess(KratosUnittest.TestCase):
 
     def test_SetMovingLoadMultipleConditions(self):
         self._TestSetMovingLoadMultipleConditions()
+
+    def test_SetMovingLoadMultipleConditionsRestart(self):
+        self._TestSetMovingLoadMultipleConditionsRestart()
 
     def test_SetMovingLoadMultipleConditionsOffsetPositive(self):
         self._TestSetMovingLoadMultipleConditionsOffSetPositive()

--- a/applications/StructuralMechanicsApplication/tests/test_set_moving_load_process.py
+++ b/applications/StructuralMechanicsApplication/tests/test_set_moving_load_process.py
@@ -2004,26 +2004,26 @@ class TestSetMovingLoadProcess(KratosUnittest.TestCase):
         self.checkRHS(rhs, [0.0, -2.0, 0.0, 0.0])
 
 
-    # def test_SetMovingLoad(self):
-    #     self._TestSetMovingLoad()
-    #
-    # def test_SetMovingLoadOffsetPositive(self):
-    #     self._TestSetMovingLoadOffsetPositive()
-    #
-    # def test_SetMovingLoadOffsetNegative(self):
-    #     self._TestSetMovingLoadOffsetNegative()
-    #
-    # def test_SetMovingLoadReverseGeom(self):
-    #     self._TestSetMovingLoadReverseGeom()
-    #
-    # def test_SetMovingLoadReverseGeomOffsetPositive(self):
-    #     self._TestSetMovingLoadReverseGeomOffsetPositive()
-    #
-    # def test_SetMovingLoadReverseGeomOffsetNegative(self):
-    #     self._TestSetMovingLoadReverseGeomOffsetNegative()
-    #
-    # def test_SetMovingLoadMultipleConditions(self):
-    #     self._TestSetMovingLoadMultipleConditions()
+    def test_SetMovingLoad(self):
+        self._TestSetMovingLoad()
+
+    def test_SetMovingLoadOffsetPositive(self):
+        self._TestSetMovingLoadOffsetPositive()
+
+    def test_SetMovingLoadOffsetNegative(self):
+        self._TestSetMovingLoadOffsetNegative()
+
+    def test_SetMovingLoadReverseGeom(self):
+        self._TestSetMovingLoadReverseGeom()
+
+    def test_SetMovingLoadReverseGeomOffsetPositive(self):
+        self._TestSetMovingLoadReverseGeomOffsetPositive()
+
+    def test_SetMovingLoadReverseGeomOffsetNegative(self):
+        self._TestSetMovingLoadReverseGeomOffsetNegative()
+
+    def test_SetMovingLoadMultipleConditions(self):
+        self._TestSetMovingLoadMultipleConditions()
 
     def test_SetMovingLoadMultipleConditionsRestart(self):
         self._TestSetMovingLoadMultipleConditionsRestart()


### PR DESCRIPTION
before a vector of sorted conditions was serialized, this sometimes caused problems with memory ( I do not know why and I cannot reproduce in a small test)

Now a vector of sorted condition ids are serialized

also changed std::vector<bool> to std::vector<int> for safety