### PR TITLE
[Core] Return Status Report from `LinearSolver::PerformSolutionStep`

### DIFF
--- a/applications/ContactStructuralMechanicsApplication/custom_linear_solvers/mixedulm_linear_solver.h
+++ b/applications/ContactStructuralMechanicsApplication/custom_linear_solvers/mixedulm_linear_solver.h
@@ -1,7 +1,7 @@
 // KRATOS    ______            __             __  _____ __                  __                   __
 //          / ____/___  ____  / /_____ ______/ /_/ ___// /________  _______/ /___  ___________ _/ /
-//         / /   / __ \/ __ \/ __/ __ `/ ___/ __/\__ \/ __/ ___/ / / / ___/ __/ / / / ___/ __ `/ / 
-//        / /___/ /_/ / / / / /_/ /_/ / /__/ /_ ___/ / /_/ /  / /_/ / /__/ /_/ /_/ / /  / /_/ / /  
+//         / /   / __ \/ __ \/ __/ __ `/ ___/ __/\__ \/ __/ ___/ / / / ___/ __/ / / / ___/ __ `/ /
+//        / /___/ /_/ / / / / /_/ /_/ / /__/ /_ ___/ / /_/ /  / /_/ / /__/ /_/ /_/ / /  / /_/ / /
 //        \____/\____/_/ /_/\__/\__,_/\___/\__//____/\__/_/   \__,_/\___/\__/\__,_/_/   \__,_/_/  MECHANICS
 //
 //  License:         BSD License
@@ -297,14 +297,8 @@ public:
         mpSolverDispBlock->InitializeSolutionStep(mKDispModified, mDisp, mResidualDisp);
     }
 
-    /**
-     * @brief This function actually performs the solution work, eventually taking advantage of what was done before in the
-     * @details Initialize and InitializeSolutionStep functions.
-     * @param rA System matrix
-     * @param rX Solution vector. it's also the initial guess for iterative linear solvers.
-     * @param rB Right hand side vector.
-    */
-    void PerformSolutionStep (
+    /// @copydoc LinearSolver::PerformSolutionStep
+    bool PerformSolutionStep (
         SparseMatrixType& rA,
         VectorType& rX,
         VectorType& rB
@@ -352,6 +346,8 @@ public:
             // Write back solution
             SetLMIPart(rX, mLMInactive);
         }
+
+        return false;
     }
 
     /**
@@ -380,7 +376,7 @@ public:
         mpSolverDispBlock->Clear();
 
         // Clear displacement DoFs
-        auto& r_data_dofs = mDisplacementDofs.GetContainer(); 
+        auto& r_data_dofs = mDisplacementDofs.GetContainer();
         for (IndexType i=0; i<r_data_dofs.size(); ++i) {
             delete r_data_dofs[i];
         }
@@ -499,7 +495,7 @@ public:
      * @details To make an example when solving a mixed u-p problem, it is important to identify the row associated to v and p. Another example is the automatic prescription of rotation null-space for smoothed-aggregation solvers which require knowledge on the spatial position of the nodes associated to a given dof. This function is the place to eventually provide such data
      * @param rA System matrix
      * @param rX Solution vector. It's also the initial guess for iterative linear solvers.
-     * @param rB Right hand side vector.     
+     * @param rB Right hand side vector.
      * @param rDofSet Reference to the container of the problem's degrees of freedom (stored by the BuilderAndSolver)
      * @param rModelPart Reference to the ModelPart containing the contact problem.
      */
@@ -775,7 +771,7 @@ public:
      * @brief This method retrieves the displacement DoFs of the system ordered according to the resolution order
      * @return The displacement DoFs of the system
      */
-    const DofsArrayType& GetDisplacementDofs() const 
+    const DofsArrayType& GetDisplacementDofs() const
     {
         return mDisplacementDofs;
     }
