### PR TITLE
[Core] Add Properties::GetData method to make it consistent.

### DIFF
--- a/kratos/includes/properties.h
+++ b/kratos/includes/properties.h
@@ -538,6 +538,7 @@ public:
      * @brief This method returns the whole data container
      * @return Data container
      */
+    KRATOS_DEPRECATED_MESSAGE("This method is deprecated. Use 'GetData()' instead.")
     ContainerType& Data()
     {
         return mData;
@@ -547,7 +548,18 @@ public:
      * @brief This method returns the whole data container (constant)
      * @return Data container
      */
+    KRATOS_DEPRECATED_MESSAGE("This method is deprecated. Use 'GetData()' instead.")
     ContainerType const& Data() const
+    {
+        return mData;
+    }
+
+    const ContainerType& GetData() const
+    {
+        return mData;
+    }
+
+    ContainerType& GetData()
     {
         return mData;
     }

--- a/kratos/utilities/properties_utilities.cpp
+++ b/kratos/utilities/properties_utilities.cpp
@@ -28,8 +28,8 @@ void CopyPropertiesValues(
 {
     KRATOS_TRY
 
-    const auto& r_origin_data = rOriginProperties.Data();
-    auto& r_destination_data = rDestinatiionProperties.Data();
+    const auto& r_origin_data = rOriginProperties.GetData();
+    auto& r_destination_data = rDestinatiionProperties.GetData();
     if (!r_destination_data.IsEmpty()) r_destination_data.Clear();
 
     // Copy data


### PR DESCRIPTION
**📝 Description**

The `GetData` method is present in `Element`, `Condition`, and `Node` classes, and they have already deprecated the `Data` methods. This PR does the same for the `Properties` as well to make it consistent.

**🆕 Changelog**
- Add `Properties::GetData` method
- Deprecate `Properties::Data` method
- Update use cases in the core.
