### PR TITLE
[Core] Add shape based copy to/ from methods to `DataTypeTraits`

### DIFF
--- a/kratos/tests/cpp_tests/utilities/test_data_type_traits.cpp
+++ b/kratos/tests/cpp_tests/utilities/test_data_type_traits.cpp
@@ -951,18 +951,18 @@ KRATOS_TEST_CASE_IN_SUITE(DataTypeTraitsNestedDenseMatrixSizeWithShape, KratosCo
 
     KRATOS_EXPECT_EQ(data_type_traits::Dimension, shape.size());
     KRATOS_EXPECT_EQ(data_type_traits::Size(shape.begin(), shape.end()), 2150400);
-    KRATOS_EXPECT_FALSE(data_type_traits::IsValidShape(shape.begin(), shape.end()));
+    KRATOS_EXPECT_FALSE(data_type_traits::IsValidShape(shape.data(), shape.data() + shape.size()));
 
     shape[3] = 10;
     shape[6] = 3;
-    KRATOS_EXPECT_TRUE(data_type_traits::IsValidShape(shape.begin(), shape.end()));
+    KRATOS_EXPECT_TRUE(data_type_traits::IsValidShape(shape.data(), shape.data() + shape.size()));
     KRATOS_EXPECT_EQ(data_type_traits::Size(shape.begin(), shape.end()), 768000);
-    KRATOS_EXPECT_FALSE(data_type_traits::IsValidShape(shape.begin(), shape.end() - 1));
-    KRATOS_EXPECT_FALSE(data_type_traits::IsValidShape(shape.begin() + 1, shape.end()));
+    KRATOS_EXPECT_FALSE(data_type_traits::IsValidShape(shape.data(), shape.data() + shape.size() - 1));
+    KRATOS_EXPECT_FALSE(data_type_traits::IsValidShape(shape.data() + 1, shape.data() + shape.size()));
 
     shape[3] = 5;
     shape[6] = 2;
-    KRATOS_EXPECT_TRUE(data_type_traits::IsValidShape(shape.begin(), shape.end()));
+    KRATOS_EXPECT_TRUE(data_type_traits::IsValidShape(shape.data(), shape.data() + shape.size()));
     KRATOS_EXPECT_EQ(data_type_traits::Size(shape.begin(), shape.end()), 256000);
 }
 
@@ -980,7 +980,7 @@ KRATOS_TEST_CASE_IN_SUITE(DataTypeTraitsNestedDenseMatrixCopyToContiguousDataWit
     shape[6] = 2;       // array_1d dim
 
     KRATOS_EXPECT_EQ(data_type_traits::Dimension, shape.size());
-    KRATOS_EXPECT_TRUE(data_type_traits::IsValidShape(shape.begin(), shape.end()));
+    KRATOS_EXPECT_TRUE(data_type_traits::IsValidShape(shape.data(), shape.data() + shape.size()));
     KRATOS_EXPECT_EQ(data_type_traits::Size(shape.begin(), shape.end()), 720);
 
     // generate the data
@@ -1072,7 +1072,7 @@ KRATOS_TEST_CASE_IN_SUITE(DataTypeTraitsNestedDenseMatrixCopyFromContiguousDataW
     shape[6] = 2;       // array_1d dim
 
     KRATOS_EXPECT_EQ(data_type_traits::Dimension, shape.size());
-    KRATOS_EXPECT_TRUE(data_type_traits::IsValidShape(shape.begin(), shape.end()));
+    KRATOS_EXPECT_TRUE(data_type_traits::IsValidShape(shape.data(), shape.data() + shape.size()));
     KRATOS_EXPECT_EQ(data_type_traits::Size(shape.begin(), shape.end()), 720);
 
     // generate the data

--- a/kratos/tests/cpp_tests/utilities/test_data_type_traits.cpp
+++ b/kratos/tests/cpp_tests/utilities/test_data_type_traits.cpp
@@ -936,4 +936,193 @@ KRATOS_TEST_CASE_IN_SUITE(DataTypeTraitsNestedZeroSize, KratosCoreFastSuite)
     KRATOS_EXPECT_EQ(data_type_9_trait::Shape(test_data_type_9), data_type_9_shape);
 }
 
+KRATOS_TEST_CASE_IN_SUITE(DataTypeTraitsNestedDenseMatrixSizeWithShape, KratosCoreFastSuite)
+{
+    using data_type_traits = DataTypeTraits<std::vector<DenseMatrix<array_1d<std::vector<DenseVector<array_1d<double, 3>>>, 10>>>>;
+
+    std::vector<unsigned int> shape(7);
+    shape[0] = 10;
+    shape[1] = 4;
+    shape[2] = 8;
+    shape[3] = 12;
+    shape[4] = 20;
+    shape[5] = 4;
+    shape[6] = 7;
+
+    KRATOS_EXPECT_EQ(data_type_traits::Dimension, shape.size());
+    KRATOS_EXPECT_EQ(data_type_traits::Size(shape.begin(), shape.end()), 2150400);
+    KRATOS_EXPECT_FALSE(data_type_traits::IsValidShape(shape.begin(), shape.end()));
+
+    shape[3] = 10;
+    shape[6] = 3;
+    KRATOS_EXPECT_TRUE(data_type_traits::IsValidShape(shape.begin(), shape.end()));
+    KRATOS_EXPECT_EQ(data_type_traits::Size(shape.begin(), shape.end()), 768000);
+    KRATOS_EXPECT_FALSE(data_type_traits::IsValidShape(shape.begin(), shape.end() - 1));
+    KRATOS_EXPECT_FALSE(data_type_traits::IsValidShape(shape.begin() + 1, shape.end()));
+
+    shape[3] = 5;
+    shape[6] = 2;
+    KRATOS_EXPECT_TRUE(data_type_traits::IsValidShape(shape.begin(), shape.end()));
+    KRATOS_EXPECT_EQ(data_type_traits::Size(shape.begin(), shape.end()), 256000);
+}
+
+KRATOS_TEST_CASE_IN_SUITE(DataTypeTraitsNestedDenseMatrixCopyToContiguousDataWithShape, KratosCoreFastSuite)
+{
+    using data_type_traits = DataTypeTraits<std::vector<DenseMatrix<array_1d<std::vector<DenseVector<array_1d<int, 3>>>, 10>>>>;
+
+    std::vector<unsigned int> shape(7);
+    shape[0] = 3;       // vector dim
+    shape[1] = 2;       // matrix 1dim
+    shape[2] = 2;       // matrix 2dim
+    shape[3] = 5;       // array_1d dim
+    shape[4] = 2;       // vector dim
+    shape[5] = 3;       // dense vector dim
+    shape[6] = 2;       // array_1d dim
+
+    KRATOS_EXPECT_EQ(data_type_traits::Dimension, shape.size());
+    KRATOS_EXPECT_TRUE(data_type_traits::IsValidShape(shape.begin(), shape.end()));
+    KRATOS_EXPECT_EQ(data_type_traits::Size(shape.begin(), shape.end()), 720);
+
+    // generate the data
+    unsigned int value = 0;
+    using vec_type_1 = data_type_traits::ContainerType;
+    vec_type_1 data;
+    for (unsigned int vec_i = 0; vec_i < 5; ++vec_i) {
+        using mat_type_1 = DataTypeTraits<vec_type_1>::ValueType;
+        mat_type_1 mat_1(3, 4);
+        for (unsigned int mat_i = 0; mat_i < 3; ++mat_i) {
+            for (unsigned int mat_j = 0; mat_j < 4; ++mat_j) {
+                using arr_type_1 = DataTypeTraits<mat_type_1>::ValueType;
+                arr_type_1 arr_1;
+                for (unsigned int arr_i = 0; arr_i < 10; ++arr_i) {
+                    using vec_type_2 = DataTypeTraits<arr_type_1>::ValueType;
+                    vec_type_2 vec_2;
+                    for (unsigned int vec_j = 0; vec_j < 5; ++vec_j) {
+                        using dvec_type_1 = DataTypeTraits<vec_type_2>::ValueType;
+                        dvec_type_1 dvec(4);
+                        for (unsigned int dvec_i = 0; dvec_i < 4; ++dvec_i) {
+                            using arr_type_2 = DataTypeTraits<dvec_type_1>::ValueType;
+                            arr_type_2 arr_2;
+                            for (unsigned int arr_j = 0; arr_j < 3; ++arr_j) {
+                                arr_2[arr_j] = ++value;
+                            }
+                            dvec[dvec_i] = arr_2;
+                        }
+                        vec_2.push_back(dvec);
+                    }
+                    arr_1[arr_i] = vec_2;
+                }
+                mat_1(mat_i, mat_j) = arr_1;
+            }
+        }
+        data.push_back(mat_1);
+    }
+
+    // first copy all the data
+    std::vector<int> all_data(data_type_traits::Size(data));
+    data_type_traits::CopyToContiguousData(all_data.data(), data);
+    for (unsigned int i = 0; i < all_data.size(); ++i) {
+        KRATOS_EXPECT_EQ(all_data[i], i + 1);
+    }
+
+    const auto& r_origin_shape = data_type_traits::Shape(data);
+
+    std::vector<int> copied_data(720);
+    data_type_traits::CopyToContiguousData(copied_data.data(), data, shape.begin(), shape.end());
+
+    std::vector<unsigned int> copy_dim_lengths;
+    for (unsigned int i = 0; i < shape.size() - 1; ++i) {
+        copy_dim_lengths.push_back(std::accumulate(shape.begin() + i + 1, shape.end(), 1, std::multiplies<int>{}));
+    }
+
+    std::vector<unsigned int> orig_dim_lengths;
+    for (unsigned int i = 0; i < r_origin_shape.size() - 1; ++i) {
+        orig_dim_lengths.push_back(std::accumulate(r_origin_shape.begin() + i + 1, r_origin_shape.end(), 1, std::multiplies<int>{}));
+    }
+
+    std::vector<unsigned int> current_copy_dim_index(copy_dim_lengths.size());
+    for (unsigned int i = 0; i < 720; ++i) {
+        unsigned int index_remainder = i;
+        for (unsigned int j = 0; j < copy_dim_lengths.size(); ++j) {
+            current_copy_dim_index[j] = index_remainder / copy_dim_lengths[j];
+            index_remainder -= current_copy_dim_index[j] * copy_dim_lengths[j];
+        }
+
+        unsigned int orig_i = 0;
+        for (unsigned int j = 0; j < orig_dim_lengths.size(); ++j) {
+            orig_i += current_copy_dim_index[j] * orig_dim_lengths[j];
+        }
+
+        KRATOS_EXPECT_EQ(copied_data[i], all_data[orig_i + index_remainder]);
+    }
+
+}
+
+KRATOS_TEST_CASE_IN_SUITE(DataTypeTraitsNestedDenseMatrixCopyFromContiguousDataWithShape, KratosCoreFastSuite)
+{
+    using data_type_traits = DataTypeTraits<std::vector<DenseMatrix<array_1d<std::vector<DenseVector<array_1d<int, 3>>>, 10>>>>;
+
+    std::vector<unsigned int> shape(7);
+    shape[0] = 3;       // vector dim
+    shape[1] = 2;       // matrix 1dim
+    shape[2] = 2;       // matrix 2dim
+    shape[3] = 5;       // array_1d dim
+    shape[4] = 2;       // vector dim
+    shape[5] = 3;       // dense vector dim
+    shape[6] = 2;       // array_1d dim
+
+    KRATOS_EXPECT_EQ(data_type_traits::Dimension, shape.size());
+    KRATOS_EXPECT_TRUE(data_type_traits::IsValidShape(shape.begin(), shape.end()));
+    KRATOS_EXPECT_EQ(data_type_traits::Size(shape.begin(), shape.end()), 720);
+
+    // generate the data
+    unsigned int value = 0;
+    using vec_type_1 = data_type_traits::ContainerType;
+    vec_type_1 data;
+    for (unsigned int vec_i = 0; vec_i < 5; ++vec_i) {
+        using mat_type_1 = DataTypeTraits<vec_type_1>::ValueType;
+        mat_type_1 mat_1(3, 4);
+        for (unsigned int mat_i = 0; mat_i < 3; ++mat_i) {
+            for (unsigned int mat_j = 0; mat_j < 4; ++mat_j) {
+                using arr_type_1 = DataTypeTraits<mat_type_1>::ValueType;
+                arr_type_1 arr_1;
+                for (unsigned int arr_i = 0; arr_i < 10; ++arr_i) {
+                    using vec_type_2 = DataTypeTraits<arr_type_1>::ValueType;
+                    vec_type_2 vec_2;
+                    for (unsigned int vec_j = 0; vec_j < 5; ++vec_j) {
+                        using dvec_type_1 = DataTypeTraits<vec_type_2>::ValueType;
+                        dvec_type_1 dvec(4);
+                        for (unsigned int dvec_i = 0; dvec_i < 4; ++dvec_i) {
+                            using arr_type_2 = DataTypeTraits<dvec_type_1>::ValueType;
+                            arr_type_2 arr_2;
+                            for (unsigned int arr_j = 0; arr_j < 3; ++arr_j) {
+                                arr_2[arr_j] = ++value;
+                            }
+                            dvec[dvec_i] = arr_2;
+                        }
+                        vec_2.push_back(dvec);
+                    }
+                    arr_1[arr_i] = vec_2;
+                }
+                mat_1(mat_i, mat_j) = arr_1;
+            }
+        }
+        data.push_back(mat_1);
+    }
+
+    // first copy all the data
+    std::vector<int> all_data(data_type_traits::Size(shape.begin(), shape.end()));
+    data_type_traits::CopyToContiguousData(all_data.data(), data, shape.begin(), shape.end());
+
+    data_type_traits::ContainerType check_data;
+    data_type_traits::Reshape(check_data, shape);
+    data_type_traits::CopyFromContiguousData(check_data, all_data.data(), shape.begin(), shape.end());
+
+    std::vector<int> check_flat_data(data_type_traits::Size(shape.begin(), shape.end()));
+    data_type_traits::CopyToContiguousData(check_flat_data.data(), check_data, shape.begin(), shape.end());
+
+    KRATOS_CHECK_VECTOR_EQUAL(check_flat_data, all_data);
+
+}
+
 } // namespace Kratos::Testing

