### PR TITLE
[Core] Missing python standard modeler constructor in `ConnectivityPreserveModeler`

### DIFF
--- a/kratos/python/add_modeler_to_python.cpp
+++ b/kratos/python/add_modeler_to_python.cpp
@@ -80,6 +80,7 @@ void  AddModelerToPython(pybind11::module& m)
 
     py::class_<ConnectivityPreserveModeler,ConnectivityPreserveModeler::Pointer,Modeler>(m,"ConnectivityPreserveModeler")
     .def(py::init< >())
+    .def(py::init<Model&, Parameters>())
     .def("GenerateModelPart",
         [] (Modeler& rModeler, ModelPart& origin_model_part, ModelPart& destination_model_part, const std::string& rElementName, const std::string& rConditionName)
         {rModeler.GenerateModelPart(origin_model_part, destination_model_part,


### PR DESCRIPTION
**📝 Description**

Missing python standard modeler constructor in `ConnectivityPreserveModeler`.

**🆕 Changelog**

- [Missing python standard modeler constructor in `ConnectivityPreserveModeler`](https://github.com/KratosMultiphysics/Kratos/commit/e9c701e6a365c77a4eaf6ecb03369c314da87c4b)