### PR TITLE
Improve CI visibility of python output

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,7 +171,7 @@ jobs:
         fi
         export PYTHONPATH=${PYTHONPATH}:${GITHUB_WORKSPACE}/bin/${{ matrix.build-type }}
         export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${GITHUB_WORKSPACE}/bin/${{ matrix.build-type }}/libs
-        python3 kratos/python_scripts/testing/run_python_tests.py -v 2 -l nightly -c python3
+        python3 kratos/python_scripts/testing/run_python_tests.py -v 2 -l nightly -c python3 > /dev/null
 
     - name: Prepare Parallel Env
       shell: bash
@@ -220,7 +220,7 @@ jobs:
         export OMP_NUM_THREADS=1
         export PYTHONPATH=${PYTHONPATH}:${GITHUB_WORKSPACE}/bin/${{ matrix.build-type }}
         export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${GITHUB_WORKSPACE}/bin/${{ matrix.build-type }}/libs
-        python3 kratos/python_scripts/testing/run_python_mpi_tests.py --mpi_flags "--hostfile ${GITHUB_WORKSPACE}/ci_hostfile" -l mpi_nightly -n 2
+        python3 kratos/python_scripts/testing/run_python_mpi_tests.py --mpi_flags "--hostfile ${GITHUB_WORKSPACE}/ci_hostfile" -l mpi_nightly -n 2 > /dev/null
 
     - name: Running Python MPI tests (3 Cores)
       shell: bash
@@ -231,7 +231,7 @@ jobs:
         export OMP_NUM_THREADS=1
         export PYTHONPATH=${PYTHONPATH}:${GITHUB_WORKSPACE}/bin/${{ matrix.build-type }}
         export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${GITHUB_WORKSPACE}/bin/${{ matrix.build-type }}/libs
-        python3 kratos/python_scripts/testing/run_python_mpi_tests.py --mpi_flags "--hostfile ${GITHUB_WORKSPACE}/ci_hostfile" -l mpi_nightly -n 3
+        python3 kratos/python_scripts/testing/run_python_mpi_tests.py --mpi_flags "--hostfile ${GITHUB_WORKSPACE}/ci_hostfile" -l mpi_nightly -n 3 > /dev/null
 
     - name: Running Python MPI tests (4 Cores)
       shell: bash
@@ -242,7 +242,7 @@ jobs:
         export OMP_NUM_THREADS=1
         export PYTHONPATH=${PYTHONPATH}:${GITHUB_WORKSPACE}/bin/${{ matrix.build-type }}
         export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${GITHUB_WORKSPACE}/bin/${{ matrix.build-type }}/libs
-        python3 kratos/python_scripts/testing/run_python_mpi_tests.py --mpi_flags "--hostfile ${GITHUB_WORKSPACE}/ci_hostfile" -l mpi_nightly -n 4
+        python3 kratos/python_scripts/testing/run_python_mpi_tests.py --mpi_flags "--hostfile ${GITHUB_WORKSPACE}/ci_hostfile" -l mpi_nightly -n 4 > /dev/null
 
 
   windows:

--- a/.github/workflows/configure_core.sh
+++ b/.github/workflows/configure_core.sh
@@ -33,14 +33,14 @@ rm -rf "${KRATOS_BUILD}/${KRATOS_BUILD_TYPE}/CMakeFiles"
 echo "Kratos build type is ${KRATOS_BUILD_TYPE}"
 
 # Configure
