### PR TITLE
[Core] Add `StringToVector` and `CountValuesUntilPrefix` utility functions for `StringUtilities`

### DIFF
--- a/kratos/tests/cpp_tests/utilities/test_string_utilities.cpp
+++ b/kratos/tests/cpp_tests/utilities/test_string_utilities.cpp
@@ -214,6 +214,18 @@ KRATOS_TEST_CASE_IN_SUITE(TrimRight, KratosCoreFastSuite)
     KRATOS_EXPECT_EQ(StringUtilities::TrimRight(" Kra\ntos MP "), " Kra\ntos MP");
 }
 
+KRATOS_TEST_CASE_IN_SUITE(SplitStringIntoAVector, KratosCoreFastSuite)
+{
+    const std::string string_to_split = "The cake is a lie";
+    const std::vector<std::string> splitted_string = StringUtilities::SplitStringIntoAVector(string_to_split);
+    KRATOS_EXPECT_EQ(splitted_string.size(), 5);
+    KRATOS_EXPECT_EQ(splitted_string[0], "The");
+    KRATOS_EXPECT_EQ(splitted_string[1], "cake");
+    KRATOS_EXPECT_EQ(splitted_string[2], "is");
+    KRATOS_EXPECT_EQ(splitted_string[3], "a");
+    KRATOS_EXPECT_EQ(splitted_string[4], "lie");
+}
+
 KRATOS_TEST_CASE_IN_SUITE(StringToVector, KratosCoreFastSuite)
 {
     // BasicIntegerParsing

--- a/kratos/tests/cpp_tests/utilities/test_string_utilities.cpp
+++ b/kratos/tests/cpp_tests/utilities/test_string_utilities.cpp
@@ -344,7 +344,7 @@ KRATOS_TEST_CASE_IN_SUITE(CountValuesUntilPrefix, KratosCoreFastSuite)
 
     // Test case 2: Prefix not found
     {
-        std::string input = "value1 value2 value3";
+        std::string input = "value1\tvalue2\tvalue3";
         std::string prefix = "value4";
         std::size_t expected_count = 3;
         std::size_t actual_count = StringUtilities::CountValuesUntilPrefix(input, prefix);

--- a/kratos/tests/cpp_tests/utilities/test_string_utilities.cpp
+++ b/kratos/tests/cpp_tests/utilities/test_string_utilities.cpp
@@ -214,4 +214,160 @@ KRATOS_TEST_CASE_IN_SUITE(TrimRight, KratosCoreFastSuite)
     KRATOS_EXPECT_EQ(StringUtilities::TrimRight(" Kra\ntos MP "), " Kra\ntos MP");
 }
 
+KRATOS_TEST_CASE_IN_SUITE(StringToVector, KratosCoreFastSuite)
+{
+    // BasicIntegerParsing
+    {
+        std::string input = "[1.0, 2.5, 3.14]";
+        std::vector<double> expected = {1.0, 2.5, 3.14};
+        std::vector<double> actual = StringUtilities::StringToVector<double>(input);
+        for (size_t i = 0; i < expected.size(); ++i) {
+            KRATOS_EXPECT_EQ(actual[i], expected[i]);
+        }
+    }
+
+    // ParsingWithVariousSpaces
+    {
+        std::string input = "[10, 20, -5]";
+        std::vector<int> expected = {10, 20, -5};
+        std::vector<int> actual = StringUtilities::StringToVector<int>(input);
+        for (size_t i = 0; i < expected.size(); ++i) {
+            KRATOS_EXPECT_EQ(actual[i], expected[i]);
+        }
+    }
+
+    // SingleElementVector
+    {
+        std::string input = "  [ 1.1 ,  2.2,3.3  , 4.4 ]  ";
+        std::vector<double> expected = {1.1, 2.2, 3.3, 4.4};
+        std::vector<double> actual = StringUtilities::StringToVector<double>(input);
+        for (size_t i = 0; i < expected.size(); ++i) {
+            KRATOS_EXPECT_EQ(actual[i], expected[i]);
+        }
+
+        std::string input_int = " [ 5,  15,25 ] ";
+        std::vector<int> expected_int = {5, 15, 25};
+        std::vector<int> actual_int = StringUtilities::StringToVector<int>(input_int);
+        for (size_t i = 0; i < expected_int.size(); ++i) {
+            KRATOS_EXPECT_EQ(actual_int[i], expected_int[i]);
+        }
+    }
+
+    // EmptyVectorInput
+    {
+        std::string input = "[42.0]";
+        std::vector<double> expected = {42.0};
+        std::vector<double> actual = StringUtilities::StringToVector<double>(input);
+        KRATOS_EXPECT_EQ(actual.size(), expected.size());
+        KRATOS_EXPECT_EQ(actual.size(), 1);
+        KRATOS_EXPECT_EQ(actual[0], expected[0]);
+
+        std::string input_int = "[7]";
+        std::vector<int> expected_int = {7};
+        std::vector<int> actual_int = StringUtilities::StringToVector<int>(input_int);
+        KRATOS_EXPECT_EQ(actual_int.size(), expected_int.size());
+        KRATOS_EXPECT_EQ(actual_int.size(), 1);
+        KRATOS_EXPECT_EQ(actual_int[0], expected_int[0]);
+    }
+
+    // IntegerTruncationFromDoubleString
+    {
+        std::string input1 = "[]";
+        std::vector<double> expected_empty = {};
+        std::vector<double> actual1 = StringUtilities::StringToVector<double>(input1);
+        KRATOS_EXPECT_EQ(actual1.size(), 0);
+        KRATOS_EXPECT_EQ(actual1.size(), expected_empty.size());
+
+        std::string input2 = "[ ]"; // Empty with space
+        std::vector<int> actual2 = StringUtilities::StringToVector<int>(input2);
+        KRATOS_EXPECT_EQ(actual2.size(), 0);
+        KRATOS_EXPECT_EQ(actual2.size(), expected_empty.size());
+
+        std::string input3 = ""; // Completely empty string
+        std::vector<double> actual3 = StringUtilities::StringToVector<double>(input3);
+        KRATOS_EXPECT_EQ(actual3.size(), 0);
+        KRATOS_EXPECT_EQ(actual3.size(), expected_empty.size());
+    }
+
+    // InputWithoutBrackets
+    {
+        // The function is designed to remove brackets if present.
+        // If not present, it should still parse the comma-separated values.
+        std::string input = "1.5, 2.5, 3.5";
+        std::vector<double> expected = {1.5, 2.5, 3.5};
+        std::vector<double> actual = StringUtilities::StringToVector<double>(input);
+        for (size_t i = 0; i < expected.size(); ++i) {
+            KRATOS_EXPECT_EQ(actual[i], expected[i]);
+        }
+    }
+
+    // InvalidElementMixedWithValid
+    {
+        // "two" cannot be parsed as double. The function currently logs a warning
+        // and continues, so "two" should be skipped.
+        std::string input = "[1.0, two, 3.0, four, 5.5]";
+        std::vector<double> expected = {1.0, 3.0, 5.5}; // "two" and "four" should be skipped
+        std::vector<double> actual = StringUtilities::StringToVector<double>(input);
+        for (size_t i = 0; i < expected.size(); ++i) {
+            KRATOS_EXPECT_EQ(actual[i], expected[i]);
+        }
+    }
+
+    // InvalidNumberFormat
+    {
+        std::string input_double = "[1.2.3, 4.5]"; // "1.2.3" is invalid for double
+        std::vector<double> expected_double = {4.5};
+        std::vector<double> actual_double = StringUtilities::StringToVector<double>(input_double);
+        for (size_t i = 0; i < expected_double.size(); ++i) {
+            KRATOS_EXPECT_EQ(actual_double[i], expected_double[i]);
+        }
+
+        std::string input_int = "[10, 20x, 30]"; // "20x" is invalid for int
+        std::vector<int> expected_int = {10, 30};
+        std::vector<int> actual_int = StringUtilities::StringToVector<int>(input_int);
+        for (size_t i = 0; i < expected_int.size(); ++i) {
+            KRATOS_EXPECT_EQ(actual_int[i], expected_int[i]);
+        }
+    }
+}
+
+KRATOS_TEST_CASE_IN_SUITE(CountValuesUntilPrefix, KratosCoreFastSuite)
+{
+    // Test case 1: Basic functionality
+    {
+        std::string input = "value1 value2 value3";
+        std::string prefix = "value2";
+        std::size_t expected_count = 1;
+        std::size_t actual_count = StringUtilities::CountValuesUntilPrefix(input, prefix);
+        KRATOS_EXPECT_EQ(actual_count, expected_count);
+    }
+
+    // Test case 2: Prefix not found
+    {
+        std::string input = "value1 value2 value3";
+        std::string prefix = "value4";
+        std::size_t expected_count = 3;
+        std::size_t actual_count = StringUtilities::CountValuesUntilPrefix(input, prefix);
+        KRATOS_EXPECT_EQ(actual_count, expected_count);
+    }
+
+    // Test case 3: Empty input
+    {
+        std::string input = "";
+        std::string prefix = "value1";
+        std::size_t expected_count = 0;
+        std::size_t actual_count = StringUtilities::CountValuesUntilPrefix(input, prefix);
+        KRATOS_EXPECT_EQ(actual_count, expected_count);
+    }
+
+    // Test case 4: Empty prefix
+    {
+        std::string input = "value1 value2 value3";
+        std::string prefix = "";
+        std::size_t expected_count = 0;
+        std::size_t actual_count = StringUtilities::CountValuesUntilPrefix(input, prefix);
+        KRATOS_EXPECT_EQ(actual_count, expected_count);
+    }
+}
+
 } // namespace Kratos::Testing

