### PR TITLE
[Core] Fix segfault in voxel mesher test

### DIFF
--- a/kratos/tests/cpp_tests/modeler/test_voxel_mesh_modeler.cpp
+++ b/kratos/tests/cpp_tests/modeler/test_voxel_mesh_modeler.cpp
@@ -195,7 +195,6 @@ KRATOS_TEST_CASE_IN_SUITE(XCartesianRayPlaneIntersection, KratosCoreFastSuite)
 		KRATOS_EXPECT_EQ(ray_2.GetIntersections().size(), 0);
 
 		KRATOS_EXPECT_NEAR(ray_1.GetIntersections()[0].first, .4, 1e-6);
-		KRATOS_EXPECT_NEAR(ray_2.GetIntersections()[0].first, .4, 1e-6);
 	}
 
 
@@ -243,7 +242,6 @@ KRATOS_TEST_CASE_IN_SUITE(XCartesianRayPlaneIntersection, KratosCoreFastSuite)
 		KRATOS_EXPECT_EQ(ray_2.GetIntersections().size(), 0);
 
 		KRATOS_EXPECT_NEAR(ray_1.GetIntersections()[0].first, .4, 1e-6);
-		KRATOS_EXPECT_NEAR(ray_2.GetIntersections()[0].first, .4, 1e-6);
 	}
 
 


### PR DESCRIPTION
**📝 Description**
Removes the check for the element 0 of the `ray_2` as its size should be 0 (as checked before).