### PR TITLE
fixing signs in distance and output order

### DIFF
--- a/kratos/modeler/operation/compute_surrogate_boundary_data.cpp
+++ b/kratos/modeler/operation/compute_surrogate_boundary_data.cpp
@@ -104,7 +104,7 @@ void ComputeSurrogateBoundaryData::Execute()
 
                         for (std::size_t ii = 0; ii < 3; ii++)
                         {
-                            surrogate_boundary_data[node_index].GetVectorDistance()[ii] = point[ii] - closest_point[ii];
+                            surrogate_boundary_data[node_index].GetVectorDistance()[ii] = closest_point[ii] - point[ii];
                         }
                     } else {
                         KRATOS_WARNING("SurrogateBoundaryModeler") << "Input geometry has no elements or conditions. Unable to compute distance to skin." << std::endl;
@@ -149,9 +149,9 @@ std::string ComputeSurrogateBoundaryData::PrintSurrogateBoundaryData(std::vector
 
     rOStream << "=== Node Data ===" << std::endl;
 
-    for (std::size_t i = 0; i < n[0]; ++i) {
+    for (std::size_t k = 0; k < n[2]; ++k) {
         for (std::size_t j = 0; j < n[1]; ++j) {
-            for (std::size_t k = 0; k < n[2]; ++k) {
+            for (std::size_t i = 0; i < n[0]; ++i) {
                 SurrogateBoundaryNode& node = rSurrogateBoundaryData[GetNodeIndex(i,j,k)];;
                 auto& v = node.GetVectorDistance();
                 rOStream << node.IsActive() << " " << node.IsInside() << " "


### PR DESCRIPTION
There was a sign error because distance was being computed as origin - destiny instead of destiny - origin.

Also the output is now reordered (from z,y,x to x,y,z)