### PR TITLE
[Core] Adding benchmarks for `unordered_set` and `unordered_map`

### DIFF
--- a/kratos/benchmarks/unordered_map.cpp
+++ b/kratos/benchmarks/unordered_map.cpp
@@ -76,17 +76,6 @@ static void BM_Unordered_Map_Delete(benchmark::State& state) {
 }
 BENCHMARK(BM_Unordered_Map_Delete)->Range(1 << 10, 1 << 20);
 
-// // Benchmark for rehashing
-// static void BM_Unordered_Map_Rehash(benchmark::State& state) {
-//     std::vector<int> data = generate_random_integers(state.range(0));
-//     Kratos::unordered_map<int, int> umap;
-//     for (auto _ : state) {
-//         umap.insert(data.begin(), data.end());
-//         umap.rehash(umap.size() * 2);
-//     }
-// }
-// BENCHMARK(BM_Unordered_Map_Rehash)->Range(1 << 10, 1 << 20);
-
 // Benchmark for iteration
 static void BM_Unordered_Map_Iteration(benchmark::State& state) {
     std::vector<int> data = generate_random_integers(state.range(0));

--- a/kratos/benchmarks/unordered_map.cpp
+++ b/kratos/benchmarks/unordered_map.cpp
@@ -1,0 +1,107 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
+//
+//  Main authors:    Vicente Mataix Ferrandiz
+//
+
+// System includes
+#include <random>
+#include <vector>
+
+// External includes
+#include <benchmark/benchmark.h>
+
+// Project includes
+#include "containers/unordered_map.h"
+
+namespace Kratos
+{
+// Function to generate random integers
+std::vector<int> generate_random_integers(size_t size) {
+    std::vector<int> data(size);
+    std::random_device rd;
+    std::mt19937 gen(rd());
+    std::uniform_int_distribution<> dis(1, 1000000);
+    for (size_t i = 0; i < size; ++i) {
+        data[i] = dis(gen);
+    }
+    return data;
+}
+
+// Benchmark for insertion
+static void BM_Unordered_Map_Insert(benchmark::State& state) {
+    std::vector<int> data = generate_random_integers(state.range(0));
+    for (auto _ : state) {
+        Kratos::unordered_map<int, int> umap;
+        for (const auto& val : data) {
+            umap[val] = val;
+        }
+    }
+}
+BENCHMARK(BM_Unordered_Map_Insert)->Range(1 << 10, 1 << 20);
+
+// Benchmark for lookup
+static void BM_Unordered_Map_Lookup(benchmark::State& state) {
+    std::vector<int> data = generate_random_integers(state.range(0));
+    Kratos::unordered_map<int, int> umap;
+    for (const auto& val : data) {
+        umap[val] = val;
+    }
+    for (auto _ : state) {
+        for (const auto& val : data) {
+            benchmark::DoNotOptimize(umap.find(val));
+        }
+    }
+}
+BENCHMARK(BM_Unordered_Map_Lookup)->Range(1 << 10, 1 << 20);
+
+// Benchmark for deletion
+static void BM_Unordered_Map_Delete(benchmark::State& state) {
+    std::vector<int> data = generate_random_integers(state.range(0));
+    for (auto _ : state) {
+        Kratos::unordered_map<int, int> umap;
+        for (const auto& val : data) {
+            umap[val] = val;
+        }
+        for (const auto& val : data) {
+            umap.erase(val);
+        }
+    }
+}
+BENCHMARK(BM_Unordered_Map_Delete)->Range(1 << 10, 1 << 20);
+
+// // Benchmark for rehashing
+// static void BM_Unordered_Map_Rehash(benchmark::State& state) {
+//     std::vector<int> data = generate_random_integers(state.range(0));
+//     Kratos::unordered_map<int, int> umap;
+//     for (auto _ : state) {
+//         umap.insert(data.begin(), data.end());
+//         umap.rehash(umap.size() * 2);
+//     }
+// }
+// BENCHMARK(BM_Unordered_Map_Rehash)->Range(1 << 10, 1 << 20);
+
+// Benchmark for iteration
+static void BM_Unordered_Map_Iteration(benchmark::State& state) {
+    std::vector<int> data = generate_random_integers(state.range(0));
+    Kratos::unordered_map<int, int> umap;
+    for (const auto& val : data) {
+        umap[val] = val;
+    }
+    for (auto _ : state) {
+        for (const auto& pair : umap) {
+            benchmark::DoNotOptimize(pair);
+        }
+    }
+}
+BENCHMARK(BM_Unordered_Map_Iteration)->Range(1 << 10, 1 << 20);
+
+}  // namespace Kratos
+
+BENCHMARK_MAIN();

--- a/kratos/benchmarks/unordered_set.cpp
+++ b/kratos/benchmarks/unordered_set.cpp
@@ -1,0 +1,98 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
+//
+//  Main authors:    Vicente Mataix Ferrandiz
+//
+
+// System includes
+#include <random>
+
+// External includes
+#include <benchmark/benchmark.h>
+
+// Project includes
+#include "containers/unordered_set.h"
+
+namespace Kratos
+{
+
+// Function to generate random integers
+std::vector<int> generate_random_integers(size_t size) {
+    std::vector<int> data(size);
+    std::random_device rd;
+    std::mt19937 gen(rd());
+    std::uniform_int_distribution<> dis(1, 1000000);
+    for (size_t i = 0; i < size; ++i) {
+        data[i] = dis(gen);
+    }
+    return data;
+}
+
+// Benchmark for insertion
+static void BM_Unordered_Set_Insert(benchmark::State& state) {
+    std::vector<int> data = generate_random_integers(state.range(0));
+    for (auto _ : state) {
+        Kratos::unordered_set<int> uset;
+        for (const auto& val : data) {
+            uset.insert(val);
+        }
+    }
+}
+BENCHMARK(BM_Unordered_Set_Insert)->Range(1 << 10, 1 << 20);
+
+// Benchmark for lookup
+static void BM_Unordered_Set_Lookup(benchmark::State& state) {
+    std::vector<int> data = generate_random_integers(state.range(0));
+    Kratos::unordered_set<int> uset(data.begin(), data.end());
+    for (auto _ : state) {
+        for (const auto& val : data) {
+            benchmark::DoNotOptimize(uset.find(val));
+        }
+    }
+}
+BENCHMARK(BM_Unordered_Set_Lookup)->Range(1 << 10, 1 << 20);
+
+// Benchmark for deletion
+static void BM_Unordered_Set_Delete(benchmark::State& state) {
+    std::vector<int> data = generate_random_integers(state.range(0));
+    for (auto _ : state) {
+        Kratos::unordered_set<int> uset(data.begin(), data.end());
+        for (const auto& val : data) {
+            uset.erase(val);
+        }
+    }
+}
+BENCHMARK(BM_Unordered_Set_Delete)->Range(1 << 10, 1 << 20);
+
+// Benchmark for rehashing
+static void BM_Unordered_Set_Rehash(benchmark::State& state) {
+    std::vector<int> data = generate_random_integers(state.range(0));
+    Kratos::unordered_set<int> uset;
+    for (auto _ : state) {
+        uset.insert(data.begin(), data.end());
+        uset.rehash(uset.size() * 2);
+    }
+}
+BENCHMARK(BM_Unordered_Set_Rehash)->Range(1 << 10, 1 << 20);
+
+// Benchmark for iteration
+static void BM_Unordered_Set_Iteration(benchmark::State& state) {
+    std::vector<int> data = generate_random_integers(state.range(0));
+    Kratos::unordered_set<int> uset(data.begin(), data.end());
+    for (auto _ : state) {
+        for (const auto& val : uset) {
+            benchmark::DoNotOptimize(val);
+        }
+    }
+}
+BENCHMARK(BM_Unordered_Set_Iteration)->Range(1 << 10, 1 << 20);
+
+}  // namespace Kratos
+
+BENCHMARK_MAIN();

--- a/kratos/benchmarks/unordered_set.cpp
+++ b/kratos/benchmarks/unordered_set.cpp
@@ -70,16 +70,6 @@ static void BM_Unordered_Set_Delete(benchmark::State& state) {
 }
 BENCHMARK(BM_Unordered_Set_Delete)->Range(1 << 10, 1 << 20);
 
-// Benchmark for rehashing
-static void BM_Unordered_Set_Rehash(benchmark::State& state) {
-    std::vector<int> data = generate_random_integers(state.range(0));
-    Kratos::unordered_set<int> uset;
-    for (auto _ : state) {
-        uset.insert(data.begin(), data.end());
-        uset.rehash(uset.size() * 2);
-    }
-}
-BENCHMARK(BM_Unordered_Set_Rehash)->Range(1 << 10, 1 << 20);
 
 // Benchmark for iteration
 static void BM_Unordered_Set_Iteration(benchmark::State& state) {


### PR DESCRIPTION
**📝 Description**

Adding benchmarks for `unordered_set` and `unordered_map`, ported from https://github.com/KratosMultiphysics/Kratos/pull/12861, as transition PR, as it looks like that we may finally use a different library.

**🆕 Changelog**

- [Adding benchmarks for `unordered_set` and `unordered_map`](https://github.com/KratosMultiphysics/Kratos/commit/ea6c3d8b94b0555c506882b59dd8fd308753f477)