### PR TITLE
[Several] Remove remaining deprecated warning for `std::filesystem`

### DIFF
--- a/applications/CSharpWrapperApplication/tests/cpp_tests/test_calculate.cpp
+++ b/applications/CSharpWrapperApplication/tests/cpp_tests/test_calculate.cpp
@@ -86,8 +86,8 @@ namespace Kratos {
             })");
             const std::string &r_json_text = json_parameters.PrettyPrintJsonString();
             std::filebuf buffer;
-            file_path = std::filesystem::current_path() / "file.json";
-            buffer.open(file_path.string().c_str(), std::ios::out);
+            std::filesystem::path file_path_json = std::filesystem::current_path() / "file.json";
+            buffer.open(file_path_json.string().c_str(), std::ios::out);
             std::ostream os(&buffer);
             os << r_json_text;
             buffer.close();

--- a/applications/CSharpWrapperApplication/tests/cpp_tests/test_calculate.cpp
+++ b/applications/CSharpWrapperApplication/tests/cpp_tests/test_calculate.cpp
@@ -8,10 +8,10 @@
 //                                 |_|                     |_|   |_|                    |_|   |_|
 //
 //
-//  License: BSD License
-//   license: CSharpWrapperApplication/license.txt
+//  License:         BSD License
+//                   license: CSharpWrapperApplication/license.txt
 //
-//  Main authors:  Vicente Mataix Ferrandiz
+//  Main authors:    Vicente Mataix Ferrandiz
 //
 
 // System includes
