### PR TITLE
[StructuralMechanicsApplication] increased tolerance for double comparison

### DIFF
--- a/applications/GeoMechanicsApplication/tests/test_set_multiple_moving_load_process.py
+++ b/applications/GeoMechanicsApplication/tests/test_set_multiple_moving_load_process.py
@@ -718,7 +718,7 @@ class KratosGeoMechanicsSetMultipleMovingLoadProcessTests(KratosUnittest.TestCas
             cond.CalculateLocalSystem(lhs, rhs, self.model_part.ProcessInfo)
             all_rhs.append(list(rhs))
 
-        self.assertTrue(np.allclose(all_rhs, [[0.0, 0.0, 0.0, -2.0], [0.0, 0.0, 0.0, 0.0]]))
+        self.assertTrue(np.allclose(all_rhs, [[0.0, 0.0, 0.0, 0.0], [0.0, -2.0, 0.0, 0.0]]))
 
         # move load to next element, also increase time step
         self.model_part.ProcessInfo.SetValue(KratosMultiphysics.DELTA_TIME, 0.75)
@@ -778,7 +778,7 @@ class KratosGeoMechanicsSetMultipleMovingLoadProcessTests(KratosUnittest.TestCas
             cond.CalculateLocalSystem(lhs, rhs, self.model_part.ProcessInfo)
             all_rhs.append(list(rhs))
 
-        self.assertTrue(np.allclose(all_rhs, [[0.0, 0.0, 0.0, -2.0], [0.0, 0.0, 0.0, 0.0]]))
+        self.assertTrue(np.allclose(all_rhs, [[0.0, 0.0, 0.0, 0.0], [0.0, -2.0, 0.0, 0.0]]))
 
         # move load to element connection element
         self.next_solution_step(process)

--- a/applications/StructuralMechanicsApplication/custom_conditions/moving_load_condition.cpp
+++ b/applications/StructuralMechanicsApplication/custom_conditions/moving_load_condition.cpp
@@ -95,13 +95,14 @@ template< std::size_t TDim, std::size_t TNumNodes >
 void MovingLoadCondition<TDim, TNumNodes>::InitializeSolutionStep(const ProcessInfo& rCurrentProcessInfo)
 {
     const double local_x_coord = this->GetValue(MOVING_LOAD_LOCAL_DISTANCE);
+    constexpr double tolerance = std::numeric_limits<double>::epsilon() * 1000.0;
 
     // check if cond should be calculated
     mIsMovingLoad = false;
     for (IndexType i = 0; i < TDim; ++i) {
-        if (std::abs(this->GetValue(POINT_LOAD)[i]) > std::numeric_limits<double>::epsilon() && 
-            local_x_coord <= this->GetGeometry().Length() + std::numeric_limits<double>::epsilon() && 
-            local_x_coord >= 0.0 - std::numeric_limits<double>::epsilon()) {
+        if (std::abs(this->GetValue(POINT_LOAD)[i]) > tolerance &&
+            local_x_coord <= this->GetGeometry().Length() + tolerance &&
+            local_x_coord >= 0.0 - tolerance) {
 
             mIsMovingLoad = true;
         }

--- a/applications/StructuralMechanicsApplication/custom_processes/set_moving_load_process.cpp
+++ b/applications/StructuralMechanicsApplication/custom_processes/set_moving_load_process.cpp
@@ -122,7 +122,7 @@ Condition& SetMovingLoadProcess::GetFirstConditionFromCoord(const double FirstCo
 
 Condition& SetMovingLoadProcess::GetFirstCondition(const Point FirstPoint, const Point SecondPoint, const array_1d<int,3> Direction, std::vector<Condition>& rEndConditions)
 {
-    constexpr double tolerance = std::numeric_limits<double>::epsilon() * 1000;
+    constexpr double tolerance = std::numeric_limits<double>::epsilon() * 1000.0;
 
     // sort on x-coord, if x coords are equal, sort on y coord, if y coord is equal sort on z-coord
     if (std::abs(FirstPoint[0] - SecondPoint[0]) > tolerance){
@@ -138,7 +138,7 @@ Condition& SetMovingLoadProcess::GetFirstCondition(const Point FirstPoint, const
 
 bool SetMovingLoadProcess::IsConditionReversed(const Condition& rCondition, const array_1d<int, 3> Direction)
 {
-    constexpr double tolerance = std::numeric_limits<double>::epsilon() * 1000;
+    constexpr double tolerance = std::numeric_limits<double>::epsilon() * 1000.0;
 
     auto& r_points = rCondition.GetGeometry().Points();
     if (std::abs(r_points[0].X0() - r_points[1].X0()) > tolerance){

--- a/applications/StructuralMechanicsApplication/custom_processes/set_moving_load_process.cpp
+++ b/applications/StructuralMechanicsApplication/custom_processes/set_moving_load_process.cpp
@@ -122,7 +122,7 @@ Condition& SetMovingLoadProcess::GetFirstConditionFromCoord(const double FirstCo
 
 Condition& SetMovingLoadProcess::GetFirstCondition(const Point FirstPoint, const Point SecondPoint, const array_1d<int,3> Direction, std::vector<Condition>& rEndConditions)
 {
-    constexpr double tolerance = std::numeric_limits<double>::epsilon();
+    constexpr double tolerance = std::numeric_limits<double>::epsilon() * 1000;
 
     // sort on x-coord, if x coords are equal, sort on y coord, if y coord is equal sort on z-coord
     if (std::abs(FirstPoint[0] - SecondPoint[0]) > tolerance){
@@ -138,7 +138,7 @@ Condition& SetMovingLoadProcess::GetFirstCondition(const Point FirstPoint, const
 
 bool SetMovingLoadProcess::IsConditionReversed(const Condition& rCondition, const array_1d<int, 3> Direction)
 {
-    constexpr double tolerance = std::numeric_limits<double>::epsilon();
+    constexpr double tolerance = std::numeric_limits<double>::epsilon() * 1000;
 
     auto& r_points = rCondition.GetGeometry().Points();
     if (std::abs(r_points[0].X0() - r_points[1].X0()) > tolerance){
@@ -360,6 +360,7 @@ void SetMovingLoadProcess::ExecuteInitializeSolutionStep()
     // bool to check if load is already added, such that a load is not added twice if the load is exactly at a shared node.
     bool is_moving_load_added = false;
 
+	constexpr double tolerance = std::numeric_limits<double>::epsilon() * 1000.0;
     // loop over sorted conditions vector
     for (IndexType i = 0; i < mSortedConditionsIds.size(); ++i) {
         auto& r_cond = mrModelPart.GetCondition(mSortedConditionsIds[i]);
@@ -367,8 +368,8 @@ void SetMovingLoadProcess::ExecuteInitializeSolutionStep()
         const double element_length = r_geom.Length();
 
         // if moving load is located at current condition element, apply moving load, else apply a zero load
-        if (distance_cond + element_length >= mCurrentDistance - std::numeric_limits<double>::epsilon() && 
-            distance_cond <= mCurrentDistance + std::numeric_limits<double>::epsilon() && 
+        if (distance_cond + element_length >= mCurrentDistance - tolerance &&
+            distance_cond <= mCurrentDistance + tolerance &&
             !is_moving_load_added){
 
             double local_distance;

--- a/applications/StructuralMechanicsApplication/tests/test_loading_conditions_moving.py
+++ b/applications/StructuralMechanicsApplication/tests/test_loading_conditions_moving.py
@@ -962,8 +962,8 @@ class TestLoadingConditionsMoving(KratosUnittest.TestCase):
 
         strategy = self.setup_strategy(mp)
         # create nodes
-        second_coord = [0.3, 0.0, 0.0]
-        third_coord = [0.15, 0.0, 0.0]
+        second_coord = [200.3, 0.0, 0.0]
+        third_coord = [100.15, 0.0, 0.0]
         mp.CreateNewNode(1,0.0,0.0,0.0)
         mp.CreateNewNode(2,second_coord[0],second_coord[1],second_coord[2])
         mp.CreateNewNode(3, third_coord[0], third_coord[1], third_coord[2])
@@ -988,8 +988,8 @@ class TestLoadingConditionsMoving(KratosUnittest.TestCase):
         cond.SetValue(StructuralMechanicsApplication.POINT_LOAD, load_on_cond)
 
         # set load outside condition with a local distance with a floating point inaccuracy
-        # ( 0.1+0.2 = 0.30000000000000004)
-        cond.SetValue(StructuralMechanicsApplication.MOVING_LOAD_LOCAL_DISTANCE, 0.1+0.2)
+        # ( 100.1+100.2 = 200.30000000000001)
+        cond.SetValue(StructuralMechanicsApplication.MOVING_LOAD_LOCAL_DISTANCE, 100.1+100.2)
         strategy.InitializeSolutionStep()
         cond.CalculateLocalSystem(lhs, rhs, mp.ProcessInfo)
 

--- a/applications/StructuralMechanicsApplication/tests/test_set_moving_load_process.py
+++ b/applications/StructuralMechanicsApplication/tests/test_set_moving_load_process.py
@@ -985,8 +985,8 @@ class TestSetMovingLoadProcess(KratosUnittest.TestCase):
             cond.CalculateLocalSystem(lhs, rhs, mp.ProcessInfo)
             all_rhs.append(list(rhs))
 
-        self.checkRHS(all_rhs[0], [0.0, 0.0, 0.0, -2.0])
-        self.checkRHS(all_rhs[1], [0.0, 0.0, 0.0, 0.0])
+        self.checkRHS(all_rhs[0], [0.0, 0.0, 0.0, 0.0])
+        self.checkRHS(all_rhs[1], [0.0, -2.0, 0.0, 0.0])
 
         # move load to next element, also increase time step
         mp.ProcessInfo.SetValue(KratosMultiphysics.DELTA_TIME, 0.75)
@@ -1078,8 +1078,8 @@ class TestSetMovingLoadProcess(KratosUnittest.TestCase):
             cond.CalculateLocalSystem(lhs, rhs, mp.ProcessInfo)
             all_rhs.append(list(rhs))
 
-        self.checkRHS(all_rhs[0], [0.0, 0.0, 0.0, -2.0])
-        self.checkRHS(all_rhs[1], [0.0, 0.0, 0.0, 0.0])
+        self.checkRHS(all_rhs[0], [0.0, 0.0, 0.0, 0.0])
+        self.checkRHS(all_rhs[1], [0.0, -2.0, 0.0, 0.0])
 
         # move load to element connection element
         process.ExecuteFinalizeSolutionStep()


### PR DESCRIPTION
tolerance for double comparison in moving load is increased, as the std::numerical_limits<double>epsilon is too small