### PR TITLE
[Core[ Bugfix to the Master Slave Constraint const GetValue method

### DIFF
--- a/kratos/includes/master_slave_constraint.h
+++ b/kratos/includes/master_slave_constraint.h
@@ -555,7 +555,7 @@ public:
      * @param rThisVariable The variable to get
      */
     template<class TVariableType>
-    typename TVariableType::Type& GetValue(const TVariableType& rThisVariable) const
+    typename TVariableType::Type const& GetValue(const TVariableType& rThisVariable) const
     {
         return mData.GetValue(rThisVariable);
     }


### PR DESCRIPTION
**📝 Description**
As in the title

**🆕 Changelog**
- `MasterSlaveConstraint::GetValue() const` is made to be `const` correct