@@ -28,10 +28,10 @@ namespace Kratos {
     namespace Testing {
         void CreateMDPAFile() {
             std::filebuf buffer;
-            buffer.open(FilesystemExtensions::JoinPaths({FilesystemExtensions::CurrentWorkingDirectory(), "file.mdpa"}), std::ios::out);
+            std::filesystem::path file_path = std::filesystem::current_path() / "file.mdpa";
+            buffer.open(file_path.string().c_str(), std::ios::out);
             std::ostream os(&buffer);
-            os
-                    << "Begin ModelPartData\nEnd ModelPartData\n\nBegin Properties  0\n    DENSITY 2700.000000\n    YOUNG_MODULUS 7000000.000000\n    POISSON_RATIO 0.300000\n    BODY_FORCE [3] (0.000000,0.000000,0.000000)\n    THICKNESS 1.000000\nEnd Properties\n\nBegin Nodes\n        1        0.0        0.0         0.0\n        2        0.0        0.0         1.0\n        3        1.0        0.0         0.0\n        4        1.0        1.0         0.0\nEnd Nodes\n\nBegin Elements SmallDisplacementElement3D4N\n    1 0 1 2 3 4\nEnd Elements\n\nBegin SubModelPart BasePart // Note that this would be a sub sub modelpart\n    Begin SubModelPartNodes\n        1\n        2\n    End SubModelPartNodes\n    Begin SubModelPart inner_part\n        Begin SubModelPartNodes\n            1\n        End SubModelPartNodes\n    End SubModelPart\nEnd SubModelPart";
+            os << "Begin ModelPartData\nEnd ModelPartData\n\nBegin Properties  0\n    DENSITY 2700.000000\n    YOUNG_MODULUS 7000000.000000\n    POISSON_RATIO 0.300000\n    BODY_FORCE [3] (0.000000,0.000000,0.000000)\n    THICKNESS 1.000000\nEnd Properties\n\nBegin Nodes\n        1        0.0        0.0         0.0\n        2        0.0        0.0         1.0\n        3        1.0        0.0         0.0\n        4        1.0        1.0         0.0\nEnd Nodes\n\nBegin Elements SmallDisplacementElement3D4N\n    1 0 1 2 3 4\nEnd Elements\n\nBegin SubModelPart BasePart // Note that this would be a sub sub modelpart\n    Begin SubModelPartNodes\n        1\n        2\n    End SubModelPartNodes\n    Begin SubModelPart inner_part\n        Begin SubModelPartNodes\n            1\n        End SubModelPartNodes\n    End SubModelPart\nEnd SubModelPart";
             buffer.close();
         }
 
@@ -86,7 +86,8 @@ namespace Kratos {
             })");
             const std::string &r_json_text = json_parameters.PrettyPrintJsonString();
             std::filebuf buffer;
-            buffer.open(FilesystemExtensions::JoinPaths({FilesystemExtensions::CurrentWorkingDirectory(), "file.json"}), std::ios::out);
+            file_path = std::filesystem::current_path() / "file.json";
+            buffer.open(file_path.string().c_str(), std::ios::out);
             std::ostream os(&buffer);
             os << r_json_text;
             buffer.close();
@@ -102,9 +103,9 @@ namespace Kratos {
 
             // Import mdpa
             CreateMDPAFile();
-            const std::string file_name = FilesystemExtensions::JoinPaths({FilesystemExtensions::CurrentWorkingDirectory(), "file.mdpa"});
+            std::filesystem::path file_path = std::filesystem::current_path() / "file.mdpa";
             CSharpKratosWrapper::KratosWrapper *wrapperInstance = new CSharpKratosWrapper::KratosWrapper();
-            wrapperInstance->init(file_name.c_str());
+            wrapperInstance->init(file_path.string().c_str());
             CSharpKratosWrapper::ModelPartWrapper *mainModelPart = wrapperInstance->getRootModelPartWrapper();
             // Get some API info
             mainModelPart->retrieveResults();
@@ -191,7 +192,7 @@ namespace Kratos {
 //             KRATOS_EXPECT_NEAR(y[3], 1.0, float_epsilon);
 //             KRATOS_EXPECT_NEAR(z[3], 0.0, float_epsilon);
 
-            std::filesystem::remove((FilesystemExtensions::JoinPaths({FilesystemExtensions::CurrentWorkingDirectory(), "file.mdpa"})).c_str());
+            std::filesystem::remove(file_path);
         }
 
         /**
@@ -205,11 +206,11 @@ namespace Kratos {
             // Import mdpa
             CreateMDPAFile();
             CreateJSONFile();
-            const std::string file_name = FilesystemExtensions::JoinPaths({FilesystemExtensions::CurrentWorkingDirectory(), "file.mdpa"});
-            const std::string file_name_json = FilesystemExtensions::JoinPaths({FilesystemExtensions::CurrentWorkingDirectory(), "file.json"});
+            std::filesystem::path file_path = std::filesystem::current_path() / "file.mdpa";
+            std::filesystem::path file_path_json = std::filesystem::current_path() / "file.json";
             CSharpKratosWrapper::KratosWrapper *wrapperInstance = new CSharpKratosWrapper::KratosWrapper();
 
-            wrapperInstance->init(file_name.c_str(), file_name_json.c_str());
+            wrapperInstance->init(file_path.string().c_str(), file_path_json.string().c_str());
             CSharpKratosWrapper::ModelPartWrapper *mainModelPart = wrapperInstance->getRootModelPartWrapper();
 
             // Get some API info
@@ -297,8 +298,8 @@ namespace Kratos {
 //             KRATOS_EXPECT_NEAR(y[3], 1.0, float_epsilon);
 //             KRATOS_EXPECT_NEAR(z[3], 0.0, float_epsilon);
 
-            std::filesystem::remove((FilesystemExtensions::JoinPaths({FilesystemExtensions::CurrentWorkingDirectory(), "file.mdpa"})).c_str());
-            std::filesystem::remove((FilesystemExtensions::JoinPaths({FilesystemExtensions::CurrentWorkingDirectory(), "file.json"})).c_str());
+            std::filesystem::remove(file_path);
+            std::filesystem::remove(file_path_json);
         }
 
     } // namespace Testing

--- a/applications/ContactStructuralMechanicsApplication/tests/cpp_tests/linear_solvers/test_mixedulm_linear_solver.cpp
+++ b/applications/ContactStructuralMechanicsApplication/tests/cpp_tests/linear_solvers/test_mixedulm_linear_solver.cpp
@@ -60,7 +60,8 @@ void CreateAuxiliaryFiles()
     const std::string lhs = "%%MatrixMarket matrix coordinate real general\n16 16 184\n1 1 4.00969e+10\n1 2 0\n1 3 0\n1 4 0\n1 7 0\n1 8 0\n2 1 0\n2 2 1.35566e+11\n2 3 0\n2 4 0\n2 7 0\n2 8 0\n3 1 0\n3 2 0\n3 3 1.4559e+11\n3 4 0\n3 5 0\n3 6 0\n3 7 0\n3 8 0\n3 9 0\n3 10 0\n3 11 0\n3 12 0\n3 13 0\n3 14 0\n4 1 0\n4 2 0\n4 3 0\n4 4 2.22633e+10\n4 5 0\n4 6 -1.0345e+11\n4 7 0\n4 8 -6.20547e+09\n4 9 0\n4 10 -1.14853e-05\n4 11 0\n4 12 0.000525451\n4 13 0\n4 14 5.1725e+10\n5 3 0\n5 4 0\n5 5 2.069e+11\n5 6 0\n5 7 0\n5 8 0\n5 9 0\n5 10 0\n5 11 0\n5 12 0\n5 13 0\n5 14 0\n6 3 0\n6 4 -1.0345e+11\n6 5 0\n6 6 0\n6 7 0\n6 8 0\n6 9 0\n6 10 0\n6 11 0\n6 12 0.00103942\n6 13 0\n6 14 1.0345e+11\n7 1 0\n7 2 0\n7 3 0\n7 4 0\n7 5 0\n7 6 0\n7 7 1.4559e+11\n7 8 0\n7 9 0\n7 10 0\n7 11 0\n7 12 0\n7 13 0\n7 14 0\n8 1 0\n8 2 0\n8 3 0\n8 4 -6.20547e+09\n8 5 0\n8 6 0\n8 7 0\n8 8 2.22633e+10\n8 9 0\n8 10 -1.0345e+11\n8 11 0\n8 12 5.1725e+10\n8 13 0\n8 14 5.74263e-06\n9 3 0\n9 4 0\n9 5 0\n9 6 0\n9 7 0\n9 8 0\n9 9 2.069e+11\n9 10 0\n9 11 0\n9 12 0\n9 13 0\n9 14 0\n10 3 0\n10 4 -1.14853e-05\n10 5 0\n10 6 0\n10 7 0\n10 8 -1.0345e+11\n10 9 0\n10 10 0\n10 11 0\n10 12 1.0345e+11\n10 13 0\n10 14 1.14853e-05\n11 3 0\n11 4 0\n11 5 0\n11 6 0\n11 7 0\n11 8 0\n11 9 0\n11 10 0\n11 11 1.45464e+11\n11 12 0\n11 13 0\n11 14 0\n11 15 0\n11 16 0\n12 3 0\n12 4 0.000525451\n12 5 0\n12 6 0.00103942\n12 7 0\n12 8 5.1725e+10\n12 9 0\n12 10 1.0345e+11\n12 11 0\n12 12 2.22572e+10\n12 13 0\n12 14 -6.13145e+09\n12 15 0\n12 16 0\n13 3 0\n13 4 0\n13 5 0\n13 6 0\n13 7 0\n13 8 0\n13 9 0\n13 10 0\n13 11 0\n13 12 0\n13 13 1.45464e+11\n13 14 0\n13 15 0\n13 16 0\n14 3 0\n14 4 5.1725e+10\n14 5 0\n14 6 1.0345e+11\n14 7 0\n14 8 5.74263e-06\n14 9 0\n14 10 1.14853e-05\n14 11 0\n14 12 -6.13145e+09\n14 13 0\n14 14 2.22572e+10\n14 15 0\n14 16 0\n15 11 0\n15 12 0\n15 13 0\n15 14 0\n15 15 4.0137e+10\n15 16 0\n16 11 0\n16 12 0\n16 13 0\n16 14 0\n16 15 0\n16 16 1.35701e+11\n";
 
     std::filebuf buffer_lhs;
-    buffer_lhs.open(std::filesystem::path(FilesystemExtensions::CurrentWorkingDirectory()) / "A_testing_condensation.mm",std::ios::out);
+    std::filesystem::path file_path = std::filesystem::current_path() / "A_testing_condensation.mm";
+    buffer_lhs.open(file_path.string().c_str(),std::ios::out);
     std::ostream os_lhs(&buffer_lhs);
     os_lhs << lhs;
     buffer_lhs.close();
@@ -68,7 +69,8 @@ void CreateAuxiliaryFiles()
     const std::string rhs = "%%MatrixMarket matrix array real general\n16 1\n0\n0\n0\n-5.1725e+07\n0\n-1.0345e+08\n0\n-5.1725e+07\n0\n-1.0345e+08\n0\n-6.23386e+08\n0\n-6.23386e+08\n0\n0\n";
 
     std::filebuf buffer_rhs;
-    buffer_rhs.open(std::filesystem::path(FilesystemExtensions::CurrentWorkingDirectory()) / "b_testing_condensation.rhs",std::ios::out);
+    file_path = std::filesystem::current_path() / "b_testing_condensation.rhs";
+    buffer_rhs.open(file_path.string().c_str(),std::ios::out);
     std::ostream os_rhs(&buffer_rhs);
     os_rhs << rhs;
     buffer_rhs.close();
@@ -981,12 +983,14 @@ KRATOS_TEST_CASE_IN_SUITE(MixedULMLinearSolverRealSystem, KratosContactStructura
 
     // CHANGE THIS TO ADAPT TO YOUR PROBLEM
     CreateAuxiliaryFiles();
-    const bool read_a = Kratos::ReadMatrixMarketMatrix((std::filesystem::path(FilesystemExtensions::CurrentWorkingDirectory()) / "A_testing_condensation.mm").c_str(), A);
-    const bool read_b = Kratos::ReadMatrixMarketVector((std::filesystem::path(FilesystemExtensions::CurrentWorkingDirectory()) / "b_testing_condensation.rhs").c_str(), b);
+    std::filesystem::path file_path_a = std::filesystem::current_path() / "A_testing_condensation.mm";
+    const bool read_a = Kratos::ReadMatrixMarketMatrix(file_path_a.string().c_str(), A);
+    std::filesystem::path file_path_b = std::filesystem::current_path() / "b_testing_condensation.rhs";
+    const bool read_b = Kratos::ReadMatrixMarketVector(file_path_b.string().c_str(), b);
 
     // Removing files
-    std::filesystem::remove(std::filesystem::path(FilesystemExtensions::CurrentWorkingDirectory()) / "A_testing_condensation.mm");
-    std::filesystem::remove(std::filesystem::path(FilesystemExtensions::CurrentWorkingDirectory()) / "b_testing_condensation.rhs");
+    std::filesystem::remove(file_path_a);
+    std::filesystem::remove(file_path_b);
 
     if (read_a && read_b) {
         // We solve the reference system

--- a/applications/ContactStructuralMechanicsApplication/tests/cpp_tests/linear_solvers/test_mixedulm_linear_solver.cpp
+++ b/applications/ContactStructuralMechanicsApplication/tests/cpp_tests/linear_solvers/test_mixedulm_linear_solver.cpp
@@ -69,8 +69,8 @@ void CreateAuxiliaryFiles()
     const std::string rhs = "%%MatrixMarket matrix array real general\n16 1\n0\n0\n0\n-5.1725e+07\n0\n-1.0345e+08\n0\n-5.1725e+07\n0\n-1.0345e+08\n0\n-6.23386e+08\n0\n-6.23386e+08\n0\n0\n";
 
     std::filebuf buffer_rhs;
-    file_path = std::filesystem::current_path() / "b_testing_condensation.rhs";
-    buffer_rhs.open(file_path.string().c_str(),std::ios::out);
+    std::filesystem::path file_path_json = std::filesystem::current_path() / "b_testing_condensation.rhs";
+    buffer_rhs.open(file_path_json.string().c_str(),std::ios::out);
     std::ostream os_rhs(&buffer_rhs);
     os_rhs << rhs;
     buffer_rhs.close();

--- a/applications/ContactStructuralMechanicsApplication/tests/cpp_tests/linear_solvers/test_mixedulm_linear_solver.cpp
+++ b/applications/ContactStructuralMechanicsApplication/tests/cpp_tests/linear_solvers/test_mixedulm_linear_solver.cpp
@@ -60,7 +60,7 @@ void CreateAuxiliaryFiles()
     const std::string lhs = "%%MatrixMarket matrix coordinate real general\n16 16 184\n1 1 4.00969e+10\n1 2 0\n1 3 0\n1 4 0\n1 7 0\n1 8 0\n2 1 0\n2 2 1.35566e+11\n2 3 0\n2 4 0\n2 7 0\n2 8 0\n3 1 0\n3 2 0\n3 3 1.4559e+11\n3 4 0\n3 5 0\n3 6 0\n3 7 0\n3 8 0\n3 9 0\n3 10 0\n3 11 0\n3 12 0\n3 13 0\n3 14 0\n4 1 0\n4 2 0\n4 3 0\n4 4 2.22633e+10\n4 5 0\n4 6 -1.0345e+11\n4 7 0\n4 8 -6.20547e+09\n4 9 0\n4 10 -1.14853e-05\n4 11 0\n4 12 0.000525451\n4 13 0\n4 14 5.1725e+10\n5 3 0\n5 4 0\n5 5 2.069e+11\n5 6 0\n5 7 0\n5 8 0\n5 9 0\n5 10 0\n5 11 0\n5 12 0\n5 13 0\n5 14 0\n6 3 0\n6 4 -1.0345e+11\n6 5 0\n6 6 0\n6 7 0\n6 8 0\n6 9 0\n6 10 0\n6 11 0\n6 12 0.00103942\n6 13 0\n6 14 1.0345e+11\n7 1 0\n7 2 0\n7 3 0\n7 4 0\n7 5 0\n7 6 0\n7 7 1.4559e+11\n7 8 0\n7 9 0\n7 10 0\n7 11 0\n7 12 0\n7 13 0\n7 14 0\n8 1 0\n8 2 0\n8 3 0\n8 4 -6.20547e+09\n8 5 0\n8 6 0\n8 7 0\n8 8 2.22633e+10\n8 9 0\n8 10 -1.0345e+11\n8 11 0\n8 12 5.1725e+10\n8 13 0\n8 14 5.74263e-06\n9 3 0\n9 4 0\n9 5 0\n9 6 0\n9 7 0\n9 8 0\n9 9 2.069e+11\n9 10 0\n9 11 0\n9 12 0\n9 13 0\n9 14 0\n10 3 0\n10 4 -1.14853e-05\n10 5 0\n10 6 0\n10 7 0\n10 8 -1.0345e+11\n10 9 0\n10 10 0\n10 11 0\n10 12 1.0345e+11\n10 13 0\n10 14 1.14853e-05\n11 3 0\n11 4 0\n11 5 0\n11 6 0\n11 7 0\n11 8 0\n11 9 0\n11 10 0\n11 11 1.45464e+11\n11 12 0\n11 13 0\n11 14 0\n11 15 0\n11 16 0\n12 3 0\n12 4 0.000525451\n12 5 0\n12 6 0.00103942\n12 7 0\n12 8 5.1725e+10\n12 9 0\n12 10 1.0345e+11\n12 11 0\n12 12 2.22572e+10\n12 13 0\n12 14 -6.13145e+09\n12 15 0\n12 16 0\n13 3 0\n13 4 0\n13 5 0\n13 6 0\n13 7 0\n13 8 0\n13 9 0\n13 10 0\n13 11 0\n13 12 0\n13 13 1.45464e+11\n13 14 0\n13 15 0\n13 16 0\n14 3 0\n14 4 5.1725e+10\n14 5 0\n14 6 1.0345e+11\n14 7 0\n14 8 5.74263e-06\n14 9 0\n14 10 1.14853e-05\n14 11 0\n14 12 -6.13145e+09\n14 13 0\n14 14 2.22572e+10\n14 15 0\n14 16 0\n15 11 0\n15 12 0\n15 13 0\n15 14 0\n15 15 4.0137e+10\n15 16 0\n16 11 0\n16 12 0\n16 13 0\n16 14 0\n16 15 0\n16 16 1.35701e+11\n";
 
     std::filebuf buffer_lhs;
-    buffer_lhs.open(FilesystemExtensions::JoinPaths({FilesystemExtensions::CurrentWorkingDirectory(), "A_testing_condensation.mm"}),std::ios::out);
+    buffer_lhs.open(std::filesystem::path(FilesystemExtensions::CurrentWorkingDirectory()) / "A_testing_condensation.mm",std::ios::out);
     std::ostream os_lhs(&buffer_lhs);
     os_lhs << lhs;
     buffer_lhs.close();
@@ -68,7 +68,7 @@ void CreateAuxiliaryFiles()
     const std::string rhs = "%%MatrixMarket matrix array real general\n16 1\n0\n0\n0\n-5.1725e+07\n0\n-1.0345e+08\n0\n-5.1725e+07\n0\n-1.0345e+08\n0\n-6.23386e+08\n0\n-6.23386e+08\n0\n0\n";
 
     std::filebuf buffer_rhs;
-    buffer_rhs.open(FilesystemExtensions::JoinPaths({FilesystemExtensions::CurrentWorkingDirectory(), "b_testing_condensation.rhs"}),std::ios::out);
+    buffer_rhs.open(std::filesystem::path(FilesystemExtensions::CurrentWorkingDirectory()) / "b_testing_condensation.rhs",std::ios::out);
     std::ostream os_rhs(&buffer_rhs);
     os_rhs << rhs;
     buffer_rhs.close();
@@ -981,12 +981,12 @@ KRATOS_TEST_CASE_IN_SUITE(MixedULMLinearSolverRealSystem, KratosContactStructura
 
     // CHANGE THIS TO ADAPT TO YOUR PROBLEM
     CreateAuxiliaryFiles();
-    const bool read_a = Kratos::ReadMatrixMarketMatrix(FilesystemExtensions::JoinPaths({FilesystemExtensions::CurrentWorkingDirectory(), "A_testing_condensation.mm"}).c_str(), A);
-    const bool read_b = Kratos::ReadMatrixMarketVector(FilesystemExtensions::JoinPaths({FilesystemExtensions::CurrentWorkingDirectory(), "b_testing_condensation.rhs"}).c_str(), b);
+    const bool read_a = Kratos::ReadMatrixMarketMatrix((std::filesystem::path(FilesystemExtensions::CurrentWorkingDirectory()) / "A_testing_condensation.mm").c_str(), A);
+    const bool read_b = Kratos::ReadMatrixMarketVector((std::filesystem::path(FilesystemExtensions::CurrentWorkingDirectory()) / "b_testing_condensation.rhs").c_str(), b);
 
     // Removing files
-    std::filesystem::remove(FilesystemExtensions::JoinPaths({FilesystemExtensions::CurrentWorkingDirectory(), "A_testing_condensation.mm"}));
-    std::filesystem::remove(FilesystemExtensions::JoinPaths({FilesystemExtensions::CurrentWorkingDirectory(), "b_testing_condensation.rhs"}));
+    std::filesystem::remove(std::filesystem::path(FilesystemExtensions::CurrentWorkingDirectory()) / "A_testing_condensation.mm");
+    std::filesystem::remove(std::filesystem::path(FilesystemExtensions::CurrentWorkingDirectory()) / "b_testing_condensation.rhs");
 
     if (read_a && read_b) {
         // We solve the reference system

--- a/applications/MeshingApplication/tests/cpp_tests/mmg/test_mmg_io.cpp
+++ b/applications/MeshingApplication/tests/cpp_tests/mmg/test_mmg_io.cpp
@@ -11,6 +11,7 @@
 //
 
 #ifdef INCLUDE_MMG
+
 // System includes
 #include<iostream>
 
@@ -26,131 +27,129 @@
 #include "meshing_application_variables.h"
 #include "custom_io/mmg/mmg_io.h"
 
-namespace Kratos
+namespace Kratos::Testing
 {
-    namespace Testing
-    {
-        /**
-        * Checks the correct work of the level set MMG IO
-        * Test triangle
-        */
-        KRATOS_TEST_CASE_IN_SUITE(MMGIO1, KratosMeshingApplicationFastSuite)
-        {
-            Model this_model;
-            ModelPart& r_model_part = this_model.CreateModelPart("Main", 2);
+/**
+* Checks the correct work of the level set MMG IO
+* Test triangle
+*/
+KRATOS_TEST_CASE_IN_SUITE(MMGIO1, KratosMeshingApplicationFastSuite)
+{
+    Model this_model;
+    ModelPart& r_model_part = this_model.CreateModelPart("Main", 2);
 
-            Properties::Pointer p_elem_prop = r_model_part.CreateNewProperties(0);
+    Properties::Pointer p_elem_prop = r_model_part.CreateNewProperties(0);
 
-            auto& process_info = r_model_part.GetProcessInfo();
-            process_info[STEP] = 1;
-            process_info[NL_ITERATION_NUMBER] = 1;
+    auto& process_info = r_model_part.GetProcessInfo();
+    process_info[STEP] = 1;
+    process_info[NL_ITERATION_NUMBER] = 1;
 
-            CppTestsUtilities::Create2DGeometry(r_model_part, "Element2D3N");
+    CppTestsUtilities::Create2DGeometry(r_model_part, "Element2D3N");
 
-            // Set DISTANCE and other variables
-            Vector ref_metric(3);
-            ref_metric[0] = 1.0;
-            ref_metric[1] = 1.0;
-            ref_metric[2] = 0.0;
-            for (std::size_t i_node = 0; i_node < r_model_part.Nodes().size(); ++i_node) {
-                auto it_node = r_model_part.Nodes().begin() + i_node;
-                it_node->SetValue(METRIC_TENSOR_2D, ref_metric);
-            }
+    // Set DISTANCE and other variables
+    Vector ref_metric(3);
+    ref_metric[0] = 1.0;
+    ref_metric[1] = 1.0;
+    ref_metric[2] = 0.0;
+    for (std::size_t i_node = 0; i_node < r_model_part.Nodes().size(); ++i_node) {
+        auto it_node = r_model_part.Nodes().begin() + i_node;
+        it_node->SetValue(METRIC_TENSOR_2D, ref_metric);
+    }
 
-            // Auxiliar submodelpart to check colors
-            auto& r_sub = r_model_part.CreateSubModelPart("AuxiliarSubModelPart");
+    // Auxiliar submodelpart to check colors
+    auto& r_sub = r_model_part.CreateSubModelPart("AuxiliarSubModelPart");
 
-            // Now we create the conditions
-            r_sub.AddNode(r_model_part.pGetNode(1));
-            r_sub.AddNode(r_model_part.pGetNode(2));
-            auto p_cond = r_sub.CreateNewCondition("LineCondition2D2N", 1, {{1,2}}, p_elem_prop);
+    // Now we create the conditions
+    r_sub.AddNode(r_model_part.pGetNode(1));
+    r_sub.AddNode(r_model_part.pGetNode(2));
+    auto p_cond = r_sub.CreateNewCondition("LineCondition2D2N", 1, {{1,2}}, p_elem_prop);
 
-            // Compute read/write
-            Parameters params = Parameters(R"({ "echo_level" : 0 })" );
-            MmgIO<MMGLibrary::MMG2D> mmg_io(FilesystemExtensions::JoinPaths({FilesystemExtensions::CurrentWorkingDirectory(), "mmg_output_2d"}));
-            mmg_io.WriteModelPart(r_model_part);
+    // Compute read/write
+    Parameters params = Parameters(R"({ "echo_level" : 0 })" );
+    MmgIO<MMGLibrary::MMG2D> mmg_io(FilesystemExtensions::JoinPaths({FilesystemExtensions::CurrentWorkingDirectory(), "mmg_output_2d"}));
+    mmg_io.WriteModelPart(r_model_part);
 
-            Model this_aux_model;
-            ModelPart& r_aux_model_part = this_aux_model.CreateModelPart("Main", 2);
+    Model this_aux_model;
+    ModelPart& r_aux_model_part = this_aux_model.CreateModelPart("Main", 2);
 
-            mmg_io.ReadModelPart(r_aux_model_part);
+    mmg_io.ReadModelPart(r_aux_model_part);
 
-            KRATOS_EXPECT_EQ(r_model_part.NumberOfNodes(), r_aux_model_part.NumberOfNodes());
-            KRATOS_EXPECT_EQ(r_model_part.NumberOfElements(), r_aux_model_part.NumberOfElements());
+    KRATOS_EXPECT_EQ(r_model_part.NumberOfNodes(), r_aux_model_part.NumberOfNodes());
+    KRATOS_EXPECT_EQ(r_model_part.NumberOfElements(), r_aux_model_part.NumberOfElements());
 
-            for (auto& r_sub_model_part_name : r_model_part.GetSubModelPartNames()) {
-                KRATOS_EXPECT_TRUE(r_aux_model_part.HasSubModelPart(r_sub_model_part_name));
-            }
+    for (auto& r_sub_model_part_name : r_model_part.GetSubModelPartNames()) {
+        KRATOS_EXPECT_TRUE(r_aux_model_part.HasSubModelPart(r_sub_model_part_name));
+    }
 
-            std::filesystem::remove((FilesystemExtensions::JoinPaths({FilesystemExtensions::CurrentWorkingDirectory(), "mmg_output_2d.mesh"})).c_str());
-            std::filesystem::remove((FilesystemExtensions::JoinPaths({FilesystemExtensions::CurrentWorkingDirectory(), "mmg_output_2d.sol"})).c_str());
-            std::filesystem::remove((FilesystemExtensions::JoinPaths({FilesystemExtensions::CurrentWorkingDirectory(), "mmg_output_2d.json"})).c_str());
-            std::filesystem::remove((FilesystemExtensions::JoinPaths({FilesystemExtensions::CurrentWorkingDirectory(), "mmg_output_2d.cond.ref.json"})).c_str());
-            std::filesystem::remove((FilesystemExtensions::JoinPaths({FilesystemExtensions::CurrentWorkingDirectory(), "mmg_output_2d.elem.ref.json"})).c_str());
-        }
+    std::filesystem::remove((FilesystemExtensions::JoinPaths({FilesystemExtensions::CurrentWorkingDirectory(), "mmg_output_2d.mesh"})).c_str());
+    std::filesystem::remove((FilesystemExtensions::JoinPaths({FilesystemExtensions::CurrentWorkingDirectory(), "mmg_output_2d.sol"})).c_str());
+    std::filesystem::remove((FilesystemExtensions::JoinPaths({FilesystemExtensions::CurrentWorkingDirectory(), "mmg_output_2d.json"})).c_str());
+    std::filesystem::remove((FilesystemExtensions::JoinPaths({FilesystemExtensions::CurrentWorkingDirectory(), "mmg_output_2d.cond.ref.json"})).c_str());
+    std::filesystem::remove((FilesystemExtensions::JoinPaths({FilesystemExtensions::CurrentWorkingDirectory(), "mmg_output_2d.elem.ref.json"})).c_str());
+}
 
-        /**
-        * Checks the correct work of the level set MMG IO
-        * Test tetrahedra
-        */
-        KRATOS_TEST_CASE_IN_SUITE(MMGIO2, KratosMeshingApplicationFastSuite)
-        {
-            Model this_model;
-            ModelPart& r_model_part = this_model.CreateModelPart("Main", 2);
+/**
+* Checks the correct work of the level set MMG IO
+* Test tetrahedra
+*/
+KRATOS_TEST_CASE_IN_SUITE(MMGIO2, KratosMeshingApplicationFastSuite)
+{
+    Model this_model;
+    ModelPart& r_model_part = this_model.CreateModelPart("Main", 2);
 
-            r_model_part.AddNodalSolutionStepVariable(DISTANCE);
-            r_model_part.AddNodalSolutionStepVariable(DISTANCE_GRADIENT);
+    r_model_part.AddNodalSolutionStepVariable(DISTANCE);
+    r_model_part.AddNodalSolutionStepVariable(DISTANCE_GRADIENT);
 
-            Properties::Pointer p_elem_prop = r_model_part.CreateNewProperties(0);
+    Properties::Pointer p_elem_prop = r_model_part.CreateNewProperties(0);
 
-            auto& process_info = r_model_part.GetProcessInfo();
-            process_info[STEP] = 1;
-            process_info[NL_ITERATION_NUMBER] = 1;
+    auto& process_info = r_model_part.GetProcessInfo();
+    process_info[STEP] = 1;
+    process_info[NL_ITERATION_NUMBER] = 1;
 
-            CppTestsUtilities::Create3DGeometry(r_model_part, "Element3D4N");
+    CppTestsUtilities::Create3DGeometry(r_model_part, "Element3D4N");
 
-            // Set DISTANCE and other variables
-            array_1d<double, 6> ref_metric = ZeroVector(6);
-            ref_metric[0] = 1.0;
-            ref_metric[1] = 1.0;
-            ref_metric[2] = 1.0;
-            for (std::size_t i_node = 0; i_node < r_model_part.Nodes().size(); ++i_node) {
-                auto it_node = r_model_part.Nodes().begin() + i_node;
-                it_node->SetValue(METRIC_TENSOR_3D, ref_metric);
-            }
+    // Set DISTANCE and other variables
+    array_1d<double, 6> ref_metric = ZeroVector(6);
+    ref_metric[0] = 1.0;
+    ref_metric[1] = 1.0;
+    ref_metric[2] = 1.0;
+    for (std::size_t i_node = 0; i_node < r_model_part.Nodes().size(); ++i_node) {
+        auto it_node = r_model_part.Nodes().begin() + i_node;
+        it_node->SetValue(METRIC_TENSOR_3D, ref_metric);
+    }
 
-            // Auxiliar submodelpart to check colors
-            auto& r_sub = r_model_part.CreateSubModelPart("AuxiliarSubModelPart");
+    // Auxiliar submodelpart to check colors
+    auto& r_sub = r_model_part.CreateSubModelPart("AuxiliarSubModelPart");
 
-            // Now we create the conditions
-            r_sub.AddNode(r_model_part.pGetNode(1));
-            r_sub.AddNode(r_model_part.pGetNode(2));
-            r_sub.AddNode(r_model_part.pGetNode(3));
-            auto p_cond = r_sub.CreateNewCondition("SurfaceCondition3D3N", 1, {{1,2,3}}, p_elem_prop);
+    // Now we create the conditions
+    r_sub.AddNode(r_model_part.pGetNode(1));
+    r_sub.AddNode(r_model_part.pGetNode(2));
+    r_sub.AddNode(r_model_part.pGetNode(3));
+    auto p_cond = r_sub.CreateNewCondition("SurfaceCondition3D3N", 1, {{1,2,3}}, p_elem_prop);
 
-            // Compute read/write
-            Parameters params = Parameters(R"({ "echo_level" : 0 })" );
-            MmgIO<MMGLibrary::MMG3D> mmg_io(FilesystemExtensions::JoinPaths({FilesystemExtensions::CurrentWorkingDirectory(), "mmg_output_3d"}));
-            mmg_io.WriteModelPart(r_model_part);
+    // Compute read/write
+    Parameters params = Parameters(R"({ "echo_level" : 0 })" );
+    MmgIO<MMGLibrary::MMG3D> mmg_io(FilesystemExtensions::JoinPaths({FilesystemExtensions::CurrentWorkingDirectory(), "mmg_output_3d"}));
+    mmg_io.WriteModelPart(r_model_part);
 
-            Model this_aux_model;
-            ModelPart& r_aux_model_part = this_aux_model.CreateModelPart("Main", 2);
+    Model this_aux_model;
+    ModelPart& r_aux_model_part = this_aux_model.CreateModelPart("Main", 2);
 
-            mmg_io.ReadModelPart(r_aux_model_part);
+    mmg_io.ReadModelPart(r_aux_model_part);
 
-            KRATOS_EXPECT_EQ(r_model_part.NumberOfNodes(), r_aux_model_part.NumberOfNodes());
-            KRATOS_EXPECT_EQ(r_model_part.NumberOfElements(), r_aux_model_part.NumberOfElements());
+    KRATOS_EXPECT_EQ(r_model_part.NumberOfNodes(), r_aux_model_part.NumberOfNodes());
+    KRATOS_EXPECT_EQ(r_model_part.NumberOfElements(), r_aux_model_part.NumberOfElements());
 
-            for (auto& r_sub_model_part_name : r_model_part.GetSubModelPartNames()) {
-                KRATOS_EXPECT_TRUE(r_aux_model_part.HasSubModelPart(r_sub_model_part_name));
-            }
+    for (auto& r_sub_model_part_name : r_model_part.GetSubModelPartNames()) {
+        KRATOS_EXPECT_TRUE(r_aux_model_part.HasSubModelPart(r_sub_model_part_name));
+    }
 
-            std::filesystem::remove((FilesystemExtensions::JoinPaths({FilesystemExtensions::CurrentWorkingDirectory(), "mmg_output_3d.mesh"})).c_str());
-            std::filesystem::remove((FilesystemExtensions::JoinPaths({FilesystemExtensions::CurrentWorkingDirectory(), "mmg_output_3d.sol"})).c_str());
-            std::filesystem::remove((FilesystemExtensions::JoinPaths({FilesystemExtensions::CurrentWorkingDirectory(), "mmg_output_3d.json"})).c_str());
-            std::filesystem::remove((FilesystemExtensions::JoinPaths({FilesystemExtensions::CurrentWorkingDirectory(), "mmg_output_3d.cond.ref.json"})).c_str());
-            std::filesystem::remove((FilesystemExtensions::JoinPaths({FilesystemExtensions::CurrentWorkingDirectory(), "mmg_output_3d.elem.ref.json"})).c_str());
-        }
-    } // namespace Testing
-}  // namespace Kratos.
+    std::filesystem::remove((FilesystemExtensions::JoinPaths({FilesystemExtensions::CurrentWorkingDirectory(), "mmg_output_3d.mesh"})).c_str());
+    std::filesystem::remove((FilesystemExtensions::JoinPaths({FilesystemExtensions::CurrentWorkingDirectory(), "mmg_output_3d.sol"})).c_str());
+    std::filesystem::remove((FilesystemExtensions::JoinPaths({FilesystemExtensions::CurrentWorkingDirectory(), "mmg_output_3d.json"})).c_str());
+    std::filesystem::remove((FilesystemExtensions::JoinPaths({FilesystemExtensions::CurrentWorkingDirectory(), "mmg_output_3d.cond.ref.json"})).c_str());
+    std::filesystem::remove((FilesystemExtensions::JoinPaths({FilesystemExtensions::CurrentWorkingDirectory(), "mmg_output_3d.elem.ref.json"})).c_str());
+}
+
+}  // namespace Kratos::Testing.
 #endif

