### PR TITLE
[Core] Add `SkippableEntity` method to `InputOutputUtilities` for geometry type checks

### DIFF
--- a/kratos/input_output/vtk_output.cpp
+++ b/kratos/input_output/vtk_output.cpp
@@ -25,6 +25,7 @@
 #include "processes/fast_transfer_between_model_parts_process.h"
 #include "utilities/parallel_utilities.h"
 #include "utilities/reduction_utilities.h"
+#include "utilities/input_output_utilities.h"
 #include "input_output/vtk_definitions.h"
 
 namespace Kratos
@@ -302,8 +303,7 @@ void VtkOutput::WriteHeaderToFile(const ModelPart& rModelPart, std::ofstream& rF
                 << "\n";
     if(mFileFormat == VtkOutput::FileFormat::VTK_ASCII) {
         rFileStream << "ASCII" << "\n";
-    }
-    else if (mFileFormat == VtkOutput::FileFormat::VTK_BINARY) {
+    } else if (mFileFormat == VtkOutput::FileFormat::VTK_BINARY) {
         rFileStream << "BINARY" << "\n";
     }
     rFileStream << "DATASET UNSTRUCTURED_GRID"
@@ -380,7 +380,7 @@ template<typename TContainerType>
 std::size_t VtkOutput::DetermineVtkContainerSize(const TContainerType& rContainer) const
 {
     return block_for_each<SumReduction<std::size_t>>(rContainer,[this](const typename TContainerType::data_type& rEntity) {
-        if (SkippableEntity(rEntity)) {
+        if (InputOutputUtilities::SkippableEntity(rEntity, "VtkOutput")) {
             return 0;
         } else {
             return 1;
@@ -395,7 +395,7 @@ template<typename TContainerType>
 std::size_t VtkOutput::DetermineVtkCellListSize(const TContainerType& rContainer) const
 {
     return block_for_each<SumReduction<std::size_t>>(rContainer,[this](const typename TContainerType::data_type& rEntity) -> std::size_t {
-        if (SkippableEntity(rEntity)) {
+        if (InputOutputUtilities::SkippableEntity(rEntity, "VtkOutput")) {
             return 0;
         } else {
             return rEntity.GetGeometry().PointsNumber() + 1;
@@ -415,7 +415,7 @@ void VtkOutput::WriteConnectivity(const TContainerType& rContainer, std::ofstrea
 
     const auto& r_id_map = mKratosIdToVtkId; // const reference to not accidentially modify the map
     for (const auto& r_entity : rContainer) {
-        if (SkippableEntity(r_entity)) continue;
+        if (InputOutputUtilities::SkippableEntity(r_entity, "VtkOutput")) continue;
         auto p_geom = r_entity.pGetGeometry();
         const unsigned int number_of_nodes = p_geom->PointsNumber();
         p_geom = ReorderConnectivity(p_geom);
@@ -441,7 +441,7 @@ void VtkOutput::WriteCellType(const TContainerType& rContainer, std::ofstream& r
 {
     // Write entity types
     for (const auto& r_entity : rContainer) {
-        if (SkippableEntity(r_entity)) continue;
+        if (InputOutputUtilities::SkippableEntity(r_entity, "VtkOutput")) continue;
         int cell_type = -1;
         const auto& r_geometry = r_entity.GetGeometry();
         const auto& r_kratos_cell = r_geometry.GetGeometryType();
@@ -886,7 +886,7 @@ void VtkOutput::WriteFlagContainerVariable(
                 << DetermineVtkContainerSize(rContainer) << "  float\n";
 
     for (const auto& r_entity : rContainer) {
-        if (SkippableEntity(r_entity)) continue;
+        if (InputOutputUtilities::SkippableEntity(r_entity, "VtkOutput")) continue;
         const float result = r_entity.IsDefined(Flag) ? float(r_entity.Is(Flag)) : -1.0;
         WriteScalarDataToFile(result, rFileStream);
         if (mFileFormat == VtkOutput::FileFormat::VTK_ASCII) rFileStream <<"\n";
@@ -906,7 +906,7 @@ void VtkOutput::WriteScalarContainerVariable(
                 << DetermineVtkContainerSize(rContainer) << "  float\n";
 
     for (const auto& r_entity : rContainer) {
-        if (SkippableEntity(r_entity)) continue;
+        if (InputOutputUtilities::SkippableEntity(r_entity, "VtkOutput")) continue;
         const double result = r_entity.GetValue(rVariable);
         WriteScalarDataToFile((float)result, rFileStream);
         if (mFileFormat == VtkOutput::FileFormat::VTK_ASCII) rFileStream <<"\n";
@@ -939,7 +939,7 @@ void VtkOutput::WriteIntegrationScalarContainerVariable(
 
         double aux_value;
         for (auto& r_entity : rContainer) { // TODO: CalculateOnIntegrationPoints should be const methods
-            if (SkippableEntity(r_entity)) continue;
+            if (InputOutputUtilities::SkippableEntity(r_entity, "VtkOutput")) continue;
             aux_value = 0.0;
             std::vector<TVarType> aux_result(integration_points_number);
             r_entity.CalculateOnIntegrationPoints(rVariable, aux_result, r_process_info);
@@ -972,7 +972,7 @@ void VtkOutput::WriteVectorContainerVariable(
     rFileStream << rVariable.Name() << " " << res_size << " " << container_size << "  float\n";
 
     for (const auto& r_entity : rContainer) {
-        if (SkippableEntity(r_entity)) continue;
+        if (InputOutputUtilities::SkippableEntity(r_entity, "VtkOutput")) continue;
         const auto& r_result = r_entity.GetValue(rVariable);
         WriteVectorDataToFile(r_result, rFileStream);
         if (mFileFormat == VtkOutput::FileFormat::VTK_ASCII) rFileStream <<"\n";
@@ -1014,7 +1014,7 @@ void VtkOutput::WriteIntegrationVectorContainerVariable(
 
     TVarType aux_value;
     for (auto& r_entity : rContainer) { // TODO: CalculateOnIntegrationPoints should be const methods
-        if (SkippableEntity(r_entity)) continue;
+        if (InputOutputUtilities::SkippableEntity(r_entity, "VtkOutput")) continue;
         aux_value = ZeroVector(res_size);
         std::vector<TVarType> aux_result(integration_points_number);
         r_entity.CalculateOnIntegrationPoints(rVariable, aux_result, r_process_info);
@@ -1105,7 +1105,7 @@ void VtkOutput::WritePropertiesIdsToFile(
                 << DetermineVtkContainerSize(rContainer) << "  int\n";
 
     for (const auto& r_entity : rContainer) {
-        if (SkippableEntity(r_entity)) continue;
+        if (InputOutputUtilities::SkippableEntity(r_entity, "VtkOutput")) continue;
         WriteScalarDataToFile((int)r_entity.GetProperties().Id(), rFileStream);
         if (mFileFormat == VtkOutput::FileFormat::VTK_ASCII) rFileStream <<"\n";
     }
@@ -1124,7 +1124,7 @@ void VtkOutput::WriteIdsToFile(
                 << DetermineVtkContainerSize(rContainer) << "  int\n";
 
     for (const auto& r_entity : rContainer) {
-        if (SkippableEntity(r_entity)) continue;
+        if (InputOutputUtilities::SkippableEntity(r_entity, "VtkOutput")) continue;
         WriteScalarDataToFile((int)r_entity.Id(), rFileStream);
         if (mFileFormat == VtkOutput::FileFormat::VTK_ASCII) rFileStream <<"\n";
     }
@@ -1174,61 +1174,8 @@ void VtkOutput::WriteModelPartWithoutNodesToFile(ModelPart& rModelPart, const st
     // Actually writing the
     WriteModelPartToFile(r_auxiliar_model_part, true, rOutputFilename);
 
-    // Deletin auxiliar modek part
+    // Deleting auxiliary modek part
     r_model.DeleteModelPart("AUXILIAR_" + r_name_model_part);
-}
-
-/***********************************************************************************/
-/***********************************************************************************/
-
-template<typename TEntityType>
-bool VtkOutput::SkippableEntity(const TEntityType& rEntity) const
-{
-    constexpr bool is_element = std::is_same_v<TEntityType, Element>;
-    constexpr bool is_condition = std::is_same_v<TEntityType, Condition>;
-    if constexpr (is_element || is_condition) {
-        const auto& r_geometry = rEntity.GetGeometry();
-        switch (r_geometry.GetGeometryType()) {
-            case GeometryData::KratosGeometryType::Kratos_Nurbs_Curve:
-                KRATOS_WARNING("VtkOutput") << "Skipping geometry type: Kratos_Nurbs_Curve" << std::endl;
-                return true;
-            case GeometryData::KratosGeometryType::Kratos_Nurbs_Surface:
-                KRATOS_WARNING("VtkOutput") << "Skipping geometry type: Kratos_Nurbs_Surface" << std::endl;
-                return true;
-            case GeometryData::KratosGeometryType::Kratos_Nurbs_Volume:
-                KRATOS_WARNING("VtkOutput") << "Skipping geometry type: Kratos_Nurbs_Volume" << std::endl;
-                return true;
-            case GeometryData::KratosGeometryType::Kratos_Nurbs_Curve_On_Surface:
-                KRATOS_WARNING("VtkOutput") << "Skipping geometry type: Kratos_Nurbs_Curve_On_Surface" << std::endl;
-                return true;
-            case GeometryData::KratosGeometryType::Kratos_Surface_In_Nurbs_Volume:
-                KRATOS_WARNING("VtkOutput") << "Skipping geometry type: Kratos_Surface_In_Nurbs_Volume" << std::endl;
-                return true;
-            case GeometryData::KratosGeometryType::Kratos_Brep_Curve:
-                KRATOS_WARNING("VtkOutput") << "Skipping geometry type: Kratos_Brep_Curve" << std::endl;
-                return true;
-            case GeometryData::KratosGeometryType::Kratos_Brep_Surface:
-                KRATOS_WARNING("VtkOutput") << "Skipping geometry type: Kratos_Brep_Surface" << std::endl;
-                return true;
-            case GeometryData::KratosGeometryType::Kratos_Brep_Curve_On_Surface:
-                KRATOS_WARNING("VtkOutput") << "Skipping geometry type: Kratos_Brep_Curve_On_Surface" << std::endl;
-                return true;
-            case GeometryData::KratosGeometryType::Kratos_Coupling_Geometry:
-                KRATOS_WARNING("VtkOutput") << "Skipping geometry type: Kratos_Coupling_Geometry" << std::endl;
-                return true;
-            case GeometryData::KratosGeometryType::Kratos_Quadrature_Point_Curve_On_Surface_Geometry:
-                KRATOS_WARNING("VtkOutput") << "Skipping geometry type: Kratos_Quadrature_Point_Curve_On_Surface_Geometry" << std::endl;
-                return true;
-            case GeometryData::KratosGeometryType::Kratos_Quadrature_Point_Surface_In_Volume_Geometry:
-                KRATOS_WARNING("VtkOutput") << "Skipping geometry type: Kratos_Quadrature_Point_Surface_In_Volume_Geometry" << std::endl;
-                return true;
-            default:
-                // For any other geometry type, do nothing and continue execution
-                break; 
-        }
-    }
-
-    return false;
 }
 
 } // namespace Kratos

--- a/kratos/input_output/vtk_output.cpp
+++ b/kratos/input_output/vtk_output.cpp
@@ -379,7 +379,7 @@ void VtkOutput::WriteConditionsAndElementsToFile(const ModelPart& rModelPart, st
 template<typename TContainerType>
 std::size_t VtkOutput::DetermineVtkContainerSize(const TContainerType& rContainer) const
 {
-    return block_for_each<SumReduction<std::size_t>>(rContainer,[this](const typename TContainerType::data_type& rEntity) {
+    return block_for_each<SumReduction<std::size_t>>(rContainer,[](const typename TContainerType::data_type& rEntity) {
         if (InputOutputUtilities::SkippableEntity(rEntity, "VtkOutput")) {
             return 0;
         } else {
@@ -394,7 +394,7 @@ std::size_t VtkOutput::DetermineVtkContainerSize(const TContainerType& rContaine
 template<typename TContainerType>
 std::size_t VtkOutput::DetermineVtkCellListSize(const TContainerType& rContainer) const
 {
-    return block_for_each<SumReduction<std::size_t>>(rContainer,[this](const typename TContainerType::data_type& rEntity) -> std::size_t {
+    return block_for_each<SumReduction<std::size_t>>(rContainer,[](const typename TContainerType::data_type& rEntity) -> std::size_t {
         if (InputOutputUtilities::SkippableEntity(rEntity, "VtkOutput")) {
             return 0;
         } else {

--- a/kratos/input_output/vtk_output.h
+++ b/kratos/input_output/vtk_output.h
@@ -528,14 +528,6 @@ private:
      */
     void WriteModelPartWithoutNodesToFile(ModelPart& rModelPart, const std::string& rOutputFilename);
 
-    /**
-     * @brief Checks if the given geometry can be skipped during output
-     * @param rGeometry the geometry to be checked
-     * @return true if the geometry can be skipped, false otherwise
-     */
-    template<typename TEntityType>
-    bool SkippableEntity(const TEntityType& rEntity) const;
-
     ///@}
 };
 

--- a/kratos/utilities/input_output_utilities.cpp
+++ b/kratos/utilities/input_output_utilities.cpp
@@ -11,6 +11,9 @@
 //
 
 // System includes
+#include <string>      // For std::string
+#include <sstream>     // For std::stringstream
+#include <iomanip>     // For std::setw and std::setfill
 
 // External includes
 
@@ -79,5 +82,26 @@ bool InputOutputUtilities::SkippableEntity(
 template bool InputOutputUtilities::SkippableEntity<Node>(const Node&, const std::string&);
 template bool InputOutputUtilities::SkippableEntity<Element>(const Element&, const std::string&);
 template bool InputOutputUtilities::SkippableEntity<Condition>(const Condition&, const std::string&);
+
+/***********************************************************************************/
+/***********************************************************************************/
+
+std::string InputOutputUtilities::GenerateStepLabel(
+    const std::size_t Step,
+    const std::size_t Spaces
+    )
+{
+    // 1. Create a stringstream object to build the string.
+    std::stringstream ss;
+
+    // 2. Use stream manipulators to format the output:
+    //    - std::setw(Spaces): Sets the total width of the string.
+    //    - std::setfill('0'): Sets the character used for padding.
+    //    - std::right: Aligns the number to the right (so padding is on the left).
+    ss << std::setw(Spaces) << std::setfill('0') << std::right << Step;
+
+    // 3. Return the resulting formatted string.
+    return ss.str();
+}
 
 } // namespace Kratos

--- a/kratos/utilities/input_output_utilities.cpp
+++ b/kratos/utilities/input_output_utilities.cpp
@@ -1,0 +1,83 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
+//
+//  Main authors:    Vicente Mataix Ferrandiz
+//
+
+// System includes
+
+// External includes
+
+// Project includes
+#include "includes/element.h"
+#include "includes/condition.h"
+#include "utilities/input_output_utilities.h"
+
+namespace Kratos
+{
+
+template<typename TEntityType>
+bool InputOutputUtilities::SkippableEntity(
+    const TEntityType& rEntity,
+    const std::string& rWarningLabel
+    )
+{
+    constexpr bool is_element = std::is_same_v<TEntityType, Element>;
+    constexpr bool is_condition = std::is_same_v<TEntityType, Condition>;
+    if constexpr (is_element || is_condition) {
+        const auto& r_geometry = rEntity.GetGeometry();
+        switch (r_geometry.GetGeometryType()) {
+            case GeometryData::KratosGeometryType::Kratos_Nurbs_Curve:
+                KRATOS_WARNING(rWarningLabel) << "Skipping geometry type: Kratos_Nurbs_Curve" << std::endl;
+                return true;
+            case GeometryData::KratosGeometryType::Kratos_Nurbs_Surface:
+                KRATOS_WARNING(rWarningLabel) << "Skipping geometry type: Kratos_Nurbs_Surface" << std::endl;
+                return true;
+            case GeometryData::KratosGeometryType::Kratos_Nurbs_Volume:
+                KRATOS_WARNING(rWarningLabel) << "Skipping geometry type: Kratos_Nurbs_Volume" << std::endl;
+                return true;
+            case GeometryData::KratosGeometryType::Kratos_Nurbs_Curve_On_Surface:
+                KRATOS_WARNING(rWarningLabel) << "Skipping geometry type: Kratos_Nurbs_Curve_On_Surface" << std::endl;
+                return true;
+            case GeometryData::KratosGeometryType::Kratos_Surface_In_Nurbs_Volume:
+                KRATOS_WARNING(rWarningLabel) << "Skipping geometry type: Kratos_Surface_In_Nurbs_Volume" << std::endl;
+                return true;
+            case GeometryData::KratosGeometryType::Kratos_Brep_Curve:
+                KRATOS_WARNING(rWarningLabel) << "Skipping geometry type: Kratos_Brep_Curve" << std::endl;
+                return true;
+            case GeometryData::KratosGeometryType::Kratos_Brep_Surface:
+                KRATOS_WARNING(rWarningLabel) << "Skipping geometry type: Kratos_Brep_Surface" << std::endl;
+                return true;
+            case GeometryData::KratosGeometryType::Kratos_Brep_Curve_On_Surface:
+                KRATOS_WARNING(rWarningLabel) << "Skipping geometry type: Kratos_Brep_Curve_On_Surface" << std::endl;
+                return true;
+            case GeometryData::KratosGeometryType::Kratos_Coupling_Geometry:
+                KRATOS_WARNING(rWarningLabel) << "Skipping geometry type: Kratos_Coupling_Geometry" << std::endl;
+                return true;
+            case GeometryData::KratosGeometryType::Kratos_Quadrature_Point_Curve_On_Surface_Geometry:
+                KRATOS_WARNING(rWarningLabel) << "Skipping geometry type: Kratos_Quadrature_Point_Curve_On_Surface_Geometry" << std::endl;
+                return true;
+            case GeometryData::KratosGeometryType::Kratos_Quadrature_Point_Surface_In_Volume_Geometry:
+                KRATOS_WARNING(rWarningLabel) << "Skipping geometry type: Kratos_Quadrature_Point_Surface_In_Volume_Geometry" << std::endl;
+                return true;
+            default:
+                // For any other geometry type, do nothing and continue execution
+                break;
+        }
+    }
+
+    return false;
+}
+
+/// Explicit instantation for Element and Condition (also Node as is used in VtkOutput)
+template bool InputOutputUtilities::SkippableEntity<Node>(const Node&, const std::string&);
+template bool InputOutputUtilities::SkippableEntity<Element>(const Element&, const std::string&);
+template bool InputOutputUtilities::SkippableEntity<Condition>(const Condition&, const std::string&);
+
+} // namespace Kratos

--- a/kratos/utilities/input_output_utilities.h
+++ b/kratos/utilities/input_output_utilities.h
@@ -1,0 +1,53 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
+//
+//  Main authors:    Vicente Mataix Ferrandiz
+//
+
+#pragma once
+
+// System includes
+
+// External includes
+
+// Project includes
+#include "includes/define.h"
+
+namespace Kratos
+{
+///@addtogroup KratosCore
+
+///@name Kratos Classes
+///@{
+/**
+ * @class InputOutputUtilities
+ * @ingroup KratosCore
+ * @brief Utilities for common input/output operations
+ * @author Vicente Mataix Ferrandiz
+ */
+class KRATOS_API(KRATOS_CORE) InputOutputUtilities
+{
+public:
+    /**
+     * @brief Checks if the given entity can be skipped during output
+     * @param rEntity The entity to be checked
+     * @param rWarningLabel The warning label to be used
+     * @return true if the entity can be skipped, false otherwise
+     * @tparam TEntityType the type of the entity
+     */
+    template<typename TEntityType>
+    static bool SkippableEntity(
+        const TEntityType& rEntity,
+        const std::string& rWarningLabel
+        );
+};
+
+///@}
+
+} // namespace Kratos

--- a/kratos/utilities/input_output_utilities.h
+++ b/kratos/utilities/input_output_utilities.h
@@ -46,6 +46,18 @@ public:
         const TEntityType& rEntity,
         const std::string& rWarningLabel
         );
+
+    /**
+     * @brief This method generates a string label for the step with a given step and the number of spaces considered.
+     * @details For example Step = 3 and Spaces = 6, would be "000003".
+     * @param Step The numerical value of the step.
+     * @param Spaces The total desired width of the output string, padded with leading zeros.
+     * @return A zero-padded string representation of the step.
+     */
+    static std::string GenerateStepLabel(
+        const std::size_t Step,
+        const std::size_t Spaces
+        );
 };
 
 ///@}


### PR DESCRIPTION
**📝 Description**

Add `SkippableEntity` method to `InputOutputUtilities` for geometry type checks. These utilities will be used in future new IO implementations and the pourpose is to reduce future code duplications. Some other code duplications may be moved here in the future.

**🆕 Changelog**

- [Add `SkippableEntity` method to `InputOutputUtilities` for geometry type checks](https://github.com/KratosMultiphysics/Kratos/commit/713c57fac351d81aad2170a259fa4ff811e6ec58)
- [Refactor `VtkOutput`: Replace `SkippableEntity` method with `InputOutputUtilities`](https://github.com/KratosMultiphysics/Kratos/commit/92578c2691048c997e2c67117dfa25ed9e054dae)
