### PR TITLE
[GeoMechanicsApplication] Improved handling of unit tests that need to run conditionally

### DIFF
--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_constitutive/test_incremental_linear_elastic_3D_law.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_constitutive/test_incremental_linear_elastic_3D_law.cpp
@@ -185,10 +185,13 @@ KRATOS_TEST_CASE_IN_SUITE(GeoIncrementalLinearElastic3DLawReturnsExpectedStress_
     KRATOS_EXPECT_VECTOR_RELATIVE_NEAR(expected_stress, stress, 1e-3);
 }
 
-#ifdef KRATOS_DEBUG
 KRATOS_TEST_CASE_IN_SUITE(GeoIncrementalLinearElastic3DLawThrows_WhenElementProvidedStrainIsSetToFalse,
                           KratosGeoMechanicsFastSuiteWithoutKernel)
 {
+#ifndef KRATOS_DEBUG
+    GTEST_SKIP() << "This test requires a debug build";
+#endif
+
     auto law = CreateIncrementalLinearElastic3DLaw();
 
     ConstitutiveLaw::Parameters parameters;
@@ -197,6 +200,5 @@ KRATOS_TEST_CASE_IN_SUITE(GeoIncrementalLinearElastic3DLawThrows_WhenElementProv
     KRATOS_EXPECT_EXCEPTION_IS_THROWN(law.CalculateMaterialResponsePK2(parameters),
                                       "The GeoLinearElasticLaw needs an element provided strain");
 }
-#endif
 
 } // namespace Kratos::Testing

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_constitutive/test_incremental_linear_elastic_3D_law.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_constitutive/test_incremental_linear_elastic_3D_law.cpp
@@ -185,7 +185,7 @@ KRATOS_TEST_CASE_IN_SUITE(GeoIncrementalLinearElastic3DLawReturnsExpectedStress_
     KRATOS_EXPECT_VECTOR_RELATIVE_NEAR(expected_stress, stress, 1e-3);
 }
 
