### PR TITLE
[GeoMechanicsApplication] Remove redundant k0 input parameter

### DIFF
--- a/applications/GeoMechanicsApplication/custom_processes/README.md
+++ b/applications/GeoMechanicsApplication/custom_processes/README.md
@@ -122,7 +122,6 @@ The process is defined as follows in "ProjectParameters.json" (also found in som
       "process_name": "ApplyK0ProcedureProcess",
       "Parameters": {
         "model_part_name": "PorousDomain.porous_computational_model_part",
-        "variable_name": "CAUCHY_STRESS_TENSOR",
         "use_standard_procedure": true
       }
     }

--- a/applications/GeoMechanicsApplication/tests/C-Phi_reduction_process/ProjectParameters_stage1.json
+++ b/applications/GeoMechanicsApplication/tests/C-Phi_reduction_process/ProjectParameters_stage1.json
@@ -83,8 +83,7 @@
         "auxiliary_process_list": [
             {
                 "Parameters": {
-                    "model_part_name": "PorousDomain.porous_computational_model_part",
-                    "variable_name": "CAUCHY_STRESS_TENSOR"
+                    "model_part_name": "PorousDomain.porous_computational_model_part"
                 },
                 "kratos_module": "KratosMultiphysics.GeoMechanicsApplication",
                 "process_name": "ApplyK0ProcedureProcess",

--- a/applications/GeoMechanicsApplication/tests/test_k0_procedure_process/test_k0_procedure_k0_nc/ProjectParameters.json
+++ b/applications/GeoMechanicsApplication/tests/test_k0_procedure_process/test_k0_procedure_k0_nc/ProjectParameters.json
@@ -242,8 +242,7 @@
         "kratos_module": "KratosMultiphysics.GeoMechanicsApplication",
         "process_name": "ApplyK0ProcedureProcess",
         "Parameters": {
-          "model_part_name": "PorousDomain.porous_computational_model_part",
-          "variable_name": "CAUCHY_STRESS_TENSOR"
+          "model_part_name": "PorousDomain.porous_computational_model_part"
         }
       }
     ]

--- a/applications/GeoMechanicsApplication/tests/test_k0_procedure_process/test_k0_procedure_k0_nc_3D/ProjectParameters.json
+++ b/applications/GeoMechanicsApplication/tests/test_k0_procedure_process/test_k0_procedure_k0_nc_3D/ProjectParameters.json
@@ -160,8 +160,7 @@
         "kratos_module": "KratosMultiphysics.GeoMechanicsApplication",
         "process_name": "ApplyK0ProcedureProcess",
         "Parameters": {
-          "model_part_name": "PorousDomain.porous_computational_model_part",
-          "variable_name": "CAUCHY_STRESS_TENSOR"
+          "model_part_name": "PorousDomain.porous_computational_model_part"
         }
       }]
     }

--- a/applications/GeoMechanicsApplication/tests/test_k0_procedure_process/test_k0_procedure_k0_nc_layers/ProjectParameters.json
+++ b/applications/GeoMechanicsApplication/tests/test_k0_procedure_process/test_k0_procedure_k0_nc_layers/ProjectParameters.json
@@ -243,8 +243,7 @@
         "kratos_module": "KratosMultiphysics.GeoMechanicsApplication",
         "process_name": "ApplyK0ProcedureProcess",
         "Parameters": {
-          "model_part_name": "PorousDomain.porous_computational_model_part",
-          "variable_name": "CAUCHY_STRESS_TENSOR"
+          "model_part_name": "PorousDomain.porous_computational_model_part"
         }
       }
     ]

--- a/applications/GeoMechanicsApplication/tests/test_k0_procedure_process/test_k0_procedure_k0_nc_ocr/ProjectParameters.json
+++ b/applications/GeoMechanicsApplication/tests/test_k0_procedure_process/test_k0_procedure_k0_nc_ocr/ProjectParameters.json
@@ -178,8 +178,7 @@
         "kratos_module": "KratosMultiphysics.GeoMechanicsApplication",
         "process_name":  "ApplyK0ProcedureProcess",
         "Parameters":    {
-          "model_part_name": "PorousDomain.porous_computational_model_part",
-          "variable_name":   "CAUCHY_STRESS_TENSOR"
+          "model_part_name": "PorousDomain.porous_computational_model_part"
         }
       }
     ]

