### PR TITLE
[External] Purge unused features from `gidpost`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -659,6 +659,11 @@ if(${EXCLUDE_KRATOS_CORE} MATCHES OFF)
   set(ENABLE_PARALLEL_EXAMPLE OFF)
   set(ENABLE_HDF5 OFF)
   set(ZLIB_FOUND TRUE)
+
+  # (for gidpost )Disable examples and fortran examples.
+  set(ENABLE_EXAMPLES OFF)
+  set(ENABLE_FORTRAN_EXAMPLES OFF)
+
   add_subdirectory(external_libraries/gidpost)
   add_subdirectory(kratos)
 endif()

--- a/external_libraries/gidpost/source/CMakeLists.txt
+++ b/external_libraries/gidpost/source/CMakeLists.txt
@@ -3,7 +3,7 @@
 message( STATUS "* Configuring gidpost library" )
 
 set (gidpost_source 
-  gidpost.c gidpost_cluster.c gidpostFILES.c gidpostInt.c  gidpostfor.c gidpostforAPI.c
+  gidpost.c gidpost_cluster.c gidpostFILES.c gidpostInt.c
   gidpostHash.c hashtab.c recycle.c lookupa.c)
 
 file(GLOB SOURCE_FILES "${CMAKE_CURRENT_SOURCE_DIR}/source/*.c")


### PR DESCRIPTION
**📝 Description**

This fixes compilation in Windows. Cherrypicking from @roigcarlo. This fixes our workflows in @KratosMultiphysics/altair 

**🆕 Changelog**

- [Purge features unused features from gpost](https://github.com/KratosMultiphysics/Kratos/commit/7b0b30d0462edd9021753eeb38fb34acca5bbdae)
- [Maybe removing fortran?](https://github.com/KratosMultiphysics/Kratos/commit/cbf30c9523fee4bf747a0dbced1fcc50c2c5ca7d)