--- a/kratos/utilities/data_type_traits.h
+++ b/kratos/utilities/data_type_traits.h
@@ -52,9 +52,9 @@ public:
     ///@{
 
     /**
-     * @brief Returns whther the given @ref TCheckIndex is dynamic.
+     * @brief Returns whther the given @p TCheckIndex is dynamic.
      *
-     * This method returns true if the @ref TCheckIndex of the dimension
+     * This method returns true if the @p TCheckIndex of the dimension
      * corresponds to a dynamic type. If not, this returns false.
      *
      * @tparam TCheckIndex          User input dimension index.
@@ -70,10 +70,9 @@ public:
     /**
      * @brief Checks if the given shape is valid.
      * @details This method checks if the given shape is valid in the sense
-     *          that, dimensionality is correct as well as the values for each
-     *          static dimension is less or equal to the actual data types
-     *          static dimension value.
-     *
+     *          that, dimensionality is correct as well as the number of components for each
+     *          static dimension is less or equal to the actual static data types'
+     *          number of components.
      * @param pShapeBegin           Beginning of the shape array.
      * @param pShapeEnd             End of the shape array.
      */
@@ -101,9 +100,9 @@ public:
     /**
      * @brief Get the size of the underlying container given the shape
      *
-     * This method returns number of @ref PrimitiveType values contained recursively
-     * using the given shape with @ref pShapeBegin indicating the pointer to the
-     * start of the shape array and @ref pShapeEnd indicating the pointer to the
+     * This method returns number of @p PrimitiveType values contained recursively
+     * using the given shape with @p pShapeBegin indicating the pointer to the
+     * start of the shape array and @p pShapeEnd indicating the pointer to the
      * end of the shape array.
      *
      * @param pShapeBegin           Begining of the shape array.
@@ -120,9 +119,8 @@ public:
 
     /**
      * @brief Returns a vector with the shape of the value.
-     *
-     * Scalars have the shape of [] (an empty vector).
-     *
+     * @details This return the shape of the value. Scalars have
+     *          shape of [] (an empty vector).
      * @return std::vector<TIndexType>    Returns an empty vector as the shape.
      */
     template<class TIndexType = unsigned int>
@@ -218,11 +216,11 @@ public:
     /**
      * @brief Copies the given Value to contiguous array.
      *
-     * This method copies content of the @ref rValue to a contiguous array
-     * at @ref pContiguousDataBegin. The array pointed by @ref pContiguousDataBegin
+     * This method copies content of the @p rValue to a contiguous array
+     * at @p pContiguousDataBegin. The array pointed by @p pContiguousDataBegin
      * should be sized correctly.
      *
-     * @warning This may seg fault if the @ref pContiguousDataBegin is not correctly sized.
+     * @warning This may seg fault if the @p pContiguousDataBegin is not correctly sized.
      *
      * @param pContiguousDataBegin      Starting value pointer of the contiguous array.
      * @param rValue                    Value to be copied to contiguous array.
@@ -237,8 +235,8 @@ public:
     /**
      * @brief Copies the given container element value to contiguous array.
      *
-     * This method copies all the elements of @ref rContainer recursively to the
-     * provided @ref pContiguousDataBegin.
+     * This method copies all the elements of @p rContainer recursively to the
+     * provided @p pContiguousDataBegin.
      *
      * @warning This may segfault if the contiguous array given by @p pContiguousDataBegin
      *          is not correctly sized.
@@ -261,10 +259,10 @@ public:
     /**
      * @brief Copies data from contiguous array to rValue.
      *
-     * This method copies data from contiguous array to the passed @ref rValue.
+     * This method copies data from contiguous array to the passed @p rValue.
      * The contiguous array is given by the @refpContiguousDataBegin.
      *
-     * @warning This may seg fault if the @ref pContiguousDataBegin is not correctly sized.
+     * @warning This may seg fault if the @p pContiguousDataBegin is not correctly sized.
      *
      * @param rValue                Output value which contains copied values.
      * @param pContiguousDataBegin  Array to copy data from.
@@ -279,10 +277,10 @@ public:
     /**
      * @brief Copies contiguous values to the container.
      *
-     * This method copies all the contiguous values in the given @ref pContiguousDataBegin pointer
-     * to the @ref rContainer.
+     * This method copies all the contiguous values in the given @p pContiguousDataBegin pointer
+     * to the @p rContainer.
      *
-     * @warning This may seg-fault if the the contiguous array given by @ref pContiguousDataBegin
+     * @warning This may seg-fault if the the contiguous array given by @p pContiguousDataBegin
      *          is not correctly sized.
      *
      * @param rContainer            Container to copy values to.
@@ -359,9 +357,9 @@ public:
     ///@{
 
     /**
-     * @brief Returns whther the given @ref TCheckIndex is dynamic.
+     * @brief Returns whther the given @p TCheckIndex is dynamic.
      *
-     * This method returns true if the @ref TCheckIndex of the dimension
+     * This method returns true if the @p TCheckIndex of the dimension
      * corresponds to a dynamic type. If not, this returns false.
      *
      * @tparam TCheckIndex          User input dimension index.
@@ -377,10 +375,9 @@ public:
     /**
      * @brief Checks if the given shape is valid.
      * @details This method checks if the given shape is valid in the sense
-     *          that, dimensionality is correct as well as the values for each
-     *          static dimension is less or equal to the actual data types
-     *          static dimension value.
-     *
+     *          that, dimensionality is correct as well as the number of components for each
+     *          static dimension is less or equal to the actual static data types'
+     *          number of components.
      * @param pShapeBegin           Beginning of the shape array.
      * @param pShapeEnd             End of the shape array.
      */
@@ -397,8 +394,8 @@ public:
     /**
      * @brief Gets the size of underlying rContainer.
      *
-     * This method returns number of @ref PrimitiveType values contained in
-     * the @ref rContainer recursively.
+     * This method returns number of @p PrimitiveType values contained in
+     * the @p rContainer recursively.
      *
      * @param rContainer        The container to calculate the size.
      * @return TIndexType       Number of primitive type values in rContainer.
@@ -416,9 +413,9 @@ public:
     /**
      * @brief Get the size of the underlying container given the shape
      *
-     * This method returns number of @ref PrimitiveType values contained recursively
-     * using the given shape with @ref pShapeBegin indicating the pointer to the
-     * start of the shape array and @ref pShapeEnd indicating the pointer to the
+     * This method returns number of @p PrimitiveType values contained recursively
+     * using the given shape with @p pShapeBegin indicating the pointer to the
+     * start of the shape array and @p pShapeEnd indicating the pointer to the
      * end of the shape array.
      *
      * @param pShapeBegin           Begining of the shape array.
@@ -440,7 +437,7 @@ public:
      * in a recursive manner.
      *
      * @param rContainer                    Value to compute the shape.
-     * @return std::vector<TIndexType>    Shape of the @ref rContainer.
+     * @return std::vector<TIndexType>    Shape of the @p rContainer.
      */
     template<class TIndexType = unsigned int>
     static inline std::vector<TIndexType> Shape(const ContainerType& rContainer)
@@ -480,13 +477,13 @@ public:
     /**
      * @brief Reshapes the given value to given shape.
      *
-     * This method reshapes the given @ref rContainer to the @ref rShape
+     * This method reshapes the given @p rContainer to the @p rShape
      * recursively.
      *
-     * If this method has changed size of @ref rContainer or any of the elements
+     * If this method has changed size of @p rContainer or any of the elements
      * of the container, then true is returned. False is returned if no
-     * change is required in @ref rContainer to comply with the given
-     * @ref rShape.
+     * change is required in @p rContainer to comply with the given
+     * @p rShape.
      *
      * @param rContainer    Container to be resized recursively.
      * @param rShape        Shape to be used in resizing.
@@ -504,13 +501,13 @@ public:
     /**
      * @brief Reshapes the given value to given shape.
      *
-     * This method reshapes the given @ref rContainer to the shape given by @ref pShapeBegin
-     * and @ref pShapeEnd recursively.
+     * This method reshapes the given @p rContainer to the shape given by @p pShapeBegin
+     * and @p pShapeEnd recursively.
      *
-     * If this method has changed size of @ref rContainer or any of the elements
+     * If this method has changed size of @p rContainer or any of the elements
      * of the container, then true is returned. False is returned if no
-     * change is required in @ref rContainer to comply with the given shape
-     * represented by @ref pShapeBegin and @ref pShapeEnd.
+     * change is required in @p rContainer to comply with the given shape
+     * represented by @p pShapeBegin and @p pShapeEnd.
      *
      * @param rContainer    Container to be resized recursively.
      * @param pShapeBegin   Begin of the shape vector.
@@ -542,8 +539,8 @@ public:
     /**
      * @brief Get the Contiguous data pointer of the given container.
      *
-     * This method returns the underlying contiguous data ppinter of the given @ref rContainer.
-     * If the underlying data structure of @ref rContainer is not contiguous, this will
+     * This method returns the underlying contiguous data ppinter of the given @p rContainer.
+     * If the underlying data structure of @p rContainer is not contiguous, this will
      * throw a compiler time error.
      *
      * @param rValue                    Container to retireve the contiguous array pointer.
@@ -574,8 +571,8 @@ public:
     /**
      * @brief Get the Contiguous data pointer of the given container.
      *
-     * This method returns the underlying contiguous data ppinter of the given @ref rContainer.
-     * If the underlying data structure of @ref rContainer is not contiguous, this will
+     * This method returns the underlying contiguous data ppinter of the given @p rContainer.
+     * If the underlying data structure of @p rContainer is not contiguous, this will
      * throw a compiler time error.
      *
      * @param rValue                    Container to retireve the contiguous array pointer.
@@ -606,10 +603,10 @@ public:
     /**
      * @brief Copies the given container element value to contiguous array.
      *
-     * This method copies all the elements of @ref rContainer recursively to the
-     * provided @ref pContiguousDataBegin.
+     * This method copies all the elements of @p rContainer recursively to the
+     * provided @p pContiguousDataBegin.
      *
-     * @warning This may seg-fault if the the contiguous array given by @ref pContiguousDataBegin
+     * @warning This may seg-fault if the the contiguous array given by @p pContiguousDataBegin
      *          is not correctly sized.
      *
      * @param pContiguousDataBegin      Contiguous array pointer.
@@ -628,10 +625,10 @@ public:
     /**
      * @brief Copies the given container element value to contiguous array.
      *
-     * This method copies all the elements of @ref rContainer recursively to the
-     * provided @ref pContiguousDataBegin.
+     * This method copies all the elements of @p rContainer recursively to the
+     * provided @p pContiguousDataBegin.
      *
-     * @warning This may seg-fault if the the contiguous array given by @ref pContiguousDataBegin
+     * @warning This may seg-fault if the the contiguous array given by @p pContiguousDataBegin
      *          is not correctly sized.
      *
      * @param pContiguousDataBegin      Contiguous array pointer.
@@ -655,10 +652,10 @@ public:
     /**
      * @brief Copies contiguous values to the container.
      *
-     * This method copies all the contiguous values in the given @ref pContiguousDataBegin pointer
-     * to the @ref rContainer.
+     * This method copies all the contiguous values in the given @p pContiguousDataBegin pointer
+     * to the @p rContainer.
      *
-     * @warning This may seg-fault if the the contiguous array given by @ref pContiguousDataBegin
+     * @warning This may seg-fault if the the contiguous array given by @p pContiguousDataBegin
      *          is not correctly sized.
      *
      * @param rContainer            Container to copy values to.
@@ -677,10 +674,10 @@ public:
     /**
      * @brief Copies contiguous values to the container.
      *
-     * This method copies all the contiguous values in the given @ref pContiguousDataBegin pointer
-     * to the @ref rContainer.
+     * This method copies all the contiguous values in the given @p pContiguousDataBegin pointer
+     * to the @p rContainer.
      *
-     * @warning This may seg-fault if the the contiguous array given by @ref pContiguousDataBegin
+     * @warning This may seg-fault if the the contiguous array given by @p pContiguousDataBegin
      *          is not correctly sized.
      *
      * @param rContainer            Container to copy values to.
@@ -759,9 +756,9 @@ public:
     ///@{
 
     /**
-     * @brief Returns whther the given @ref TCheckIndex is dynamic.
+     * @brief Returns whther the given @p TCheckIndex is dynamic.
      *
-     * This method returns true if the @ref TCheckIndex of the dimension
+     * This method returns true if the @p TCheckIndex of the dimension
      * corresponds to a dynamic type. If not, this returns false.
      *
      * @tparam TCheckIndex          User input dimension index.
@@ -777,10 +774,9 @@ public:
     /**
      * @brief Checks if the given shape is valid.
      * @details This method checks if the given shape is valid in the sense
-     *          that, dimensionality is correct as well as the values for each
-     *          static dimension is less or equal to the actual data types
-     *          static dimension value.
-     *
+     *          that, dimensionality is correct as well as the number of components for each
+     *          static dimension is less or equal to the actual static data types'
+     *          number of components.
      * @param pShapeBegin           Beginning of the shape array.
      * @param pShapeEnd             End of the shape array.
      */
