### PR TITLE
[External] Bring last changes from `tinyexpr`. Also fix `-Warray-bounds` warnings

### DIFF
--- a/external_libraries/tinyexpr/tinyexpr/tinyexpr.c
+++ b/external_libraries/tinyexpr/tinyexpr/tinyexpr.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Zlib
 /*
  * TINYEXPR - Tiny recursive descent parser and evaluation engine in C
  *
@@ -81,12 +82,15 @@ typedef struct state {
 #define IS_CLOSURE(TYPE) (((TYPE) & TE_CLOSURE0) != 0)
 #define ARITY(TYPE) ( ((TYPE) & (TE_FUNCTION0 | TE_CLOSURE0)) ? ((TYPE) & 0x00000007) : 0 )
 #define NEW_EXPR(type, ...) new_expr((type), (const te_expr*[]){__VA_ARGS__})
+#define CHECK_NULL(ptr, ...) if ((ptr) == NULL) { __VA_ARGS__; return NULL; }
 
 static te_expr *new_expr(const int type, const te_expr *parameters[]) {
     const int arity = ARITY(type);
     const int psize = sizeof(void*) * arity;
     const int size = (sizeof(te_expr) - sizeof(void*)) + psize + (IS_CLOSURE(type) ? sizeof(void*) : 0);
     te_expr *ret = malloc(size);
+    CHECK_NULL(ret);
+
     memset(ret, 0, size);
     if (arity && parameters) {
         memcpy(ret->parameters, parameters, psize);
@@ -155,6 +159,11 @@ static double IsGreaterEqual(const double a, const double b) {return a >= b ? 1.
 static double IsLess(const double a, const double b) {return a < b ? 1.0 : 0.0;}
 static double IsLessEqual(const double a, const double b) {return a <= b ? 1.0 : 0.0;}
 
+#ifdef _MSC_VER
+#pragma function (ceil)
+#pragma function (floor)
+#endif
+
 static const te_variable functions[] = {
     /* must be in alphabetical order */
     {"abs", fabs,                       TE_FUNCTION1 | TE_FLAG_PURE, 0},
