### PR TITLE
[CI] Disable MPMRestartTestDynamicCantilever2D

### DIFF
--- a/applications/MPMApplication/tests/restart_tests.py
+++ b/applications/MPMApplication/tests/restart_tests.py
@@ -98,7 +98,7 @@ class MPMRestartTestFactory(KratosUnittest.TestCase):
             mpm_analysis.MpmAnalysis(model_save, self.project_parameters_save).Run()
             mpm_analysis.MpmAnalysis(model_load, self.project_parameters_load).Run()
 
-
+@KratosUnittest.skip("This test has a race Condition in the CI causing a memory corruption. Please check")
 class MPMRestartTestDynamicCantilever2D(MPMRestartTestFactory):
     file_name = "beam_tests/dynamic_cantilever/dynamic_cantilever_consistent_mass_test"
 


### PR DESCRIPTION
**📝 Description**
This test fails randomly with a memory corruption (aprox 1 over 12 executions with 4 cores). 

@KratosMultiphysics/mpm  Please use this PR to fix it or approve the disabling until you have time to take a look at it. 