-KRATOS_TEST_CASE_IN_SUITE(GeoIncrementalLinearElastic3DLawThrows_WhenElementProvidedStrainIsSetToFalse,
+KRATOS_TEST_CASE_IN_SUITE(GeoIncrementalLinearElastic3DLawRaisesADebugError_WhenElementProvidedStrainIsSetToFalse,
                           KratosGeoMechanicsFastSuiteWithoutKernel)
 {
 #ifndef KRATOS_DEBUG

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_constitutive/test_incremental_linear_elastic_plane_strain_2D_law.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_constitutive/test_incremental_linear_elastic_plane_strain_2D_law.cpp
@@ -185,10 +185,13 @@ KRATOS_TEST_CASE_IN_SUITE(GeoLinearElasticPlaneStrain2DLawReturnsExpectedStress_
     KRATOS_EXPECT_VECTOR_RELATIVE_NEAR(expected_stress, stress, 1e-3);
 }
 
-#ifdef KRATOS_DEBUG
 KRATOS_TEST_CASE_IN_SUITE(GeoLinearElasticPlaneStrain2DLawThrows_WhenElementProvidedStrainIsSetToFalse,
                           KratosGeoMechanicsFastSuiteWithoutKernel)
 {
+#ifndef KRATOS_DEBUG
+    GTEST_SKIP() << "This test requires a debug build";
+#endif
+
     auto law = CreateLinearElasticPlaneStrainLaw();
 
     ConstitutiveLaw::Parameters parameters;
@@ -197,7 +200,6 @@ KRATOS_TEST_CASE_IN_SUITE(GeoLinearElasticPlaneStrain2DLawThrows_WhenElementProv
     KRATOS_EXPECT_EXCEPTION_IS_THROWN(law.CalculateMaterialResponsePK2(parameters),
                                       "The GeoLinearElasticLaw needs an element provided strain");
 }
-#endif
 
 KRATOS_TEST_CASE_IN_SUITE(GeoLinearElasticPlaneStrain2DLawChecksYoungModulusAndPoissonRatio,
                           KratosGeoMechanicsFastSuiteWithoutKernel)

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_constitutive/test_incremental_linear_elastic_plane_strain_2D_law.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_constitutive/test_incremental_linear_elastic_plane_strain_2D_law.cpp
@@ -185,7 +185,7 @@ KRATOS_TEST_CASE_IN_SUITE(GeoLinearElasticPlaneStrain2DLawReturnsExpectedStress_
     KRATOS_EXPECT_VECTOR_RELATIVE_NEAR(expected_stress, stress, 1e-3);
 }
 
-KRATOS_TEST_CASE_IN_SUITE(GeoLinearElasticPlaneStrain2DLawThrows_WhenElementProvidedStrainIsSetToFalse,
+KRATOS_TEST_CASE_IN_SUITE(GeoLinearElasticPlaneStrain2DLawRaisesADebugError_WhenElementProvidedStrainIsSetToFalse,
                           KratosGeoMechanicsFastSuiteWithoutKernel)
 {
 #ifndef KRATOS_DEBUG

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_utilities/test_constitutive_law_utilities.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_utilities/test_constitutive_law_utilities.cpp
@@ -108,11 +108,12 @@ KRATOS_TEST_CASE_IN_SUITE(FrictionAngleCanBeFetchedFromUMatParameters, KratosGeo
                                       "Material 0 does not have UMAT_PARAMETERS");
 }
 
-// The following test only raises errors when using debug builds
-#ifdef KRATOS_DEBUG
-
 KRATOS_TEST_CASE_IN_SUITE(ThrowExceptionWhenIndexInUMatParametersIsOutOfBounds, KratosGeoMechanicsFastSuiteWithoutKernel)
 {
+#ifndef KRATOS_DEBUG
+    GTEST_SKIP() << "This test requires a debug build";
+#endif
+
     auto properties      = Properties{};
     auto umat_parameters = Vector{2};
     umat_parameters <<= 2.0, 30.0;
@@ -128,7 +129,5 @@ KRATOS_TEST_CASE_IN_SUITE(ThrowExceptionWhenIndexInUMatParametersIsOutOfBounds, 
         ConstitutiveLawUtilities::GetCohesion(properties),
         "Got out-of-bounds INDEX_OF_UMAT_C_PARAMETER (material ID: 0): 3 is not in range [1, 2]");
 }
-
-#endif
 
 } // namespace Kratos::Testing

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_utilities/test_constitutive_law_utilities.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_utilities/test_constitutive_law_utilities.cpp
@@ -108,7 +108,7 @@ KRATOS_TEST_CASE_IN_SUITE(FrictionAngleCanBeFetchedFromUMatParameters, KratosGeo
                                       "Material 0 does not have UMAT_PARAMETERS");
 }
 
-KRATOS_TEST_CASE_IN_SUITE(ThrowExceptionWhenIndexInUMatParametersIsOutOfBounds, KratosGeoMechanicsFastSuiteWithoutKernel)
+KRATOS_TEST_CASE_IN_SUITE(RaiseADebugErrorWhenIndexInUMatParametersIsOutOfBounds, KratosGeoMechanicsFastSuiteWithoutKernel)
 {
 #ifndef KRATOS_DEBUG
     GTEST_SKIP() << "This test requires a debug build";

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_utilities/test_equation_of_motion.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_utilities/test_equation_of_motion.cpp
@@ -199,12 +199,13 @@ KRATOS_TEST_CASE_IN_SUITE(TheInternalForceVectorIsTheIntegralOfBTransposedTimesS
                                        expected_internal_force_vector, Defaults::relative_tolerance)
 }
 
-// The following tests only raise errors when using debug builds
-#ifdef KRATOS_DEBUG
-
 KRATOS_TEST_CASE_IN_SUITE(CalculatingTheInternalForceVectorFailsWhenTheInputVectorsHaveDifferentSizes,
                           KratosGeoMechanicsFastSuiteWithoutKernel)
 {
+#ifndef KRATOS_DEBUG
+    GTEST_SKIP() << "This test requires a debug build";
+#endif
+
     const auto b_matrix       = Matrix{ScalarMatrix{2, 8, 1.0}};
     const auto b_matrices     = std::vector<Matrix>{b_matrix}; // Error: missing one matrix
     const auto stress_vector  = Vector{ScalarVector{2, 1.0}};
@@ -219,6 +220,10 @@ KRATOS_TEST_CASE_IN_SUITE(CalculatingTheInternalForceVectorFailsWhenTheInputVect
 KRATOS_TEST_CASE_IN_SUITE(CalculatingTheInternalForceVectorFailsWhenAllInputVectorsAreEmpty,
                           KratosGeoMechanicsFastSuiteWithoutKernel)
 {
+#ifndef KRATOS_DEBUG
+    GTEST_SKIP() << "This test requires a debug build";
+#endif
+
     const auto b_matrices               = std::vector<Matrix>{};
     const auto stress_vectors           = std::vector<Vector>{};
     const auto integration_coefficients = std::vector<double>{};
@@ -231,6 +236,10 @@ KRATOS_TEST_CASE_IN_SUITE(CalculatingTheInternalForceVectorFailsWhenAllInputVect
 KRATOS_TEST_CASE_IN_SUITE(CalculatingTheInternalForceVectorFailsWhenBMatricesHaveDifferentSizes,
                           KratosGeoMechanicsFastSuiteWithoutKernel)
 {
+#ifndef KRATOS_DEBUG
+    GTEST_SKIP() << "This test requires a debug build";
+#endif
+
     const auto b_matrices = std::vector<Matrix>{ScalarMatrix{2, 8, 1.0}, ScalarMatrix{1, 8, 1.0}}; // Error: matrices have different numbers of rows
     const auto stress_vector            = Vector{ScalarVector{2, 1.0}};
     const auto stress_vectors           = std::vector<Vector>{stress_vector, stress_vector};
@@ -244,6 +253,10 @@ KRATOS_TEST_CASE_IN_SUITE(CalculatingTheInternalForceVectorFailsWhenBMatricesHav
 KRATOS_TEST_CASE_IN_SUITE(CalculatingTheInternalForceVectorFailsWhenStressVectorsHaveDifferentSizes,
                           KratosGeoMechanicsFastSuiteWithoutKernel)
 {
+#ifndef KRATOS_DEBUG
+    GTEST_SKIP() << "This test requires a debug build";
+#endif
+
     const auto b_matrix   = Matrix{ScalarMatrix{2, 8, 1.0}};
     const auto b_matrices = std::vector<Matrix>{b_matrix, b_matrix};
     const auto stress_vectors = std::vector<Vector>{ScalarVector{2, 1.0}, ScalarVector{3, 1.0}}; // Error: vectors have different sizes
@@ -257,6 +270,10 @@ KRATOS_TEST_CASE_IN_SUITE(CalculatingTheInternalForceVectorFailsWhenStressVector
 KRATOS_TEST_CASE_IN_SUITE(CalculatingTheInternalForceVectorFailsWhenTheMatrixVectorProductCantBeComputed,
                           KratosGeoMechanicsFastSuiteWithoutKernel)
 {
+#ifndef KRATOS_DEBUG
+    GTEST_SKIP() << "This test requires a debug build";
+#endif
+
     // Error: transpose of the B-matrix has more columns (3) than the number of stress components (2)
     const auto b_matrix                 = Matrix{ScalarMatrix{3, 8, 1.0}};
     const auto b_matrices               = std::vector<Matrix>{b_matrix, b_matrix};
@@ -267,7 +284,5 @@ KRATOS_TEST_CASE_IN_SUITE(CalculatingTheInternalForceVectorFailsWhenTheMatrixVec
     KRATOS_EXPECT_EXCEPTION_IS_THROWN(
         GeoEquationOfMotionUtilities::CalculateInternalForceVector(b_matrices, stress_vectors, integration_coefficients), "Cannot calculate the internal force vector: matrix-vector product cannot be calculated due to size mismatch")
 }
-
-#endif
 
 } // namespace Kratos::Testing

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_utilities/test_equation_of_motion.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_utilities/test_equation_of_motion.cpp
@@ -199,7 +199,7 @@ KRATOS_TEST_CASE_IN_SUITE(TheInternalForceVectorIsTheIntegralOfBTransposedTimesS
                                        expected_internal_force_vector, Defaults::relative_tolerance)
 }
 
-KRATOS_TEST_CASE_IN_SUITE(CalculatingTheInternalForceVectorFailsWhenTheInputVectorsHaveDifferentSizes,
+KRATOS_TEST_CASE_IN_SUITE(CalculatingTheInternalForceVectorRaisesADebugErrorWhenTheInputVectorsHaveDifferentSizes,
                           KratosGeoMechanicsFastSuiteWithoutKernel)
 {
 #ifndef KRATOS_DEBUG
@@ -217,7 +217,7 @@ KRATOS_TEST_CASE_IN_SUITE(CalculatingTheInternalForceVectorFailsWhenTheInputVect
         "Cannot calculate the internal force vector: input vectors have different sizes")
 }
 
-KRATOS_TEST_CASE_IN_SUITE(CalculatingTheInternalForceVectorFailsWhenAllInputVectorsAreEmpty,
+KRATOS_TEST_CASE_IN_SUITE(CalculatingTheInternalForceVectorRaisesADebugErrorWhenAllInputVectorsAreEmpty,
                           KratosGeoMechanicsFastSuiteWithoutKernel)
 {
 #ifndef KRATOS_DEBUG
@@ -233,7 +233,7 @@ KRATOS_TEST_CASE_IN_SUITE(CalculatingTheInternalForceVectorFailsWhenAllInputVect
         "Cannot calculate the internal force vector: input vectors are empty")
 }
 
-KRATOS_TEST_CASE_IN_SUITE(CalculatingTheInternalForceVectorFailsWhenBMatricesHaveDifferentSizes,
+KRATOS_TEST_CASE_IN_SUITE(CalculatingTheInternalForceVectorRaisesADebugErrorWhenBMatricesHaveDifferentSizes,
                           KratosGeoMechanicsFastSuiteWithoutKernel)
 {
 #ifndef KRATOS_DEBUG
@@ -250,7 +250,7 @@ KRATOS_TEST_CASE_IN_SUITE(CalculatingTheInternalForceVectorFailsWhenBMatricesHav
         "Cannot calculate the internal force vector: B-matrices have different sizes")
 }
 
-KRATOS_TEST_CASE_IN_SUITE(CalculatingTheInternalForceVectorFailsWhenStressVectorsHaveDifferentSizes,
+KRATOS_TEST_CASE_IN_SUITE(CalculatingTheInternalForceVectorRaisesADebugErrorWhenStressVectorsHaveDifferentSizes,
                           KratosGeoMechanicsFastSuiteWithoutKernel)
 {
 #ifndef KRATOS_DEBUG
@@ -267,7 +267,7 @@ KRATOS_TEST_CASE_IN_SUITE(CalculatingTheInternalForceVectorFailsWhenStressVector
         "Cannot calculate the internal force vector: stress vectors have different sizes")
 }
 
-KRATOS_TEST_CASE_IN_SUITE(CalculatingTheInternalForceVectorFailsWhenTheMatrixVectorProductCantBeComputed,
+KRATOS_TEST_CASE_IN_SUITE(CalculatingTheInternalForceVectorRaisesADebugErrorWhenTheMatrixVectorProductCantBeComputed,
                           KratosGeoMechanicsFastSuiteWithoutKernel)
 {
 #ifndef KRATOS_DEBUG


### PR DESCRIPTION
**📝 Description**

Use `GTEST_SKIP` rather than not compiling unit tests that need to be run conditionally. So far, several unit tests are skipped when non-debug builds are used.

With these changes, the total number of unit tests that is run is identical for all build types. However, the number of skipped tests may differ.