@@ -162,13 +171,13 @@ static const te_variable functions[] = {
     {"asin", asin,                      TE_FUNCTION1 | TE_FLAG_PURE, 0},
     {"atan", atan,                      TE_FUNCTION1 | TE_FLAG_PURE, 0},
     {"atan2", atan2,                    TE_FUNCTION2 | TE_FLAG_PURE, 0},
-// {"ceil", ceil,                   TE_FUNCTION1 | TE_FLAG_PURE, 0}, // NOTE: Fail in Windows
+    {"ceil", ceil,                      TE_FUNCTION1 | TE_FLAG_PURE, 0},
     {"cos", cos,                        TE_FUNCTION1 | TE_FLAG_PURE, 0},
     {"cosh", cosh,                      TE_FUNCTION1 | TE_FLAG_PURE, 0},
     {"e", e,                            TE_FUNCTION0 | TE_FLAG_PURE, 0},
     {"exp", exp,                        TE_FUNCTION1 | TE_FLAG_PURE, 0},
     {"fac", fac,                        TE_FUNCTION1 | TE_FLAG_PURE, 0},
-// {"floor", floor,                   TE_FUNCTION1 | TE_FLAG_PURE, 0}, // NOTE: Fail in Windows
+    {"floor", floor,                    TE_FUNCTION1 | TE_FLAG_PURE, 0},
     {"ln", log,                         TE_FUNCTION1 | TE_FLAG_PURE, 0},
 #ifdef TE_NAT_LOG
     {"log", log,                        TE_FUNCTION1 | TE_FLAG_PURE, 0},
@@ -233,7 +242,7 @@ static double add(const double a, const double b) {return a + b;}
 static double sub(const double a, const double b) {return a - b;}
 static double mul(const double a, const double b) {return a * b;}
 static double divide(const double a, const double b) {return a / b;}
-static double negate(double a) {return -a;}
+static double negate(const double a) {return -a;}
 static double comma(const double a, const double b) {(void)a; return b;}
 
 
@@ -257,7 +266,7 @@ void next_token(state *s) {
                 const char *start;
                 start = s->next;
                 while (isalpha(s->next[0]) || isdigit(s->next[0]) || (s->next[0] == '_')) s->next++;
-
+                
                 const te_variable *var = find_lookup(s, start, s->next - start);
                 if (!var) var = find_builtin(start, s->next - start);
 
@@ -316,12 +325,16 @@ static te_expr *base(state *s) {
     switch (TYPE_MASK(s->type)) {
         case TOK_NUMBER:
             ret = new_expr(TE_CONSTANT, 0);
+            CHECK_NULL(ret);
+
             ret->value = s->value;
             next_token(s);
             break;
 
         case TOK_VARIABLE:
             ret = new_expr(TE_VARIABLE, 0);
+            CHECK_NULL(ret);
+
             ret->bound = s->bound;
             next_token(s);
             break;
@@ -329,6 +342,8 @@ static te_expr *base(state *s) {
         case TE_FUNCTION0:
         case TE_CLOSURE0:
             ret = new_expr(s->type, 0);
+            CHECK_NULL(ret);
+
             ret->function = s->function;
             if (IS_CLOSURE(s->type)) ret->parameters[0] = s->context;
             next_token(s);
@@ -345,10 +360,13 @@ static te_expr *base(state *s) {
         case TE_FUNCTION1:
         case TE_CLOSURE1:
             ret = new_expr(s->type, 0);
+            CHECK_NULL(ret);
+
             ret->function = s->function;
             if (IS_CLOSURE(s->type)) ret->parameters[1] = s->context;
             next_token(s);
             ret->parameters[0] = power(s);
+            CHECK_NULL(ret->parameters[0], te_free(ret));
             break;
 
         case TE_FUNCTION2: case TE_FUNCTION3: case TE_FUNCTION4:
@@ -358,6 +376,8 @@ static te_expr *base(state *s) {
             arity = ARITY(s->type);
 
             ret = new_expr(s->type, 0);
+            CHECK_NULL(ret);
+
             ret->function = s->function;
             if (IS_CLOSURE(s->type)) ret->parameters[arity] = s->context;
             next_token(s);
@@ -369,6 +389,8 @@ static te_expr *base(state *s) {
                 for(i = 0; i < arity; i++) {
                     next_token(s);
                     ret->parameters[i] = expr(s);
+                    CHECK_NULL(ret->parameters[i], te_free(ret));
+
                     if(s->type != TOK_SEP) {
                         break;
                     }
@@ -385,6 +407,8 @@ static te_expr *base(state *s) {
         case TOK_OPEN:
             next_token(s);
             ret = list(s);
+            CHECK_NULL(ret);
+
             if (s->type != TOK_CLOSE) {
                 s->type = TOK_ERROR;
             } else {
@@ -394,6 +418,8 @@ static te_expr *base(state *s) {
 
         default:
             ret = new_expr(0, 0);
+            CHECK_NULL(ret);
+
             s->type = TOK_ERROR;
             ret->value = NAN;
             break;
@@ -416,7 +442,12 @@ static te_expr *power(state *s) {
     if (sign == 1) {
         ret = base(s);
     } else {
-        ret = NEW_EXPR(TE_FUNCTION1 | TE_FLAG_PURE, base(s));
+        te_expr *b = base(s);
+        CHECK_NULL(b);
+
+        ret = NEW_EXPR(TE_FUNCTION1 | TE_FLAG_PURE, b);
+        CHECK_NULL(ret, te_free(b));
+
         ret->function = negate;
     }
 
@@ -427,6 +458,7 @@ static te_expr *power(state *s) {
 static te_expr *factor(state *s) {
     /* <factor>    =    <power> {"^" <power>} */
     te_expr *ret = power(s);
+    CHECK_NULL(ret);
 
     int neg = 0;
 
@@ -445,19 +477,33 @@ static te_expr *factor(state *s) {
 
         if (insertion) {
             /* Make exponentiation go right-to-left. */
-            te_expr *insert = NEW_EXPR(TE_FUNCTION2 | TE_FLAG_PURE, insertion->parameters[1], power(s));
+            te_expr *p = power(s);
+            CHECK_NULL(p, te_free(ret));
+
+            te_expr *insert = NEW_EXPR(TE_FUNCTION2 | TE_FLAG_PURE, insertion->parameters[1], p);
+            CHECK_NULL(insert, te_free(p), te_free(ret));
+
             insert->function = t;
             insertion->parameters[1] = insert;
             insertion = insert;
         } else {
-            ret = NEW_EXPR(TE_FUNCTION2 | TE_FLAG_PURE, ret, power(s));
+            te_expr *p = power(s);
+            CHECK_NULL(p, te_free(ret));
+
+            te_expr *prev = ret;
+            ret = NEW_EXPR(TE_FUNCTION2 | TE_FLAG_PURE, ret, p);
+            CHECK_NULL(ret, te_free(p), te_free(prev));
+
             ret->function = t;
             insertion = ret;
         }
     }
 
     if (neg) {
+        te_expr *prev = ret;
         ret = NEW_EXPR(TE_FUNCTION1 | TE_FLAG_PURE, ret);
+        CHECK_NULL(ret, te_free(prev));
+
         ret->function = negate;
     }
 
@@ -467,11 +513,18 @@ static te_expr *factor(state *s) {
 static te_expr *factor(state *s) {
     /* <factor>    =    <power> {"^" <power>} */
     te_expr *ret = power(s);
+    CHECK_NULL(ret);
 
     while (s->type == TOK_INFIX && (s->function == pow)) {
         te_fun2 t = s->function;
         next_token(s);
-        ret = NEW_EXPR(TE_FUNCTION2 | TE_FLAG_PURE, ret, power(s));
+        te_expr *p = power(s);
+        CHECK_NULL(p, te_free(ret));
+
+        te_expr *prev = ret;
+        ret = NEW_EXPR(TE_FUNCTION2 | TE_FLAG_PURE, ret, p);
+        CHECK_NULL(ret, te_free(p), te_free(prev));
+
         ret->function = t;
     }
 
@@ -484,11 +537,18 @@ static te_expr *factor(state *s) {
 static te_expr *term(state *s) {
     /* <term>      =    <factor> {("*" | "/" | "%") <factor>} */
     te_expr *ret = factor(s);
+    CHECK_NULL(ret);
 
     while (s->type == TOK_INFIX && (s->function == mul || s->function == divide || s->function == fmod)) {
         te_fun2 t = s->function;
         next_token(s);
-        ret = NEW_EXPR(TE_FUNCTION2 | TE_FLAG_PURE, ret, factor(s));
+        te_expr *f = factor(s);
+        CHECK_NULL(f, te_free(ret));
+
+        te_expr *prev = ret;
+        ret = NEW_EXPR(TE_FUNCTION2 | TE_FLAG_PURE, ret, f);
+        CHECK_NULL(ret, te_free(f), te_free(prev));
+
         ret->function = t;
     }
 
@@ -499,11 +559,18 @@ static te_expr *term(state *s) {
 static te_expr *expr(state *s) {
     /* <expr>      =    <term> {("+" | "-") <term>} */
     te_expr *ret = term(s);
+    CHECK_NULL(ret);
 
     while (s->type == TOK_INFIX && (s->function == add || s->function == sub)) {
         te_fun2 t = s->function;
         next_token(s);
-        ret = NEW_EXPR(TE_FUNCTION2 | TE_FLAG_PURE, ret, term(s));
+        te_expr *te = term(s);
+        CHECK_NULL(te, te_free(ret));
+
+        te_expr *prev = ret;
+        ret = NEW_EXPR(TE_FUNCTION2 | TE_FLAG_PURE, ret, te);
+        CHECK_NULL(ret, te_free(te), te_free(prev));
+
         ret->function = t;
     }
 
@@ -514,10 +581,17 @@ static te_expr *expr(state *s) {
 static te_expr *list(state *s) {
     /* <list>      =    <expr> {"," <expr>} */
     te_expr *ret = expr(s);
+    CHECK_NULL(ret);
 
     while (s->type == TOK_SEP) {
         next_token(s);
-        ret = NEW_EXPR(TE_FUNCTION2 | TE_FLAG_PURE, ret, expr(s));
+        te_expr *e = expr(s);
+        CHECK_NULL(e, te_free(ret));
+
+        te_expr *prev = ret;
+        ret = NEW_EXPR(TE_FUNCTION2 | TE_FLAG_PURE, ret, e);
+        CHECK_NULL(ret, te_free(e), te_free(prev));
+
         ret->function = comma;
     }
 
@@ -606,6 +680,10 @@ te_expr *te_compile(const char *expression, const te_variable *variables, int va
 
     next_token(&s);
     te_expr *root = list(&s);
+    if (root == NULL) {
+        if (error) *error = -1;
+        return NULL;
+    }
 
     if (s.type != TOK_END) {
         te_free(root);
@@ -624,6 +702,7 @@ te_expr *te_compile(const char *expression, const te_variable *variables, int va
 
 double te_interp(const char *expression, int *error) {
     te_expr *n = te_compile(expression, 0, 0, error);
+
     double ret;
     if (n) {
         ret = te_eval(n);


### PR DESCRIPTION
**📝 Description**

Bring last changes from `tinyexpr`.

Also fixing the following  `-Warray-bounds` warning:

~~~c++
/home/ubuntu/src/Kratos/external_libraries/tinyexpr/tinyexpr/tinyexpr.c: In function ‘base’: /home/ubuntu/src/Kratos/external_libraries/tinyexpr/tinyexpr/tinyexpr.c:325:16: warning: array subscript ‘te_expr[0]’ is partly outside array bounds of ‘unsigned char[16]’ [-Warray-bounds=] 325 | ret->bound = s->bound; | ^~ In function ‘new_expr’, inlined from ‘base’ at /home/ubuntu/src/Kratos/external_libraries/tinyexpr/tinyexpr/tinyexpr.c:324:19: /home/ubuntu/src/Kratos/external_libraries/tinyexpr/tinyexpr/tinyexpr.c:89:20: note: object of size 16 allocated by ‘malloc’ 89 | te_expr *ret = malloc(size); | ^~~~~~~~~~~~ In function ‘new_expr’, inlined from ‘base’ at /home/ubuntu/src/Kratos/external_libraries/tinyexpr/tinyexpr/tinyexpr.c:318:19: /home/ubuntu/src/Kratos/external_libraries/tinyexpr/tinyexpr/tinyexpr.c:94:15: warning: array subscript ‘te_expr[0]’ is partly outside array bounds of ‘unsigned char[16]’ [-Warray-bounds=] 94 | ret->type = type; | ~~~~~~~~~~^~~~~~ /home/ubuntu/src/Kratos/external_libraries/tinyexpr/tinyexpr/tinyexpr.c:89:20: note: object of size 16 allocated by ‘malloc’ 89 | te_expr *ret = malloc(size); | ^~~~~~~~~~~~ /home/ubuntu/src/Kratos/external_libraries/tinyexpr/tinyexpr/tinyexpr.c: In function ‘base’: /home/ubuntu/src/Kratos/external_libraries/tinyexpr/tinyexpr/tinyexpr.c:319:16: warning: array subscript ‘te_expr[0]’ is partly outside array bounds of ‘unsigned char[16]’ [-Warray-bounds=] 319 | ret->value = s->value; | ^~ In function ‘new_expr’, inlined from ‘base’ at /home/ubuntu/src/Kratos/external_libraries/tinyexpr/tinyexpr/tinyexpr.c:318:19: /home/ubuntu/src/Kratos/external_libraries/tinyexpr/tinyexpr/tinyexpr.c:89:20: note: object of size 16 allocated by ‘malloc’ 89 | te_expr *ret = malloc(size); | ^~~~~~~~~~~~ /home/ubuntu/src/Kratos/external_libraries/tinyexpr/tinyexpr/tinyexpr.c: In function ‘base’: /home/ubuntu/src/Kratos/external_libraries/tinyexpr/tinyexpr/tinyexpr.c:398:16: warning: array subscript ‘te_expr[0]’ is partly outside array bounds of ‘unsigned char[16]’ [-Warray-bounds=] 398 | ret->value = NAN; | ^~ In function ‘new_expr’, inlined from ‘base’ at /home/ubuntu/src/Kratos/external_libraries/tinyexpr/tinyexpr/tinyexpr.c:396:19: /home/ubuntu/src/Kratos/external_libraries/tinyexpr/tinyexpr/tinyexpr.c:89:20: note: object of size 16 allocated by ‘malloc’ 89 | te_expr *ret = malloc(size)
~~~

The warnings indicated that `te_expr` objects, particularly those with zero arity, were being allocated with a size potentially smaller than `sizeof(te_expr)` as understood by the compiler for static analysis. This could lead to warnings when accessing members of these objects via a te_expr* pointer.

The fix modifies the new_expr function:
1. Includes `<stddef.h>` for the offsetof macro.
2. Adjusts the memory allocation logic:
   - It calculates the required size using `offsetof(te_expr, parameters)` plus space for actual parameters and any closure context.
   - It then ensures that the allocated size is always at least `sizeof(te_expr)`. This guarantees that the `te_expr` pointer refers to a memory block that matches the full size of the structure, satisfying compiler checks even for zero-arity expressions.
3. Adds a `NULL` check after `malloc` for robustness.

This change ensures that `te_expr` objects are allocated with sufficient memory to prevent the `-Warray-bounds` warnings and improves the overall robustness of the memory allocation in tinyexpr.

**🆕 Changelog**

- [Bring last changes from tinyexpr](https://github.com/KratosMultiphysics/Kratos/commit/9a920354c2a6820a99ac0ec4b9ecf21b60826df5)
- [Fix -Warray-bounds warnings in tinyexpr.c](https://github.com/KratosMultiphysics/Kratos/pull/13486/commits/176505b2adaef86c29f8f43cb8d4c41b9b2bd3b4)
