### PR TITLE
[Core][MPI] Missing `DenseVector` in `vector` definition may the compiler fail

### DIFF
--- a/kratos/mpi/utilities/parallel_fill_communicator.cpp
+++ b/kratos/mpi/utilities/parallel_fill_communicator.cpp
@@ -208,7 +208,7 @@ void ParallelFillCommunicator::ComputeCommunicationPlan(ModelPart& rModelPart)
     // Get number of processors.
     const int num_processors = mrDataComm.Size();
     // Find all ghost nodes on this process and mark the corresponding neighbour process for communication.
-    std::vector<bool> receive_from_neighbour(num_processors, false);
+    DenseVector<bool> receive_from_neighbour(num_processors, false);
     for (const auto& rNode : rModelPart.Nodes())
     {
         const int partition_index = rNode.FastGetSolutionStepValue(PARTITION_INDEX);

--- a/kratos/mpi/utilities/parallel_fill_communicator.cpp
+++ b/kratos/mpi/utilities/parallel_fill_communicator.cpp
@@ -208,7 +208,7 @@ void ParallelFillCommunicator::ComputeCommunicationPlan(ModelPart& rModelPart)
     // Get number of processors.
     const int num_processors = mrDataComm.Size();
     // Find all ghost nodes on this process and mark the corresponding neighbour process for communication.
-    vector<bool> receive_from_neighbour(num_processors, false);
+    std::vector<bool> receive_from_neighbour(num_processors, false);
     for (const auto& rNode : rModelPart.Nodes())
     {
         const int partition_index = rNode.FastGetSolutionStepValue(PARTITION_INDEX);


### PR DESCRIPTION
**📝 Description**

Missing `DenseVector` in `vector` definition may the compiler fail. I guess compiler was using the boost vector.

**🆕 Changelog**

- [Use `DenseVector`](https://github.com/KratosMultiphysics/Kratos/pull/13505/commits/26ebe1bc510f66e72cad7c6954419bb6e7667d06)
