### PR TITLE
[Core] Fix the deprecated `Data()` method in `model_part_io.cpp`

### DIFF
--- a/kratos/sources/model_part_io.cpp
+++ b/kratos/sources/model_part_io.cpp
@@ -184,7 +184,7 @@ void ModelPartIO::WriteProperties(PropertiesContainerType const& rThisProperties
     for (auto i_properties = rThisProperties.begin() ; i_properties != rThisProperties.end() ; ++i_properties) {
         std::ostringstream aux_ostream;
         (*mpStream) << "Begin Properties " << i_properties->Id() << std::endl;
-        i_properties->Data().PrintData(aux_ostream);
+        i_properties->GetData().PrintData(aux_ostream);
 
         aux_string = aux_ostream.str();
 


### PR DESCRIPTION
**📝 Description**

Fixes the deprecated `Data()` method with `GetData()` in `kratos/sources/model_part_io.cpp` as per the warning message.

~~~sh
/__w/Kratos/Kratos/kratos/sources/model_part_io.cpp:187:23: warning: 'Data' is deprecated: This method is deprecated. Use 'GetData()' instead. [-Wdeprecated-declarations] i_properties->Data().PrintData(aux_ostream); ^ /__w/Kratos/Kratos/kratos/includes/properties.h:541:5: note: 'Data' has been explicitly marked deprecated here KRATOS_DEPRECATED_MESSAGE("This method is deprecated. Use 'GetData()' instead.") ^ /__w/Kratos/Kratos/kratos/includes/define.h:769:57: note: expanded from macro 'KRATOS_DEPRECATED_MESSAGE' #define KRATOS_DEPRECATED_MESSAGE(deprecated_message) [[deprecated(deprecated_message)]]
~~~

**🆕 Changelog**

- [Fix the deprecated `Data()` method in `model_part_io.cpp`](https://github.com/KratosMultiphysics/Kratos/commit/23b9fd56d8afcd3a64b8094dd014e9850f9fbd39)
