### PR TITLE
[Core] Avoid Ublas namespace polluting with explicit call in `BrepUtilities`

### DIFF
--- a/kratos/utilities/geometry_utilities/brep_trimming_utilities.h
+++ b/kratos/utilities/geometry_utilities/brep_trimming_utilities.h
@@ -115,7 +115,7 @@ namespace Kratos
                 return;
             }
 
-            matrix<DPState> dpstates(n, n);
+            boost::numeric::ublas::matrix<DPState> dpstates(n, n);
 
             //init states and visibility
             for (IndexType i = 0; i < (n - 1); i++) {


### PR DESCRIPTION
**📝 Description**

I just realized that Ublas is polluting our namespace. This is going to be problematic in a future if we want to get rid of Ublas. In here I explicitily call Ublas so in a future refactoring will be easier to identify the Ublas use.

**🆕 Changelog**

- [Avoid Ublas namespace polluting with explicit call in `BrepUtilities`](https://github.com/KratosMultiphysics/Kratos/commit/49c85fbaced9e47fe011d3e019910e612e9b6990)
