### PR TITLE
[Core] Avoid Ublas namespace polluting with explicit call in `array_1d`

### DIFF
--- a/kratos/containers/array_1d.h
+++ b/kratos/containers/array_1d.h
@@ -22,14 +22,15 @@
 #include <initializer_list>
 
 // External	includes
+#include <boost/numeric/ublas/vector_expression.hpp>
+#include <boost/numeric/ublas/storage.hpp>
+#include <boost/numeric/ublas/detail/vector_assign.hpp>
+#include <boost/numeric/ublas/detail/iterator.hpp> // For container_const_reference etc.
+#include <boost/numeric/ublas/functional.hpp> // For scalar_assign etc.
 
 // Project includes
 #include "includes/define.h"
 #include "includes/ublas_interface.h"
-
-#include <boost/numeric/ublas/vector_expression.hpp>
-#include <boost/numeric/ublas/storage.hpp>
-#include <boost/numeric/ublas/detail/vector_assign.hpp>
 
 namespace Kratos
 {
@@ -60,10 +61,6 @@ template<class T,	std::size_t	N>
 class	array_1d	: public boost::numeric::ublas::vector_expression< array_1d<T, N> >
 {
 public:
-//#ifndef	BOOST_UBLAS_NO_PROXY_SHORTCUTS
-//		BOOST_UBLAS_USING vector_expression<array_1d<T, N> >::operator ();
-//#endif
-
     ///@name Type	Definitions
     ///@{
 
@@ -82,7 +79,6 @@ public:
     typedef	boost::numeric::ublas::vector_reference<self_type>	closure_type;
     typedef	self_type vector_temporary_type;
     typedef	boost::numeric::ublas::dense_tag storage_category;
-//		typedef	concrete_tag simd_category; //removed for the new ublas
 
     ///@}
     ///@name Life	Cycle
@@ -91,62 +87,46 @@ public:
     /// Default constructor.
     BOOST_UBLAS_INLINE
     array_1d ():
-        vector_expression<self_type> ()
+        boost::numeric::ublas::vector_expression<self_type> ()
     {
-        // intentionally does not initialize the contents for performance reasons
     }
 
     explicit BOOST_UBLAS_INLINE
     array_1d (size_type array_size):
-        vector_expression<self_type> ()
+        boost::numeric::ublas::vector_expression<self_type> ()
     {
-        // intentionally does not initialize the contents for performance reasons
     }
 
     explicit BOOST_UBLAS_INLINE
     array_1d (size_type array_size, value_type v):
-        vector_expression<self_type> ()
+        boost::numeric::ublas::vector_expression<self_type> ()
     {
         KRATOS_DEBUG_ERROR_IF(array_size>N) << "Given size is greater than the size of the array!" << std::endl;
-
         std::fill(data().begin(), data().begin() + array_size, v);
-        // intentionally does not initialize the remaining entries for performance reasons
     }
 
     explicit BOOST_UBLAS_INLINE
     array_1d (const std::initializer_list<value_type>& rInitList):
-        vector_expression<self_type> ()
+        boost::numeric::ublas::vector_expression<self_type> ()
     {
         KRATOS_DEBUG_ERROR_IF(rInitList.size()>N) << "Size of list greater than the size of the array!" << std::endl;
-
-        std::copy(rInitList.begin(), rInitList.end(), data().begin()); // copy content of initializer list
-        // intentionally does not initialize the remaining entries for performance reasons
+        std::copy(rInitList.begin(), rInitList.end(), data().begin());
     }
 
     BOOST_UBLAS_INLINE
     array_1d (size_type array_size,	const array_type & rdata):
-        vector_expression<self_type> (),
+        boost::numeric::ublas::vector_expression<self_type> (),
         data_ (rdata) {}
 
     BOOST_UBLAS_INLINE
     array_1d (const array_1d &v):
-        vector_expression<self_type> (),
+        boost::numeric::ublas::vector_expression<self_type> (),
         data_ (v.data_)	{}
-
-//		template<class AE>
-//		BOOST_UBLAS_INLINE
-//		array_1d (const vector_expression<AE>	&ae):
-//			vector_expression<self_type> ()	{
-//			vector_assign (scalar_assign<reference,	typename AE::value_type> (), *this,	ae);
-//		template<class AE> //boost 1.33.1
-//		BOOST_UBLAS_INLINE
-//		array_1d (const vector_expression<AE> &ae):
-//            vector_expression<self_type> () {
-//            vector_assign<scalar_assign> (*this, ae);
 
     template<class AE>
     BOOST_UBLAS_INLINE
-    array_1d (const boost::numeric::ublas::vector_expression<AE> &ae)
+    array_1d (const boost::numeric::ublas::vector_expression<AE> &ae) :
+      boost::numeric::ublas::vector_expression<self_type> () // Initialize base class
     {
         boost::numeric::ublas::vector_assign<boost::numeric::ublas::scalar_assign> (*this, ae);
     }
@@ -195,30 +175,24 @@ public:
     array_1d &operator = (const boost::numeric::ublas::vector_expression<AE>	&ae)
     {
         return assign (self_type	(ae));
-        //self_type temporary	(ae);
-        //return assign_temporary	(temporary);
     }
     template<class AE>
     BOOST_UBLAS_INLINE
     array_1d &operator +=	(const boost::numeric::ublas::vector_expression<AE> &ae)
     {
         return assign (self_type	(*this + ae));
-        //self_type temporary	(*this + ae);
-        //return assign_temporary	(temporary);
     }
     template<class AE>
     BOOST_UBLAS_INLINE
     array_1d &operator -=	(const boost::numeric::ublas::vector_expression<AE> &ae)
     {
         return assign (self_type	(*this - ae));
-        //self_type temporary	(*this - ae);
-        //return assign_temporary	(temporary);
     }
     template<class AT>
     BOOST_UBLAS_INLINE
     array_1d &operator /=	(const AT &at)
     {
-        vector_assign_scalar<scalar_divides_assign> (*this, at); //included for ublas 1.33.1
+        boost::numeric::ublas::vector_assign_scalar<boost::numeric::ublas::scalar_divides_assign> (*this, at);
         return *this;
     }
 
@@ -252,35 +226,32 @@ public:
         return *this;
     }
 
-
     template<class AT>
     BOOST_UBLAS_INLINE
     array_1d &operator *=	(const AT &at)
     {
-        vector_assign_scalar<scalar_multiplies_assign> (*this, at); //included for ublas 1.33.1
+        boost::numeric::ublas::vector_assign_scalar<boost::numeric::ublas::scalar_multiplies_assign> (*this, at);
         return *this;
     }
     template<class AE>
     BOOST_UBLAS_INLINE
     array_1d &plus_assign	(const boost::numeric::ublas::vector_expression<AE> &ae)
     {
-        vector_assign<scalar_plus_assign> (*this, ae); //included for ublas 1.33.1
-        //vector_assign (scalar_plus_assign<reference, typename AE::value_type> (), *this, ae);
+        boost::numeric::ublas::vector_assign<boost::numeric::ublas::scalar_plus_assign> (*this, ae);
         return *this;
     }
     template<class AE>
     BOOST_UBLAS_INLINE
     array_1d &assign (const boost::numeric::ublas::vector_expression<AE>	&ae)
     {
-        vector_assign<scalar_assign> (*this, ae); //included for ublas 1.33.1
-        //vector_assign (scalar_assign<reference,	typename AE::value_type> (), *this,	ae);
+        boost::numeric::ublas::vector_assign<boost::numeric::ublas::scalar_assign> (*this, ae);
         return *this;
     }
     // Swapping
     BOOST_UBLAS_INLINE
     void swap (array_1d &v)
     {
-        if (this !=	&v)
+        if (this !=	&v) 
         {
             data ().swap (v.data ());
         }
@@ -293,22 +264,6 @@ public:
     }
 #endif
 
-    // Element insertion and erasure
-    // These functions should work with	std::vector.
-    // Thanks to Kresimir Fresl	for	spotting this.
-//		BOOST_UBLAS_INLINE
-//		void insert	(size_type i, const_reference t) {
-    // FIXME: only works for EqualityComparable	value types.
-    // BOOST_UBLAS_CHECK (data () [i] == value_type	(0), bad_index ());
-    // Previously: data	().insert (data	().begin ()	+ i, t);
-//			data ()	[i]	= t;
-//		}
-//		BOOST_UBLAS_INLINE
-//		void erase (size_type i) {
-//			// Previously: data	().erase (data ().begin	() + i);
-//			data ()	[i]	= value_type (0);
-//		}
-    // Element assignment
     BOOST_UBLAS_INLINE
     reference insert_element (size_type i, const_reference t)
     {
@@ -324,7 +279,6 @@ public:
     BOOST_UBLAS_INLINE
     void clear ()
     {
-        // Previously: data	().clear ();
         std::fill (data	().begin (), data ().end (), value_type	(0));
     }
 
@@ -332,16 +286,14 @@ public:
     ///@name Access
     ///@{
 
-    // Iterator	types
 private:
-    // Use the storage array1 iterator
     typedef	typename array_type::const_iterator const_iterator_type;
     typedef	typename array_type::iterator iterator_type;
 
 public:
 #ifdef BOOST_UBLAS_USE_INDEXED_ITERATOR
-    typedef	indexed_iterator<self_type,	dense_random_access_iterator_tag> iterator;
-    typedef	indexed_const_iterator<self_type, dense_random_access_iterator_tag>	const_iterator;
+    typedef	boost::numeric::ublas::indexed_iterator<self_type,	boost::numeric::ublas::dense_random_access_iterator_tag> iterator;
+    typedef	boost::numeric::ublas::indexed_const_iterator<self_type, boost::numeric::ublas::dense_random_access_iterator_tag>	const_iterator;
 #else
     class const_iterator;
     class iterator;
@@ -375,8 +327,7 @@ public:
     BOOST_UBLAS_INLINE
     array_1d &minus_assign (const	boost::numeric::ublas::vector_expression<AE> &ae)
     {
-        vector_assign<scalar_minus_assign>(*this,ae);
-        //vector_assign (scalar_minus_assign<reference, typename AE::value_type> (), *this, ae);
+        boost::numeric::ublas::vector_assign<boost::numeric::ublas::scalar_minus_assign>(*this,ae);
         return *this;
     }
     BOOST_UBLAS_INLINE
@@ -392,12 +343,12 @@ public:
 
 #ifndef	BOOST_UBLAS_USE_INDEXED_ITERATOR
     class const_iterator:
-        public container_const_reference<array_1d>,
-        public random_access_iterator_base<dense_random_access_iterator_tag,
+        public boost::numeric::ublas::container_const_reference<self_type>,
+        public boost::numeric::ublas::random_access_iterator_base<typename boost::numeric::ublas::dense_random_access_iterator_tag, //dense_random_access_iterator_tag
         const_iterator, value_type, difference_type>
     {
     public:
-        typedef	dense_random_access_iterator_tag iterator_category;
+        typedef	typename boost::numeric::ublas::dense_random_access_iterator_tag iterator_category; //dense_random_access_iterator_tag
 #ifdef BOOST_MSVC_STD_ITERATOR
         typedef	const_reference	reference;
 #else
@@ -407,20 +358,19 @@ public:
         typedef	const typename array_1d::pointer pointer;
 #endif
 
-        // Construction	and	destruction
         BOOST_UBLAS_INLINE
         const_iterator ():
-            container_const_reference<self_type> (), it_ ()	{}
+            boost::numeric::ublas::container_const_reference<self_type> (), it_ ()	{}
         BOOST_UBLAS_INLINE
         const_iterator (const self_type	&v,	const const_iterator_type &it):
-            container_const_reference<self_type> (v), it_ (it) {}
+            boost::numeric::ublas::container_const_reference<self_type> (v), it_ (it) {}
         BOOST_UBLAS_INLINE
 #ifndef	BOOST_UBLAS_QUALIFIED_TYPENAME
         const_iterator (const iterator &it):
 #else
         const_iterator (const typename self_type::iterator &it):
 #endif
-            container_const_reference<self_type> (it ()), it_ (it.it_) {}
+            boost::numeric::ublas::container_const_reference<self_type> (it ()), it_ (it.it_) {}
 
         // Arithmetic
         BOOST_UBLAS_INLINE
@@ -502,12 +452,12 @@ public:
 
 #ifndef	BOOST_UBLAS_USE_INDEXED_ITERATOR
     class iterator:
-        public container_reference<array_1d>,
-        public random_access_iterator_base<dense_random_access_iterator_tag,
+        public boost::numeric::ublas::container_reference<self_type>,
+        public boost::numeric::ublas::random_access_iterator_base<typename boost::numeric::ublas::dense_random_access_iterator_tag, //dense_random_access_iterator_tag
         iterator, value_type, difference_type>
     {
     public:
-        typedef	dense_random_access_iterator_tag iterator_category;
+        typedef	typename boost::numeric::ublas::dense_random_access_iterator_tag iterator_category; //dense_random_access_iterator_tag
 #ifndef	BOOST_MSVC_STD_ITERATOR
         typedef	typename array_1d::difference_type difference_type;
         typedef	typename array_1d::value_type	value_type;
@@ -515,13 +465,12 @@ public:
         typedef	typename array_1d::pointer pointer;
 #endif
 
-        // Construction	and	destruction
         BOOST_UBLAS_INLINE
         iterator ():
-            container_reference<self_type> (), it_ () {}
+            boost::numeric::ublas::container_reference<self_type> (), it_ () {}
         BOOST_UBLAS_INLINE
         iterator (self_type	&v,	const iterator_type	&it):
-            container_reference<self_type> (v),	it_	(it) {}
+            boost::numeric::ublas::container_reference<self_type> (v),	it_	(it) {}
 
         // Arithmetic
         BOOST_UBLAS_INLINE
@@ -596,11 +545,9 @@ public:
 
     private:
         iterator_type it_;
-
         friend class const_iterator;
     };
 #endif
-
 
     BOOST_UBLAS_INLINE
     const_iterator begin ()	const
@@ -624,10 +571,8 @@ public:
         return find	(data_.size	());
     }
 
-    // Reverse iterator
-
 #ifdef BOOST_MSVC_STD_ITERATOR
-    typedef	reverse_iterator_base<const_iterator, value_type, const_reference> const_reverse_iterator;
+    typedef	boost::numeric::ublas::reverse_iterator_base<const_iterator, value_type, const_reference> const_reverse_iterator;
 #else
     typedef	boost::numeric::ublas::reverse_iterator_base<const_iterator> const_reverse_iterator;
 #endif
@@ -644,7 +589,7 @@ public:
     }
 
 #ifdef BOOST_MSVC_STD_ITERATOR
-    typedef	reverse_iterator_base<iterator,	value_type,	reference> reverse_iterator;
+    typedef	boost::numeric::ublas::reverse_iterator_base<iterator,	value_type,	reference> reverse_iterator;
 #else
     typedef	boost::numeric::ublas::reverse_iterator_base<iterator>	reverse_iterator;
 #endif
@@ -663,62 +608,47 @@ public:
     ///@name Inquiry
     ///@{
 
-
     ///@}
     ///@name Input and output
     ///@{
-
 
     ///@}
     ///@name Friends
     ///@{
 
-
     ///@}
-
 protected:
     ///@name Protected static	Member Variables
     ///@{
-
 
     ///@}
     ///@name Protected member	Variables
     ///@{
 
-
     ///@}
     ///@name Protected Operators
     ///@{
-
 
     ///@}
     ///@name Protected Operations
     ///@{
 
-
     ///@}
     ///@name Protected  Access
     ///@{
-
 
     ///@}
     ///@name Protected Inquiry
     ///@{
 
-
     ///@}
     ///@name Protected LifeCycle
     ///@{
 
-
     ///@}
-
 private:
-
-
     ///@name Static Member Variables
     ///@{
-
 
     ///@}
     ///@name Member Variables
@@ -730,29 +660,23 @@ private:
     ///@name Private Operators
     ///@{
 
-
     ///@}
     ///@name Private Operations
     ///@{
-
 
     ///@}
     ///@name Private	Access
     ///@{
 
-
     ///@}
     ///@name Private Inquiry
     ///@{
-
 
     ///@}
     ///@name Un accessible methods
     ///@{
 
-
     ///@}
-
 }; // Class	array_1d
 
 ///@}
@@ -764,8 +688,6 @@ private:
 ///@{
 
 ///@}
-
-
 }  // namespace	Kratos.
 
 namespace AuxiliaryHashCombine
@@ -787,7 +709,7 @@ namespace AuxiliaryHashCombine
         std::hash<TClassType> hasher;
         rSeed ^= hasher(rValue) + 0x9e3779b9 + (rSeed<<6) + (rSeed>>2);
     }
-} /// namespace
+} /// namespace AuxiliaryHashCombine
 
 namespace std
 {
@@ -800,4 +722,4 @@ struct hash<Kratos::array_1d<T,N>>
             return seed;
         }
 };
-} // namespace std.
+} /// namespace std


### PR DESCRIPTION
**📝 Description**

I just realized that Ublas is polluting our namespace. This is going to be problematic in a future if we want to get rid of Ublas. In here I explicitily call Ublas so in a future refactoring will be easier to identify the Ublas use.

**🆕 Changelog**

- [Avoid Ublas namespace polluting with explicit call in  `array_1d`](https://github.com/KratosMultiphysics/Kratos/commit/9f13378dde0d14978d54fd4d43c439659fbb15a4)