-cmake -H"${KRATOS_SOURCE}" -B"${KRATOS_BUILD}/${KRATOS_BUILD_TYPE}" \
-${KRATOS_CMAKE_OPTIONS_FLAGS}                                       \
--DUSE_MPI=ON                                                        \
--DCMAKE_CXX_FLAGS="${KRATOS_CMAKE_CXX_FLAGS} -O0 -Wall"             \
--DCMAKE_POLICY_VERSION_MINIMUM=3.5                                  \
--DTRILINOS_INCLUDE_DIR="/usr/include/trilinos"                      \
--DTRILINOS_LIBRARY_DIR="/usr/lib/x86_64-linux-gnu"                  \
--DTRILINOS_LIBRARY_PREFIX="trilinos_"                               \
+cmake -H"${KRATOS_SOURCE}" -B"${KRATOS_BUILD}/${KRATOS_BUILD_TYPE}" -Wno-dev    \
+${KRATOS_CMAKE_OPTIONS_FLAGS}                                                   \
+-DUSE_MPI=ON                                                                    \
+-DCMAKE_CXX_FLAGS="${KRATOS_CMAKE_CXX_FLAGS} -O0 -Wall"                         \
+-DCMAKE_POLICY_VERSION_MINIMUM=3.5                                              \
+-DTRILINOS_INCLUDE_DIR="/usr/include/trilinos"                                  \
+-DTRILINOS_LIBRARY_DIR="/usr/lib/x86_64-linux-gnu"                              \
+-DTRILINOS_LIBRARY_PREFIX="trilinos_"                                           \
 -DCMAKE_UNITY_BUILD=ON
 
 # Build

--- a/.github/workflows/configure_core_applications.sh
+++ b/.github/workflows/configure_core_applications.sh
@@ -36,17 +36,17 @@ rm -rf "${KRATOS_BUILD}/${KRATOS_BUILD_TYPE}/CMakeFiles"
 echo "Kratos build type is ${KRATOS_BUILD_TYPE}"
 
 # Configure
-cmake -H"${KRATOS_SOURCE}" -B"${KRATOS_BUILD}/${KRATOS_BUILD_TYPE}" \
-${KRATOS_CMAKE_OPTIONS_FLAGS}                                       \
--DUSE_MPI=ON                                                        \
--DEXCLUDE_KRATOS_CORE=ON                                            \
--DEXCLUDE_AUTOMATIC_DEPENDENCIES=ON                                 \
--DREMOVE_INSTALL_DIRECTORIES=OFF                                    \
--DCMAKE_CXX_FLAGS="${KRATOS_CMAKE_CXX_FLAGS} -O0 -Wall"             \
--DCMAKE_POLICY_VERSION_MINIMUM=3.5                                  \
--DTRILINOS_INCLUDE_DIR="/usr/include/trilinos"                      \
--DTRILINOS_LIBRARY_DIR="/usr/lib/x86_64-linux-gnu"                  \
--DTRILINOS_LIBRARY_PREFIX="trilinos_"                               \
+cmake -H"${KRATOS_SOURCE}" -B"${KRATOS_BUILD}/${KRATOS_BUILD_TYPE}" -Wno-dev    \
+${KRATOS_CMAKE_OPTIONS_FLAGS}                                                   \
+-DUSE_MPI=ON                                                                    \
+-DEXCLUDE_KRATOS_CORE=ON                                                        \
+-DEXCLUDE_AUTOMATIC_DEPENDENCIES=ON                                             \
+-DREMOVE_INSTALL_DIRECTORIES=OFF                                                \
+-DCMAKE_CXX_FLAGS="${KRATOS_CMAKE_CXX_FLAGS} -O0 -Wall"                         \
+-DCMAKE_POLICY_VERSION_MINIMUM=3.5                                              \
+-DTRILINOS_INCLUDE_DIR="/usr/include/trilinos"                                  \
+-DTRILINOS_LIBRARY_DIR="/usr/lib/x86_64-linux-gnu"                              \
+-DTRILINOS_LIBRARY_PREFIX="trilinos_"                                           \
 -DCMAKE_UNITY_BUILD=ON
 
 # Build

--- a/.github/workflows/configure_dependencies.sh
+++ b/.github/workflows/configure_dependencies.sh
@@ -37,19 +37,19 @@ rm -rf "${KRATOS_BUILD}/${KRATOS_BUILD_TYPE}/CMakeFiles"
 echo "Kratos build type is ${KRATOS_BUILD_TYPE}"
 
 # Configure
