### PR TITLE
[Core] Making optional to preserve constraints in `ConnectivityPreserveModeler`

### DIFF
--- a/kratos/modeler/connectivity_preserve_modeler.h
+++ b/kratos/modeler/connectivity_preserve_modeler.h
@@ -271,6 +271,9 @@ private:
     /// The pointer to the Model object.
     Model* mpModel = nullptr;
 
+    /// If the constraints are preserved when duplicating the model part (could be relevant for cases where we don't want to preserve them because physical reasons). True by default.
+    bool mPreserveConstraints = true;
+
     ///@}
 };
 


### PR DESCRIPTION
**📝 Description**

Making optional to preserve constraints in `ConnectivityPreserveModeler`. True by default.

**🆕 Changelog**

- [Making optional to preserve constraints in `ConnectivityPreserveModeler`](https://github.com/KratosMultiphysics/Kratos/commit/83bfb36da4384aa96f9800fd0f0d9d1a05969d09)
