### PR TITLE
[Core][Geometry] Fix C++17 warning for `std::minmax` in the `TriBoxOverlap` function in `Triangle2D3`

### DIFF
--- a/kratos/geometries/triangle_2d_3.h
+++ b/kratos/geometries/triangle_2d_3.h
@@ -2067,11 +2067,13 @@ private:
         //  the triangle against the AABB
 
         // test in X-direction
-        min_max = std::minmax({vert0[0],vert1[0],vert2[0]});
+        min_max.first = std::min({vert0[0], vert1[0], vert2[0]});
+        min_max.second = std::max({vert0[0], vert1[0], vert2[0]});
         if(min_max.first>rBoxHalfSize[0] || min_max.second<-rBoxHalfSize[0]) return false;
 
         // test in Y-direction
-        min_max = std::minmax({vert0[1],vert1[1],vert2[1]});
+        min_max.first = std::min({vert0[1], vert1[1], vert2[1]});
+        min_max.second = std::max({vert0[1], vert1[1], vert2[1]});
         if(min_max.first>rBoxHalfSize[1] || min_max.second<-rBoxHalfSize[1]) return false;
 
         // test in Z-direction


### PR DESCRIPTION
**📝 Description**

I downloaded last version of Ubuntu (24.04, yes, is one year old) and I got following warning with GCC 13:

~~~sh
In file included from /usr/include/c++/13/functional:67, from /home/ubuntu/src/Kratos/external_libraries/intrusive_ptr/intrusive_ptr.hpp:18, from /home/ubuntu/src/Kratos/kratos/includes/smart_pointers.h:22, from /home/ubuntu/src/Kratos/kratos/includes/define.h:24, from /home/ubuntu/src/Kratos/kratos/sources/cfd_variables.cpp:18: /usr/include/c++/13/bits/stl_algo.h: In instantiation of ‘constexpr std::pair<_FIter, _FIter> std::minmax(initializer_list<_Tp>) [with _Tp = double]’: /home/ubuntu/src/Kratos/kratos/geometries/triangle_2d_3.h:2070:30: required from ‘bool Kratos::Triangle2D3
~~~

This PR replaces `std::minmax` with `std::initializer_list` in the `TriBoxOverlap` function, using separate calls to `std::min` and `std::max`. This modification resolves a compiler warning that arose from changes in how parameters are passed to `std::minmax` in C++17 when used with `std::initializer_list`. The updated approach is functionally the same but prevents the warning.

**🆕 Changelog**

- [Fix C++17 warning for `std::minmax` in the `TriBoxOverlap` function in `Triangle2D3`](https://github.com/KratosMultiphysics/Kratos/commit/8f05dd95c11ef8a2783bf85659295956f7afd559)
