### PR TITLE
[MPM] Remove default block size for AMGCL

### DIFF
--- a/applications/MPMApplication/python_scripts/mpm_solver.py
+++ b/applications/MPMApplication/python_scripts/mpm_solver.py
@@ -84,7 +84,6 @@ class MPMSolver(PythonSolver):
                 "verbosity" : 0,
                 "tolerance": 1e-7,
                 "scaling": false,
-                "block_size": 3,
                 "use_block_matrices_if_possible" : true,
                 "coarse_enough" : 50
             }
@@ -520,7 +519,7 @@ class MPMSolver(PythonSolver):
         # this function avoids the long call to ProcessInfo and is also safer
         # in case the detection of a restart is changed later
         return self.material_point_model_part.ProcessInfo[KratosMultiphysics.IS_RESTARTED]
-    
+
 # TODO: Remove this temporary fix once PR #13376 is merged
 def _SetProcessInfo(target_model_part: KratosMultiphysics.ModelPart,
                     process_info: KratosMultiphysics.ProcessInfo) -> None:


### PR DESCRIPTION
The `MPMSolver` occasionally lies to AMGCL about the block size of the matrix it produces. Namely, it specifies a block size of `3` even in 2D analyses.

This is not a problem right now because the correct block size gets deduced in `AMGCLSolver::ProvideAdditionalData`, but #13624 introduces a slight behavior change. Namely, if `"block_size"` is specified by the user, `AMGCLSolver` assumes the user knows better and does not override it with the deduced size.

##

Just to be clear, this change does not constitute a behavior change for the `MPMApplication`. The default behavior right now, and also after #13624 is that the deduced block size is used. This PR just prevents the `MPMSolver` from lying to AMGCL.