@@ -800,8 +796,8 @@ public:
     /**
      * @brief Gets the size of underlying rContainer.
      *
-     * This method returns number of @ref PrimitiveType values contained in
-     * the @ref rContainer recursively.
+     * This method returns number of @p PrimitiveType values contained in
+     * the @p rContainer recursively.
      *
      * @param rContainer        The container to calculate the size.
      * @return TIndexType       Number of primitive type values in rContainer.
@@ -815,9 +811,9 @@ public:
     /**
      * @brief Get the size of the underlying container given the shape
      *
-     * This method returns number of @ref PrimitiveType values contained recursively
-     * using the given shape with @ref pShapeBegin indicating the pointer to the
-     * start of the shape array and @ref pShapeEnd indicating the pointer to the
+     * This method returns number of @p PrimitiveType values contained recursively
+     * using the given shape with @p pShapeBegin indicating the pointer to the
+     * start of the shape array and @p pShapeEnd indicating the pointer to the
      * end of the shape array.
      *
      * @param pShapeBegin           Begining of the shape array.
@@ -839,7 +835,7 @@ public:
      * in a recursive manner.
      *
      * @param rContainer                    Value to compute the shape.
-     * @return std::vector<TIndexType>    Shape of the @ref rContainer.
+     * @return std::vector<TIndexType>    Shape of the @p rContainer.
      */
     template<class TIndexType = unsigned int>
     static inline std::vector<TIndexType> Shape(const ContainerType& rContainer)
@@ -879,13 +875,13 @@ public:
     /**
      * @brief Reshapes the given value to given shape.
      *
-     * This method reshapes the given @ref rContainer to the @ref rShape
+     * This method reshapes the given @p rContainer to the @p rShape
      * recursively.
      *
-     * If this method has changed size of @ref rContainer or any of the elements
+     * If this method has changed size of @p rContainer or any of the elements
      * of the container, then true is returned. False is returned if no
-     * change is required in @ref rContainer to comply with the given
-     * @ref rShape.
+     * change is required in @p rContainer to comply with the given
+     * @p rShape.
      *
      * @param rContainer    Container to be resized recursively.
      * @param rShape        Shape to be used in resizing.
@@ -903,13 +899,13 @@ public:
     /**
      * @brief Reshapes the given value to given shape.
      *
-     * This method reshapes the given @ref rContainer to the shape given by @ref pShapeBegin
-     * and @ref pShapeEnd recursively.
+     * This method reshapes the given @p rContainer to the shape given by @p pShapeBegin
+     * and @p pShapeEnd recursively.
      *
-     * If this method has changed size of @ref rContainer or any of the elements
+     * If this method has changed size of @p rContainer or any of the elements
      * of the container, then true is returned. False is returned if no
-     * change is required in @ref rContainer to comply with the given shape
-     * represented by @ref pShapeBegin and @ref pShapeEnd.
+     * change is required in @p rContainer to comply with the given shape
+     * represented by @p pShapeBegin and @p pShapeEnd.
      *
      * @param rContainer    Container to be resized recursively.
      * @param pShapeBegin   Begin of the shape vector.
@@ -946,8 +942,8 @@ public:
     /**
      * @brief Get the Contiguous data pointer of the given container.
      *
-     * This method returns the underlying contiguous data ppinter of the given @ref rContainer.
-     * If the underlying data structure of @ref rContainer is not contiguous, this will
+     * This method returns the underlying contiguous data ppinter of the given @p rContainer.
+     * If the underlying data structure of @p rContainer is not contiguous, this will
      * throw a compiler time error.
      *
      * @param rValue                    Container to retireve the contiguous array pointer.
@@ -978,8 +974,8 @@ public:
     /**
      * @brief Get the Contiguous data pointer of the given container.
      *
-     * This method returns the underlying contiguous data ppinter of the given @ref rContainer.
-     * If the underlying data structure of @ref rContainer is not contiguous, this will
+     * This method returns the underlying contiguous data ppinter of the given @p rContainer.
+     * If the underlying data structure of @p rContainer is not contiguous, this will
      * throw a compiler time error.
      *
      * @param rValue                    Container to retireve the contiguous array pointer.
@@ -1010,10 +1006,10 @@ public:
     /**
      * @brief Copies the given container element value to contiguous array.
      *
-     * This method copies all the elements of @ref rContainer recursively to the
-     * provided @ref pContiguousDataBegin.
+     * This method copies all the elements of @p rContainer recursively to the
+     * provided @p pContiguousDataBegin.
      *
-     * @warning This may seg-fault if the the contiguous array given by @ref pContiguousDataBegin
+     * @warning This may seg-fault if the the contiguous array given by @p pContiguousDataBegin
      *          is not correctly sized.
      *
      * @param pContiguousDataBegin      Contiguous array pointer.
@@ -1034,10 +1030,10 @@ public:
     /**
      * @brief Copies the given container element value to contiguous array.
      *
-     * This method copies all the elements of @ref rContainer recursively to the
-     * provided @ref pContiguousDataBegin.
+     * This method copies all the elements of @p rContainer recursively to the
+     * provided @p pContiguousDataBegin.
      *
-     * @warning This may seg-fault if the the contiguous array given by @ref pContiguousDataBegin
+     * @warning This may seg-fault if the the contiguous array given by @p pContiguousDataBegin
      *          is not correctly sized.
      *
      * @param pContiguousDataBegin      Contiguous array pointer.
@@ -1065,10 +1061,10 @@ public:
     /**
      * @brief Copies contiguous values to the container.
      *
-     * This method copies all the contiguous values in the given @ref pContiguousDataBegin pointer
-     * to the @ref rContainer.
+     * This method copies all the contiguous values in the given @p pContiguousDataBegin pointer
+     * to the @p rContainer.
      *
-     * @warning This may seg-fault if the the contiguous array given by @ref pContiguousDataBegin
+     * @warning This may seg-fault if the the contiguous array given by @p pContiguousDataBegin
      *          is not correctly sized.
      *
      * @param rContainer            Container to copy values to.
@@ -1089,10 +1085,10 @@ public:
     /**
      * @brief Copies contiguous values to the container.
      *
-     * This method copies all the contiguous values in the given @ref pContiguousDataBegin pointer
-     * to the @ref rContainer.
+     * This method copies all the contiguous values in the given @p pContiguousDataBegin pointer
+     * to the @p rContainer.
      *
-     * @warning This may seg-fault if the the contiguous array given by @ref pContiguousDataBegin
+     * @warning This may seg-fault if the the contiguous array given by @p pContiguousDataBegin
      *          is not correctly sized.
      *
      * @param rContainer            Container to copy values to.
@@ -1168,9 +1164,9 @@ public:
     ///@{
 
     /**
-     * @brief Returns whther the given @ref TCheckIndex is dynamic.
+     * @brief Returns whther the given @p TCheckIndex is dynamic.
      *
-     * This method returns true if the @ref TCheckIndex of the dimension
+     * This method returns true if the @p TCheckIndex of the dimension
      * corresponds to a dynamic type. If not, this returns false.
      *
      * @tparam TCheckIndex          User input dimension index.
@@ -1186,10 +1182,9 @@ public:
     /**
      * @brief Checks if the given shape is valid.
      * @details This method checks if the given shape is valid in the sense
-     *          that, dimensionality is correct as well as the values for each
-     *          static dimension is less or equal to the actual data types
-     *          static dimension value.
-     *
+     *          that, dimensionality is correct as well as the number of components for each
+     *          static dimension is less or equal to the actual static data types'
+     *          number of components.
      * @param pShapeBegin           Beginning of the shape array.
      * @param pShapeEnd             End of the shape array.
      */
@@ -1208,8 +1203,8 @@ public:
     /**
      * @brief Gets the size of underlying rContainer.
      *
-     * This method returns number of @ref PrimitiveType values contained in
-     * the @ref rContainer recursively.
+     * This method returns number of @p PrimitiveType values contained in
+     * the @p rContainer recursively.
      *
      * @param rContainer        The container to calculate the size.
      * @return TIndexType       Number of primitive type values in rContainer.
@@ -1223,9 +1218,9 @@ public:
     /**
      * @brief Get the size of the underlying container given the shape
      *
-     * This method returns number of @ref PrimitiveType values contained recursively
-     * using the given shape with @ref pShapeBegin indicating the pointer to the
-     * start of the shape array and @ref pShapeEnd indicating the pointer to the
+     * This method returns number of @p PrimitiveType values contained recursively
+     * using the given shape with @p pShapeBegin indicating the pointer to the
+     * start of the shape array and @p pShapeEnd indicating the pointer to the
      * end of the shape array.
      *
      * @param pShapeBegin           Begining of the shape array.
@@ -1247,7 +1242,7 @@ public:
      * in a recursive manner.
      *
      * @param rContainer                    Value to compute the shape.
-     * @return std::vector<TIndexType>    Shape of the @ref rContainer.
+     * @return std::vector<TIndexType>    Shape of the @p rContainer.
      */
     template<class TIndexType = unsigned int>
     static inline std::vector<TIndexType> Shape(const ContainerType& rContainer)