-cmake -H"${KRATOS_SOURCE}" -B"${KRATOS_BUILD}/${KRATOS_BUILD_TYPE}" \
-${KRATOS_CMAKE_OPTIONS_FLAGS}                                       \
--DUSE_MPI=ON                                                        \
--DEXCLUDE_KRATOS_CORE=ON                                            \
--DEXCLUDE_AUTOMATIC_DEPENDENCIES=ON                                 \
--DREMOVE_INSTALL_DIRECTORIES=OFF                                    \
--DCMAKE_CXX_FLAGS="${KRATOS_CMAKE_CXX_FLAGS} -O0 -Wall"             \
--DCMAKE_POLICY_VERSION_MINIMUM=3.5                                  \
--DTRILINOS_INCLUDE_DIR="/usr/include/trilinos"                      \
--DTRILINOS_LIBRARY_DIR="/usr/lib/x86_64-linux-gnu"                  \
--DTRILINOS_LIBRARY_PREFIX="trilinos_"                               \
--DCMAKE_UNITY_BUILD=ON                                              \
--DINCLUDE_MMG=ON                                                    \
+cmake -H"${KRATOS_SOURCE}" -B"${KRATOS_BUILD}/${KRATOS_BUILD_TYPE}" -Wno-dev    \
+${KRATOS_CMAKE_OPTIONS_FLAGS}                                                   \
+-DUSE_MPI=ON                                                                    \
+-DEXCLUDE_KRATOS_CORE=ON                                                        \
+-DEXCLUDE_AUTOMATIC_DEPENDENCIES=ON                                             \
+-DREMOVE_INSTALL_DIRECTORIES=OFF                                                \
+-DCMAKE_CXX_FLAGS="${KRATOS_CMAKE_CXX_FLAGS} -O0 -Wall"                         \
+-DCMAKE_POLICY_VERSION_MINIMUM=3.5                                              \
+-DTRILINOS_INCLUDE_DIR="/usr/include/trilinos"                                  \
+-DTRILINOS_LIBRARY_DIR="/usr/lib/x86_64-linux-gnu"                              \
+-DTRILINOS_LIBRARY_PREFIX="trilinos_"                                           \
+-DCMAKE_UNITY_BUILD=ON                                                          \
+-DINCLUDE_MMG=ON                                                                \
 
 # Build
 cmake --build "${KRATOS_BUILD}/${KRATOS_BUILD_TYPE}" --target install -- -j${KRATOS_CI_CORES}

--- a/.github/workflows/configure_research_applications.sh
+++ b/.github/workflows/configure_research_applications.sh
@@ -51,17 +51,17 @@ rm -rf "${KRATOS_BUILD}/${KRATOS_BUILD_TYPE}/CMakeFiles"
 echo "Kratos build type is ${KRATOS_BUILD_TYPE}"
 
 # Configure
