### PR TITLE
[Several] Fix `warning: ‘static std::string Kratos::FilesystemExtensions::CurrentWorkingDirectory()’ is deprecated: Please use std::filesystem directly [-Wdeprecated-declarations]`

### DIFF
--- a/applications/CSharpWrapperApplication/tests/cpp_tests/test_calculate.cpp
+++ b/applications/CSharpWrapperApplication/tests/cpp_tests/test_calculate.cpp
@@ -191,7 +191,7 @@ namespace Kratos {
 //             KRATOS_EXPECT_NEAR(y[3], 1.0, float_epsilon);
 //             KRATOS_EXPECT_NEAR(z[3], 0.0, float_epsilon);
 
-            Kratos::filesystem::remove((FilesystemExtensions::JoinPaths({FilesystemExtensions::CurrentWorkingDirectory(), "file.mdpa"})).c_str());
+            std::filesystem::remove((FilesystemExtensions::JoinPaths({FilesystemExtensions::CurrentWorkingDirectory(), "file.mdpa"})).c_str());
         }
 
         /**
@@ -297,8 +297,8 @@ namespace Kratos {
 //             KRATOS_EXPECT_NEAR(y[3], 1.0, float_epsilon);
 //             KRATOS_EXPECT_NEAR(z[3], 0.0, float_epsilon);
 
-            Kratos::filesystem::remove((FilesystemExtensions::JoinPaths({FilesystemExtensions::CurrentWorkingDirectory(), "file.mdpa"})).c_str());
-            Kratos::filesystem::remove((FilesystemExtensions::JoinPaths({FilesystemExtensions::CurrentWorkingDirectory(), "file.json"})).c_str());
+            std::filesystem::remove((FilesystemExtensions::JoinPaths({FilesystemExtensions::CurrentWorkingDirectory(), "file.mdpa"})).c_str());
+            std::filesystem::remove((FilesystemExtensions::JoinPaths({FilesystemExtensions::CurrentWorkingDirectory(), "file.json"})).c_str());
         }
 
     } // namespace Testing

--- a/applications/ContactStructuralMechanicsApplication/tests/cpp_tests/linear_solvers/test_mixedulm_linear_solver.cpp
+++ b/applications/ContactStructuralMechanicsApplication/tests/cpp_tests/linear_solvers/test_mixedulm_linear_solver.cpp
@@ -16,7 +16,6 @@
 // External includes
 
 // Project includes
-#include "includes/define.h"
 #include "includes/model_part.h"
 #include "includes/matrix_market_interface.h"
 #include "includes/kratos_filesystem.h"
@@ -986,8 +985,8 @@ KRATOS_TEST_CASE_IN_SUITE(MixedULMLinearSolverRealSystem, KratosContactStructura
     const bool read_b = Kratos::ReadMatrixMarketVector(FilesystemExtensions::JoinPaths({FilesystemExtensions::CurrentWorkingDirectory(), "b_testing_condensation.rhs"}).c_str(), b);
 
     // Removing files
-    Kratos::filesystem::remove(FilesystemExtensions::JoinPaths({FilesystemExtensions::CurrentWorkingDirectory(), "A_testing_condensation.mm"}));
-    Kratos::filesystem::remove(FilesystemExtensions::JoinPaths({FilesystemExtensions::CurrentWorkingDirectory(), "b_testing_condensation.rhs"}));
+    std::filesystem::remove(FilesystemExtensions::JoinPaths({FilesystemExtensions::CurrentWorkingDirectory(), "A_testing_condensation.mm"}));
+    std::filesystem::remove(FilesystemExtensions::JoinPaths({FilesystemExtensions::CurrentWorkingDirectory(), "b_testing_condensation.rhs"}));
 
     if (read_a && read_b) {
         // We solve the reference system

--- a/applications/MeshingApplication/tests/cpp_tests/mmg/test_mmg_io.cpp
+++ b/applications/MeshingApplication/tests/cpp_tests/mmg/test_mmg_io.cpp
@@ -4,8 +4,8 @@
 //        | |  | | |___ ___) |  _  || || |\  | |_| |
 //        |_|  |_|_____|____/|_| |_|___|_| \_|\____| APPLICATION
 //
-//  License:		 BSD License
-//                       license: MeshingApplication/license.txt
+//  License:         BSD License
+//                   license: MeshingApplication/license.txt
 //
 //  Main authors:    Vicente Mataix Ferrandiz
 //
@@ -82,11 +82,11 @@ namespace Kratos
                 KRATOS_EXPECT_TRUE(r_aux_model_part.HasSubModelPart(r_sub_model_part_name));
             }
 
-            Kratos::filesystem::remove((FilesystemExtensions::JoinPaths({FilesystemExtensions::CurrentWorkingDirectory(), "mmg_output_2d.mesh"})).c_str());
-            Kratos::filesystem::remove((FilesystemExtensions::JoinPaths({FilesystemExtensions::CurrentWorkingDirectory(), "mmg_output_2d.sol"})).c_str());
-            Kratos::filesystem::remove((FilesystemExtensions::JoinPaths({FilesystemExtensions::CurrentWorkingDirectory(), "mmg_output_2d.json"})).c_str());
-            Kratos::filesystem::remove((FilesystemExtensions::JoinPaths({FilesystemExtensions::CurrentWorkingDirectory(), "mmg_output_2d.cond.ref.json"})).c_str());
-            Kratos::filesystem::remove((FilesystemExtensions::JoinPaths({FilesystemExtensions::CurrentWorkingDirectory(), "mmg_output_2d.elem.ref.json"})).c_str());
+            std::filesystem::remove((FilesystemExtensions::JoinPaths({FilesystemExtensions::CurrentWorkingDirectory(), "mmg_output_2d.mesh"})).c_str());
+            std::filesystem::remove((FilesystemExtensions::JoinPaths({FilesystemExtensions::CurrentWorkingDirectory(), "mmg_output_2d.sol"})).c_str());
+            std::filesystem::remove((FilesystemExtensions::JoinPaths({FilesystemExtensions::CurrentWorkingDirectory(), "mmg_output_2d.json"})).c_str());
+            std::filesystem::remove((FilesystemExtensions::JoinPaths({FilesystemExtensions::CurrentWorkingDirectory(), "mmg_output_2d.cond.ref.json"})).c_str());
+            std::filesystem::remove((FilesystemExtensions::JoinPaths({FilesystemExtensions::CurrentWorkingDirectory(), "mmg_output_2d.elem.ref.json"})).c_str());
         }
 
         /**
@@ -145,11 +145,11 @@ namespace Kratos
                 KRATOS_EXPECT_TRUE(r_aux_model_part.HasSubModelPart(r_sub_model_part_name));
             }
 
-            Kratos::filesystem::remove((FilesystemExtensions::JoinPaths({FilesystemExtensions::CurrentWorkingDirectory(), "mmg_output_3d.mesh"})).c_str());
-            Kratos::filesystem::remove((FilesystemExtensions::JoinPaths({FilesystemExtensions::CurrentWorkingDirectory(), "mmg_output_3d.sol"})).c_str());
-            Kratos::filesystem::remove((FilesystemExtensions::JoinPaths({FilesystemExtensions::CurrentWorkingDirectory(), "mmg_output_3d.json"})).c_str());
-            Kratos::filesystem::remove((FilesystemExtensions::JoinPaths({FilesystemExtensions::CurrentWorkingDirectory(), "mmg_output_3d.cond.ref.json"})).c_str());
-            Kratos::filesystem::remove((FilesystemExtensions::JoinPaths({FilesystemExtensions::CurrentWorkingDirectory(), "mmg_output_3d.elem.ref.json"})).c_str());
+            std::filesystem::remove((FilesystemExtensions::JoinPaths({FilesystemExtensions::CurrentWorkingDirectory(), "mmg_output_3d.mesh"})).c_str());
+            std::filesystem::remove((FilesystemExtensions::JoinPaths({FilesystemExtensions::CurrentWorkingDirectory(), "mmg_output_3d.sol"})).c_str());
+            std::filesystem::remove((FilesystemExtensions::JoinPaths({FilesystemExtensions::CurrentWorkingDirectory(), "mmg_output_3d.json"})).c_str());
+            std::filesystem::remove((FilesystemExtensions::JoinPaths({FilesystemExtensions::CurrentWorkingDirectory(), "mmg_output_3d.cond.ref.json"})).c_str());
+            std::filesystem::remove((FilesystemExtensions::JoinPaths({FilesystemExtensions::CurrentWorkingDirectory(), "mmg_output_3d.elem.ref.json"})).c_str());
         }
     } // namespace Testing
 }  // namespace Kratos.


### PR DESCRIPTION
**📝 Description**

Fix `warning: ‘static std::string Kratos::FilesystemExtensions::CurrentWorkingDirectory()’ is deprecated: Please use std::filesystem directly [-Wdeprecated-declarations]`.

**🆕 Changelog**

- [Contact, fix `warning: ‘static std::string Kratos::FilesystemExtensions::CurrentWorkingDirectory()’ is deprecated: Please use std::filesystem directly [-Wdeprecated-declarations]`](https://github.com/KratosMultiphysics/Kratos/commit/7c9fcd1bfd93c96d2415ee85a2a031b0e8e32757)
- [Meshing, fix `warning: ‘static std::string Kratos::FilesystemExtensions::CurrentWorkingDirectory()’ is deprecated: Please use std::filesystem directly [-Wdeprecated-declarations]`](https://github.com/KratosMultiphysics/Kratos/commit/79109d60ac015ca06b8e96f14e72ef4ae09c3587)
- [C#, fix `warning: ‘static std::string Kratos::FilesystemExtensions::CurrentWorkingDirectory()’ is deprecated: Please use std::filesystem directly [-Wdeprecated-declarations]`](https://github.com/KratosMultiphysics/Kratos/commit/1cdfad37e30a5083f629e079d2504197848a2e4e)