@@ -1587,7 +1583,7 @@ private:
     inline void AllocateBlocks()
     {
         // Clear displacement DoFs
-        auto& r_data_dofs = mDisplacementDofs.GetContainer(); 
+        auto& r_data_dofs = mDisplacementDofs.GetContainer();
         for (IndexType i=0; i<r_data_dofs.size(); ++i) {
             delete r_data_dofs[i];
         }

--- a/applications/LinearSolversApplication/custom_solvers/eigen_dense_direct_solver.h
+++ b/applications/LinearSolversApplication/custom_solvers/eigen_dense_direct_solver.h
@@ -84,7 +84,7 @@ public:
      * @param rX Solution vector
      * @param rB Right hand side vector
      */
-    void PerformSolutionStep(MatrixType& rA, VectorType& rX, VectorType& rB) override
+    bool PerformSolutionStep(MatrixType& rA, VectorType& rX, VectorType& rB) override
     {
         Eigen::Map<Kratos::EigenDynamicVector<DataType>> x(rX.data().begin(), rX.size());
         Eigen::Map<Kratos::EigenDynamicVector<DataType>> b(rB.data().begin(), rB.size());
@@ -92,6 +92,7 @@ public:
         const bool success = m_solver.Solve(b, x);
 
         KRATOS_ERROR_IF(!success) << "Solving failed!\n" << m_solver.GetSolverErrorMessages() << std::endl;
+        return success;
     }
 
     /**
@@ -104,9 +105,7 @@ public:
     bool Solve(MatrixType &rA, VectorType &rX, VectorType &rB) override
     {
         InitializeSolutionStep(rA, rX, rB);
-        PerformSolutionStep(rA, rX, rB);
-
-        return true;
+        return PerformSolutionStep(rA, rX, rB);
     }
 
     /** Multi solve method for solving a set of linear systems with same coefficient matrix.

--- a/applications/LinearSolversApplication/custom_solvers/eigen_direct_solver.h
+++ b/applications/LinearSolversApplication/custom_solvers/eigen_direct_solver.h
@@ -110,7 +110,7 @@ public:
      * @param rX Solution vector
      * @param rB Right hand side vector
      */
-    void PerformSolutionStep(SparseMatrixType& rA, VectorType& rX, VectorType& rB) override
+    bool PerformSolutionStep(SparseMatrixType& rA, VectorType& rX, VectorType& rB) override
     {
         Eigen::Map<Kratos::EigenDynamicVector<DataType>> x(rX.data().begin(), rX.size());
         Eigen::Map<Kratos::EigenDynamicVector<DataType>> b(rB.data().begin(), rB.size());
@@ -118,6 +118,7 @@ public:
         const bool success = m_solver.Solve(b, x);
 
         KRATOS_ERROR_IF(!success) << "Solving failed!\n" << m_solver.GetSolverErrorMessages() << std::endl;
+        return success;
     }
 
     /**
@@ -130,9 +131,7 @@ public:
     bool Solve(SparseMatrixType &rA, VectorType &rX, VectorType &rB) override
     {
         InitializeSolutionStep(rA, rX, rB);
-        PerformSolutionStep(rA, rX, rB);
-
-        return true;
+        return PerformSolutionStep(rA, rX, rB);
     }
 
     /**

--- a/kratos/future/linear_solvers/linear_solver.h
+++ b/kratos/future/linear_solvers/linear_solver.h
@@ -148,10 +148,12 @@ public:
      * @param rA. System matrix
      * @param rX. Solution vector. it's also the initial guess for iterative linear solvers.
      * @param rB. Right hand side vector.
+     * @return @p true if the provided system was solved successfully satisfying the given requirements, @p false otherwise.
      */
-    virtual void PerformSolutionStep(SparseMatrixType& rA, VectorType& rX, VectorType& rB)
+    virtual bool PerformSolutionStep(SparseMatrixType& rA, VectorType& rX, VectorType& rB)
     {
         KRATOS_ERROR << "Calling linear solver base class" << std::endl;
+        return false;
     }
 
     /**

--- a/kratos/linear_solvers/fallback_linear_solver.h
+++ b/kratos/linear_solvers/fallback_linear_solver.h
@@ -227,19 +227,14 @@ public:
         GetCurrentSolver()->FinalizeSolutionStep(rA, rX, rB);
     }
 
-    /**
-     * @brief This function actually performs the solution work, eventually taking advantage of what was done before in the Initialize and InitializeSolutionStep functions.
-     * @param rA. System matrix
-     * @param rX. Solution vector. it's also the initial guess for iterative linear solvers.
-     * @param rB. Right hand side vector.
-     */
-    void PerformSolutionStep(
+    /// @copydoc LinearSolver::PerformSolutionStep
+    bool PerformSolutionStep(
         SparseMatrixType& rA,
         VectorType& rX,
         VectorType& rB
         ) override
     {
-        GetCurrentSolver()->PerformSolutionStep(rA, rX, rB);
+        return GetCurrentSolver()->PerformSolutionStep(rA, rX, rB);
     }
 
     /**
@@ -356,7 +351,7 @@ public:
 
     /**
      * @brief Checks if additional physical data is needed by the solver.
-     * @details Some solvers may require a minimum degree of knowledge of the structure of the matrix. 
+     * @details Some solvers may require a minimum degree of knowledge of the structure of the matrix.
      * For instance, when solving a mixed u-p problem, it is important to identify the row associated with v and p.
      * Another example is the automatic prescription of rotation null-space for smoothed-aggregation solvers,
      * which require knowledge of the spatial position of the nodes associated with a given degree of freedom (DOF).

--- a/kratos/linear_solvers/linear_solver.h
+++ b/kratos/linear_solvers/linear_solver.h
@@ -124,7 +124,7 @@ public:
     ///@{
 
     /**
-     * @brief This function is designed to be called as few times as possible. 
+     * @brief This function is designed to be called as few times as possible.
      * @details It creates the data structures that only depend on the connectivity of the matrix (and not on its coefficients) so that the memory can be allocated once and expensive operations can be done only when strictly  needed
      * @param rA. System matrix
      * @param rX. Solution vector. it's also the initial guess for iterative linear solvers.
@@ -151,8 +151,9 @@ public:
      * @param rA. System matrix
      * @param rX. Solution vector. it's also the initial guess for iterative linear solvers.
      * @param rB. Right hand side vector.
+     * @return @p true if the provided system was solved successfully satisfying the given requirements, @p false otherwise.
      */
-    virtual void PerformSolutionStep(SparseMatrixType& rA, VectorType& rX, VectorType& rB)
+    virtual bool PerformSolutionStep(SparseMatrixType& rA, VectorType& rX, VectorType& rB)
     {
         KRATOS_ERROR << "Calling linear solver base class" << std::endl;
     }
@@ -221,7 +222,7 @@ public:
 
     /**
      * @brief Checks if additional physical data is needed by the solver.
-     * @details Some solvers may require a minimum degree of knowledge of the structure of the matrix. 
+     * @details Some solvers may require a minimum degree of knowledge of the structure of the matrix.
      * For instance, when solving a mixed u-p problem, it is important to identify the row associated with v and p.
      * Another example is the automatic prescription of rotation null-space for smoothed-aggregation solvers,
      * which require knowledge of the spatial position of the nodes associated with a given degree of freedom (DOF).
@@ -234,7 +235,7 @@ public:
 
     /**
      * @brief Provides additional physical data required by the solver.
-     * @details Some solvers may require a minimum degree of knowledge of the structure of the matrix. 
+     * @details Some solvers may require a minimum degree of knowledge of the structure of the matrix.
      * For example, when solving a mixed u-p problem, it is important to identify the row associated with v and p.
      * Another example is the automatic prescription of rotation null-space for smoothed-aggregation solvers,
      * which require knowledge of the spatial position of the nodes associated with a given degree of freedom (DOF).

--- a/kratos/linear_solvers/skyline_lu_custom_scalar_solver.h
+++ b/kratos/linear_solvers/skyline_lu_custom_scalar_solver.h
@@ -85,7 +85,7 @@ public:
         pSolver = Kratos::make_shared<SolverType>(*pBuiltinMatrix);
     }
 
-    void PerformSolutionStep(SparseMatrixType& rA, VectorType& rX, VectorType& rB) override
+    bool PerformSolutionStep(SparseMatrixType& rA, VectorType& rX, VectorType& rB) override
     {
         std::vector<DataType> x(rX.size());
         std::vector<DataType> b(rB.size());
@@ -95,6 +95,8 @@ public:
         (*pSolver)(b, x);
 
         std::copy(std::begin(x), std::end(x), std::begin(rX));
+
+        return true;
     }
 
     bool Solve(SparseMatrixType& rA, VectorType& rX, VectorType& rB) override


### PR DESCRIPTION
`LinearSolver::PerformSolutionStep` is supposed to do the heavy lifting and know whether the solver succeeded, yet it does not return such info even though `LinearSolver::Solve` does.

This PR changes `LinearSolver::PerformSolutionStep`'s return type from `void` to `bool`.
