### PR TITLE
[Core] Correcting a bug inside brep curve on surface regarding the clamping

### DIFF
--- a/kratos/geometries/brep_curve_on_surface.h
+++ b/kratos/geometries/brep_curve_on_surface.h
@@ -400,7 +400,7 @@ public:
 
         const double max_parameter = mCurveNurbsInterval.MaxParameter();
         if (rPointLocalCoordinates[0] > max_parameter) {
-            rClosestPointLocalCoordinates[0] = min_parameter;
+            rClosestPointLocalCoordinates[0] = max_parameter;
             return 0;
         } else if (std::abs(rPointLocalCoordinates[0] - max_parameter) < Tolerance) {
             rClosestPointLocalCoordinates[0] = rPointLocalCoordinates[0];


### PR DESCRIPTION
**Description**
This PR addresses a bug in the `BrepCurveOnSurface` geometry related to the clamping behavior when a local coordinate lies outside the valid parameter range of the underlying NURBS curve.

The function `ClosestPointLocalToLocalSpace` has been updated to ensure that the input point's coordinate is correctly clamped to the curve's domain, defined by mCurveNurbsInterval.MinParameter() and MaxParameter(). The revised logic now:

-> Clamps to the minimum parameter if the input coordinate is less than the start of the interval.

-> Clamps to the maximum parameter if the input coordinate exceeds the end of the interval.

Treats values near the domain boundaries (within a given tolerance) as valid and returns a special flag (2), indicating a near-boundary condition.