@@ -1288,13 +1283,13 @@ public:
     /**
      * @brief Reshapes the given value to given shape.
      *
-     * This method reshapes the given @ref rContainer to the @ref rShape
+     * This method reshapes the given @p rContainer to the @p rShape
      * recursively.
      *
-     * If this method has changed size of @ref rContainer or any of the elements
+     * If this method has changed size of @p rContainer or any of the elements
      * of the container, then true is returned. False is returned if no
-     * change is required in @ref rContainer to comply with the given
-     * @ref rShape.
+     * change is required in @p rContainer to comply with the given
+     * @p rShape.
      *
      * @param rContainer    Container to be resized recursively.
      * @param rShape        Shape to be used in resizing.
@@ -1312,13 +1307,13 @@ public:
     /**
      * @brief Reshapes the given value to given shape.
      *
-     * This method reshapes the given @ref rContainer to the shape given by @ref pShapeBegin
-     * and @ref pShapeEnd recursively.
+     * This method reshapes the given @p rContainer to the shape given by @p pShapeBegin
+     * and @p pShapeEnd recursively.
      *
-     * If this method has changed size of @ref rContainer or any of the elements
+     * If this method has changed size of @p rContainer or any of the elements
      * of the container, then true is returned. False is returned if no
-     * change is required in @ref rContainer to comply with the given shape
-     * represented by @ref pShapeBegin and @ref pShapeEnd.
+     * change is required in @p rContainer to comply with the given shape
+     * represented by @p pShapeBegin and @p pShapeEnd.
      *
      * @param rContainer    Container to be resized recursively.
      * @param pShapeBegin   Begin of the shape vector.
@@ -1355,8 +1350,8 @@ public:
     /**
      * @brief Get the Contiguous data pointer of the given container.
      *
-     * This method returns the underlying contiguous data ppinter of the given @ref rContainer.
-     * If the underlying data structure of @ref rContainer is not contiguous, this will
+     * This method returns the underlying contiguous data ppinter of the given @p rContainer.
+     * If the underlying data structure of @p rContainer is not contiguous, this will
      * throw a compiler time error.
      *
      * @param rValue                    Container to retireve the contiguous array pointer.
@@ -1387,8 +1382,8 @@ public:
     /**
      * @brief Get the Contiguous data pointer of the given container.
      *
-     * This method returns the underlying contiguous data ppinter of the given @ref rContainer.
-     * If the underlying data structure of @ref rContainer is not contiguous, this will
+     * This method returns the underlying contiguous data ppinter of the given @p rContainer.
+     * If the underlying data structure of @p rContainer is not contiguous, this will
      * throw a compiler time error.
      *
      * @param rValue                    Container to retireve the contiguous array pointer.
@@ -1419,10 +1414,10 @@ public:
     /**
      * @brief Copies the given container element value to contiguous array.
      *
-     * This method copies all the elements of @ref rContainer recursively to the
-     * provided @ref pContiguousDataBegin.
+     * This method copies all the elements of @p rContainer recursively to the
+     * provided @p pContiguousDataBegin.
      *
-     * @warning This may seg-fault if the the contiguous array given by @ref pContiguousDataBegin
+     * @warning This may seg-fault if the the contiguous array given by @p pContiguousDataBegin
      *          is not correctly sized.
      *
      * @param pContiguousDataBegin      Contiguous array pointer.
@@ -1443,10 +1438,10 @@ public:
     /**
      * @brief Copies the given container element value to contiguous array.
      *
-     * This method copies all the elements of @ref rContainer recursively to the
-     * provided @ref pContiguousDataBegin.
+     * This method copies all the elements of @p rContainer recursively to the
+     * provided @p pContiguousDataBegin.
      *
-     * @warning This may seg-fault if the the contiguous array given by @ref pContiguousDataBegin
+     * @warning This may seg-fault if the the contiguous array given by @p pContiguousDataBegin
      *          is not correctly sized.
      *
      * @param pContiguousDataBegin      Contiguous array pointer.
@@ -1476,10 +1471,10 @@ public:
     /**
      * @brief Copies contiguous values to the container.
      *
-     * This method copies all the contiguous values in the given @ref pContiguousDataBegin pointer
-     * to the @ref rContainer.
+     * This method copies all the contiguous values in the given @p pContiguousDataBegin pointer
+     * to the @p rContainer.
      *
-     * @warning This may seg-fault if the the contiguous array given by @ref pContiguousDataBegin
+     * @warning This may seg-fault if the the contiguous array given by @p pContiguousDataBegin
      *          is not correctly sized.
      *
      * @param rContainer            Container to copy values to.
@@ -1500,10 +1495,10 @@ public:
     /**
      * @brief Copies contiguous values to the container.
      *
-     * This method copies all the contiguous values in the given @ref pContiguousDataBegin pointer
-     * to the @ref rContainer.
+     * This method copies all the contiguous values in the given @p pContiguousDataBegin pointer
+     * to the @p rContainer.
      *
-     * @warning This may seg-fault if the the contiguous array given by @ref pContiguousDataBegin
+     * @warning This may seg-fault if the the contiguous array given by @p pContiguousDataBegin
      *          is not correctly sized.
      *
      * @param rContainer            Container to copy values to.
@@ -1579,9 +1574,9 @@ public:
     ///@{
 
     /**
-     * @brief Returns whther the given @ref TCheckIndex is dynamic.
+     * @brief Returns whther the given @p TCheckIndex is dynamic.
      *
-     * This method returns true if the @ref TCheckIndex of the dimension
+     * This method returns true if the @p TCheckIndex of the dimension
      * corresponds to a dynamic type. If not, this returns false.
      *
      * @tparam TCheckIndex          User input dimension index.
@@ -1597,10 +1592,9 @@ public:
     /**
      * @brief Checks if the given shape is valid.
      * @details This method checks if the given shape is valid in the sense
-     *          that, dimensionality is correct as well as the values for each
-     *          static dimension is less or equal to the actual data types
-     *          static dimension value.
-     *
+     *          that, dimensionality is correct as well as the number of components for each
+     *          static dimension is less or equal to the actual static data types'
+     *          number of components.
      * @param pShapeBegin           Beginning of the shape array.
      * @param pShapeEnd             End of the shape array.
      */
@@ -1620,8 +1614,8 @@ public:
     /**
      * @brief Gets the size of underlying rContainer.
      *
-     * This method returns number of @ref PrimitiveType values contained in
-     * the @ref rContainer recursively.
+     * This method returns number of @p PrimitiveType values contained in
+     * the @p rContainer recursively.
      *
      * @param rContainer        The container to calculate the size.
      * @return TIndexType       Number of primitive type values in rContainer.
@@ -1635,9 +1629,9 @@ public:
     /**
      * @brief Get the size of the underlying container given the shape
      *
-     * This method returns number of @ref PrimitiveType values contained recursively
-     * using the given shape with @ref pShapeBegin indicating the pointer to the
-     * start of the shape array and @ref pShapeEnd indicating the pointer to the
+     * This method returns number of @p PrimitiveType values contained recursively
+     * using the given shape with @p pShapeBegin indicating the pointer to the
+     * start of the shape array and @p pShapeEnd indicating the pointer to the
      * end of the shape array.
      *
      * @param pShapeBegin           Begining of the shape array.
@@ -1659,7 +1653,7 @@ public:
      * in a recursive manner.
      *
      * @param rContainer                    Value to compute the shape.
-     * @return std::vector<TIndexType>    Shape of the @ref rContainer.
+     * @return std::vector<TIndexType>    Shape of the @p rContainer.
      */
     template<class TIndexType = unsigned int>
     static inline std::vector<TIndexType> Shape(const ContainerType& rContainer)
@@ -1693,13 +1687,13 @@ public:
     /**
      * @brief Reshapes the given value to given shape.
      *
-     * This method reshapes the given @ref rContainer to the @ref rShape
+     * This method reshapes the given @p rContainer to the @p rShape
      * recursively.
      *
-     * If this method has changed size of @ref rContainer or any of the elements
+     * If this method has changed size of @p rContainer or any of the elements
      * of the container, then true is returned. False is returned if no
-     * change is required in @ref rContainer to comply with the given
-     * @ref rShape.
+     * change is required in @p rContainer to comply with the given
+     * @p rShape.
      *
      * @param rContainer    Container to be resized recursively.
      * @param rShape        Shape to be used in resizing.
@@ -1717,13 +1711,13 @@ public:
     /**
      * @brief Reshapes the given value to given shape.
      *
-     * This method reshapes the given @ref rContainer to the shape given by @ref pShapeBegin
-     * and @ref pShapeEnd recursively.
+     * This method reshapes the given @p rContainer to the shape given by @p pShapeBegin
+     * and @p pShapeEnd recursively.
      *
-     * If this method has changed size of @ref rContainer or any of the elements
+     * If this method has changed size of @p rContainer or any of the elements
      * of the container, then true is returned. False is returned if no
-     * change is required in @ref rContainer to comply with the given shape
-     * represented by @ref pShapeBegin and @ref pShapeEnd.
+     * change is required in @p rContainer to comply with the given shape
+     * represented by @p pShapeBegin and @p pShapeEnd.
      *
      * @param rContainer    Container to be resized recursively.
      * @param pShapeBegin   Begin of the shape vector.
@@ -1755,8 +1749,8 @@ public:
     /**
      * @brief Get the Contiguous data pointer of the given container.
      *
-     * This method returns the underlying contiguous data ppinter of the given @ref rContainer.
-     * If the underlying data structure of @ref rContainer is not contiguous, this will
+     * This method returns the underlying contiguous data ppinter of the given @p rContainer.
+     * If the underlying data structure of @p rContainer is not contiguous, this will
      * throw a compiler time error.
      *
      * @param rValue                    Container to retireve the contiguous array pointer.
@@ -1770,8 +1764,8 @@ public:
     /**
      * @brief Get the Contiguous data pointer of the given container.
      *
-     * This method returns the underlying contiguous data ppinter of the given @ref rContainer.
-     * If the underlying data structure of @ref rContainer is not contiguous, this will
+     * This method returns the underlying contiguous data ppinter of the given @p rContainer.
+     * If the underlying data structure of @p rContainer is not contiguous, this will
      * throw a compiler time error.
      *
      * @param rValue                    Container to retireve the contiguous array pointer.
@@ -1785,10 +1779,10 @@ public:
     /**
      * @brief Copies the given container element value to contiguous array.
      *
-     * This method copies all the elements of @ref rContainer recursively to the
-     * provided @ref pContiguousDataBegin.
+     * This method copies all the elements of @p rContainer recursively to the
+     * provided @p pContiguousDataBegin.
      *
-     * @warning This may seg-fault if the the contiguous array given by @ref pContiguousDataBegin
+     * @warning This may seg-fault if the the contiguous array given by @p pContiguousDataBegin
      *          is not correctly sized.
      *
      * @param pContiguousDataBegin      Contiguous array pointer.
@@ -1804,10 +1798,10 @@ public:
     /**
      * @brief Copies the given container element value to contiguous array.
      *
-     * This method copies all the elements of @ref rContainer recursively to the
-     * provided @ref pContiguousDataBegin.
+     * This method copies all the elements of @p rContainer recursively to the
+     * provided @p pContiguousDataBegin.
      *
-     * @warning This may seg-fault if the the contiguous array given by @ref pContiguousDataBegin
+     * @warning This may seg-fault if the the contiguous array given by @p pContiguousDataBegin
      *          is not correctly sized.
      *
      * @param pContiguousDataBegin      Contiguous array pointer.
@@ -1832,10 +1826,10 @@ public:
     /**
      * @brief Copies contiguous values to the container.
      *
-     * This method copies all the contiguous values in the given @ref pContiguousDataBegin pointer
-     * to the @ref rContainer.
+     * This method copies all the contiguous values in the given @p pContiguousDataBegin pointer
+     * to the @p rContainer.
      *
-     * @warning This may seg-fault if the the contiguous array given by @ref pContiguousDataBegin
+     * @warning This may seg-fault if the the contiguous array given by @p pContiguousDataBegin
      *          is not correctly sized.
      *
      * @param rContainer            Container to copy values to.
@@ -1851,10 +1845,10 @@ public:
     /**
      * @brief Copies contiguous values to the container.
      *
-     * This method copies all the contiguous values in the given @ref pContiguousDataBegin pointer
-     * to the @ref rContainer.
+     * This method copies all the contiguous values in the given @p pContiguousDataBegin pointer
+     * to the @p rContainer.
      *
-     * @warning This may seg-fault if the the contiguous array given by @ref pContiguousDataBegin
+     * @warning This may seg-fault if the the contiguous array given by @p pContiguousDataBegin
      *          is not correctly sized.
      *
      * @param rContainer            Container to copy values to.
@@ -1923,9 +1917,9 @@ public:
     ///@{
 
     /**
-     * @brief Returns whther the given @ref TCheckIndex is dynamic.
+     * @brief Returns whther the given @p TCheckIndex is dynamic.
      *
-     * This method returns true if the @ref TCheckIndex of the dimension
+     * This method returns true if the @p TCheckIndex of the dimension
      * corresponds to a dynamic type. If not, this returns false.
      *
      * @tparam TCheckIndex          User input dimension index.
@@ -1941,10 +1935,9 @@ public:
     /**
      * @brief Checks if the given shape is valid.
      * @details This method checks if the given shape is valid in the sense
-     *          that, dimensionality is correct as well as the values for each
-     *          static dimension is less or equal to the actual data types
-     *          static dimension value.
-     *
+     *          that, dimensionality is correct as well as the number of components for each
+     *          static dimension is less or equal to the actual static data types'
+     *          number of components.
      * @param pShapeBegin           Beginning of the shape array.
      * @param pShapeEnd             End of the shape array.
      */
@@ -1963,8 +1956,8 @@ public:
     /**
      * @brief Gets the size of underlying rContainer.
      *
-     * This method returns number of @ref PrimitiveType values contained in
-     * the @ref rContainer recursively.
+     * This method returns number of @p PrimitiveType values contained in
+     * the @p rContainer recursively.
      *
      * @param rContainer        The container to calculate the size.
      * @return TIndexType       Number of primitive type values in rContainer.
@@ -1978,9 +1971,9 @@ public:
     /**
      * @brief Get the size of the underlying container given the shape
      *
-     * This method returns number of @ref PrimitiveType values contained recursively
-     * using the given shape with @ref pShapeBegin indicating the pointer to the
-     * start of the shape array and @ref pShapeEnd indicating the pointer to the
+     * This method returns number of @p PrimitiveType values contained recursively
+     * using the given shape with @p pShapeBegin indicating the pointer to the
+     * start of the shape array and @p pShapeEnd indicating the pointer to the
      * end of the shape array.
      *
      * @param pShapeBegin           Begining of the shape array.
@@ -2002,7 +1995,7 @@ public:
      * in a recursive manner.
      *
      * @param rContainer                    Value to compute the shape.
-     * @return std::vector<TIndexType>    Shape of the @ref rContainer.
+     * @return std::vector<TIndexType>    Shape of the @p rContainer.
      */
     template<class TIndexType = unsigned int>
     static inline std::vector<TIndexType> Shape(const ContainerType& rContainer)
