### PR TITLE
[External] GiD_Post ->Hotfix print clusters as point for

### DIFF
--- a/external_libraries/gidpost/source/gidpostFILES.c
+++ b/external_libraries/gidpost/source/gidpostFILES.c
@@ -148,7 +148,7 @@ static GP_CONST char * strElementType[]= {
   "Pyramid",
   "Sphere",
   "Circle",
-  "Cluster"
+  "Point" // <-- This stands for the cluster element type
 };
 
 GP_CONST char * GetElementTypeName( GiD_ElementType type )


### PR DESCRIPTION
**📝 Description**
GiD does not understand the word Cluster. We print Point instead

Fixes https://github.com/KratosMultiphysics/GiDInterface/issues/1016

With this change, when `kratos/includes/gid_io.h` function `WriteClusterMesh` calls 
`GiD_fBeginMesh(mMeshFile, "Kratos Mesh",GiD_3D,GiD_Cluster,1);` :

What is printed in the postprocess files is 
`MESH "Kratos Mesh" dimension 3 ElemType Point Nnode 1`
instead of
`MESH "Kratos Mesh" dimension 3 ElemType Cluster Nnode 1`
