### PR TITLE
[CMake] Improve `Boost` detection when manually setting `BOOST_ROOT`

### DIFF
--- a/cmake_modules/KratosBoost.cmake
+++ b/cmake_modules/KratosBoost.cmake
@@ -3,6 +3,11 @@
 # Check if the BOOST_ROOT environment variable is defined
 if(DEFINED ENV{BOOST_ROOT})
   set(BOOST_ROOT $ENV{BOOST_ROOT})
+  # Check that boost/any.hpp exists in the BOOST_ROOT include directory
+  if(EXISTS "${BOOST_ROOT}/boost/any.hpp")
+    set(BOOST_INCLUDEDIR "${BOOST_ROOT}")
+    set(BOOST_LIBRARYDIR "${BOOST_ROOT}")
+  endif(EXISTS "${BOOST_ROOT}/boost/any.hpp")
 else(DEFINED ENV{BOOST_ROOT})
   # Check if BOOST_INCLUDEDIR and BOOST_LIBRARYDIR are already defined as environment variables
   if(DEFINED ENV{BOOST_INCLUDEDIR})


### PR DESCRIPTION
**📝 Description**

Improve `Boost` detection when manually setting `BOOST_ROOT`. Without this if later it detects Boost in the system path it will ignore the `BOOST_ROOT`.

**🆕 Changelog**

- [Improve `Boost` detection when manually setting `BOOST_ROOT`](https://github.com/KratosMultiphysics/Kratos/commit/fed3bd00ba5f12f4c426193e45b70aa8a096756b)