--- a/kratos/utilities/string_utilities.cpp
+++ b/kratos/utilities/string_utilities.cpp
@@ -242,6 +242,23 @@ std::string TrimRight(
 /***********************************************************************************/
 /***********************************************************************************/
 
+std::vector<std::string> SplitStringIntoAVector(const std::string& rText)
+{
+    std::istringstream iss(rText);
+    std::string word;
+    std::vector<std::string> words;
+
+    // The stream extraction operator (>>) automatically skips whitespace
+    // (including spaces and tabs) by default.
+    while (iss >> word) {
+        words.push_back(word);
+    }
+    return words;
+};
+
+/***********************************************************************************/
+/***********************************************************************************/
+
 template <typename TType>
 std::vector<TType> StringToVector(const std::string& rInputString)
 {

--- a/kratos/utilities/string_utilities.cpp
+++ b/kratos/utilities/string_utilities.cpp
@@ -19,6 +19,7 @@
 // External includes
 
 // Project includes
+#include "input_output/logger.h"
 #include "utilities/string_utilities.h"
 
 namespace Kratos::StringUtilities {
@@ -175,12 +176,18 @@ std::string ReplaceAllSubstrings(
     return output_string;
 }
 
+/***********************************************************************************/
+/***********************************************************************************/
+
 std::string Trim(
     const std::string& rInputString,
     const bool RemoveNullChar)
 {
     return TrimLeft(TrimRight(rInputString, RemoveNullChar), RemoveNullChar);
 }
+
+/***********************************************************************************/
+/***********************************************************************************/
 
 std::function<bool(std::string::value_type)> TrimChar(const bool RemoveNullChar)
 {
@@ -194,6 +201,9 @@ std::function<bool(std::string::value_type)> TrimChar(const bool RemoveNullChar)
         return std::isspace(character);
     };
 }
+
+/***********************************************************************************/
+/***********************************************************************************/
 
 std::string TrimLeft(
     const std::string& rInputString,
@@ -211,6 +221,9 @@ std::string TrimLeft(
     return output_string;
 }
 
+/***********************************************************************************/
+/***********************************************************************************/
+
 std::string TrimRight(
     const std::string& rInputString,
     const bool RemoveNullChar)
@@ -224,6 +237,89 @@ std::string TrimRight(
     );
 
     return output_string;
+}
+
+/***********************************************************************************/
+/***********************************************************************************/
+
+template <typename TType>
+std::vector<TType> StringToVector(const std::string& rInputString)
+{
+    std::vector<TType> result;
+    std::string str = rInputString; // Make a mutable copy
+
+    // 1. Remove '[' and ']' from the outer string if they exist
+    // Trim the input string first to handle cases like "  [1,2,3]  "
+    str = Trim(str);
+    if (!str.empty() && str.front() == '[') {
+        str.erase(0, 1);
+    }
+    if (!str.empty() && str.back() == ']') {
+        str.pop_back();
+    }
+
+    // If the string is empty after removing brackets and trimming (e.g., "[]" or "[ ]" or ""), return an empty vector
+    if (Trim(str).empty()) {
+        return result;
+    }
+
+    // 2. Use stringstream to split by comma and parse elements
+    std::stringstream ss(str);
+    std::string segment;
+
+    // Split the string by comma
+    while (std::getline(ss, segment, ',')) {
+        // Trim whitespace from the individual segment
+        std::string trimmedSegment = Trim(segment);
+        if (!trimmedSegment.empty()) {
+            TType value;
+            std::stringstream converter(trimmedSegment);
+
+            // Try to convert the segment to type TType
+            // The "converter >> value" attempts the conversion.
+            // The "!(converter >> std::ws).eof()" checks if there's anything left in the stream
+            // after the value and any trailing whitespace. If there is, it's an error (e.g. "1.2abc" or "12x").
+            if (converter >> value && (converter >> std::ws).eof()) {
+                result.push_back(value);
+            } else {
+                // Handle cases where conversion is not possible (e.g., non-numeric characters)
+                KRATOS_WARNING("StringUtilities") << "Invalid argument for conversion: '" << trimmedSegment << "'" << std::endl;
+            }
+        }
+    }
+    return result;
+}
+
+// Explicit instantiation of the template function for double and integer types
+template KRATOS_API(KRATOS_CORE) std::vector<double> StringToVector<double>(const std::string& rInputString);
+template KRATOS_API(KRATOS_CORE) std::vector<int> StringToVector<int>(const std::string& rInputString);
+template KRATOS_API(KRATOS_CORE) std::vector<unsigned int> StringToVector<unsigned int>(const std::string& rInputString);
+template KRATOS_API(KRATOS_CORE) std::vector<std::size_t> StringToVector<std::size_t>(const std::string& rInputString);
+
+/***********************************************************************************/
+/***********************************************************************************/
+
+std::size_t CountValuesUntilPrefix(
+    const std::string& rInputString,
+    const std::string& rStopPrefix
+    )
+{
+    std::istringstream iss(rInputString); // Use a string stream to easily extract tokens
+    std::string token;
+    std::size_t count = 0;
+
+    while (iss >> token) { // Read tokens one by one
+        // Check if the current token starts with the rStopPrefix
+        // string::find(substring_to_find, starting_position)
+        // If rStopPrefix is found at the beginning of token (position 0), it returns 0.
+        // If rStopPrefix is empty, token.find("", 0) also returns 0,
+        // meaning an empty rStopPrefix will cause the loop to break on the first token, returning 0.
+        if (token.find(rStopPrefix, 0) == 0) {
+            break; // Stop condition met, do not count this token or subsequent ones
+        }
+        count++; // Increment count for tokens that do not meet the stop condition
+    }
+    return count;
 }
 
 } // namespace Kratos::StringUtilities

--- a/kratos/utilities/string_utilities.h
+++ b/kratos/utilities/string_utilities.h
@@ -150,6 +150,16 @@ namespace StringUtilities
         const std::string& rInputString,
         const bool RemoveNullChar = false);
 
