### PR TITLE
[Core] Remove deprecated `Timer` function calls in the Python bindings

### DIFF
--- a/kratos/python/add_other_utilities_to_python.cpp
+++ b/kratos/python/add_other_utilities_to_python.cpp
@@ -253,8 +253,6 @@ void AddOtherUtilitiesToPython(pybind11::module &m)
         .def_static("GetTime", &Timer::GetTime)
         .def_static("SetOutputFile", &Timer::SetOutputFile)
         .def_static("CloseOutputFile", &Timer::CloseOutputFile)
-        .def_static("SetOuputFile", &Timer::SetOuputFile) // TODO: Remove this line eventually, it is a typo
-        .def_static("CloseOuputFile", &Timer::CloseOuputFile) // TODO: Remove this line eventually, it is a typo
         .def_static("GetPrintOnScreen", &Timer::GetPrintOnScreen)
         .def_static("SetPrintOnScreen", &Timer::SetPrintOnScreen)
         .def_static("GetPrintIntervalInformation", &Timer::GetPrintIntervalInformation)


### PR DESCRIPTION
**📝 Description**

Correct the misspelled and deprecated `SetOuputFile` and `CloseOuputFile` to the proper `SetOutputFile` and `CloseOutputFile` within the Python bindings for the `Timer` utility.

As indicated by the **TODO** comments in `kratos/python/add_other_utilities_to_python.cpp`.

**🆕 Changelog**

- [Remove deprecated `Timer` function calls in the Python bindings](https://github.com/KratosMultiphysics/Kratos/commit/53d56481f02e7aa111753eedf0e76b17d9f5ae62)