@@ -2042,13 +2035,13 @@ public:
     /**
      * @brief Reshapes the given value to given shape.
      *
-     * This method reshapes the given @ref rContainer to the @ref rShape
+     * This method reshapes the given @p rContainer to the @p rShape
      * recursively.
      *
-     * If this method has changed size of @ref rContainer or any of the elements
+     * If this method has changed size of @p rContainer or any of the elements
      * of the container, then true is returned. False is returned if no
-     * change is required in @ref rContainer to comply with the given
-     * @ref rShape.
+     * change is required in @p rContainer to comply with the given
+     * @p rShape.
      *
      * @param rContainer    Container to be resized recursively.
      * @param rShape        Shape to be used in resizing.
@@ -2066,13 +2059,13 @@ public:
     /**
      * @brief Reshapes the given value to given shape.
      *
-     * This method reshapes the given @ref rContainer to the shape given by @ref pShapeBegin
-     * and @ref pShapeEnd recursively.
+     * This method reshapes the given @p rContainer to the shape given by @p pShapeBegin
+     * and @p pShapeEnd recursively.
      *
-     * If this method has changed size of @ref rContainer or any of the elements
+     * If this method has changed size of @p rContainer or any of the elements
      * of the container, then true is returned. False is returned if no
-     * change is required in @ref rContainer to comply with the given shape
-     * represented by @ref pShapeBegin and @ref pShapeEnd.
+     * change is required in @p rContainer to comply with the given shape
+     * represented by @p pShapeBegin and @p pShapeEnd.
      *
      * @param rContainer    Container to be resized recursively.
      * @param pShapeBegin   Begin of the shape vector.
@@ -2109,8 +2102,8 @@ public:
     /**
      * @brief Get the Contiguous data pointer of the given container.
      *
-     * This method returns the underlying contiguous data ppinter of the given @ref rContainer.
-     * If the underlying data structure of @ref rContainer is not contiguous, this will
+     * This method returns the underlying contiguous data ppinter of the given @p rContainer.
+     * If the underlying data structure of @p rContainer is not contiguous, this will
      * throw a compiler time error.
      *
      * @param rValue                    Container to retireve the contiguous array pointer.
@@ -2128,8 +2121,8 @@ public:
     /**
      * @brief Get the Contiguous data pointer of the given container.
      *
-     * This method returns the underlying contiguous data ppinter of the given @ref rContainer.
-     * If the underlying data structure of @ref rContainer is not contiguous, this will
+     * This method returns the underlying contiguous data ppinter of the given @p rContainer.
+     * If the underlying data structure of @p rContainer is not contiguous, this will
      * throw a compiler time error.
      *
      * @param rValue                    Container to retireve the contiguous array pointer.
@@ -2147,10 +2140,10 @@ public:
     /**
      * @brief Copies the given container element value to contiguous array.
      *
-     * This method copies all the elements of @ref rContainer recursively to the
-     * provided @ref pContiguousDataBegin.
+     * This method copies all the elements of @p rContainer recursively to the
+     * provided @p pContiguousDataBegin.
      *
-     * @warning This may seg-fault if the the contiguous array given by @ref pContiguousDataBegin
+     * @warning This may seg-fault if the the contiguous array given by @p pContiguousDataBegin
      *          is not correctly sized.
      *
      * @param pContiguousDataBegin      Contiguous array pointer.
@@ -2171,10 +2164,10 @@ public:
     /**
      * @brief Copies the given container element value to contiguous array.
      *
-     * This method copies all the elements of @ref rContainer recursively to the
-     * provided @ref pContiguousDataBegin.
+     * This method copies all the elements of @p rContainer recursively to the
+     * provided @p pContiguousDataBegin.
      *
-     * @warning This may seg-fault if the the contiguous array given by @ref pContiguousDataBegin
+     * @warning This may seg-fault if the the contiguous array given by @p pContiguousDataBegin
      *          is not correctly sized.
      *
      * @param pContiguousDataBegin      Contiguous array pointer.
@@ -2202,10 +2195,10 @@ public:
     /**
      * @brief Copies contiguous values to the container.
      *
-     * This method copies all the contiguous values in the given @ref pContiguousDataBegin pointer
-     * to the @ref rContainer.
+     * This method copies all the contiguous values in the given @p pContiguousDataBegin pointer
+     * to the @p rContainer.
      *
-     * @warning This may seg-fault if the the contiguous array given by @ref pContiguousDataBegin
+     * @warning This may seg-fault if the the contiguous array given by @p pContiguousDataBegin
      *          is not correctly sized.
      *
      * @param rContainer            Container to copy values to.
@@ -2226,10 +2219,10 @@ public:
     /**
      * @brief Copies contiguous values to the container.
      *
-     * This method copies all the contiguous values in the given @ref pContiguousDataBegin pointer
-     * to the @ref rContainer.
+     * This method copies all the contiguous values in the given @p pContiguousDataBegin pointer
+     * to the @p rContainer.
      *
-     * @warning This may seg-fault if the the contiguous array given by @ref pContiguousDataBegin
+     * @warning This may seg-fault if the the contiguous array given by @p pContiguousDataBegin
      *          is not correctly sized.
      *
      * @param rContainer            Container to copy values to.

--- a/kratos/utilities/data_type_traits.h
+++ b/kratos/utilities/data_type_traits.h
@@ -70,7 +70,7 @@ public:
     /**
      * @brief Checks if the given shape is valid.
      *
-     * @param pShapeBegin           Begining of the shape array.
+     * @param pShapeBegin           Beginning of the shape array.
      * @param pShapeEnd             End of the shape array.
      */
     template<class TIteratorType>

--- a/kratos/utilities/data_type_traits.h
+++ b/kratos/utilities/data_type_traits.h
@@ -69,15 +69,21 @@ public:
 
     /**
      * @brief Checks if the given shape is valid.
+     * @details This method checks if the given shape is valid in the sense
+     *          that, dimensionality is correct as well as the values for each
+     *          static dimension is less or equal to the actual data types
+     *          static dimension value.
      *
      * @param pShapeBegin           Beginning of the shape array.
      * @param pShapeEnd             End of the shape array.
      */
-    template<class TIteratorType>
+    template<class TIntegerType>
     static bool inline IsValidShape(
-        TIteratorType pShapeBegin,
-        TIteratorType pShapeEnd)
+        TIntegerType const * pShapeBegin,
+        TIntegerType const * pShapeEnd)
     {
+        // this class is reserved for primitive types such as int, double, bool,...
+        // therefore, there should not be any dimensionality. Should only be an empty shape.
         return pShapeBegin == pShapeEnd;
     }
 
@@ -370,16 +376,22 @@ public:
 
     /**
      * @brief Checks if the given shape is valid.
+     * @details This method checks if the given shape is valid in the sense
+     *          that, dimensionality is correct as well as the values for each
+     *          static dimension is less or equal to the actual data types
+     *          static dimension value.
      *
-     * @param pShapeBegin           Begining of the shape array.
+     * @param pShapeBegin           Beginning of the shape array.
      * @param pShapeEnd             End of the shape array.
      */
-    template<class TIteratorType>
+    template<class TIntegerType>
     static bool inline IsValidShape(
-        TIteratorType pShapeBegin,
-        TIteratorType pShapeEnd)
+        TIntegerType const * pShapeBegin,
+        TIntegerType const * pShapeEnd)
     {
-        return pShapeBegin != pShapeEnd && (*pShapeBegin) <= TSize && ValueTraits::template IsValidShape<TIteratorType>(pShapeBegin + 1, pShapeEnd);
+        // this is an array_1d, so first dimension is used by the array_1d.
+        // the static size check is done here.
+        return pShapeBegin != pShapeEnd && (*pShapeBegin) <= TSize && ValueTraits::template IsValidShape<TIntegerType>(pShapeBegin + 1, pShapeEnd);
     }
 
     /**
@@ -764,16 +776,25 @@ public:
 
     /**
      * @brief Checks if the given shape is valid.
+     * @details This method checks if the given shape is valid in the sense
+     *          that, dimensionality is correct as well as the values for each
+     *          static dimension is less or equal to the actual data types
+     *          static dimension value.
      *
-     * @param pShapeBegin           Begining of the shape array.
+     * @param pShapeBegin           Beginning of the shape array.
      * @param pShapeEnd             End of the shape array.
      */
-    template<class TIteratorType>
+    template<class TIntegerType>
     static bool inline IsValidShape(
-        TIteratorType pShapeBegin,
-        TIteratorType pShapeEnd)
+        TIntegerType const * pShapeBegin,
+        TIntegerType const * pShapeEnd)
     {
-        return pShapeBegin != pShapeEnd && ValueTraits::template IsValidShape<TIteratorType>(pShapeBegin + 1, pShapeEnd);
+        // this is a dense vector, hence the first dimension of the given shape
+        // is used to identify the number of components in the dense vector.
+        // Since the dense vector is dynamic, this does not check the given
+        // number of components in the shape with what will be available.
+        // it only checks whether the dimension is available in the shape.
+        return pShapeBegin != pShapeEnd && ValueTraits::template IsValidShape<TIntegerType>(pShapeBegin + 1, pShapeEnd);
     }
 
     /**
@@ -1164,16 +1185,24 @@ public:
 
     /**
      * @brief Checks if the given shape is valid.
+     * @details This method checks if the given shape is valid in the sense
+     *          that, dimensionality is correct as well as the values for each
+     *          static dimension is less or equal to the actual data types
+     *          static dimension value.
      *
-     * @param pShapeBegin           Begining of the shape array.
+     * @param pShapeBegin           Beginning of the shape array.
      * @param pShapeEnd             End of the shape array.
      */
-    template<class TIteratorType>
+    template<class TIntegerType>
     static bool inline IsValidShape(
-        TIteratorType pShapeBegin,
-        TIteratorType pShapeEnd)
+        TIntegerType const * pShapeBegin,
+        TIntegerType const * pShapeEnd)
     {
-        return pShapeBegin != pShapeEnd && (pShapeBegin + 1) != pShapeEnd && ValueTraits::template IsValidShape<TIteratorType>(pShapeBegin + 2, pShapeEnd);
+        // this is for the matrix type.
+        // first two dimensions of the shape is used to define the matrix row and column
+        // number of components. Since matrix is dynamic, this
+        // only check whether the required dimensions are available.
+        return pShapeBegin != pShapeEnd && (pShapeBegin + 1) != pShapeEnd && ValueTraits::template IsValidShape<TIntegerType>(pShapeBegin + 2, pShapeEnd);
     }
 
     /**
@@ -1567,16 +1596,25 @@ public:
 
     /**
      * @brief Checks if the given shape is valid.
+     * @details This method checks if the given shape is valid in the sense
+     *          that, dimensionality is correct as well as the values for each
+     *          static dimension is less or equal to the actual data types
+     *          static dimension value.
      *
-     * @param pShapeBegin           Begining of the shape array.
+     * @param pShapeBegin           Beginning of the shape array.
      * @param pShapeEnd             End of the shape array.
      */
-    template<class TIteratorType>
+    template<class TIntegerType>
     static bool inline IsValidShape(
-        TIteratorType pShapeBegin,
-        TIteratorType pShapeEnd)
+        TIntegerType const * pShapeBegin,
+        TIntegerType const * pShapeEnd)
     {
-        return pShapeBegin != pShapeEnd;
+        // this is also considered as an array of chars.
+        // hence it should only have one dimension.
+        // since string is dynamic, number of components
+        // in the dimension is not checked. Only the
+        // availability of the dimension is checked.
+        return (pShapeBegin + 1) == pShapeEnd;
     }
 
     /**
@@ -1902,16 +1940,24 @@ public:
 
     /**
      * @brief Checks if the given shape is valid.
+     * @details This method checks if the given shape is valid in the sense
+     *          that, dimensionality is correct as well as the values for each
+     *          static dimension is less or equal to the actual data types
+     *          static dimension value.
      *
-     * @param pShapeBegin           Begining of the shape array.
+     * @param pShapeBegin           Beginning of the shape array.
      * @param pShapeEnd             End of the shape array.
      */
-    template<class TIteratorType>
+    template<class TIntegerType>
     static bool inline IsValidShape(
-        TIteratorType pShapeBegin,
-        TIteratorType pShapeEnd)
+        TIntegerType const * pShapeBegin,
+        TIntegerType const * pShapeEnd)
     {
-        return pShapeBegin != pShapeEnd && ValueTraits::template IsValidShape<TIteratorType>(pShapeBegin + 1, pShapeEnd);
+        // This is a vector type, and first dimension represents
+        // the number of components in the vector. Hence the availability
+        // of the dimension is checked. Since std::vector is dynamic,
+        // the number of component in the std::vector is not checked.
+        return pShapeBegin != pShapeEnd && ValueTraits::template IsValidShape<TIntegerType>(pShapeBegin + 1, pShapeEnd);
     }
 
     /**

--- a/kratos/utilities/data_type_traits.h
+++ b/kratos/utilities/data_type_traits.h
@@ -68,12 +68,46 @@ public:
     }
 
     /**
+     * @brief Checks if the given shape is valid.
+     *
+     * @param pShapeBegin           Begining of the shape array.
+     * @param pShapeEnd             End of the shape array.
+     */
+    template<class TIteratorType>
+    static bool inline IsValidShape(
+        TIteratorType pShapeBegin,
+        TIteratorType pShapeEnd)
+    {
+        return pShapeBegin == pShapeEnd;
+    }
+
+    /**
      * @brief Returns the size of the value.
      *
      * @return TIndexType Size of the value.
      */
     template<class TIndexType = unsigned int>
     static inline TIndexType Size(const ContainerType&)
