### PR TITLE
[GeoMechanicsApplication] Fixed the displacements and water pressures when their derivatives are prescribed

### DIFF
--- a/applications/GeoMechanicsApplication/tests/prescribed_derivative_tests/prescribed_acceleration/ProjectParameters.json
+++ b/applications/GeoMechanicsApplication/tests/prescribed_derivative_tests/prescribed_acceleration/ProjectParameters.json
@@ -142,6 +142,18 @@
           "value":           0.0,
           "table":           0
         }
+      }, {
+        "python_module": "apply_vector_constraint_table_process",
+        "kratos_module": "KratosMultiphysics.GeoMechanicsApplication",
+        "process_name":  "ApplyVectorConstraintTableProcess",
+        "Parameters":    {
+          "model_part_name": "PorousDomain.Line_acceleration",
+          "variable_name":   "DISPLACEMENT",
+          "active":          [true, false, false],
+          "is_fixed":        [true, false, false],
+          "value":           [0.0, 0.0, 0.0],
+          "table":           [0, 0, 0]
+        }
       }
     ],
     "loads_process_list":       [

--- a/applications/GeoMechanicsApplication/tests/prescribed_derivative_tests/prescribed_dt_water_pressure/ProjectParameters.json
+++ b/applications/GeoMechanicsApplication/tests/prescribed_derivative_tests/prescribed_dt_water_pressure/ProjectParameters.json
@@ -130,6 +130,17 @@
           "value":           [0.0, 0.0, 0.0],
           "table":           [0, 0, 0]
         }
+      }, {
+        "python_module": "apply_scalar_constraint_table_process",
+        "kratos_module": "KratosMultiphysics.GeoMechanicsApplication",
+        "process_name":  "ApplyScalarConstraintTableProcess",
+        "Parameters":    {
+          "model_part_name": "PorousDomain.Line_dt_water_pressure",
+          "variable_name":   "WATER_PRESSURE",
+          "is_fixed":        true,
+          "value":           0.0,
+          "table":           0
+        }
       }
     ],
     "loads_process_list":       [

--- a/applications/GeoMechanicsApplication/tests/prescribed_derivative_tests/prescribed_velocity/ProjectParameters.json
+++ b/applications/GeoMechanicsApplication/tests/prescribed_derivative_tests/prescribed_velocity/ProjectParameters.json
@@ -142,6 +142,18 @@
           "value":           0.0,
           "table":           0
         }
+      }, {
+        "python_module": "apply_vector_constraint_table_process",
+        "kratos_module": "KratosMultiphysics.GeoMechanicsApplication",
+        "process_name":  "ApplyVectorConstraintTableProcess",
+        "Parameters":    {
+          "model_part_name": "PorousDomain.Line_velocity",
+          "variable_name":   "DISPLACEMENT",
+          "active":          [true, false, false],
+          "is_fixed":        [true, false, false],
+          "value":           [0.0, 0.0, 0.0],
+          "table":           [0, 0, 0]
+        }
       }
     ],
     "loads_process_list":       [


### PR DESCRIPTION
At this moment, the displacements/water pressures are not automatically fixed as degrees of freedom when their derivatives are prescribed. Therefore, we need to manually fix them in these test cases.
