### PR TITLE
[FastPR][Core] Fix warning in PointerVectorSet ctor

### DIFF
--- a/kratos/containers/pointer_vector_set.h
+++ b/kratos/containers/pointer_vector_set.h
@@ -147,7 +147,8 @@ public:
     explicit PointerVectorSet(const TContainerType& rContainer) :  mData(rContainer), mSortedPartSize(size_type()), mMaxBufferSize(1)
     {
         Sort();
-        std::unique(mData.begin(), mData.end(), EqualKeyTo());
+        auto last = std::unique(mData.begin(), mData.end(), EqualKeyTo());
+        mData.erase(last, mData.end());
     }
 
     /// Destructor.


### PR DESCRIPTION
**📝 Description**
While working on #13734 the Windows CI raised the following warning `D:\a\Kratos\Kratos\kratos\containers\pointer_vector_set.h(150,14): warning C4858: discarding return value: The 'unique' algorithm returns the iterator past the last element that should be kept. You need to call container.erase(result, container.end()) afterwards. `. 

Most probably it has been in there for a while but we never realized because this constructor was never used. This makes me wonder if we should better remove it as we can do the same with the begin/end one above.