+    {
+        return 1;
+    }
+
+    /**
+     * @brief Get the size of the underlying container given the shape
+     *
+     * This method returns number of @ref PrimitiveType values contained recursively
+     * using the given shape with @ref pShapeBegin indicating the pointer to the
+     * start of the shape array and @ref pShapeEnd indicating the pointer to the
+     * end of the shape array.
+     *
+     * @param pShapeBegin           Begining of the shape array.
+     * @param pShapeEnd             End of the shape array.
+     * @return TIndexType           Number of primitive type values in the shape.
+     */
+    template<class TIteratorType, class TIndexType = unsigned int>
+    static inline TIndexType Size(
+        TIteratorType pShapeBegin,
+        TIteratorType pShapeEnd)
     {
         return 1;
     }
@@ -195,6 +229,30 @@ public:
     }
 
     /**
+     * @brief Copies the given container element value to contiguous array.
+     *
+     * This method copies all the elements of @ref rContainer recursively to the
+     * provided @ref pContiguousDataBegin.
+     *
+     * @warning This may seg-fault if the the contiguous array given by @ref pContiguousDataBegin
+     *          is not correctly sized.
+     *
+     * @param pContiguousDataBegin      Contiguous array pointer.
+     * @param rContainer                Container to copy data to the contiguous array.
+     * @param pShapeBegin               Begining of the shape array.
+     * @param pShapeEnd                 End of the shape array.
+     */
+    template<class TIteratorType>
+    inline static void CopyToContiguousData(
+        PrimitiveType* pContiguousDataBegin,
+        const ContainerType& rContainer,
+        TIteratorType pShapeBegin,
+        TIteratorType pShapeEnd)
+    {
+        *pContiguousDataBegin = rContainer;
+    }
+
+    /**
      * @brief Copies data from contiguous array to rValue.
      *
      * This method copies data from contiguous array to the passed @ref rValue.
@@ -210,6 +268,30 @@ public:
         PrimitiveType const * pContiguousDataBegin)
     {
         rValue = *pContiguousDataBegin;
+    }
+
+    /**
+     * @brief Copies contiguous values to the container.
+     *
+     * This method copies all the contiguous values in the given @ref pContiguousDataBegin pointer
+     * to the @ref rContainer.
+     *
+     * @warning This may seg-fault if the the contiguous array given by @ref pContiguousDataBegin
+     *          is not correctly sized.
+     *
+     * @param rContainer            Container to copy values to.
+     * @param pContiguousDataBegin  Contiguous data container from which values are copied from.
+     * @param pShapeBegin           Begining of the shape array.
+     * @param pShapeEnd             End of the shape array.
+     */
+    template<class TIteratorType>
+    inline static void CopyFromContiguousData(
+        ContainerType& rContainer,
+        PrimitiveType const * pContiguousDataBegin,
+        TIteratorType pShapeBegin,
+        TIteratorType pShapeEnd)
+    {
+        rContainer = *pContiguousDataBegin;
     }
 
     ///@}
@@ -287,6 +369,20 @@ public:
     }
 
     /**
+     * @brief Checks if the given shape is valid.
+     *
+     * @param pShapeBegin           Begining of the shape array.
+     * @param pShapeEnd             End of the shape array.
+     */
+    template<class TIteratorType>
+    static bool inline IsValidShape(
+        TIteratorType pShapeBegin,
+        TIteratorType pShapeEnd)
+    {
+        return pShapeBegin != pShapeEnd && (*pShapeBegin) <= TSize && ValueTraits::template IsValidShape<TIteratorType>(pShapeBegin + 1, pShapeEnd);
+    }
+
+    /**
      * @brief Gets the size of underlying rContainer.
      *
      * This method returns number of @ref PrimitiveType values contained in
@@ -303,6 +399,26 @@ public:
         } else {
             return TSize * ValueTraits::template Size<TIndexType>(rContainer[0]);
         }
+    }
+
+    /**
+     * @brief Get the size of the underlying container given the shape
+     *
+     * This method returns number of @ref PrimitiveType values contained recursively
+     * using the given shape with @ref pShapeBegin indicating the pointer to the
+     * start of the shape array and @ref pShapeEnd indicating the pointer to the
+     * end of the shape array.
+     *
+     * @param pShapeBegin           Begining of the shape array.
+     * @param pShapeEnd             End of the shape array.
+     * @return TIndexType           Number of primitive type values in the shape.
+     */
+    template<class TIteratorType, class TIndexType = unsigned int>
+    static inline TIndexType Size(
+        TIteratorType pShapeBegin,
+        TIteratorType pShapeEnd)
+    {
+        return (*pShapeBegin) * ValueTraits::template Size<TIteratorType, TIndexType>(pShapeBegin + 1, pShapeEnd);
     }
 
     /**
@@ -363,7 +479,7 @@ public:
      * @param rContainer    Container to be resized recursively.
      * @param rShape        Shape to be used in resizing.
      * @return true         If the rContainer or its elements has changed due to resizing.
-     * @return false        If the rContaienr has not changed.
+     * @return false        If the rContainer has not changed.
      */
     template<class TIndexType = unsigned int>
     static inline bool Reshape(
@@ -388,7 +504,7 @@ public:
      * @param pShapeBegin   Begin of the shape vector.
      * @param pShapeEnd     End of the shape vector.
      * @return true         If the rContainer or its elements has changed due to resizing.
-     * @return false        If the rContaienr has not changed.
+     * @return false        If the rContainer has not changed.
      */
     template<class TIndexType = unsigned int>
     static inline bool Reshape(
@@ -396,7 +512,7 @@ public:
         TIndexType const * pShapeBegin,
         TIndexType const * pShapeEnd)
     {
-        KRATOS_ERROR_IF_NOT(std::distance(pShapeBegin, pShapeEnd) >= 1 && *pShapeBegin == static_cast<TIndexType>(TSize))
+        KRATOS_ERROR_IF_NOT(std::distance(pShapeBegin, pShapeEnd) >= 1 && *pShapeBegin <= static_cast<TIndexType>(TSize))
             << "Invalid shape/dimension given for array_1d data type [ Expected shape = " << Shape(rContainer) << ", provided shape = "
             << std::vector<TIndexType>(pShapeBegin, pShapeEnd) << " ].\n";
 
@@ -485,7 +601,7 @@ public:
      *          is not correctly sized.
      *
      * @param pContiguousDataBegin      Contiguous array pointer.
-     * @param rContainer                Contaienr to copy data to the contiguous array.
+     * @param rContainer                Container to copy data to the contiguous array.
      */
     inline static void CopyToContiguousData(
         PrimitiveType* pContiguousDataBegin,
@@ -494,6 +610,33 @@ public:
         const auto stride = ValueTraits::Size(rContainer[0]);
         for (unsigned int i = 0; i < TSize; ++i) {
             ValueTraits::CopyToContiguousData(pContiguousDataBegin + i * stride, rContainer[i]);
+        }
+    }
+
+    /**
+     * @brief Copies the given container element value to contiguous array.
+     *
+     * This method copies all the elements of @ref rContainer recursively to the
+     * provided @ref pContiguousDataBegin.
+     *
+     * @warning This may seg-fault if the the contiguous array given by @ref pContiguousDataBegin
+     *          is not correctly sized.
+     *
+     * @param pContiguousDataBegin      Contiguous array pointer.
+     * @param rContainer                Container to copy data to the contiguous array.
+     * @param pShapeBegin               Begining of the shape array.
+     * @param pShapeEnd                 End of the shape array.
+     */
+    template<class TIteratorType>
+    inline static void CopyToContiguousData(
+        PrimitiveType* pContiguousDataBegin,
+        const ContainerType& rContainer,
+        TIteratorType pShapeBegin,
+        TIteratorType pShapeEnd)
+    {
+        const auto stride = ValueTraits::Size(pShapeBegin + 1, pShapeEnd);
+        for (unsigned int i = 0; i < *pShapeBegin; ++i) {
+            ValueTraits::template CopyToContiguousData<TIteratorType>(pContiguousDataBegin + i * stride, rContainer[i], pShapeBegin + 1, pShapeEnd);
         }
     }
 
@@ -516,6 +659,33 @@ public:
         const auto stride = ValueTraits::Size(rContainer[0]);
         for (unsigned int i = 0; i < TSize; ++i) {
             ValueTraits::CopyFromContiguousData(rContainer[i], pContiguousDataBegin + i * stride);
+        }
+    }
+
+    /**
+     * @brief Copies contiguous values to the container.
+     *
+     * This method copies all the contiguous values in the given @ref pContiguousDataBegin pointer
+     * to the @ref rContainer.
+     *
+     * @warning This may seg-fault if the the contiguous array given by @ref pContiguousDataBegin
+     *          is not correctly sized.
+     *
+     * @param rContainer            Container to copy values to.
+     * @param pContiguousDataBegin  Contiguous data container from which values are copied from.
+     * @param pShapeBegin           Begining of the shape array.
+     * @param pShapeEnd             End of the shape array.
+     */
+    template<class TIteratorType>
+    inline static void CopyFromContiguousData(
+        ContainerType& rContainer,
+        PrimitiveType const * pContiguousDataBegin,
+        TIteratorType pShapeBegin,
+        TIteratorType pShapeEnd)
+    {
+        const auto stride = ValueTraits::Size(pShapeBegin + 1, pShapeEnd);
+        for (unsigned int i = 0; i < *pShapeBegin; ++i) {
+            ValueTraits::template CopyFromContiguousData<TIteratorType>(rContainer[i], pContiguousDataBegin + i * stride, pShapeBegin + 1, pShapeEnd);
         }
     }
 
@@ -593,6 +763,20 @@ public:
     }
 
     /**
+     * @brief Checks if the given shape is valid.
+     *
+     * @param pShapeBegin           Begining of the shape array.
+     * @param pShapeEnd             End of the shape array.
+     */
+    template<class TIteratorType>
+    static bool inline IsValidShape(
+        TIteratorType pShapeBegin,
+        TIteratorType pShapeEnd)
+    {
+        return pShapeBegin != pShapeEnd && ValueTraits::template IsValidShape<TIteratorType>(pShapeBegin + 1, pShapeEnd);
+    }
+
+    /**
      * @brief Gets the size of underlying rContainer.
      *
      * This method returns number of @ref PrimitiveType values contained in
@@ -605,6 +789,26 @@ public:
     static inline TIndexType Size(const ContainerType& rValue)
     {
         return (rValue.empty() ? 0 : rValue.size() * ValueTraits::template Size<TIndexType>(rValue[0]));
+    }
+
+    /**
+     * @brief Get the size of the underlying container given the shape
+     *
+     * This method returns number of @ref PrimitiveType values contained recursively
+     * using the given shape with @ref pShapeBegin indicating the pointer to the
+     * start of the shape array and @ref pShapeEnd indicating the pointer to the
+     * end of the shape array.
+     *
+     * @param pShapeBegin           Begining of the shape array.
+     * @param pShapeEnd             End of the shape array.
+     * @return TIndexType           Number of primitive type values in the shape.
+     */
+    template<class TIteratorType, class TIndexType = unsigned int>
+    static inline TIndexType Size(
+        TIteratorType pShapeBegin,
+        TIteratorType pShapeEnd)
+    {
+        return (*pShapeBegin) * ValueTraits::template Size<TIteratorType, TIndexType>(pShapeBegin + 1, pShapeEnd);
     }
 
     /**
@@ -665,7 +869,7 @@ public:
      * @param rContainer    Container to be resized recursively.
      * @param rShape        Shape to be used in resizing.
      * @return true         If the rContainer or its elements has changed due to resizing.
-     * @return false        If the rContaienr has not changed.
+     * @return false        If the rContainer has not changed.
      */
     template<class TIndexType = unsigned int>
     static inline bool Reshape(
@@ -690,7 +894,7 @@ public:
      * @param pShapeBegin   Begin of the shape vector.
      * @param pShapeEnd     End of the shape vector.
      * @return true         If the rContainer or its elements has changed due to resizing.
-     * @return false        If the rContaienr has not changed.
+     * @return false        If the rContainer has not changed.
      */
     template<class TIndexType = unsigned int>
     static inline bool Reshape(
@@ -792,7 +996,7 @@ public:
      *          is not correctly sized.
      *
      * @param pContiguousDataBegin      Contiguous array pointer.
-     * @param rContainer                Contaienr to copy data to the contiguous array.
+     * @param rContainer                Container to copy data to the contiguous array.
      */
     inline static void CopyToContiguousData(
         PrimitiveType* pContiguousDataBegin,
@@ -802,6 +1006,37 @@ public:
             const auto stride = ValueTraits::Size(rContainer[0]);
             for (unsigned int i = 0; i < rContainer.size(); ++i) {
                 ValueTraits::CopyToContiguousData(pContiguousDataBegin + i * stride, rContainer[i]);
+            }
+        }
+    }
+
+    /**
+     * @brief Copies the given container element value to contiguous array.
+     *
+     * This method copies all the elements of @ref rContainer recursively to the
+     * provided @ref pContiguousDataBegin.
+     *
+     * @warning This may seg-fault if the the contiguous array given by @ref pContiguousDataBegin
+     *          is not correctly sized.
+     *
+     * @param pContiguousDataBegin      Contiguous array pointer.
+     * @param rContainer                Container to copy data to the contiguous array.
+     * @param pShapeBegin               Begining of the shape array.
+     * @param pShapeEnd                 End of the shape array.
+     */
+    template<class TIteratorType>
+    inline static void CopyToContiguousData(
+        PrimitiveType* pContiguousDataBegin,
+        const ContainerType& rContainer,
+        TIteratorType pShapeBegin,
+        TIteratorType pShapeEnd)
+    {
+        // since the range [pShapeBegin, pShapeEnd) is checked using the IsValidShape method,
+        // here we only check for the dynamic size.
+        if (*pShapeBegin <= rContainer.size()) {
+            const auto stride = ValueTraits::Size(pShapeBegin + 1, pShapeEnd);
+            for (unsigned int i = 0; i < *pShapeBegin; ++i) {
+                ValueTraits::template CopyToContiguousData<TIteratorType>(pContiguousDataBegin + i * stride, rContainer[i], pShapeBegin + 1, pShapeEnd);
             }
         }
     }
@@ -826,6 +1061,35 @@ public:
             const auto stride = ValueTraits::Size(rContainer[0]);
             for (unsigned int i = 0; i < rContainer.size(); ++i) {
                 ValueTraits::CopyFromContiguousData(rContainer[i], pContiguousDataBegin + i * stride);
+            }
+        }
+    }
+
+    /**
+     * @brief Copies contiguous values to the container.
+     *
+     * This method copies all the contiguous values in the given @ref pContiguousDataBegin pointer
+     * to the @ref rContainer.
+     *
+     * @warning This may seg-fault if the the contiguous array given by @ref pContiguousDataBegin
+     *          is not correctly sized.
+     *
+     * @param rContainer            Container to copy values to.
+     * @param pContiguousDataBegin  Contiguous data container from which values are copied from.
+     * @param pShapeBegin           Begining of the shape array.
+     * @param pShapeEnd             End of the shape array.
+     */
+    template<class TIteratorType>
+    inline static void CopyFromContiguousData(
+        ContainerType& rContainer,
+        PrimitiveType const * pContiguousDataBegin,
+        TIteratorType pShapeBegin,
+        TIteratorType pShapeEnd)
+    {
+        if (rContainer.size() >= *pShapeBegin) {
+            const auto stride = ValueTraits::Size(pShapeBegin + 1, pShapeEnd);
+            for (unsigned int i = 0; i < *pShapeBegin; ++i) {
+                ValueTraits::template CopyFromContiguousData<TIteratorType>(rContainer[i], pContiguousDataBegin + i * stride, pShapeBegin + 1, pShapeEnd);
             }
         }
     }
