### PR TITLE
[CORE] coordinate_transformation_utilitites move functions from private to protected

### DIFF
--- a/kratos/utilities/coordinate_transformation_utilities.h
+++ b/kratos/utilities/coordinate_transformation_utilities.h
@@ -974,6 +974,31 @@ protected:
 		*iComponent /= Norm;
 		return Norm;
 	}
+	
+	//auxiliary functions
+	template< unsigned int TBlockSize >
+	void ReadBlockMatrix( BoundedMatrix<double,TBlockSize, TBlockSize>& block, const Matrix& origin, const unsigned int Ibegin, const unsigned int Jbegin) const
+	{
+		for(unsigned int i=0; i<TBlockSize; i++)
+		{
+			for(unsigned int j=0; j<TBlockSize; j++)
+			{
+				block(i,j) = origin(Ibegin+i, Jbegin+j);
+			}
+		}
+	}
+
+	template< unsigned int TBlockSize >
+	void WriteBlockMatrix( const BoundedMatrix<double,TBlockSize, TBlockSize>& block, Matrix& destination, const unsigned int Ibegin, const unsigned int Jbegin) const
+	{
+		for(unsigned int i=0; i<TBlockSize; i++)
+		{
+			for(unsigned int j=0; j<TBlockSize; j++)
+			{
+				destination(Ibegin+i, Jbegin+j) = block(i,j);
+			}
+		}
+	}
 
 	///@}
 	///@name Protected  Access
@@ -1284,30 +1309,6 @@ private:
 // //         noalias(rMatrix) = Tmp;
 //     }
 
-	//auxiliary functions
-	template< unsigned int TBlockSize >
-	void ReadBlockMatrix( BoundedMatrix<double,TBlockSize, TBlockSize>& block, const Matrix& origin, const unsigned int Ibegin, const unsigned int Jbegin) const
-	{
-		for(unsigned int i=0; i<TBlockSize; i++)
-		{
-			for(unsigned int j=0; j<TBlockSize; j++)
-			{
-				block(i,j) = origin(Ibegin+i, Jbegin+j);
-			}
-		}
-	}
-
-	template< unsigned int TBlockSize >
-	void WriteBlockMatrix( const BoundedMatrix<double,TBlockSize, TBlockSize>& block, Matrix& destination, const unsigned int Ibegin, const unsigned int Jbegin) const
-	{
-		for(unsigned int i=0; i<TBlockSize; i++)
-		{
-			for(unsigned int j=0; j<TBlockSize; j++)
-			{
-				destination(Ibegin+i, Jbegin+j) = block(i,j);
-			}
-		}
-	}
 
 	///@}
 	///@name Private  Access


### PR DESCRIPTION
Hi all,

this PR moves the functions ReadBlockMatrix and WriteBlockMatrix in the coordinate_transformation_utilities.h from private access to protected access. This change is required for PR https://github.com/KratosMultiphysics/Kratos/pull/13390 to reuse these two functions.