--- a/applications/GeoMechanicsApplication/tests/test_k0_procedure_process/test_k0_procedure_k0_nc_ocr_field/ProjectParameters.json
+++ b/applications/GeoMechanicsApplication/tests/test_k0_procedure_process/test_k0_procedure_k0_nc_ocr_field/ProjectParameters.json
@@ -189,8 +189,7 @@
         "kratos_module": "KratosMultiphysics.GeoMechanicsApplication",
         "process_name":  "ApplyK0ProcedureProcess",
         "Parameters":    {
-          "model_part_name": "PorousDomain.porous_computational_model_part",
-          "variable_name":   "CAUCHY_STRESS_TENSOR"
+          "model_part_name": "PorousDomain.porous_computational_model_part"
         }
       }
     ]

--- a/applications/GeoMechanicsApplication/tests/test_k0_procedure_process/test_k0_procedure_k0_nc_pop/ProjectParameters.json
+++ b/applications/GeoMechanicsApplication/tests/test_k0_procedure_process/test_k0_procedure_k0_nc_pop/ProjectParameters.json
@@ -182,8 +182,7 @@
         "kratos_module": "KratosMultiphysics.GeoMechanicsApplication",
         "process_name":  "ApplyK0ProcedureProcess",
         "Parameters":    {
-          "model_part_name": "PorousDomain.porous_computational_model_part",
-          "variable_name":   "CAUCHY_STRESS_TENSOR"
+          "model_part_name": "PorousDomain.porous_computational_model_part"
         }
       }
     ]

--- a/applications/GeoMechanicsApplication/tests/test_k0_procedure_process/test_k0_procedure_k0_nc_pop_layers/ProjectParameters.json
+++ b/applications/GeoMechanicsApplication/tests/test_k0_procedure_process/test_k0_procedure_k0_nc_pop_layers/ProjectParameters.json
@@ -45,7 +45,6 @@
       {
         "Parameters":    {
           "model_part_name":        "PorousDomain.porous_computational_model_part",
-          "variable_name":          "CAUCHY_STRESS_TENSOR",
           "use_standard_procedure": true
         },
         "kratos_module": "KratosMultiphysics.GeoMechanicsApplication",

--- a/applications/GeoMechanicsApplication/tests/test_k0_procedure_process/test_k0_procedure_k0_nc_skew_layers/ProjectParameters.json
+++ b/applications/GeoMechanicsApplication/tests/test_k0_procedure_process/test_k0_procedure_k0_nc_skew_layers/ProjectParameters.json
@@ -180,7 +180,6 @@
         "process_name": "ApplyK0ProcedureProcess",
         "Parameters": {
           "model_part_name": "PorousDomain.porous_computational_model_part",
-          "variable_name": "CAUCHY_STRESS_TENSOR",
           "use_standard_procedure": false
         }
       }

--- a/applications/GeoMechanicsApplication/tests/test_k0_procedure_process/test_k0_procedure_k0_nc_skew_layers_dam/ProjectParameters.json
+++ b/applications/GeoMechanicsApplication/tests/test_k0_procedure_process/test_k0_procedure_k0_nc_skew_layers_dam/ProjectParameters.json
@@ -172,8 +172,7 @@
         "kratos_module": "KratosMultiphysics.GeoMechanicsApplication",
         "process_name": "ApplyK0ProcedureProcess",
         "Parameters": {
-          "model_part_name": "PorousDomain.porous_computational_model_part",
-          "variable_name": "CAUCHY_STRESS_TENSOR"
+          "model_part_name": "PorousDomain.porous_computational_model_part"
         }
       }	    
     ]}

