### PR TITLE
[Core] Refactor mesher operation methods from `Apply` to `Execute`

### DIFF
--- a/kratos/modeler/operation/compute_surrogate_boundary_data.h
+++ b/kratos/modeler/operation/compute_surrogate_boundary_data.h
@@ -50,7 +50,7 @@ public:
 
     void ValidateParameters() override;
 
-    void Apply() const override;
+    void Execute() override;
 
 private:
      /**

--- a/kratos/modeler/operation/find_contacts_in_skin_model_part.cpp
+++ b/kratos/modeler/operation/find_contacts_in_skin_model_part.cpp
@@ -44,7 +44,7 @@ void FindContactsInSkinModelPart::ValidateParameters()
     }
 }
 
-void FindContactsInSkinModelPart::Apply() const
+void FindContactsInSkinModelPart::Execute()
 {
     ContactContainer contact_container;
     Parameters parameters = GetParameters();

--- a/kratos/modeler/operation/find_contacts_in_skin_model_part.h
+++ b/kratos/modeler/operation/find_contacts_in_skin_model_part.h
@@ -43,7 +43,7 @@ public:
 
     void ValidateParameters() override;
 
-    void Apply() const override;
+    void Execute() override;
 
     void FindConditionContact(
         Condition& rCondition,

--- a/kratos/modeler/operation/voxel_mesher_operation.h
+++ b/kratos/modeler/operation/voxel_mesher_operation.h
@@ -41,7 +41,7 @@ public:
 
     virtual void ValidateParameters();
 
-    virtual void Apply() const = 0;
+    virtual void Execute() = 0;
 
 protected:
 

--- a/kratos/modeler/voxel_mesh_generator_modeler.cpp
+++ b/kratos/modeler/voxel_mesh_generator_modeler.cpp
@@ -284,7 +284,7 @@ void VoxelMeshGeneratorModeler::ApplyOperations(Parameters ThisParameters)
         const std::string label = stream.str();
         Timer::Start(label);
 
-        p_operation->Apply();
+        p_operation->Execute();
 
         Timer::Stop(label);
     }


### PR DESCRIPTION
We were discussing the possibility of converting our mesher operations into standard operations, as this would allow us to use any type of operation in our voxel modeler. This involves some changes that we want to implement progressively. For now, it simply involves renaming the Apply method to Execute, and also removing the function’s const qualifier.