### PR TITLE
[GeoMechanicsApplication] Replaced boost::tie with a structured binding

### DIFF
--- a/applications/GeoMechanicsApplication/custom_utilities/node_utilities.cpp
+++ b/applications/GeoMechanicsApplication/custom_utilities/node_utilities.cpp
@@ -26,7 +26,7 @@ void NodeUtilities::AssignUpdatedVectorVariableToNonFixedComponents(Node& rNode,
                                                                     IndexType SolutionStepIndex)
 {
     const std::vector<std::string> components = {"X", "Y", "Z"};
-    for (const auto [new_value, component] : boost::combine(rNewValues, components)) {
+    for (const auto& [new_value, component] : boost::combine(rNewValues, components)) {
         if (const auto& component_variable =
                 VariablesUtilities::GetComponentFromVectorVariable(rDestinationVariable.Name(), component);
             !rNode.IsFixed(component_variable)) {

--- a/applications/GeoMechanicsApplication/custom_utilities/node_utilities.cpp
+++ b/applications/GeoMechanicsApplication/custom_utilities/node_utilities.cpp
@@ -26,11 +26,7 @@ void NodeUtilities::AssignUpdatedVectorVariableToNonFixedComponents(Node& rNode,
                                                                     IndexType SolutionStepIndex)
 {
     const std::vector<std::string> components = {"X", "Y", "Z"};
-    for (const auto& zipped : boost::combine(rNewValues, components)) {
-        double      new_value = 0.0;
-        std::string component;
-        boost::tie(new_value, component) = zipped;
-
+    for (const auto [new_value, component] : boost::combine(rNewValues, components)) {
         if (const auto& component_variable =
                 VariablesUtilities::GetComponentFromVectorVariable(rDestinationVariable.Name(), component);
             !rNode.IsFixed(component_variable)) {


### PR DESCRIPTION
**📝 Description**
This piece of code always looks a bit cumbersome and has been bugging me since I've written it. With the new version of boost, improvements have been made to how boost::combine works with structured bindings, so we can simplify (when moving to 23, we can actually use views::zip instead of boost::combine, but one step at a time)
