### PR TITLE
[IgaApplication] quick PR to export "NurbsCurveOnSurfaceGeometry3DType" to python

### DIFF
--- a/kratos/python/add_geometries_to_python.cpp
+++ b/kratos/python/add_geometries_to_python.cpp
@@ -48,6 +48,7 @@
 #include "geometries/nurbs_volume_geometry.h"
 #include "geometries/nurbs_surface_geometry.h"
 #include "geometries/nurbs_curve_geometry.h"
+#include "geometries/nurbs_curve_on_surface_geometry.h"
 #include "geometries/surface_in_nurbs_volume_geometry.h"
 
 namespace Kratos::Python
@@ -358,6 +359,15 @@ void  AddGeometriesToPython(pybind11::module& m)
         .def("IsRational", &NurbsCurveGeometry<2, NodeContainerType>::IsRational)
         .def("Weights", &NurbsCurveGeometry<2, NodeContainerType>::Weights)
         ;
+
+    // NurbsCurveOnSurface3D
+    using NurbsCurveOnSurfaceGeometry3DType = Kratos::NurbsCurveOnSurfaceGeometry<3, NodeContainerType, NodeContainerType>;
+    py::class_<NurbsCurveOnSurfaceGeometry3DType, NurbsCurveOnSurfaceGeometry3DType::Pointer, GeometryType>(m, "NurbsCurveOnSurfaceGeometry3D")
+        .def(py::init<
+            NurbsCurveOnSurfaceGeometry3DType::NurbsSurfaceType::Pointer,
+            NurbsCurveOnSurfaceGeometry3DType::NurbsCurveType::Pointer>())
+        ;
+
 
     py::class_<SurfaceInNurbsVolumeGeometry<3, NodeContainerType>, SurfaceInNurbsVolumeGeometry<3, NodeContainerType>::Pointer, GeometryType>(m, "SurfaceInNurbsVolumeGeometry")
         .def(py::init<NurbsVolumeGeometry<NodeContainerType>::Pointer, GeometryType::Pointer>())


### PR DESCRIPTION
**📝 Description**
We need `NurbsCurveOnSurfaceGeometry3DType` to be exported to Python for the tests, particularly for the test pf the conditions, which are defined as curves on surface.