### PR TITLE
[Core] Avoid Ublas namespace polluting with explicit call in `ModelartIO`

### DIFF
--- a/kratos/sources/model_part_io.cpp
+++ b/kratos/sources/model_part_io.cpp
@@ -4845,7 +4845,7 @@ void ModelPartIO::WriteCommunicatorData(OutputFilesContainerType& OutputFiles, S
     std::vector<PartitionIndicesContainerType> local_nodes_indices(NumberOfPartitions, PartitionIndicesContainerType(number_of_colors));
     std::vector<PartitionIndicesContainerType> ghost_nodes_indices(NumberOfPartitions, PartitionIndicesContainerType(number_of_colors));
 
-    DenseMatrix<int> interface_indices = scalar_matrix<int>(NumberOfPartitions, NumberOfPartitions, -1);
+    DenseMatrix<int> interface_indices = boost::numeric::ublas::scalar_matrix<int>(NumberOfPartitions, NumberOfPartitions, -1);
 
     for(SizeType i_partition = 0 ; i_partition < NumberOfPartitions ; i_partition++)
     {


### PR DESCRIPTION
**📝 Description**

I just realized that Ublas is polluting our namespace. This is going to be problematic in a future if we want to get rid of Ublas. In here I explicitily call Ublas so in a future refactoring will be easier to identify the Ublas use.

**🆕 Changelog**

- [Avoid Ublas namespace polluting with explicit call in `ModelartIO`](https://github.com/KratosMultiphysics/Kratos/commit/cc4e5a3d48ca799e38c3b7e618a397996cd8ccd2)