@@ -899,6 +1163,20 @@ public:
     }
 
     /**
+     * @brief Checks if the given shape is valid.
+     *
+     * @param pShapeBegin           Begining of the shape array.
+     * @param pShapeEnd             End of the shape array.
+     */
+    template<class TIteratorType>
+    static bool inline IsValidShape(
+        TIteratorType pShapeBegin,
+        TIteratorType pShapeEnd)
+    {
+        return pShapeBegin != pShapeEnd && (pShapeBegin + 1) != pShapeEnd && ValueTraits::template IsValidShape<TIteratorType>(pShapeBegin + 2, pShapeEnd);
+    }
+
+    /**
      * @brief Gets the size of underlying rContainer.
      *
      * This method returns number of @ref PrimitiveType values contained in
@@ -911,6 +1189,26 @@ public:
     static inline TIndexType Size(const ContainerType& rValue)
     {
         return (rValue.size1() == 0 || rValue.size2() == 0 ? 0 : rValue.size1() * rValue.size2() * ValueTraits::template Size<TIndexType>(rValue.data()[0]));
+    }
+
+    /**
+     * @brief Get the size of the underlying container given the shape
+     *
+     * This method returns number of @ref PrimitiveType values contained recursively
+     * using the given shape with @ref pShapeBegin indicating the pointer to the
+     * start of the shape array and @ref pShapeEnd indicating the pointer to the
+     * end of the shape array.
+     *
+     * @param pShapeBegin           Begining of the shape array.
+     * @param pShapeEnd             End of the shape array.
+     * @return TIndexType           Number of primitive type values in the shape.
+     */
+    template<class TIteratorType, class TIndexType = unsigned int>
+    static inline TIndexType Size(
+        TIteratorType pShapeBegin,
+        TIteratorType pShapeEnd)
+    {
+        return (*pShapeBegin) * (*(pShapeBegin + 1)) * ValueTraits::template Size<TIteratorType, TIndexType>(pShapeBegin + 2, pShapeEnd);
     }
 
     /**
@@ -972,7 +1270,7 @@ public:
      * @param rContainer    Container to be resized recursively.
      * @param rShape        Shape to be used in resizing.
      * @return true         If the rContainer or its elements has changed due to resizing.
-     * @return false        If the rContaienr has not changed.
+     * @return false        If the rContainer has not changed.
      */
     template<class TIndexType = unsigned int>
     static inline bool Reshape(
@@ -997,7 +1295,7 @@ public:
      * @param pShapeBegin   Begin of the shape vector.
      * @param pShapeEnd     End of the shape vector.
      * @return true         If the rContainer or its elements has changed due to resizing.
-     * @return false        If the rContaienr has not changed.
+     * @return false        If the rContainer has not changed.
      */
     template<class TIndexType = unsigned int>
     static inline bool Reshape(
@@ -1099,7 +1397,7 @@ public:
      *          is not correctly sized.
      *
      * @param pContiguousDataBegin      Contiguous array pointer.
-     * @param rContainer                Contaienr to copy data to the contiguous array.
+     * @param rContainer                Container to copy data to the contiguous array.
      */
     inline static void CopyToContiguousData(
         PrimitiveType* pContiguousDataBegin,
@@ -1109,6 +1407,39 @@ public:
             const auto stride = ValueTraits::Size(rContainer(0, 0));
             for (unsigned int i = 0; i < rContainer.size1() * rContainer.size2(); ++i) {
                 ValueTraits::CopyToContiguousData(pContiguousDataBegin + i * stride, rContainer.data()[i]);
+            }
+        }
+    }
+
+    /**
+     * @brief Copies the given container element value to contiguous array.
+     *
+     * This method copies all the elements of @ref rContainer recursively to the
+     * provided @ref pContiguousDataBegin.
+     *
+     * @warning This may seg-fault if the the contiguous array given by @ref pContiguousDataBegin
+     *          is not correctly sized.
+     *
+     * @param pContiguousDataBegin      Contiguous array pointer.
+     * @param rContainer                Container to copy data to the contiguous array.
+     * @param pShapeBegin               Begining of the shape array.
+     * @param pShapeEnd                 End of the shape array.
+     */
+    template<class TIteratorType>
+    inline static void CopyToContiguousData(
+        PrimitiveType* pContiguousDataBegin,
+        const ContainerType& rContainer,
+        TIteratorType pShapeBegin,
+        TIteratorType pShapeEnd)
+    {
+        // since the range [pShapeBegin, pShapeEnd) is checked using the IsValidShape method,
+        // here we only check for the dynamic size.
+        if (*pShapeBegin <= rContainer.size1() && *(pShapeBegin + 1) <= rContainer.size2()) {
+            const auto stride = ValueTraits::Size(pShapeBegin + 2, pShapeEnd);
+            for (unsigned int i = 0; i < *pShapeBegin; ++i) {
+                for (unsigned int j = 0; j < *(pShapeBegin + 1); ++j) {
+                    ValueTraits::template CopyToContiguousData<TIteratorType>(pContiguousDataBegin + i * stride * (*pShapeBegin) + j * stride, rContainer(i, j), pShapeBegin + 2, pShapeEnd);
+                }
             }
         }
     }
@@ -1133,6 +1464,39 @@ public:
             const auto stride = ValueTraits::Size(rContainer(0, 0));
             for (unsigned int i = 0; i < rContainer.size1() * rContainer.size2(); ++i) {
                 ValueTraits::CopyFromContiguousData(rContainer.data()[i], pContiguousDataBegin + i * stride);
+            }
+        }
+    }
+
+    /**
+     * @brief Copies contiguous values to the container.
+     *
+     * This method copies all the contiguous values in the given @ref pContiguousDataBegin pointer
+     * to the @ref rContainer.
+     *
+     * @warning This may seg-fault if the the contiguous array given by @ref pContiguousDataBegin
+     *          is not correctly sized.
+     *
+     * @param rContainer            Container to copy values to.
+     * @param pContiguousDataBegin  Contiguous data container from which values are copied from.
+     * @param pShapeBegin           Begining of the shape array.
+     * @param pShapeEnd             End of the shape array.
+     */
+    template<class TIteratorType>
+    inline static void CopyFromContiguousData(
+        ContainerType& rContainer,
+        PrimitiveType const * pContiguousDataBegin,
+        TIteratorType pShapeBegin,
+        TIteratorType pShapeEnd)
+    {
+        // since the range [pShapeBegin, pShapeEnd) is checked using the IsValidShape method,
+        // here we only check for the dynamic size.
+        if (*pShapeBegin <= rContainer.size1() && *(pShapeBegin + 1) <= rContainer.size2()) {
+            const auto stride = ValueTraits::Size(pShapeBegin + 2, pShapeEnd);
+            for (unsigned int i = 0; i < *pShapeBegin; ++i) {
+                for (unsigned int j = 0; j < *(pShapeBegin + 1); ++j) {
+                    ValueTraits::template CopyFromContiguousData<TIteratorType>(rContainer(i, j), pContiguousDataBegin + i * stride * (*pShapeBegin) + j * stride, pShapeBegin + 2, pShapeEnd);
+                }
             }
         }
     }
