### PR TITLE
Import the mdpa in the SetupGeometryModel

### DIFF
--- a/kratos/python_scripts/modelers/import_mdpa_modeler.py
+++ b/kratos/python_scripts/modelers/import_mdpa_modeler.py
@@ -24,12 +24,6 @@ class ImportMDPAModeler(KratosMultiphysics.Modeler):
     def SetupGeometryModel(self):
         super().SetupGeometryModel()
 
-    def PrepareGeometryModel(self):
-        super().PrepareGeometryModel()
-
-    def SetupModelPart(self):
-        super().SetupModelPart()
-
         # Import the model part data
         # Note that at this point solvers must have already added the variables to the nodal variable data
         input_type = "mdpa"
@@ -37,6 +31,12 @@ class ImportMDPAModeler(KratosMultiphysics.Modeler):
             self.model_part,
             self.settings,
             input_type)
+
+    def PrepareGeometryModel(self):
+        super().PrepareGeometryModel()
+
+    def SetupModelPart(self):
+        super().SetupModelPart()
 
     @classmethod
     def __GetDefaultSettings(cls):


### PR DESCRIPTION
**📝 Description**
Move the import of the mdpa files to the SetupGeometryModel from the SetUpModelPart

Please mark the PR with appropriate tags: 
- mdpa, import geometry modelers

**🆕 Changelog**
Move the import of the mdpa files to the SetupGeometryModel from the SetUpModelPart. 
When using the Shifted Boundary Method we need the mdpa to be already imported in the SetUpGeometryModel, in order to create the surrogate boundary from it.

E.g.
- Move the import of the mdpa files to the SetupGeometryModel from the SetUpModelPart
