### PR TITLE
[OptApp] Fix uniqueness of the grad field names

### DIFF
--- a/applications/OptimizationApplication/python_scripts/algorithms/standardized_SciPy_constraint.py
+++ b/applications/OptimizationApplication/python_scripts/algorithms/standardized_SciPy_constraint.py
@@ -85,8 +85,8 @@ class StandardizedSciPyConstraint(ResponseRoutine):
             if save_field:
                 # save the physical gradients for post processing in unbuffered data container.
                 for physical_var, physical_gradient in self.GetRequiredPhysicalGradients().items():
-                    variable_name = f"d{self.GetResponseName()}_d{physical_var.Name()}"
                     for physical_gradient_expression in physical_gradient.GetContainerExpressions():
+                        variable_name = f"d{self.GetResponseName()}_d{physical_var.Name()}_{physical_gradient_expression.GetModelPart().Name}"
                         if self.__unbuffered_data.HasValue(variable_name): del self.__unbuffered_data[variable_name]
                         # cloning is a cheap operation, it only moves underlying pointers
                         # does not create additional memory.
@@ -94,7 +94,7 @@ class StandardizedSciPyConstraint(ResponseRoutine):
 
                 # save the filtered gradients for post processing in unbuffered data container.
                 for gradient_container_expression, control in zip(gradient_collective_expression.GetContainerExpressions(), self.GetMasterControl().GetListOfControls()):
-                    variable_name = f"d{self.GetResponseName()}_d{control.GetName()}"
+                    variable_name = f"d{self.GetResponseName()}_d{control.GetName()}_{physical_gradient_expression.GetModelPart().Name}"
                     if self.__unbuffered_data.HasValue(variable_name): del self.__unbuffered_data[variable_name]
                     # cloning is a cheap operation, it only moves underlying pointers
                     # does not create additional memory.

--- a/applications/OptimizationApplication/python_scripts/algorithms/standardized_SciPy_objective.py
+++ b/applications/OptimizationApplication/python_scripts/algorithms/standardized_SciPy_objective.py
@@ -107,8 +107,8 @@ class StandardizedSciPyObjective(ResponseRoutine):
             if save_field:
                 # save the physical gradients for post processing in unbuffered data container.
                 for physical_var, physical_gradient in self.GetRequiredPhysicalGradients().items():
-                    variable_name = f"d{self.GetResponseName()}_d{physical_var.Name()}"
                     for physical_gradient_expression in physical_gradient.GetContainerExpressions():
+                        variable_name = f"d{self.GetResponseName()}_d{physical_var.Name()}_{physical_gradient_expression.GetModelPart().Name}"
                         if self.__unbuffered_data.HasValue(variable_name): del self.__unbuffered_data[variable_name]
                         # cloning is a cheap operation, it only moves underlying pointers
                         # does not create additional memory.
@@ -116,7 +116,7 @@ class StandardizedSciPyObjective(ResponseRoutine):
 
                 # save the filtered gradients for post processing in unbuffered data container.
                 for gradient_container_expression, control in zip(gradient_collective_expression.GetContainerExpressions(), self.GetMasterControl().GetListOfControls()):
-                    variable_name = f"d{self.GetResponseName()}_d{control.GetName()}"
+                    variable_name = f"d{self.GetResponseName()}_d{control.GetName()}_{physical_gradient_expression.GetModelPart().Name}"
                     if self.__unbuffered_data.HasValue(variable_name): del self.__unbuffered_data[variable_name]
                     # cloning is a cheap operation, it only moves underlying pointers
                     # does not create additional memory.

--- a/applications/OptimizationApplication/python_scripts/algorithms/standardized_constraint.py
+++ b/applications/OptimizationApplication/python_scripts/algorithms/standardized_constraint.py
@@ -120,8 +120,8 @@ class StandardizedConstraint(ResponseRoutine):
             if save_field:
                 # save the physical gradients for post processing in unbuffered data container.
                 for physical_var, physical_gradient in self.GetRequiredPhysicalGradients().items():
-                    variable_name = f"d{self.GetResponseName()}_d{physical_var.Name()}"
                     for physical_gradient_expression in physical_gradient.GetContainerExpressions():
+                        variable_name = f"d{self.GetResponseName()}_d{physical_var.Name()}_{physical_gradient_expression.GetModelPart().Name}"
                         if self.__unbuffered_data.HasValue(variable_name): del self.__unbuffered_data[variable_name]
                         # cloning is a cheap operation, it only moves underlying pointers
                         # does not create additional memory.
@@ -129,7 +129,7 @@ class StandardizedConstraint(ResponseRoutine):
 
                 # save the filtered gradients for post processing in unbuffered data container.
                 for gradient_container_expression, control in zip(gradient_collective_expression.GetContainerExpressions(), self.GetMasterControl().GetListOfControls()):
-                    variable_name = f"d{self.GetResponseName()}_d{control.GetName()}"
+                    variable_name = f"d{self.GetResponseName()}_d{control.GetName()}_{physical_gradient_expression.GetModelPart().Name}"
                     if self.__unbuffered_data.HasValue(variable_name): del self.__unbuffered_data[variable_name]
                     # cloning is a cheap operation, it only moves underlying pointers
                     # does not create additional memory.

--- a/applications/OptimizationApplication/python_scripts/algorithms/standardized_objective.py
+++ b/applications/OptimizationApplication/python_scripts/algorithms/standardized_objective.py
@@ -93,8 +93,8 @@ class StandardizedObjective(ResponseRoutine):
             if save_field:
                 # save the physical gradients for post processing in unbuffered data container.
                 for physical_var, physical_gradient in self.GetRequiredPhysicalGradients().items():
-                    variable_name = f"d{self.GetResponseName()}_d{physical_var.Name()}"
                     for physical_gradient_expression in physical_gradient.GetContainerExpressions():
+                        variable_name = f"d{self.GetResponseName()}_d{physical_var.Name()}_{physical_gradient_expression.GetModelPart().Name}"
                         if self.__unbuffered_data.HasValue(variable_name): del self.__unbuffered_data[variable_name]
                         # cloning is a cheap operation, it only moves underlying pointers
                         # does not create additional memory.
@@ -102,7 +102,7 @@ class StandardizedObjective(ResponseRoutine):
 
                 # save the filtered gradients for post processing in unbuffered data container.
                 for gradient_container_expression, control in zip(gradient_collective_expression.GetContainerExpressions(), self.GetMasterControl().GetListOfControls()):
-                    variable_name = f"d{self.GetResponseName()}_d{control.GetName()}"
+                    variable_name = f"d{self.GetResponseName()}_d{control.GetName()}_{physical_gradient_expression.GetModelPart().Name}"
                     if self.__unbuffered_data.HasValue(variable_name): del self.__unbuffered_data[variable_name]
                     # cloning is a cheap operation, it only moves underlying pointers
                     # does not create additional memory.


### PR DESCRIPTION
**📝 Description**
A brief description of the PR.
This pull request updates the `CalculateStandardizedGradient` method across multiple files in the `OptimizationApplication` to include the `ModelPart` name in the variable names used for storing gradient data. This change ensures that gradients are uniquely identified based on their associated `ModelPart`, improving clarity and preventing potential conflicts in the unbuffered data container.