--- a/applications/MeshingApplication/tests/cpp_tests/mmg/test_mmg_io.cpp
+++ b/applications/MeshingApplication/tests/cpp_tests/mmg/test_mmg_io.cpp
@@ -66,7 +66,8 @@ KRATOS_TEST_CASE_IN_SUITE(MMGIO1, KratosMeshingApplicationFastSuite)
 
     // Compute read/write
     Parameters params = Parameters(R"({ "echo_level" : 0 })" );
-    MmgIO<MMGLibrary::MMG2D> mmg_io(FilesystemExtensions::JoinPaths({FilesystemExtensions::CurrentWorkingDirectory(), "mmg_output_2d"}));
+    std::filesystem::path file_path = std::filesystem::current_path() / "mmg_output_2d";
+    MmgIO<MMGLibrary::MMG2D> mmg_io(file_path.string());
     mmg_io.WriteModelPart(r_model_part);
 
     Model this_aux_model;
@@ -81,11 +82,11 @@ KRATOS_TEST_CASE_IN_SUITE(MMGIO1, KratosMeshingApplicationFastSuite)
         KRATOS_EXPECT_TRUE(r_aux_model_part.HasSubModelPart(r_sub_model_part_name));
     }
 
-    std::filesystem::remove((FilesystemExtensions::JoinPaths({FilesystemExtensions::CurrentWorkingDirectory(), "mmg_output_2d.mesh"})).c_str());
-    std::filesystem::remove((FilesystemExtensions::JoinPaths({FilesystemExtensions::CurrentWorkingDirectory(), "mmg_output_2d.sol"})).c_str());
-    std::filesystem::remove((FilesystemExtensions::JoinPaths({FilesystemExtensions::CurrentWorkingDirectory(), "mmg_output_2d.json"})).c_str());
-    std::filesystem::remove((FilesystemExtensions::JoinPaths({FilesystemExtensions::CurrentWorkingDirectory(), "mmg_output_2d.cond.ref.json"})).c_str());
-    std::filesystem::remove((FilesystemExtensions::JoinPaths({FilesystemExtensions::CurrentWorkingDirectory(), "mmg_output_2d.elem.ref.json"})).c_str());
+    std::filesystem::remove(std::filesystem::current_path() / "mmg_output_2d.mesh");
+    std::filesystem::remove(std::filesystem::current_path() / "mmg_output_2d.sol");
+    std::filesystem::remove(std::filesystem::current_path() / "mmg_output_2d.json");
+    std::filesystem::remove(std::filesystem::current_path() / "mmg_output_2d.cond.ref.json");
+    std::filesystem::remove(std::filesystem::current_path() / "mmg_output_2d.elem.ref.json");
 }
 
 /**
@@ -129,7 +130,8 @@ KRATOS_TEST_CASE_IN_SUITE(MMGIO2, KratosMeshingApplicationFastSuite)
 
     // Compute read/write
     Parameters params = Parameters(R"({ "echo_level" : 0 })" );
-    MmgIO<MMGLibrary::MMG3D> mmg_io(FilesystemExtensions::JoinPaths({FilesystemExtensions::CurrentWorkingDirectory(), "mmg_output_3d"}));
+    std::filesystem::path file_path = std::filesystem::current_path() / "mmg_output_3d";
+    MmgIO<MMGLibrary::MMG3D> mmg_io(file_path.string());
     mmg_io.WriteModelPart(r_model_part);
 
     Model this_aux_model;
@@ -144,11 +146,11 @@ KRATOS_TEST_CASE_IN_SUITE(MMGIO2, KratosMeshingApplicationFastSuite)
         KRATOS_EXPECT_TRUE(r_aux_model_part.HasSubModelPart(r_sub_model_part_name));
     }
 
-    std::filesystem::remove((FilesystemExtensions::JoinPaths({FilesystemExtensions::CurrentWorkingDirectory(), "mmg_output_3d.mesh"})).c_str());
-    std::filesystem::remove((FilesystemExtensions::JoinPaths({FilesystemExtensions::CurrentWorkingDirectory(), "mmg_output_3d.sol"})).c_str());
-    std::filesystem::remove((FilesystemExtensions::JoinPaths({FilesystemExtensions::CurrentWorkingDirectory(), "mmg_output_3d.json"})).c_str());
-    std::filesystem::remove((FilesystemExtensions::JoinPaths({FilesystemExtensions::CurrentWorkingDirectory(), "mmg_output_3d.cond.ref.json"})).c_str());
-    std::filesystem::remove((FilesystemExtensions::JoinPaths({FilesystemExtensions::CurrentWorkingDirectory(), "mmg_output_3d.elem.ref.json"})).c_str());
+    std::filesystem::remove(std::filesystem::current_path() / "mmg_output_3d.mesh");
+    std::filesystem::remove(std::filesystem::current_path() / "mmg_output_3d.sol");
+    std::filesystem::remove(std::filesystem::current_path() / "mmg_output_3d.json");
+    std::filesystem::remove(std::filesystem::current_path() / "mmg_output_3d.cond.ref.json");
+    std::filesystem::remove(std::filesystem::current_path() / "mmg_output_3d.elem.ref.json");
 }
 
 }  // namespace Kratos::Testing.


### PR DESCRIPTION
**📝 Description**

Remove remaining deprecated warning for `std::filesystem`.

**🆕 Changelog**

- Remove remaining deprecated warning for `std::filesystem`
