### PR TITLE
[ConstitutiveLaw] Limit verbosity of plastic integrators warnings

### DIFF
--- a/applications/ConstitutiveLawsApplication/custom_constitutive/auxiliary_files/cl_integrators/generic_cl_integrator_kinematic_plasticity.h
+++ b/applications/ConstitutiveLawsApplication/custom_constitutive/auxiliary_files/cl_integrators/generic_cl_integrator_kinematic_plasticity.h
@@ -34,7 +34,7 @@ namespace Kratos
 ///@{
 
 // The size type definition
-typedef std::size_t SizeType;
+using SizeType = std::size_t;
 
 ///@}
 ///@name  Enum's
@@ -75,10 +75,10 @@ class GenericConstitutiveLawIntegratorKinematicPlasticity
     static constexpr double tolerance = std::numeric_limits<double>::epsilon();
 
     /// Definition of index
-    typedef std::size_t IndexType;
+    using IndexType = std::size_t;
 
     /// The type of yield surface
-    typedef TYieldSurfaceType YieldSurfaceType;
+    using YieldSurfaceType = TYieldSurfaceType;
 
     /// The define the working dimension size, already defined in the yield surface
     static constexpr SizeType Dimension = YieldSurfaceType::Dimension;
@@ -87,13 +87,13 @@ class GenericConstitutiveLawIntegratorKinematicPlasticity
     static constexpr SizeType VoigtSize = YieldSurfaceType::VoigtSize;
 
     /// The definition of the Voigt array type
-    typedef array_1d<double, VoigtSize> BoundedArrayType;
+    using BoundedArrayType = array_1d<double, VoigtSize>;
 
     /// The definition of the bounded matrix type
-    typedef BoundedMatrix<double, Dimension, Dimension> BoundedMatrixType;
+    using BoundedMatrixType = BoundedMatrix<double, Dimension, Dimension>;
 
     /// The type of plastic potential
-    typedef typename YieldSurfaceType::PlasticPotentialType PlasticPotentialType;
+    using PlasticPotentialType = typename YieldSurfaceType::PlasticPotentialType;
 
     /// Counted pointer of GenericConstitutiveLawIntegratorKinematicPlasticity
     KRATOS_CLASS_POINTER_DEFINITION(GenericConstitutiveLawIntegratorKinematicPlasticity);
@@ -226,7 +226,9 @@ class GenericConstitutiveLawIntegratorKinematicPlasticity
             CalculateTangentMatrix(tangent_tensor, rConstitutiveMatrix, rYieldSurfaceDerivative, rDerivativePlasticPotential, rPlasticDenominator);
             noalias(rConstitutiveMatrix) = tangent_tensor;
         }
-        KRATOS_WARNING_IF("GenericConstitutiveLawIntegratorKinematicPlasticity", iteration > max_iter) << "Maximum number of iterations in plasticity loop reached..." << std::endl;
+        if (iteration > max_iter) {
+            KRATOS_WARNING_FIRST_N("GenericConstitutiveLawIntegratorKinematicPlasticity", 10) << "Maximum number of iterations in plasticity loop reached..." << std::endl;
+        }
     }
 
     /**
@@ -654,7 +656,6 @@ class GenericConstitutiveLawIntegratorKinematicPlasticity
     ///@{
 
     ///@}
-
   protected:
     ///@name Protected static Member Variables
     ///@{
@@ -684,7 +685,6 @@ class GenericConstitutiveLawIntegratorKinematicPlasticity
     ///@{
 
     ///@}
-
   private:
     ///@name Static Member Variables
     ///@{
@@ -714,9 +714,7 @@ class GenericConstitutiveLawIntegratorKinematicPlasticity
     ///@{
 
     ///@}
-
 }; // Class GenericYieldSurface
-
 ///@}
 
 ///@name Type Definitions

--- a/applications/ConstitutiveLawsApplication/custom_constitutive/auxiliary_files/cl_integrators/generic_cl_integrator_plasticity.h
+++ b/applications/ConstitutiveLawsApplication/custom_constitutive/auxiliary_files/cl_integrators/generic_cl_integrator_plasticity.h
@@ -34,8 +34,8 @@ namespace Kratos
 ///@name Type Definitions
 ///@{
 
-    // The size type definition
-    typedef std::size_t SizeType;
+// The size type definition
+using SizeType = std::size_t;
 
 ///@}
 ///@name  Enum's
@@ -76,10 +76,10 @@ class GenericConstitutiveLawIntegratorPlasticity
     static constexpr double tolerance = std::numeric_limits<double>::epsilon();
 
     /// Definition of index
-    typedef std::size_t IndexType;
+    using IndexType = std::size_t;
 
     /// The type of yield surface
-    typedef TYieldSurfaceType YieldSurfaceType;
+    using YieldSurfaceType = TYieldSurfaceType;
 
     /// The define the working dimension size, already defined in the yield surface
     static constexpr SizeType Dimension = YieldSurfaceType::Dimension;
@@ -88,7 +88,7 @@ class GenericConstitutiveLawIntegratorPlasticity
     static constexpr SizeType VoigtSize = YieldSurfaceType::VoigtSize;
 
     /// The type of plastic potential
-    typedef typename YieldSurfaceType::PlasticPotentialType PlasticPotentialType;
+    using PlasticPotentialType = typename YieldSurfaceType::PlasticPotentialType;
 
     /// Counted pointer of GenericConstitutiveLawIntegratorPlasticity
     KRATOS_CLASS_POINTER_DEFINITION(GenericConstitutiveLawIntegratorPlasticity);
@@ -208,7 +208,9 @@ class GenericConstitutiveLawIntegratorPlasticity
             CalculateTangentMatrix(tangent_tensor, rConstitutiveMatrix, rFflux, rGflux, rPlasticDenominator);
             noalias(rConstitutiveMatrix) = tangent_tensor;
         }
-        KRATOS_WARNING_IF("GenericConstitutiveLawIntegratorPlasticity", iteration > max_iter) << "Maximum number of iterations in plasticity loop reached..." << std::endl;
+        if (iteration > max_iter) {
+            KRATOS_WARNING_FIRST_N("GenericConstitutiveLawIntegratorKinematicPlasticity", 10) << "Maximum number of iterations in plasticity loop reached..." << std::endl;
+        }
     }
 
     /**
@@ -1048,7 +1050,6 @@ class GenericConstitutiveLawIntegratorPlasticity
     ///@{
 
     ///@}
-
   protected:
     ///@name Protected static Member Variables
     ///@{
@@ -1078,7 +1079,6 @@ class GenericConstitutiveLawIntegratorPlasticity
     ///@{
 
     ///@}
-
   private:
     ///@name Static Member Variables
     ///@{
@@ -1108,9 +1108,7 @@ class GenericConstitutiveLawIntegratorPlasticity
     ///@{
 
     ///@}
-
 }; // Class GenericYieldSurface
-
 ///@}
 
 ///@name Type Definitions


### PR DESCRIPTION
**📝 Description**

I have logs files that 99.9999% of the content is this warning. Better to limit the number of messages.

**🆕 Changelog**

- [Limit verbosity of plastic integrators warnings](https://github.com/KratosMultiphysics/Kratos/commit/311469f295178687dca19b3a6a94f0c5638e9042)
