### PR TITLE
[Core] Fix projection direction in `NewtonRaphsonCurve` to improve robustness

### DIFF
--- a/kratos/tests/cpp_tests/geometries/test_projection_nurbs_geometry.cpp
+++ b/kratos/tests/cpp_tests/geometries/test_projection_nurbs_geometry.cpp
@@ -155,10 +155,7 @@ typedef Node NodeType;
 
         KRATOS_EXPECT_VECTOR_NEAR(projected_point, projected_point2, TOLERANCE);
 
-        array_1d<double, 3> curve_extreme_point;
-        curve_extreme_point[0] = -9.0;
-        curve_extreme_point[1] = -2.0;
-        curve_extreme_point[2] = 0.0;
+        array_1d<double, 3> curve_extreme_point{-9.0, -2.0, 0.0};
 
         // Initialize projected point
         array_1d<double, 3> projected_point_extreme = ZeroVector(3);

--- a/kratos/tests/cpp_tests/geometries/test_projection_nurbs_geometry.cpp
+++ b/kratos/tests/cpp_tests/geometries/test_projection_nurbs_geometry.cpp
@@ -165,11 +165,11 @@ typedef Node NodeType;
 
         const bool is_converged_extreme = ProjectionNurbsGeometryUtilities::NewtonRaphsonCurve(parameter_extreme, curve_extreme_point, projected_point_extreme, curve);
 
-        KRATOS_EXPECT_EQ(isConvergedExtreme, true);
+        KRATOS_EXPECT_EQ(is_converged_extreme, true);
 
         KRATOS_EXPECT_NEAR(parameter_extreme[0], -1.0, TOLERANCE);
 
-        std::vector<double> projected_point_extreme1 = {-9.0, -2.0, 0.0};
+        array_1d<double, 3> projected_point_extreme1{-9.0, -2.0, 0.0};
 
         KRATOS_EXPECT_VECTOR_NEAR(projected_point_extreme, projected_point_extreme1, TOLERANCE);
     }

--- a/kratos/tests/cpp_tests/geometries/test_projection_nurbs_geometry.cpp
+++ b/kratos/tests/cpp_tests/geometries/test_projection_nurbs_geometry.cpp
@@ -163,7 +163,7 @@ typedef Node NodeType;
         // Try projection with initial guess at u = 0.0
         array_1d<double, 3> parameter_extreme = ZeroVector(3);
 
-        bool isConvergedExtreme = ProjectionNurbsGeometryUtilities::NewtonRaphsonCurve(parameter_extreme, curve_extreme_point, projected_point_extreme, curve);
+        const bool is_converged_extreme = ProjectionNurbsGeometryUtilities::NewtonRaphsonCurve(parameter_extreme, curve_extreme_point, projected_point_extreme, curve);
 
         KRATOS_EXPECT_EQ(isConvergedExtreme, true);
 

--- a/kratos/tests/cpp_tests/geometries/test_projection_nurbs_geometry.cpp
+++ b/kratos/tests/cpp_tests/geometries/test_projection_nurbs_geometry.cpp
@@ -154,6 +154,27 @@ typedef Node NodeType;
         std::vector<double> projected_point2 = {-4.694701201131293, -3.571229085898834, 0.0};
 
         KRATOS_EXPECT_VECTOR_NEAR(projected_point, projected_point2, TOLERANCE);
+
+        array_1d<double, 3> curve_extreme_point;
+        curve_extreme_point[0] = -9.0;
+        curve_extreme_point[1] = -2.0;
+        curve_extreme_point[2] = 0.0;
+
+        // Initialize projected point
+        array_1d<double, 3> projected_point_extreme = ZeroVector(3);
+
+        // Try projection with initial guess at u = 0.0
+        array_1d<double, 3> parameter_extreme = ZeroVector(3);
+
+        bool isConvergedExtreme = ProjectionNurbsGeometryUtilities::NewtonRaphsonCurve(parameter_extreme, curve_extreme_point, projected_point_extreme, curve);
+
+        KRATOS_EXPECT_EQ(isConvergedExtreme, true);
+
+        KRATOS_EXPECT_NEAR(parameter_extreme[0], -1.0, TOLERANCE);
+
+        std::vector<double> projected_point_extreme1 = {-9.0, -2.0, 0.0};
+
+        KRATOS_EXPECT_VECTOR_NEAR(projected_point_extreme, projected_point_extreme1, TOLERANCE);
     }
 
     KRATOS_TEST_CASE_IN_SUITE(NurbsSurfaceGeometryProjection3d, KratosCoreNurbsGeometriesFastSuite) {

--- a/kratos/utilities/nurbs_utilities/projection_nurbs_geometry_utilities.h
+++ b/kratos/utilities/nurbs_utilities/projection_nurbs_geometry_utilities.h
@@ -87,9 +87,18 @@ public:
 
             // Compute the increment
             delta_t = residual / (inner_prod(derivatives[2], distance_vector) + pow(norm_2(derivatives[1]), 2));
+            
+            // Compute the update vector and correct direction if needed
+            const array_1d<double, 3> update_vector = delta_t * derivatives[1];
+            const double alignment = inner_prod(update_vector, distance_vector);
+            
+            // If the update vector is not aligned with the distance vector, invert the sign to ensure moving towards the right point
+            if (alignment > 0.0) {
+                delta_t *= -1.0;
+            }
 
             // Increment the parametric coordinate
-            rProjectedPointLocalCoordinates[0] -= delta_t;
+            rProjectedPointLocalCoordinates[0] += delta_t;
 
             // Check if the increment is too small and if yes return true
             if (norm_2(delta_t * derivatives[1]) < Accuracy)
@@ -100,8 +109,10 @@ public:
             int check = rGeometry.ClosestPointLocalToLocalSpace(
                 rProjectedPointLocalCoordinates, rProjectedPointLocalCoordinates);
             if (check == 0) {
-                if (projection_reset_to_boundary) { return false; }
-                else { projection_reset_to_boundary = true; }
+                if (projection_reset_to_boundary)
+                    return false;
+                else
+                    projection_reset_to_boundary = true;
             }
         }
 


### PR DESCRIPTION
🔧 Fix: Improve Direction Handling in `NewtonRaphsonCurve` Projection

✨ What’s new
This PR enhances the robustness of the `NewtonRaphsonCurve` function in `ProjectionNurbsGeometryUtilities` by correcting the direction of the parametric update using geometric information.

🧠 Why
When projecting points far from the curve or close to the curve extremes, the Newton-Raphson update can mistakenly move in the wrong direction along the curve due to poor alignment with the tangent. This may lead to:
- Divergence or overshooting,

- Fallback to endpoints,

- Incorrect projections.

📐 How it works
We compute the global-space update vector:

```cpp
update_vector = delta_t * tangent;
```

Then compare it with the distance vector:

```cpp
alignment = inner_prod(update_vector, distance_vector);
```

If `alignment > 0.0`, we reverse `delta_t` to ensure the update moves toward the projection target.
