### PR TITLE
[ContactStructuralMechanicsApplication] Deactivate in *Windows* `ComponentsALMHyperSimplePatchTestWithEliminationContact` which fails randomly in **CI**

### DIFF
--- a/applications/ContactStructuralMechanicsApplication/tests/test_ContactStructuralMechanicsApplication.py
+++ b/applications/ContactStructuralMechanicsApplication/tests/test_ContactStructuralMechanicsApplication.py
@@ -229,7 +229,8 @@ def AssembleTestSuites():
         # Components ALM frictionless tests
         smallSuite.addTest(TComponentsALMHyperSimpleTrianglePatchTestContact('test_execution'))
         smallSuite.addTest(TComponentsALMHyperSimplePatchTestContact('test_execution'))
-        smallSuite.addTest(TComponentsALMHyperSimplePatchTestWithEliminationContact('test_execution'))
+        if os.name != 'nt': # NOTE: Failing randomly in Windows, probably a memory issue. Is the elimination B&S only God know what is happening there
+            smallSuite.addTest(TComponentsALMHyperSimplePatchTestWithEliminationContact('test_execution')) # TODO: Fix me
         smallSuite.addTest(TComponentsALMHyperSimplePatchTestWithEliminationWithConstraintContact('test_execution'))
         smallSuite.addTest(TComponentsALMHyperSimpleSlopePatchTestContact('test_execution'))
         if has_CL_application:


### PR DESCRIPTION
**📝 Description**

Deactivate in *Windows* `ComponentsALMHyperSimplePatchTestWithEliminationContact` which fails randomly in **CI**.

**🆕 Changelog**

- [Deactivate in *Windows* `ComponentsALMHyperSimplePatchTestWithEliminationContact` which fails randomly in **CI**](https://github.com/KratosMultiphysics/Kratos/commit/2ef65def4e8cf33e4b76c786261acfc8c7f875fd)
