### PR TITLE
[FastPR][Core] Add SafeAssemble to sparse arrays

### DIFF
--- a/kratos/containers/csr_matrix.h
+++ b/kratos/containers/csr_matrix.h
@@ -603,6 +603,53 @@ public:
     }
 
     template<class TMatrixType, class TIndexVectorType >
+    void SafeAssemble(
+        const TMatrixType& rMatrixInput,
+        const TIndexVectorType& EquationId
+    )
+    {
+        KRATOS_DEBUG_ERROR_IF(rMatrixInput.size1() != EquationId.size()) << "sizes of matrix and equation id do not match in Assemble" << std::endl;
+        KRATOS_DEBUG_ERROR_IF(rMatrixInput.size2() != EquationId.size()) << "sizes of matrix and equation id do not match in Assemble" << std::endl;
+
+        const unsigned int local_size = rMatrixInput.size1();
+
+        for (unsigned int i_local = 0; i_local < local_size; ++i_local) {
+            const IndexType I = EquationId[i_local];
+            if (I < size1()) {
+                const IndexType row_begin = index1_data()[I];
+                const IndexType row_end = index1_data()[I+1];
+
+                //find first entry (note that we know it exists since local_size > 0)
+                IndexType J = EquationId[0];
+                if (J < size2()) {
+                    IndexType k = BinarySearch(index2_data(), row_begin, row_end, EquationId[0]);
+                    IndexType lastJ = J;
+
+                    AtomicAdd(value_data()[k], rMatrixInput(i_local,0));
+
+                    //now find other entries. note that we assume that it is probably that next entries immediately follow in the ordering
+                    for(unsigned int j_local=1; j_local<local_size; ++j_local) {
+                        J = EquationId[j_local];
+
+                        if(k+1<row_end && index2_data()[k+1] == J) {
+                            k = k+1;
+                        } else if(J > lastJ) { //note that the case k+2 >= index2_data().size() should be impossible
+                            k = BinarySearch(index2_data(), k+2, row_end, J);
+                        } else if(J < lastJ) {
+                            k = BinarySearch(index2_data(), row_begin, k-1, J);
+                        }
+                        //the last missing case is J == lastJ, which should never happen in FEM. If that happens we can reuse k
+
+                        AtomicAdd(value_data()[k], rMatrixInput(i_local,j_local));
+
+                        lastJ = J;
+                    }
+                }
+            }
+        }
+    }
+
+    template<class TMatrixType, class TIndexVectorType >
     void Assemble(
         const TMatrixType& rMatrixInput,
         const TIndexVectorType& RowEquationId,

--- a/kratos/containers/system_vector.h
+++ b/kratos/containers/system_vector.h
@@ -285,6 +285,22 @@ public:
         }
     }
 
+    template<class TVectorType, class TIndexVectorType >
+    void SafeAssemble(
+        const TVectorType& rVectorInput,
+        const TIndexVectorType& EquationId
+    )
+    {
+        KRATOS_DEBUG_ERROR_IF(rVectorInput.size() != EquationId.size());
+
+        for(unsigned int i=0; i<EquationId.size(); ++i){
+            IndexType global_i = EquationId[i];
+            if (global_i < size()) {
+                AssembleEntry(rVectorInput[i], global_i);
+            }
+        }
+    }
+
     void AssembleEntry(
         const TDataType rValue,
         const IndexType GlobalI)


### PR DESCRIPTION
**📝 Description**
This PR adds a `SafeAssemble` method to the `CSRArray` and the `SystemVector` classes. In short, it is a copy&paste of the `Assemble` but checking that the provided equation ids. do not get out of bounds. The idea is to ease the assessment of the impact that such extra if statements might have. Most probably, we will finally keep only one version (either with or without check).

The performance test will come in a future PR including the building capabilities.
