### PR TITLE
[Core] Some `typedef` to `using` replacements

### DIFF
--- a/kratos/containers/array_1d.h
+++ b/kratos/containers/array_1d.h
@@ -70,19 +70,19 @@ public:
     /// Pointer definition of	array_1d
     KRATOS_CLASS_POINTER_DEFINITION(array_1d);
 
-    typedef std::size_t size_type;
-    typedef	std::ptrdiff_t difference_type;
-    typedef	T value_type;
-    typedef	typename boost::numeric::ublas::type_traits<T>::const_reference const_reference;
-    typedef	T &reference;
-    typedef	std::array<T,N> array_type;
-    typedef	T *pointer;
-    typedef	array_1d<T, N> self_type;
-    typedef	const boost::numeric::ublas::vector_reference<const self_type>	const_closure_type;
-    typedef	boost::numeric::ublas::vector_reference<self_type>	closure_type;
-    typedef	self_type vector_temporary_type;
-    typedef	boost::numeric::ublas::dense_tag storage_category;
-//		typedef	concrete_tag simd_category; //removed for the new ublas
+    using size_type = std::size_t;
+    using difference_type = std::ptrdiff_t;
+    using value_type = T;
+    using const_reference = typename boost::numeric::ublas::type_traits<T>::const_reference;
+    using reference = T&;
+    using array_type = std::array<T,N>;
+    using pointer = T*;
+    using self_type = array_1d<T, N>;
+    using const_closure_type = const boost::numeric::ublas::vector_reference<const self_type>;
+    using closure_type = boost::numeric::ublas::vector_reference<self_type>;
+    using vector_temporary_type = self_type;
+    using storage_category = boost::numeric::ublas::dense_tag;
+//		using simd_category = concrete_tag; //removed for the new ublas
 
     ///@}
     ///@name Life	Cycle
@@ -335,13 +335,13 @@ public:
     // Iterator	types
 private:
     // Use the storage array1 iterator
-    typedef	typename array_type::const_iterator const_iterator_type;
-    typedef	typename array_type::iterator iterator_type;
+    using const_iterator_type = typename array_type::const_iterator;
+    using iterator_type = typename array_type::iterator;
 
 public:
 #ifdef BOOST_UBLAS_USE_INDEXED_ITERATOR
-    typedef	indexed_iterator<self_type,	dense_random_access_iterator_tag> iterator;
-    typedef	indexed_const_iterator<self_type, dense_random_access_iterator_tag>	const_iterator;
+    using iterator = indexed_iterator<self_type,	dense_random_access_iterator_tag>;
+    using const_iterator = indexed_const_iterator<self_type, dense_random_access_iterator_tag>;
 #else
     class const_iterator;
     class iterator;