+    /**
+     * @brief Splits a string into a vector of words.
+     * @details This function takes an input string and splits it into individual words using
+     * whitespace as the delimiter. The extraction operator (>>) automatically skips
+     * whitespace characters (such as spaces and tabs), ensuring that each word is properly
+     * isolated and stored in the resulting vector.
+     * @param rText The input string to be split into words.
+     * @return std::vector<std::string> A vector containing all the words extracted from the input string.
+     */
+    [[nodiscard]] std::vector<std::string> KRATOS_API(KRATOS_CORE) SplitStringIntoAVector(const std::string& rText);
 
     /**
      * @brief Converts a string representation of a list into a vector of values.

--- a/kratos/utilities/string_utilities.h
+++ b/kratos/utilities/string_utilities.h
@@ -152,6 +152,41 @@ namespace StringUtilities
 
 
     /**
+     * @brief Converts a string representation of a list into a vector of values.
+     * @details This function takes a string that represents a list of values (optionally enclosed
+     * in square brackets) and converts it into a std::vector of type TType. The conversion process
+     * involves the following steps:
+     *   1. Trimming any leading or trailing whitespace from the input string.
+     *   2. Removing the outer square brackets '[' and ']' if present.
+     *   3. Checking if the string is empty after trimming; if so, it returns an empty vector.
+     *   4. Splitting the string by commas to isolate individual elements.
+     *   5. Trimming whitespace from each element and attempting to convert it to type TType.
+     * During the conversion of each element, if the conversion fails (for example, due to
+     * invalid format, extra characters, or out-of-range values), a warning is logged via KRATOS_WARNING.
+     * @tparam TType The type of the elements to be extracted and converted from the string.
+     * @param rInputString The input string containing the list of values.
+     * @return std::vector<TType> A vector containing the converted values of type TType.
+     */
+    template <typename TType>
+    [[nodiscard]] std::vector<TType> KRATOS_API(KRATOS_CORE) StringToVector(const std::string& rInputString);
+
+    /**
+     * @brief Counts space-separated values in a string until a token starting with a specific prefix is found.
+     * @details It reads tokens separated by whitespace from the input string. The count
+     * includes tokens encountered *before* a token that starts with the `rStopPrefix`.
+     * If no token starts with `rStopPrefix`, all tokens are counted.
+     * If `rStopPrefix` is an empty string, it's considered to match the beginning of any token,
+     * so the function will return 0 (as the "stop" condition is met before the first token).
+     * @param rInputString The string containing values to be counted.
+     * @param rStopPrefix The prefix that indicates a token at which counting should stop.
+     * @return The number of values counted before encountering a token starting with `rStopPrefix`.
+     */
+    [[nodiscard]] std::size_t KRATOS_API(KRATOS_CORE) CountValuesUntilPrefix(
+        const std::string& rInputString,
+        const std::string& rStopPrefix = ""
+        );
+
+    /**
      * @brief Prints the data of an object of type TClass to the given output stream with indentation.
      * @param rOStream The output stream where the data will be printed.
      * @param rThisClass The object of type TClass whose data will be printed.


### PR DESCRIPTION
**📝 Description**

Add `StringToVector` and `CountValuesUntilPrefix` utility functions for `StringUtilities` and its corresponding tests.

**🆕 Changelog**

- [Add `StringToVector` and `CountValuesUntilPrefix` utility functions for `StringUtilities`](https://github.com/KratosMultiphysics/Kratos/commit/1d5e31a071c5854755d077a9aa9d04921366956e)
- [Add tests for `StringToVector` and `CountValuesUntilPrefix` utility functions](https://github.com/KratosMultiphysics/Kratos/commit/a5e219e463d67d591d6d6fa9e99310d15ed7b8ae)
- [Update CountValuesUntilPrefix test to use tab-separated values](https://github.com/KratosMultiphysics/Kratos/commit/e72f0447678c2988b5879ee308c7203b383aec14)