### PR TITLE
[GeoMechanicsApplication] Made two Python tests more tolerant when comparing results

### DIFF
--- a/applications/GeoMechanicsApplication/tests/test_dirichlet_u.py
+++ b/applications/GeoMechanicsApplication/tests/test_dirichlet_u.py
@@ -72,7 +72,7 @@ class KratosGeoMechanicsDirichletUTests(KratosUnittest.TestCase):
             # stresses are continuous over the stages
             cauchy_stresses_2_4    = test_helper.GiDOutputFileReader.element_integration_point_values_at_time("CAUCHY_STRESS_TENSOR", time, output_data[stage_nr], [2], [3])[0][0]
             cauchy_stresses_2_4_yy = cauchy_stresses_2_4[1]
-            self.assertAlmostEqual(E*time*0.05, cauchy_stresses_2_4_yy, 2)
+            self.assertAlmostEqual(E*time*0.05, cauchy_stresses_2_4_yy, places=None, delta=1.0)
 
 if __name__ == '__main__':
     KratosUnittest.main()

--- a/applications/GeoMechanicsApplication/tests/test_integration_node_extrapolation.py
+++ b/applications/GeoMechanicsApplication/tests/test_integration_node_extrapolation.py
@@ -77,7 +77,7 @@ class KratosGeoMechanicsExtrapolationTests(KratosUnittest.TestCase):
                                 [-8.04944, -32.1978, -8.04944, -373.822, 0, 0]]
         for cauchy_stress_tensor, expected_tensor in zip(cauchy_stress_tensors, expected_tensors):
             for cauchy_stress, expected in zip(cauchy_stress_tensor, expected_tensor):
-                self.assertAlmostEqual(cauchy_stress, expected, places=4)
+                self.assertAlmostEqual(cauchy_stress, expected, places=None, delta=0.01)
 
 
         fluid_flux_vectors             = test_helper.GiDOutputFileReader.nodal_values_at_time("FLUID_FLUX_VECTOR", 1, simulation_output,


### PR DESCRIPTION
**📝 Description**
To prepare for the update of the GiD post functionality, two Python tests needed a more tolerant comparison. This PR does that by using the `delta` parameter rather than the `places` parameter of the `assertAlmostEqual` method.