@@ -397,14 +397,14 @@ public:
         const_iterator, value_type, difference_type>
     {
     public:
-        typedef	dense_random_access_iterator_tag iterator_category;
+        using iterator_category = dense_random_access_iterator_tag;
 #ifdef BOOST_MSVC_STD_ITERATOR
-        typedef	const_reference	reference;
+        using reference = const_reference;
 #else
-        typedef	typename array_1d::difference_type difference_type;
-        typedef	typename array_1d::value_type	value_type;
-        typedef	typename array_1d::const_reference reference;
-        typedef	const typename array_1d::pointer pointer;
+        using difference_type = typename array_1d::difference_type;
+        using value_type = typename array_1d::value_type;
+        using reference = typename array_1d::const_reference;
+        using pointer = const typename array_1d::pointer;
 #endif
 
         // Construction	and	destruction
@@ -507,12 +507,12 @@ public:
         iterator, value_type, difference_type>
     {
     public:
-        typedef	dense_random_access_iterator_tag iterator_category;
+        using iterator_category = dense_random_access_iterator_tag;
 #ifndef	BOOST_MSVC_STD_ITERATOR
-        typedef	typename array_1d::difference_type difference_type;
-        typedef	typename array_1d::value_type	value_type;
-        typedef	typename array_1d::reference reference;
-        typedef	typename array_1d::pointer pointer;
+        using difference_type = typename array_1d::difference_type;
+        using value_type = typename array_1d::value_type;
+        using reference = typename array_1d::reference;
+        using pointer = typename array_1d::pointer;
 #endif
 
         // Construction	and	destruction
@@ -627,9 +627,9 @@ public:
     // Reverse iterator
 
 #ifdef BOOST_MSVC_STD_ITERATOR
-    typedef	reverse_iterator_base<const_iterator, value_type, const_reference> const_reverse_iterator;
+    using const_reverse_iterator = reverse_iterator_base<const_iterator, value_type, const_reference>;
 #else
-    typedef	boost::numeric::ublas::reverse_iterator_base<const_iterator> const_reverse_iterator;
+    using const_reverse_iterator = boost::numeric::ublas::reverse_iterator_base<const_iterator>;
 #endif
 
     BOOST_UBLAS_INLINE
@@ -644,9 +644,9 @@ public:
     }
 
 #ifdef BOOST_MSVC_STD_ITERATOR
-    typedef	reverse_iterator_base<iterator,	value_type,	reference> reverse_iterator;
+    using reverse_iterator = reverse_iterator_base<iterator,	value_type,	reference>;
 #else
-    typedef	boost::numeric::ublas::reverse_iterator_base<iterator>	reverse_iterator;
+    using reverse_iterator = boost::numeric::ublas::reverse_iterator_base<iterator>;
 #endif
 
     BOOST_UBLAS_INLINE

--- a/kratos/containers/flags.h
+++ b/kratos/containers/flags.h
@@ -62,7 +62,7 @@ public:
     KRATOS_CLASS_POINTER_DEFINITION(Flags);
 
 #ifdef  _WIN32 // work around for windows int64_t error
-    typedef __int64 int64_t;
+    using int64_t = __int64;
 #endif
 
     using BlockType = int64_t;

--- a/kratos/geometries/geometry.h
+++ b/kratos/geometries/geometry.h
@@ -115,107 +115,107 @@ public:
     /** Array of counted pointers to point. This type used to hold
     geometry's points.
     */
-    typedef PointerVector<TPointType> PointsArrayType;
+    using PointsArrayType = PointerVector<TPointType>;
 
     /** Integration methods implemented in geometry.
     */
-    typedef GeometryData::IntegrationMethod IntegrationMethod;
+    using IntegrationMethod = GeometryData::IntegrationMethod;
 
     /** A Vector of counted pointers to Geometries. Used for
     returning edges of the geometry.
      */
-    typedef PointerVector<GeometryType> GeometriesArrayType;
+    using GeometriesArrayType = PointerVector<GeometryType>;
 
     /** Redefinition of geometry template parameter TPointType as this geometry point type.
      */
-    typedef TPointType PointType;
+    using PointType = TPointType;
 
     /** Type used for indexing in geometry class.std::size_t used for indexing
     point or integration point access methods and also all other
     methods which need point or integration point index.
     */
-    typedef std::size_t IndexType;
+    using IndexType = std::size_t;
 
 
     /** This typed used to return size or dimension in
     geometry. Dimension, WorkingDimension, PointsNumber and
     ... return this type as their results.
     */
-    typedef std::size_t SizeType;
+    using SizeType = std::size_t;
 
 
-    typedef typename PointType::CoordinatesArrayType CoordinatesArrayType;
+    using CoordinatesArrayType = typename PointType::CoordinatesArrayType;
 
 
     /** This type used for representing an integration point in
     geometry. This integration point is a point with an
     additional weight component.
     */
-    typedef IntegrationPoint<3> IntegrationPointType;
+    using IntegrationPointType = IntegrationPoint<3>;
 
     /** A Vector of IntegrationPointType which used to hold
     integration points related to an integration
     method. IntegrationPoints functions used this type to return
     their results.
     */
-    typedef std::vector<IntegrationPointType> IntegrationPointsArrayType;
+    using IntegrationPointsArrayType = std::vector<IntegrationPointType>;
 
     /** A Vector of IntegrationPointsArrayType which used to hold
     integration points related to different integration method
     implemented in geometry.
     */
-    typedef std::array<IntegrationPointsArrayType, static_cast<int>(GeometryData::IntegrationMethod::NumberOfIntegrationMethods)> IntegrationPointsContainerType;
+    using IntegrationPointsContainerType = std::array<IntegrationPointsArrayType, static_cast<int>(GeometryData::IntegrationMethod::NumberOfIntegrationMethods)>;
 
     /** A third order tensor used as shape functions' values
     container.
     */
-    typedef std::array<Matrix, static_cast<int>(GeometryData::IntegrationMethod::NumberOfIntegrationMethods)> ShapeFunctionsValuesContainerType;
+    using ShapeFunctionsValuesContainerType = std::array<Matrix, static_cast<int>(GeometryData::IntegrationMethod::NumberOfIntegrationMethods)>;
 
     /** A fourth order tensor used as shape functions' local
     gradients container in geometry.
     */
-    typedef GeometryData::ShapeFunctionsLocalGradientsContainerType ShapeFunctionsLocalGradientsContainerType;
+    using ShapeFunctionsLocalGradientsContainerType = GeometryData::ShapeFunctionsLocalGradientsContainerType;
 
     /** A third order tensor to hold jacobian matrices evaluated at
     integration points. Jacobian and InverseOfJacobian functions
     return this type as their result.
     */
-    typedef DenseVector<Matrix > JacobiansType;
+    using JacobiansType = DenseVector<Matrix >;
 
     /** A third order tensor to hold shape functions'  gradients.
     ShapefunctionsGradients function return this
     type as its result.
     */
-    typedef GeometryData::ShapeFunctionsGradientsType ShapeFunctionsGradientsType;
+    using ShapeFunctionsGradientsType = GeometryData::ShapeFunctionsGradientsType;
 
     /** A third order tensor to hold shape functions' local second derivatives.
     ShapefunctionsLocalGradients function return this
     type as its result.
     */
-    typedef GeometryData::ShapeFunctionsSecondDerivativesType ShapeFunctionsSecondDerivativesType;
+    using ShapeFunctionsSecondDerivativesType = GeometryData::ShapeFunctionsSecondDerivativesType;
 
     /** A fourth order tensor to hold shape functions' local third order derivatives
      */
-    typedef GeometryData::ShapeFunctionsThirdDerivativesType ShapeFunctionsThirdDerivativesType;
+    using ShapeFunctionsThirdDerivativesType = GeometryData::ShapeFunctionsThirdDerivativesType;
 
     /** Type of the normal vector used for normal to edges in geometry.
      */
-    typedef DenseVector<double> NormalType;
+    using NormalType = DenseVector<double>;
 
     /// data type stores in this container.
-    typedef typename PointType::Pointer PointPointerType;
-    typedef const PointPointerType ConstPointPointerType;
-    typedef TPointType& PointReferenceType;
-    typedef const TPointType& ConstPointReferenceType;
-    typedef std::vector<PointPointerType> PointPointerContainerType;
+    using PointPointerType = typename PointType::Pointer;
+    using ConstPointPointerType = const PointPointerType;
+    using PointReferenceType = TPointType&;
+    using ConstPointReferenceType = const TPointType&;
+    using PointPointerContainerType = std::vector<PointPointerType>;
 
-    /// PointsArrayType typedefs
-    typedef typename PointsArrayType::iterator iterator;
-    typedef typename PointsArrayType::const_iterator const_iterator;
+    /// PointsArrayType using aliases
+    using iterator = typename PointsArrayType::iterator;
+    using const_iterator = typename PointsArrayType::const_iterator;
 
-    typedef typename PointsArrayType::ptr_iterator ptr_iterator;
-    typedef typename PointsArrayType::ptr_const_iterator ptr_const_iterator;
-    typedef typename PointsArrayType::difference_type difference_type;
+    using ptr_iterator = typename PointsArrayType::ptr_iterator;
+    using ptr_const_iterator = typename PointsArrayType::ptr_const_iterator;
+    using difference_type = typename PointsArrayType::difference_type;
 
     static constexpr IndexType BACKGROUND_GEOMETRY_INDEX = std::numeric_limits<IndexType>::max();
 

--- a/kratos/includes/communicator.h
+++ b/kratos/includes/communicator.h
@@ -72,38 +72,38 @@ public:
     /// Pointer definition of Communicator
     KRATOS_CLASS_POINTER_DEFINITION(Communicator);
 
-    typedef unsigned int IndexType;
+    using IndexType = unsigned int;
 
-    typedef unsigned int SizeType;
+    using SizeType = unsigned int;
 
-    typedef Node NodeType;
+    using NodeType = Node;
 
-    typedef Properties PropertiesType;
+    using PropertiesType = Properties;
 
-    typedef Element ElementType;
+    using ElementType = Element;
 
-    typedef Condition ConditionType;
+    using ConditionType = Condition;
 
-    typedef DenseVector<int> NeighbourIndicesContainerType;
+    using NeighbourIndicesContainerType = DenseVector<int>;
 
-    typedef Mesh<NodeType, PropertiesType, ElementType, ConditionType> MeshType;
+    using MeshType = Mesh<NodeType, PropertiesType, ElementType, ConditionType>;
 
-    typedef PointerVector<MeshType> MeshesContainerType;
+    using MeshesContainerType = PointerVector<MeshType>;
 
     /// Nodes container. Which is a vector set of nodes with their Id's as key.
-    typedef MeshType::NodesContainerType NodesContainerType;
+    using NodesContainerType = MeshType::NodesContainerType;
 
     /** Iterator over the nodes. This iterator is an indirect
         iterator over Node::Pointer which turn back a reference to
         node by * operator and not a pointer for more convenient
         usage. */
-    typedef MeshType::NodeIterator NodeIterator;
+    using NodeIterator = MeshType::NodeIterator;
 
     /** Const iterator over the nodes. This iterator is an indirect
         iterator over Node::Pointer which turn back a reference to
         node by * operator and not a pointer for more convenient
         usage. */
-    typedef MeshType::NodeConstantIterator NodeConstantIterator;
+    using NodeConstantIterator = MeshType::NodeConstantIterator;
 
     /** Iterator over the properties. This iterator is an indirect
         iterator over Properties::Pointer which turn back a reference to
@@ -111,19 +111,19 @@ public:
         usage. */
 
     /// Properties container. Which is a vector set of Properties with their Id's as key.
-    typedef MeshType::PropertiesContainerType PropertiesContainerType;
+    using PropertiesContainerType = MeshType::PropertiesContainerType;
 
     /** Iterator over the Properties. This iterator is an indirect
         iterator over Node::Pointer which turn back a reference to
         node by * operator and not a pointer for more convenient
         usage. */
-    typedef MeshType::PropertiesIterator PropertiesIterator;
+    using PropertiesIterator = MeshType::PropertiesIterator;
 
     /** Const iterator over the Properties. This iterator is an indirect
         iterator over Properties::Pointer which turn back a reference to
         Properties by * operator and not a pointer for more convenient
         usage. */
-    typedef MeshType::PropertiesConstantIterator PropertiesConstantIterator;
+    using PropertiesConstantIterator = MeshType::PropertiesConstantIterator;
 
     /** Iterator over the properties. This iterator is an indirect
         iterator over Properties::Pointer which turn back a reference to
@@ -131,34 +131,34 @@ public:
         usage. */
 
     /// Element container. A vector set of Elements with their Id's as key.
-    typedef MeshType::ElementsContainerType ElementsContainerType;
+    using ElementsContainerType = MeshType::ElementsContainerType;
 
     /** Iterator over the Elements. This iterator is an indirect
         iterator over Elements::Pointer which turn back a reference to
         Element by * operator and not a pointer for more convenient
         usage. */
-    typedef MeshType::ElementIterator ElementIterator;
+    using ElementIterator = MeshType::ElementIterator;
 
     /** Const iterator over the Elements. This iterator is an indirect
         iterator over Elements::Pointer which turn back a reference to
         Element by * operator and not a pointer for more convenient
         usage. */
-    typedef MeshType::ElementConstantIterator ElementConstantIterator;
+    using ElementConstantIterator = MeshType::ElementConstantIterator;
 
     /// Condintions container. A vector set of Conditions with their Id's as key.
-    typedef MeshType::ConditionsContainerType ConditionsContainerType;
+    using ConditionsContainerType = MeshType::ConditionsContainerType;
 
     /** Iterator over the Conditions. This iterator is an indirect
        iterator over Conditions::Pointer which turn back a reference to
        Condition by * operator and not a pointer for more convenient
        usage. */
-    typedef MeshType::ConditionIterator ConditionIterator;
+    using ConditionIterator = MeshType::ConditionIterator;
 
     /** Const iterator over the Conditions. This iterator is an indirect
         iterator over Conditions::Pointer which turn back a reference to
         Condition by * operator and not a pointer for more convenient
         usage. */
-    typedef MeshType::ConditionConstantIterator ConditionConstantIterator;
+    using ConditionConstantIterator = MeshType::ConditionConstantIterator;
 
     ///@}
     ///@name Life Cycle

--- a/kratos/includes/condition.h
+++ b/kratos/includes/condition.h
@@ -64,46 +64,46 @@ public:
     KRATOS_CLASS_INTRUSIVE_POINTER_DEFINITION(Condition);
 
     ///definition of condition type
-    typedef Condition ConditionType;
+    using ConditionType = Condition;
 
     ///base type: an GeometricalObject that automatically has a unique number
-    typedef GeometricalObject BaseType;
+    using BaseType = GeometricalObject;
 
     ///definition of node type (default is: Node)
-    typedef Node NodeType;
+    using NodeType = Node;
 
     /**
      * Properties are used to store any parameters
      * related to the constitutive law
      */
-    typedef Properties PropertiesType;
+    using PropertiesType = Properties;
 
     ///definition of the geometry type with given NodeType
-    typedef Geometry<NodeType> GeometryType;
+    using GeometryType = Geometry<NodeType>;
 
     ///definition of nodes container type, redefined from GeometryType
-    typedef Geometry<NodeType>::PointsArrayType NodesArrayType;
+    using NodesArrayType = Geometry<NodeType>::PointsArrayType;
 
-    typedef Vector VectorType;
+    using VectorType = Vector;
 
-    typedef Matrix MatrixType;
+    using MatrixType = Matrix;
 
-    typedef std::size_t IndexType;
+    using IndexType = std::size_t;
 
-    typedef std::size_t SizeType;
+    using SizeType = std::size_t;
 
-    typedef Dof<double> DofType;
+    using DofType = Dof<double>;
 
-    typedef std::vector<std::size_t> EquationIdVectorType;
+    using EquationIdVectorType = std::vector<std::size_t>;
 
-    typedef std::vector<DofType::Pointer> DofsVectorType;
+    using DofsVectorType = std::vector<DofType::Pointer>;
 
-    typedef PointerVectorSet<DofType> DofsArrayType;
+    using DofsArrayType = PointerVectorSet<DofType>;
 
     ///Type definition for integration methods
-    typedef GeometryData::IntegrationMethod IntegrationMethod;
+    using IntegrationMethod = GeometryData::IntegrationMethod;
 
-    typedef GeometryData GeometryDataType;
+    using GeometryDataType = GeometryData;
     ///@}
 
 

--- a/kratos/includes/constitutive_law.h
+++ b/kratos/includes/constitutive_law.h
@@ -76,14 +76,14 @@ public:
      * Type definitions
      * NOTE: geometries are assumed to be of type Node for all problems
      */
-    typedef ProcessInfo ProcessInfoType;
-    typedef std::size_t SizeType;
-    typedef Geometry<Node > GeometryType;
+    using ProcessInfoType = ProcessInfo;
+    using SizeType = std::size_t;
+    using GeometryType = Geometry<Node >;
 
-    typedef Vector StrainVectorType;
-    typedef Vector StressVectorType;
-    typedef Matrix VoigtSizeMatrixType;           // Constitutive Matrix
-    typedef Matrix DeformationGradientMatrixType; // Def. gradient tensor
+    using StrainVectorType = Vector;
+    using StressVectorType = Vector;
+    using VoigtSizeMatrixType = Matrix;           // Constitutive Matrix
+    using DeformationGradientMatrixType = Matrix; // Def. gradient tensor
 
     /**
      * Counted pointer of ConstitutiveLaw

--- a/kratos/includes/element.h
+++ b/kratos/includes/element.h
@@ -64,46 +64,46 @@ public:
     KRATOS_CLASS_INTRUSIVE_POINTER_DEFINITION(Element);
 
     ///definition of element type
-    typedef Element ElementType;
+    using ElementType = Element;
 
     ///base type: an GeometricalObject that automatically has a unique number
-    typedef GeometricalObject BaseType;
+    using BaseType = GeometricalObject;
 
     ///definition of node type (default is: Node)
-    typedef Node NodeType;
+    using NodeType = Node;
 
     /**
      * Properties are used to store any parameters
      * related to the constitutive law
      */
-    typedef Properties PropertiesType;
+    using PropertiesType = Properties;
 
     ///definition of the geometry type with given NodeType
-    typedef Geometry<NodeType> GeometryType;
+    using GeometryType = Geometry<NodeType>;
 
     ///definition of nodes container type, redefined from GeometryType
-    typedef Geometry<NodeType>::PointsArrayType NodesArrayType;
+    using NodesArrayType = Geometry<NodeType>::PointsArrayType;
 
-    typedef Vector VectorType;
+    using VectorType = Vector;
 
-    typedef Matrix MatrixType;
+    using MatrixType = Matrix;
 
-    typedef std::size_t IndexType;
+    using IndexType = std::size_t;
 
-    typedef std::size_t SizeType;
+    using SizeType = std::size_t;
 
-    typedef Dof<double> DofType;
+    using DofType = Dof<double>;
 
-    typedef std::vector<std::size_t> EquationIdVectorType;
+    using EquationIdVectorType = std::vector<std::size_t>;
 
-    typedef std::vector<DofType::Pointer> DofsVectorType;
+    using DofsVectorType = std::vector<DofType::Pointer>;
 
-    typedef PointerVectorSet<DofType> DofsArrayType;
+    using DofsArrayType = PointerVectorSet<DofType>;
 
     ///Type definition for integration methods
-    typedef GeometryData::IntegrationMethod IntegrationMethod;
+    using IntegrationMethod = GeometryData::IntegrationMethod;
 
-    typedef GeometryData GeometryDataType;
+    using GeometryDataType = GeometryData;
     ///@}
 
     ///@name Life Cycle

--- a/kratos/includes/geometrical_object.h
+++ b/kratos/includes/geometrical_object.h
@@ -64,16 +64,16 @@ public:
     KRATOS_CLASS_INTRUSIVE_POINTER_DEFINITION(GeometricalObject);
 
     /// Definition of the node type
-    typedef Node NodeType;
+    using NodeType = Node;
 
     /// The geometry type definition
-    typedef Geometry<NodeType> GeometryType;
+    using GeometryType = Geometry<NodeType>;
 
     /// Defines the index type
-    typedef std::size_t IndexType;
+    using IndexType = std::size_t;
 
     /// Defines the result type
-    typedef std::size_t result_type;
+    using result_type = std::size_t;
 
     ///@}
     ///@name Life Cycle

--- a/kratos/includes/master_slave_constraint.h
+++ b/kratos/includes/master_slave_constraint.h
@@ -79,31 +79,31 @@ public:
     ///@{
 
     /// The definition of the base class
-    typedef IndexedObject BaseType;
+    using BaseType = IndexedObject;
 
     /// The index type definition
-    typedef std::size_t IndexType;
+    using IndexType = std::size_t;
 
     /// The DoF type definition
-    typedef Dof<double> DofType;
+    using DofType = Dof<double>;
 
     /// The DoF pointer vector type definition
-    typedef std::vector< DofType::Pointer > DofPointerVectorType;
+    using DofPointerVectorType = std::vector< DofType::Pointer >;
 
     /// The node type definition
-    typedef Node NodeType;
+    using NodeType = Node;
 
     /// The equation Id vector type definition
-    typedef std::vector<std::size_t> EquationIdVectorType;
+    using EquationIdVectorType = std::vector<std::size_t>;
 
     /// The matrix type definition
-    typedef Matrix MatrixType;
+    using MatrixType = Matrix;
 
     /// The vector type definition
-    typedef Vector VectorType;
+    using VectorType = Vector;
 
     /// The variable type definition (double)
-    typedef Kratos::Variable<double> VariableType;
+    using VariableType = Kratos::Variable<double>;
 
     /// Pointer definition of MasterSlaveConstraint
     KRATOS_CLASS_POINTER_DEFINITION(MasterSlaveConstraint);

--- a/kratos/includes/model_part.h
+++ b/kratos/includes/model_part.h
@@ -115,42 +115,42 @@ public:
     /// Pointer definition of ModelPart
     //KRATOS_CLASS_POINTER_DEFINITION(ModelPart); //INTENTIONALLY REMOVING DEFINITION - DO NOT UNCOMMENT
 
-    typedef std::size_t IndexType;
+    using IndexType = std::size_t;
 
-    typedef std::size_t SizeType;
+    using SizeType = std::size_t;
 
-    typedef Dof<double> DofType;
-    typedef std::vector< DofType::Pointer > DofsVectorType;
-    typedef Variable<double> DoubleVariableType;
-    typedef Matrix MatrixType;
-    typedef Vector VectorType;
+    using DofType = Dof<double>;
+    using DofsVectorType = std::vector< DofType::Pointer >;
+    using DoubleVariableType = Variable<double>;
+    using MatrixType = Matrix;
+    using VectorType = Vector;
 
-    typedef PointerVectorSet<DofType> DofsArrayType;
+    using DofsArrayType = PointerVectorSet<DofType>;
 
-    typedef Node NodeType;
-    typedef Geometry<NodeType> GeometryType;
-    typedef Properties PropertiesType;
-    typedef Element ElementType;
-    typedef Condition ConditionType;
+    using NodeType = Node;
+    using GeometryType = Geometry<NodeType>;
+    using PropertiesType = Properties;
+    using ElementType = Element;
+    using ConditionType = Condition;
 
-    typedef Mesh<NodeType, PropertiesType, ElementType, ConditionType> MeshType;
+    using MeshType = Mesh<NodeType, PropertiesType, ElementType, ConditionType>;
 
-    typedef PointerVector<MeshType> MeshesContainerType;
+    using MeshesContainerType = PointerVector<MeshType>;
 
     /// Nodes container. Which is a vector set of nodes with their Id's as key.
-    typedef MeshType::NodesContainerType NodesContainerType;
+    using NodesContainerType = MeshType::NodesContainerType;
 
     /** Iterator over the nodes. This iterator is an indirect
         iterator over Node::Pointer which turn back a reference to
         node by * operator and not a pointer for more convenient
         usage. */
-    typedef MeshType::NodeIterator NodeIterator;
+    using NodeIterator = MeshType::NodeIterator;
 
     /** Const iterator over the nodes. This iterator is an indirect
         iterator over Node::Pointer which turn back a reference to
         node by * operator and not a pointer for more convenient
         usage. */
-    typedef MeshType::NodeConstantIterator NodeConstantIterator;
+    using NodeConstantIterator = MeshType::NodeConstantIterator;
 
     /** Iterator over the properties. This iterator is an indirect
         iterator over Properties::Pointer which turn back a reference to
@@ -158,19 +158,19 @@ public:
         usage. */
 
     /// Properties container. Which is a vector set of Properties with their Id's as key.
-    typedef MeshType::PropertiesContainerType PropertiesContainerType;
+    using PropertiesContainerType = MeshType::PropertiesContainerType;
 
     /** Iterator over the Properties. This iterator is an indirect
         iterator over Node::Pointer which turn back a reference to
         node by * operator and not a pointer for more convenient
         usage. */
-    typedef MeshType::PropertiesIterator PropertiesIterator;
+    using PropertiesIterator = MeshType::PropertiesIterator;
 
     /** Const iterator over the Properties. This iterator is an indirect
         iterator over Properties::Pointer which turn back a reference to
         Properties by * operator and not a pointer for more convenient
         usage. */
-    typedef MeshType::PropertiesConstantIterator PropertiesConstantIterator;
+    using PropertiesConstantIterator = MeshType::PropertiesConstantIterator;
 
     /** Iterator over the properties. This iterator is an indirect
         iterator over Properties::Pointer which turn back a reference to
@@ -178,104 +178,104 @@ public:
         usage. */
 
     /// Element container. A vector set of Elements with their Id's as key.
-    typedef MeshType::ElementsContainerType ElementsContainerType;
+    using ElementsContainerType = MeshType::ElementsContainerType;
 
     /** Iterator over the Elements. This iterator is an indirect
         iterator over Elements::Pointer which turn back a reference to
         Element by * operator and not a pointer for more convenient
         usage. */
-    typedef MeshType::ElementIterator ElementIterator;
+    using ElementIterator = MeshType::ElementIterator;
 
     /** Const iterator over the Elements. This iterator is an indirect
         iterator over Elements::Pointer which turn back a reference to
         Element by * operator and not a pointer for more convenient
         usage. */
-    typedef MeshType::ElementConstantIterator ElementConstantIterator;
+    using ElementConstantIterator = MeshType::ElementConstantIterator;
 
     /// Condintions container. A vector set of Conditions with their Id's as key.
-    typedef MeshType::ConditionsContainerType ConditionsContainerType;
+    using ConditionsContainerType = MeshType::ConditionsContainerType;
 
     /** Iterator over the Conditions. This iterator is an indirect
        iterator over Conditions::Pointer which turn back a reference to
        Condition by * operator and not a pointer for more convenient
        usage. */
-    typedef MeshType::ConditionIterator ConditionIterator;
+    using ConditionIterator = MeshType::ConditionIterator;
 
     /** Const iterator over the Conditions. This iterator is an indirect
         iterator over Conditions::Pointer which turn back a reference to
         Condition by * operator and not a pointer for more convenient
         usage. */
-    typedef MeshType::ConditionConstantIterator ConditionConstantIterator;
+    using ConditionConstantIterator = MeshType::ConditionConstantIterator;
 
     /// Defining a table with double argument and result type as table type.
-    typedef Table<double,double> TableType;
+    using TableType = Table<double,double>;
 
     /// The container of the tables. A vector map of the tables.
-    typedef PointerVectorMap<SizeType, TableType> TablesContainerType;
+    using TablesContainerType = PointerVectorMap<SizeType, TableType>;
 
     /** Iterator over the Tables. This iterator is an indirect
     iterator over Tables::Pointer which turn back a reference to
     Table by * operator and not a pointer for more convenient
     usage. */
-    typedef TablesContainerType::iterator TableIterator;
+    using TableIterator = TablesContainerType::iterator;
 
     /** Const iterator over the Tables. This iterator is an indirect
     iterator over Tables::Pointer which turn back a reference to
     Table by * operator and not a pointer for more convenient
     usage. */
-    typedef TablesContainerType::const_iterator TableConstantIterator;
+    using TableConstantIterator = TablesContainerType::const_iterator;
     /**
      *
      */
     /// The container of the constraints
-    typedef MeshType::MasterSlaveConstraintType MasterSlaveConstraintType;
-    typedef MeshType::MasterSlaveConstraintContainerType MasterSlaveConstraintContainerType;
+    using MasterSlaveConstraintType = MeshType::MasterSlaveConstraintType;
+    using MasterSlaveConstraintContainerType = MeshType::MasterSlaveConstraintContainerType;
 
     /** Iterator over the constraints. This iterator is an indirect
     iterator over MasterSlaveConstraint::Pointer which turn back a reference to
     MasterSlaveConstraint by * operator and not a pointer for more convenient
     usage. */
-    typedef MeshType::MasterSlaveConstraintIteratorType MasterSlaveConstraintIteratorType;
+    using MasterSlaveConstraintIteratorType = MeshType::MasterSlaveConstraintIteratorType;
 
     /** Const iterator over the constraints. This iterator is an indirect
     iterator over MasterSlaveConstraint::Pointer which turn back a reference to
     Table by * operator and not a pointer for more convenient
     usage. */
-    typedef MeshType::MasterSlaveConstraintConstantIteratorType MasterSlaveConstraintConstantIteratorType;
+    using MasterSlaveConstraintConstantIteratorType = MeshType::MasterSlaveConstraintConstantIteratorType;
 
     /// The Geometry Container.
     /**
     * Contains all geometries, which can be addressed by specific identifiers.
     */
-    typedef GeometryContainer<GeometryType> GeometryContainerType;
+    using GeometryContainerType = GeometryContainer<GeometryType>;
 
     /// Geometry Iterator
-    typedef typename GeometryContainerType::GeometryIterator GeometryIterator;
+    using GeometryIterator = typename GeometryContainerType::GeometryIterator;
 
     /// Const Geometry Iterator
-    typedef typename GeometryContainerType::GeometryConstantIterator GeometryConstantIterator;
+    using GeometryConstantIterator = typename GeometryContainerType::GeometryConstantIterator;
 
     /// Geometry Hash Map Container. Stores with hash of Ids to corresponding geometries.
-    typedef typename GeometryContainerType::GeometriesMapType GeometriesMapType;
+    using GeometriesMapType = typename GeometryContainerType::GeometriesMapType;
 
     /// The container of the sub model parts. A hash table is used.
     /**
     */
-    typedef PointerHashMapSet<ModelPart, std::hash< std::string >, GetModelPartName, Kratos::shared_ptr<ModelPart> >  SubModelPartsContainerType;
+    using SubModelPartsContainerType = PointerHashMapSet<ModelPart, std::hash< std::string >, GetModelPartName, Kratos::shared_ptr<ModelPart> >;
 
     /// Iterator over the sub model parts of this model part.
     /**	Note that this iterator only iterates over the next level of
     	sub model parts and does not go through the hierarchy of the
     	sub model parts
     */
-    typedef SubModelPartsContainerType::iterator SubModelPartIterator;
+    using SubModelPartIterator = SubModelPartsContainerType::iterator;
 
     /// Constant iterator over the sub model parts of this model part.
     /**	Note that this iterator only iterates over the next level of
     	sub model parts and does not go through the hierarchy of the
     	sub model parts
     */
-    typedef SubModelPartsContainerType::const_iterator SubModelPartConstantIterator;
+    using SubModelPartConstantIterator = SubModelPartsContainerType::const_iterator;
 
     ///@}
     ///@name Flags

--- a/kratos/includes/smart_pointers.h
+++ b/kratos/includes/smart_pointers.h
@@ -66,16 +66,18 @@ std::ostream& operator <<(std::ostream& rOStream, const Kratos::intrusive_ptr<T>
 } // namespace Kratos
 
 
-#define KRATOS_CLASS_POINTER_DEFINITION(a) typedef Kratos::shared_ptr<a > Pointer; \
-typedef Kratos::shared_ptr<a > SharedPointer; \
-typedef Kratos::weak_ptr<a > WeakPointer; \
-typedef Kratos::unique_ptr<a > UniquePointer
+#define KRATOS_CLASS_POINTER_DEFINITION(a) \
+    using Pointer = Kratos::shared_ptr<a>; \
+    using SharedPointer = Kratos::shared_ptr<a>; \
+    using WeakPointer = Kratos::weak_ptr<a>; \
+    using UniquePointer = Kratos::unique_ptr<a>;
 
 namespace Kratos {
 template< class T > class GlobalPointer;
 }
 
-#define KRATOS_CLASS_INTRUSIVE_POINTER_DEFINITION(a) typedef typename Kratos::intrusive_ptr<a > Pointer; \
-typedef Kratos::GlobalPointer<a > WeakPointer; \
-typedef Kratos::unique_ptr<a > UniquePointer; \
-typename a::Pointer shared_from_this(){ return a::Pointer(this); }
+#define KRATOS_CLASS_INTRUSIVE_POINTER_DEFINITION(a) \
+    using Pointer = typename Kratos::intrusive_ptr<a>; \
+    using WeakPointer = Kratos::GlobalPointer<a>; \
+    using UniquePointer = Kratos::unique_ptr<a>; \
+    typename a::Pointer shared_from_this(){ return a::Pointer(this); }

--- a/kratos/includes/table.h
+++ b/kratos/includes/table.h
@@ -70,11 +70,11 @@ public:
     /// Pointer definition of Table
     KRATOS_CLASS_POINTER_DEFINITION(Table);
 
-    typedef std::array<TResultType, TResultsColumns>  result_row_type;
+    using result_row_type = std::array<TResultType, TResultsColumns>;
 
-    typedef std::pair<TArgumentType, result_row_type> RecordType;
+    using RecordType = std::pair<TArgumentType, result_row_type>;
 
-    typedef std::vector<RecordType> TableContainerType;
+    using TableContainerType = std::vector<RecordType>;
 
     ///@}
     ///@name Life Cycle
@@ -439,17 +439,17 @@ public:
     /// Pointer definition of Table
     KRATOS_CLASS_POINTER_DEFINITION(Table);
 
-    typedef double TResultType;
-    typedef double TArgumentType;
+    using TResultType = double;
+    using TArgumentType = double;
 
-    typedef std::array<TResultType, 1>  result_row_type;
+    using result_row_type = std::array<TResultType, 1>;
 
-    typedef std::pair<TArgumentType, result_row_type> RecordType;
+    using RecordType = std::pair<TArgumentType, result_row_type>;
 
-    typedef std::vector<RecordType> TableContainerType;
+    using TableContainerType = std::vector<RecordType>;
 
-    typedef Variable<TArgumentType> XVariableType;
-    typedef Variable<TResultType> YVariableType;
+    using XVariableType = Variable<TArgumentType>;
+    using YVariableType = Variable<TResultType>;
 
     ///@}
     ///@name Life Cycle


### PR DESCRIPTION
**📝 Description**

This PR refactors various type definitions (typedefs) and replaces them with modern C++ type aliasing (`using`). 

This is another test of https://github.com/apps/google-labs-jules

**🆕 Changelog**

- [Replace typedef with using in core Kratos files](https://github.com/KratosMultiphysics/Kratos/commit/23b7caf7128d5dd73ede38592ebe504ab51dce99)