@@ -1202,6 +1566,20 @@ public:
     }
 
     /**
+     * @brief Checks if the given shape is valid.
+     *
+     * @param pShapeBegin           Begining of the shape array.
+     * @param pShapeEnd             End of the shape array.
+     */
+    template<class TIteratorType>
+    static bool inline IsValidShape(
+        TIteratorType pShapeBegin,
+        TIteratorType pShapeEnd)
+    {
+        return pShapeBegin != pShapeEnd;
+    }
+
+    /**
      * @brief Gets the size of underlying rContainer.
      *
      * This method returns number of @ref PrimitiveType values contained in
@@ -1214,6 +1592,26 @@ public:
     static inline TIndexType Size(const ContainerType& rValue)
     {
         return rValue.size();
+    }
+
+    /**
+     * @brief Get the size of the underlying container given the shape
+     *
+     * This method returns number of @ref PrimitiveType values contained recursively
+     * using the given shape with @ref pShapeBegin indicating the pointer to the
+     * start of the shape array and @ref pShapeEnd indicating the pointer to the
+     * end of the shape array.
+     *
+     * @param pShapeBegin           Begining of the shape array.
+     * @param pShapeEnd             End of the shape array.
+     * @return TIndexType           Number of primitive type values in the shape.
+     */
+    template<class TIteratorType, class TIndexType = unsigned int>
+    static inline TIndexType Size(
+        TIteratorType pShapeBegin,
+        TIteratorType pShapeEnd)
+    {
+        return *pShapeBegin;
     }
 
     /**
@@ -1268,7 +1666,7 @@ public:
      * @param rContainer    Container to be resized recursively.
      * @param rShape        Shape to be used in resizing.
      * @return true         If the rContainer or its elements has changed due to resizing.
-     * @return false        If the rContaienr has not changed.
+     * @return false        If the rContainer has not changed.
      */
     template<class TIndexType = unsigned int>
     static inline bool Reshape(
@@ -1293,7 +1691,7 @@ public:
      * @param pShapeBegin   Begin of the shape vector.
      * @param pShapeEnd     End of the shape vector.
      * @return true         If the rContainer or its elements has changed due to resizing.
-     * @return false        If the rContaienr has not changed.
+     * @return false        If the rContainer has not changed.
      */
     template<class TIndexType = unsigned int>
     static inline bool Reshape(
@@ -1356,13 +1754,41 @@ public:
      *          is not correctly sized.
      *
      * @param pContiguousDataBegin      Contiguous array pointer.
-     * @param rContainer                Contaienr to copy data to the contiguous array.
+     * @param rContainer                Container to copy data to the contiguous array.
      */
     inline static void CopyToContiguousData(
         PrimitiveType* pContiguousDataBegin,
         const ContainerType& rContainer)
     {
         std::copy(rContainer.begin(), rContainer.end(), pContiguousDataBegin);
+    }
+
+    /**
+     * @brief Copies the given container element value to contiguous array.
+     *
+     * This method copies all the elements of @ref rContainer recursively to the
+     * provided @ref pContiguousDataBegin.
+     *
+     * @warning This may seg-fault if the the contiguous array given by @ref pContiguousDataBegin
+     *          is not correctly sized.
+     *
+     * @param pContiguousDataBegin      Contiguous array pointer.
+     * @param rContainer                Container to copy data to the contiguous array.
+     * @param pShapeBegin               Begining of the shape array.
+     * @param pShapeEnd                 End of the shape array.
+     */
+    template<class TIteratorType>
+    inline static void CopyToContiguousData(
+        PrimitiveType* pContiguousDataBegin,
+        const ContainerType& rContainer,
+        TIteratorType pShapeBegin,
+        TIteratorType pShapeEnd)
+    {
+        // since the range [pShapeBegin, pShapeEnd) is checked using the IsValidShape method,
+        // here we only check for the dynamic size.
+        if (*pShapeBegin <= rContainer.size()) {
+            std::copy(rContainer.begin(), rContainer.begin() + (*pShapeBegin), pContiguousDataBegin);
+        }
     }
 
     /**
@@ -1382,6 +1808,30 @@ public:
         PrimitiveType const * pContiguousDataBegin)
     {
         std::copy(pContiguousDataBegin, pContiguousDataBegin + rContainer.size(), rContainer.begin());
+    }
+
+    /**
+     * @brief Copies contiguous values to the container.
+     *
+     * This method copies all the contiguous values in the given @ref pContiguousDataBegin pointer
+     * to the @ref rContainer.
+     *
+     * @warning This may seg-fault if the the contiguous array given by @ref pContiguousDataBegin
+     *          is not correctly sized.
+     *
+     * @param rContainer            Container to copy values to.
+     * @param pContiguousDataBegin  Contiguous data container from which values are copied from.
+     * @param pShapeBegin           Begining of the shape array.
+     * @param pShapeEnd             End of the shape array.
+     */
+    template<class TIteratorType>
+    inline static void CopyFromContiguousData(
+        ContainerType& rContainer,
+        PrimitiveType const * pContiguousDataBegin,
+        TIteratorType pShapeBegin,
+        TIteratorType pShapeEnd)
+    {
+        std::copy(pContiguousDataBegin, pContiguousDataBegin + *pShapeBegin, rContainer.begin());
     }
 
     ///@}
@@ -1451,6 +1901,20 @@ public:
     }
 
     /**
+     * @brief Checks if the given shape is valid.
+     *
+     * @param pShapeBegin           Begining of the shape array.
+     * @param pShapeEnd             End of the shape array.
+     */
+    template<class TIteratorType>
+    static bool inline IsValidShape(
+        TIteratorType pShapeBegin,
+        TIteratorType pShapeEnd)
+    {
+        return pShapeBegin != pShapeEnd && ValueTraits::template IsValidShape<TIteratorType>(pShapeBegin + 1, pShapeEnd);
+    }
+
+    /**
      * @brief Gets the size of underlying rContainer.
      *
      * This method returns number of @ref PrimitiveType values contained in
@@ -1463,6 +1927,26 @@ public:
     static inline TIndexType Size(const ContainerType& rValue)
     {
         return (rValue.empty() ? 0 : rValue.size() * ValueTraits::template Size<TIndexType>(rValue[0]));
+    }
+
+    /**
+     * @brief Get the size of the underlying container given the shape
+     *
+     * This method returns number of @ref PrimitiveType values contained recursively
+     * using the given shape with @ref pShapeBegin indicating the pointer to the
+     * start of the shape array and @ref pShapeEnd indicating the pointer to the
+     * end of the shape array.
+     *
+     * @param pShapeBegin           Begining of the shape array.
+     * @param pShapeEnd             End of the shape array.
+     * @return TIndexType           Number of primitive type values in the shape.
+     */
+    template<class TIteratorType, class TIndexType = unsigned int>
+    static inline TIndexType Size(
+        TIteratorType pShapeBegin,
+        TIteratorType pShapeEnd)
+    {
+        return (*pShapeBegin) * ValueTraits::template Size<TIteratorType, TIndexType>(pShapeBegin + 1, pShapeEnd);
     }
 
     /**
@@ -1523,7 +2007,7 @@ public:
      * @param rContainer    Container to be resized recursively.
      * @param rShape        Shape to be used in resizing.
      * @return true         If the rContainer or its elements has changed due to resizing.
-     * @return false        If the rContaienr has not changed.
+     * @return false        If the rContainer has not changed.
      */
     template<class TIndexType = unsigned int>
     static inline bool Reshape(
@@ -1548,7 +2032,7 @@ public:
      * @param pShapeBegin   Begin of the shape vector.
      * @param pShapeEnd     End of the shape vector.
      * @return true         If the rContainer or its elements has changed due to resizing.
-     * @return false        If the rContaienr has not changed.
+     * @return false        If the rContainer has not changed.
      */
     template<class TIndexType = unsigned int>
     static inline bool Reshape(
@@ -1624,7 +2108,7 @@ public:
      *          is not correctly sized.
      *
      * @param pContiguousDataBegin      Contiguous array pointer.
-     * @param rContainer                Contaienr to copy data to the contiguous array.
+     * @param rContainer                Container to copy data to the contiguous array.
      */
     inline static void CopyToContiguousData(
         PrimitiveType* pContiguousDataBegin,
@@ -1634,6 +2118,37 @@ public:
             const auto stride = ValueTraits::Size(rContainer[0]);
             for (unsigned int i = 0; i < rContainer.size(); ++i) {
                 ValueTraits::CopyToContiguousData(pContiguousDataBegin + i * stride, rContainer[i]);
+            }
+        }
+    }
+
+    /**
+     * @brief Copies the given container element value to contiguous array.
+     *
+     * This method copies all the elements of @ref rContainer recursively to the
+     * provided @ref pContiguousDataBegin.
+     *
+     * @warning This may seg-fault if the the contiguous array given by @ref pContiguousDataBegin
+     *          is not correctly sized.
+     *
+     * @param pContiguousDataBegin      Contiguous array pointer.
+     * @param rContainer                Container to copy data to the contiguous array.
+     * @param pShapeBegin               Begining of the shape array.
+     * @param pShapeEnd                 End of the shape array.
+     */
+    template<class TIteratorType>
+    inline static void CopyToContiguousData(
+        PrimitiveType* pContiguousDataBegin,
+        const ContainerType& rContainer,
+        TIteratorType pShapeBegin,
+        TIteratorType pShapeEnd)
+    {
+        // since the range [pShapeBegin, pShapeEnd) is checked using the IsValidShape method,
+        // here we only check for the dynamic size.
+        if (*pShapeBegin <= rContainer.size()) {
+            const auto stride = ValueTraits::Size(pShapeBegin + 1, pShapeEnd);
+            for (unsigned int i = 0; i < *pShapeBegin; ++i) {
+                ValueTraits::template CopyToContiguousData<TIteratorType>(pContiguousDataBegin + i * stride, rContainer[i], pShapeBegin + 1, pShapeEnd);
             }
         }
     }
@@ -1658,6 +2173,35 @@ public:
             const auto stride = ValueTraits::Size(rContainer[0]);
             for (unsigned int i = 0; i < rContainer.size(); ++i) {
                 ValueTraits::CopyFromContiguousData(rContainer[i], pContiguousDataBegin + i * stride);
+            }
+        }
+    }
+
+    /**
+     * @brief Copies contiguous values to the container.
+     *
+     * This method copies all the contiguous values in the given @ref pContiguousDataBegin pointer
+     * to the @ref rContainer.
+     *
+     * @warning This may seg-fault if the the contiguous array given by @ref pContiguousDataBegin
+     *          is not correctly sized.
+     *
+     * @param rContainer            Container to copy values to.
+     * @param pContiguousDataBegin  Contiguous data container from which values are copied from.
+     * @param pShapeBegin           Begining of the shape array.
+     * @param pShapeEnd             End of the shape array.
+     */
+    template<class TIteratorType>
+    inline static void CopyFromContiguousData(
+        ContainerType& rContainer,
+        PrimitiveType const * pContiguousDataBegin,
+        TIteratorType pShapeBegin,
+        TIteratorType pShapeEnd)
+    {
+        if (rContainer.size() >= *pShapeBegin) {
+            const auto stride = ValueTraits::Size(pShapeBegin + 1, pShapeEnd);
+            for (unsigned int i = 0; i < *pShapeBegin; ++i) {
+                ValueTraits::template CopyFromContiguousData<TIteratorType>(rContainer[i], pContiguousDataBegin + i * stride, pShapeBegin + 1, pShapeEnd);
             }
         }
     }

--- a/kratos/utilities/data_type_traits.h
+++ b/kratos/utilities/data_type_traits.h
@@ -1055,6 +1055,10 @@ public:
             for (unsigned int i = 0; i < *pShapeBegin; ++i) {
                 ValueTraits::template CopyToContiguousData<TIteratorType>(pContiguousDataBegin + i * stride, rContainer[i], pShapeBegin + 1, pShapeEnd);
             }
+        } else {
+            KRATOS_ERROR
+                << "The given number of components are larger than the data size of DenseVector [ number of components in the dimension = "
+                << *pShapeBegin << ", number of components available in the data = " << rContainer.size() << " ].\n";
         }
     }
 
@@ -1108,6 +1112,10 @@ public:
             for (unsigned int i = 0; i < *pShapeBegin; ++i) {
                 ValueTraits::template CopyFromContiguousData<TIteratorType>(rContainer[i], pContiguousDataBegin + i * stride, pShapeBegin + 1, pShapeEnd);
             }
+        } else {
+            KRATOS_ERROR
+                << "The given number of components are larger than the data size of DenseVector [ number of components in the dimension = "
+                << *pShapeBegin << ", number of components available in the data = " << rContainer.size() << " ].\n";
         }
     }
 
@@ -1465,6 +1473,11 @@ public:
                     ValueTraits::template CopyToContiguousData<TIteratorType>(pContiguousDataBegin + i * stride * (*pShapeBegin) + j * stride, rContainer(i, j), pShapeBegin + 2, pShapeEnd);
                 }
             }
+        } else {
+            KRATOS_ERROR
+                << "The given number of components are larger than the data size of DenseMatrix [ number of components in the dimensions = ("
+                << *pShapeBegin << ", " << *(pShapeBegin + 1) << "), number of components available in the data = ("
+                << rContainer.size1() << ", " << rContainer.size2() << " ].\n";
         }
     }
 
@@ -1522,6 +1535,11 @@ public:
                     ValueTraits::template CopyFromContiguousData<TIteratorType>(rContainer(i, j), pContiguousDataBegin + i * stride * (*pShapeBegin) + j * stride, pShapeBegin + 2, pShapeEnd);
                 }
             }
+        } else {
+            KRATOS_ERROR
+                << "The given number of components are larger than the data size of DenseMatrix [ number of components in the dimensions = ("
+                << *pShapeBegin << ", " << *(pShapeBegin + 1) << "), number of components available in the data = ("
+                << rContainer.size1() << ", " << rContainer.size2() << " ].\n";
         }
     }
 
@@ -1820,6 +1838,10 @@ public:
         // here we only check for the dynamic size.
         if (*pShapeBegin <= rContainer.size()) {
             std::copy(rContainer.begin(), rContainer.begin() + (*pShapeBegin), pContiguousDataBegin);
+        } else {
+            KRATOS_ERROR
+                << "The given number of components are larger than the data size of std::string [ number of components in the dimension = "
+                << *pShapeBegin << ", number of components available in the data = " << rContainer.size() << " ].\n";
         }
     }
 
@@ -2189,6 +2211,10 @@ public:
             for (unsigned int i = 0; i < *pShapeBegin; ++i) {
                 ValueTraits::template CopyToContiguousData<TIteratorType>(pContiguousDataBegin + i * stride, rContainer[i], pShapeBegin + 1, pShapeEnd);
             }
+        } else {
+            KRATOS_ERROR
+                << "The given number of components are larger than the data size of std::vector [ number of components in the dimension = "
+                << *pShapeBegin << ", number of components available in the data = " << rContainer.size() << " ].\n";
         }
     }
 
@@ -2242,6 +2268,10 @@ public:
             for (unsigned int i = 0; i < *pShapeBegin; ++i) {
                 ValueTraits::template CopyFromContiguousData<TIteratorType>(rContainer[i], pContiguousDataBegin + i * stride, pShapeBegin + 1, pShapeEnd);
             }
+        } else {
+            KRATOS_ERROR
+                << "The given number of components are larger than the data size of std::vector [ number of components in the dimension = "
+                << *pShapeBegin << ", number of components available in the data = " << rContainer.size() << " ].\n";
         }
     }
 

--- a/kratos/utilities/data_type_traits.h
+++ b/kratos/utilities/data_type_traits.h
@@ -234,7 +234,7 @@ public:
      * This method copies all the elements of @ref rContainer recursively to the
      * provided @ref pContiguousDataBegin.
      *
-     * @warning This may seg-fault if the the contiguous array given by @ref pContiguousDataBegin
+     * @warning This may segfault if the contiguous array given by @p pContiguousDataBegin
      *          is not correctly sized.
      *
      * @param pContiguousDataBegin      Contiguous array pointer.


### PR DESCRIPTION
**📝 Description**
This PR adds methods to properly copy any list of types to contiguous array with a specified shape. The reverse also implemented.

**🆕 Changelog**
- Extends methods to copy to/from contiguous arrays with given shape.
- Adds unit tests
