### PR TITLE
[Core] Fix SparseContiguousRowGraph

### DIFF
--- a/kratos/containers/sparse_contiguous_row_graph.h
+++ b/kratos/containers/sparse_contiguous_row_graph.h
@@ -135,7 +135,7 @@ public:
     void Clear()
     {
         mGraph.clear();
-        mLocks.clear();
+        mLocks = decltype(mLocks)(mGraph.size());
     }
 
     inline IndexType Size() const{


### PR DESCRIPTION
**📝 Description**
Current implementation fails if `Clear` is called and `mLock` is hard-cleared. This prevents `mLock` from having size 0 and crash when adding entries.

Probably works now if `mLock` is marked as dirty mem