### PR TITLE
[Core] fixed issue with compilation ( added function definition)

### DIFF
--- a/kratos/utilities/geometry_utilities/brep_sbm_utilities.cpp
+++ b/kratos/utilities/geometry_utilities/brep_sbm_utilities.cpp
@@ -137,7 +137,7 @@ void BrepSbmUtilities<TNodeType>::CreateBrepVolumeSbmIntegrationPoints(
     const std::vector<double>& rSpansW,
     GeometrySurrogateArrayType& rOuterLoops,
     GeometrySurrogateArrayType& rInnerLoops,
-    IntegrationInfo& rIntegrationInfo);
+    IntegrationInfo& rIntegrationInfo)
 {
     KRATOS_ERROR << "This function has not been implemented yet." << std::endl;
 }

--- a/kratos/utilities/geometry_utilities/brep_sbm_utilities.cpp
+++ b/kratos/utilities/geometry_utilities/brep_sbm_utilities.cpp
@@ -129,6 +129,19 @@ void BrepSbmUtilities<TNodeType>::CreateBrepSurfaceSbmIntegrationPoints(
     }
 };
 
+template<class TNodeType>
+void BrepSbmUtilities<TNodeType>::CreateBrepVolumeSbmIntegrationPoints(
+    IntegrationPointsArrayType& rIntegrationPoints,
+    const std::vector<double>& rSpansU,
+    const std::vector<double>& rSpansV,
+    const std::vector<double>& rSpansW,
+    GeometrySurrogateArrayType& rOuterLoops,
+    GeometrySurrogateArrayType& rInnerLoops,
+    IntegrationInfo& rIntegrationInfo);
+{
+    KRATOS_ERROR << "This function has not been implemented yet." << std::endl;
+}
+
 ///@} // Kratos Classes
 template<class TNodeType>
 int BrepSbmUtilities<TNodeType>::FindKnotSpans1D(


### PR DESCRIPTION
There was an issue compiling,

D:/buildAgent/work/8e24b5f40afc538d/kratos/utilities/geometry_utilities/brep_sbm_utilities.cpp(150,62): error C4661: 'void Kratos::BrepSbmUtilities<Kratos::Node>::CreateBrepVolumeSbmIntegrationPoints(Kratos::BrepSbmUtilities<Kratos::Node>::IntegrationPointsArrayType &,const std::vector<double,std::allocator<T>> &,const std::vector<double,std::allocator<T>> &,const std::vector<double,std::allocator<T>> &,boost::numeric::ublas::vector<std::shared_ptr<Kratos::Geometry<Kratos::Node>>,boost::numeric::ublas::unbounded_array<std::shared_ptr<Kratos::Geometry<Kratos::Node>>,std::allocator<TPointerType>>> &,boost::numeric::ublas::vector<std::shared_ptr<Kratos::Geometry<Kratos::Node>>,boost::numeric::ublas::unbounded_array<std::shared_ptr<Kratos::Geometry<Kratos::Node>>,std::allocator<TPointerType>>> &,Kratos::IntegrationInfo &)': no suitable definition provided for explicit template instantiation request [D:\buildAgent\work\8e24b5f40afc538d\build\Release\kratos\KratosCore.vcxproj]