-cmake -H"${KRATOS_SOURCE}" -B"${KRATOS_BUILD}/${KRATOS_BUILD_TYPE}" \
-${KRATOS_CMAKE_OPTIONS_FLAGS}                                       \
--DUSE_MPI=ON                                                        \
--DEXCLUDE_KRATOS_CORE=ON                                            \
--DEXCLUDE_AUTOMATIC_DEPENDENCIES=ON                                 \
--DREMOVE_INSTALL_DIRECTORIES=OFF                                    \
--DCMAKE_CXX_FLAGS="${KRATOS_CMAKE_CXX_FLAGS} -O0 -Wall"             \
--DCMAKE_POLICY_VERSION_MINIMUM=3.5                                  \
--DTRILINOS_INCLUDE_DIR="/usr/include/trilinos"                      \
--DTRILINOS_LIBRARY_DIR="/usr/lib/x86_64-linux-gnu"                  \
--DTRILINOS_LIBRARY_PREFIX="trilinos_"                               \
+cmake -H"${KRATOS_SOURCE}" -B"${KRATOS_BUILD}/${KRATOS_BUILD_TYPE}" -Wno-dev    \
+${KRATOS_CMAKE_OPTIONS_FLAGS}                                                   \
+-DUSE_MPI=ON                                                                    \
+-DEXCLUDE_KRATOS_CORE=ON                                                        \
+-DEXCLUDE_AUTOMATIC_DEPENDENCIES=ON                                             \
+-DREMOVE_INSTALL_DIRECTORIES=OFF                                                \
+-DCMAKE_CXX_FLAGS="${KRATOS_CMAKE_CXX_FLAGS} -O0 -Wall"                         \
+-DCMAKE_POLICY_VERSION_MINIMUM=3.5                                              \
+-DTRILINOS_INCLUDE_DIR="/usr/include/trilinos"                                  \
+-DTRILINOS_LIBRARY_DIR="/usr/lib/x86_64-linux-gnu"                              \
+-DTRILINOS_LIBRARY_PREFIX="trilinos_"                                           \
 -DCMAKE_UNITY_BUILD=ON
 
 # Build

--- a/kratos/python_scripts/KratosUnittest.py
+++ b/kratos/python_scripts/KratosUnittest.py
@@ -184,39 +184,27 @@ def skipIfApplicationsNotAvailable(*application_names):
     reason_for_skip = 'Required Applications are missing: "{}"'.format('", "'.join(required_but_not_available_apps))
     return skipIf(len(required_but_not_available_apps) > 0, reason_for_skip)
 
-
 @contextmanager
-def SupressConsoleOutput():
+def ControlOutput(verbosity):
+    """ Controls the level of output of the application
+        0 - no output
+        1 - only errors
+        2 - all output
+    """
     with open(os.devnull, "w") as devnull:
-        old_stdout = sys.stdout
-        sys.stdout = devnull
+        if verbosity > 0:
+            old_stderr = sys.stderr
+            sys.stderr = devnull
+        if verbosity > 1:
+            old_stdout = sys.stdout
+            sys.stdout = devnull
         try:
             yield
         finally:
-            sys.stdout = old_stdout
-
-@contextmanager
-def SupressConsoleError():
-    with open(os.devnull, "w") as devnull:
-        old_stderr = sys.stderr
-        sys.stderr = devnull
-        try:
-            yield
-        finally:
-            sys.stderr = old_stderr
-
-@contextmanager
-def SupressAllConsole():
-    with open(os.devnull, "w") as devnull:
-        old_stderr = sys.stderr
-        old_stdout = sys.stdout
-        sys.stderr = devnull
-        sys.stdout = devnull
-        try:
-            yield
-        finally:
-            sys.stderr = old_stderr
-            sys.stdout = old_stdout
+            if verbosity > 0:
+                sys.stderr = old_stderr
+            if verbosity > 1:
+                sys.stdout = old_stdout
 
 def main():
     # this deliberately overiddes the function "unittest.main",

--- a/kratos/python_scripts/testing/utilities.py
+++ b/kratos/python_scripts/testing/utilities.py
@@ -162,7 +162,7 @@ class Commander(object):
                 self.exitCodes[test_suit_name] = 1
             finally:
                 if process_stdout:
-                    self.PrintOutput(process_stdout, sys.stderr)
+                    self.PrintOutput(process_stdout, sys.stdout)
                 if process_stderr:
                     self.PrintOutput(process_stderr, sys.stderr)
 


### PR DESCRIPTION
**📝 Description**
Currently output info for the python tests of the CI is too long. This makes a couple of changes:
- Redirects the out of the test subprocess to the standat sys.stdout (instead of out.stderr)
- Sends output channel to /dev/null

In the future, I intend to split the verbosity into test_verbosity and app_verbosity, so they can be controlled separately, but for the time being this should improve the readability. 

I have left the windows run without the redirection so we still have a version that outs the full info, in case someone is using that, but the plan is to take it out eventually as well. 