--- a/applications/GeoMechanicsApplication/tests/test_k0_procedure_process/test_k0_procedure_k0_umat/ProjectParameters.json
+++ b/applications/GeoMechanicsApplication/tests/test_k0_procedure_process/test_k0_procedure_k0_umat/ProjectParameters.json
@@ -242,8 +242,7 @@
         "kratos_module": "KratosMultiphysics.GeoMechanicsApplication",
         "process_name": "ApplyK0ProcedureProcess",
         "Parameters": {
-          "model_part_name": "PorousDomain.porous_computational_model_part",
-          "variable_name": "CAUCHY_STRESS_TENSOR"
+          "model_part_name": "PorousDomain.porous_computational_model_part"
         }
       }
     ]

--- a/applications/GeoMechanicsApplication/tests/test_k0_procedure_process/test_k0_procedure_phi_pop_layers/ProjectParameters.json
+++ b/applications/GeoMechanicsApplication/tests/test_k0_procedure_process/test_k0_procedure_phi_pop_layers/ProjectParameters.json
@@ -45,7 +45,6 @@
       {
         "Parameters":    {
           "model_part_name":        "PorousDomain.porous_computational_model_part",
-          "variable_name":          "CAUCHY_STRESS_TENSOR",
           "use_standard_procedure": true
         },
         "kratos_module": "KratosMultiphysics.GeoMechanicsApplication",

--- a/applications/GeoMechanicsApplication/tests/test_k0_procedure_process/test_k0_procedure_simple_dike/ProjectParameters_stage1.json
+++ b/applications/GeoMechanicsApplication/tests/test_k0_procedure_process/test_k0_procedure_simple_dike/ProjectParameters_stage1.json
@@ -150,8 +150,7 @@
         "kratos_module": "KratosMultiphysics.GeoMechanicsApplication",
         "process_name": "ApplyK0ProcedureProcess",
         "Parameters": {
-          "model_part_name": "PorousDomain.Body_sand",
-          "variable_name":   "CAUCHY_STRESS_TENSOR"
+          "model_part_name": "PorousDomain.Body_sand"
         }
       }
     ]

--- a/applications/GeoMechanicsApplication/tests/test_k0_procedure_process/test_k0_procedure_with_horizontal_layers/ProjectParameters.json
+++ b/applications/GeoMechanicsApplication/tests/test_k0_procedure_process/test_k0_procedure_with_horizontal_layers/ProjectParameters.json
@@ -43,7 +43,6 @@
             {
                 "Parameters": {
                     "model_part_name": "PorousDomain.porous_computational_model_part",
-                    "variable_name": "CAUCHY_STRESS_TENSOR",
                     "use_standard_procedure": true
                 },
                 "kratos_module": "KratosMultiphysics.GeoMechanicsApplication",

--- a/applications/GeoMechanicsApplication/tests/test_k0_procedure_process/test_k0_procedure_with_tilted_layers/ProjectParameters.json
+++ b/applications/GeoMechanicsApplication/tests/test_k0_procedure_process/test_k0_procedure_with_tilted_layers/ProjectParameters.json
@@ -43,7 +43,6 @@
             {
                 "Parameters": {
                     "model_part_name": "PorousDomain.porous_computational_model_part",
-                    "variable_name": "CAUCHY_STRESS_TENSOR",
                     "use_standard_procedure": true
                 },
                 "kratos_module": "KratosMultiphysics.GeoMechanicsApplication",

--- a/applications/GeoMechanicsApplication/tests/test_settlement_workflow/ProjectParameters_stage1.json
+++ b/applications/GeoMechanicsApplication/tests/test_settlement_workflow/ProjectParameters_stage1.json
@@ -172,8 +172,7 @@
         "kratos_module": "KratosMultiphysics.GeoMechanicsApplication",
         "process_name": "ApplyK0ProcedureProcess",
         "Parameters": {
-          "model_part_name": "PorousDomain.K0_model_part",
-          "variable_name": "CAUCHY_STRESS_TENSOR"
+          "model_part_name": "PorousDomain.K0_model_part"
         }
       }
     ]    


### PR DESCRIPTION
**📝 Description**
Input parameter "variable_name" was not used by the process. It was, however, supplied by all tests that use the k0 procedure process. The redundant input has been removed now.