### PR TITLE
[GeoMechanicsApplication] Moved C++ specification from global variable to target properties

### DIFF
--- a/applications/GeoMechanicsApplication/CMakeLists.txt
+++ b/applications/GeoMechanicsApplication/CMakeLists.txt
@@ -1,5 +1,4 @@
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
-set (CMAKE_CXX_STANDARD 20)
 
 message("**** configuring KratosGeoMechanicsApplication ****")
 
@@ -39,6 +38,7 @@ file(GLOB_RECURSE KRATOS_GEO_MECHANICS_APPLICATION_CORE
 if(${KRATOS_BUILD_TESTING} MATCHES ON)
     file(GLOB_RECURSE KRATOS_GEO_MECHANICS_APPLICATION_TESTING_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/tests/*.cpp)
     kratos_add_gtests(TARGET KratosGeoMechanicsCore SOURCES "${KRATOS_GEO_MECHANICS_APPLICATION_TESTING_SOURCES}")
+    set_target_properties("KratosGeoMechanicsCoreTest" PROPERTIES CXX_STANDARD 20)
 endif(${KRATOS_BUILD_TESTING} MATCHES ON)
 
 ## GeoMechanics python interface sources
@@ -46,7 +46,7 @@ file(GLOB_RECURSE KRATOS_GEO_MECHANICS_APPLICATION_PYTHON_INTERFACE ${CMAKE_CURR
 
 add_library(KratosGeoMechanicsCore SHARED ${KRATOS_GEO_MECHANICS_APPLICATION_CORE})
 target_link_libraries(KratosGeoMechanicsCore PUBLIC KratosCore KratosStructuralMechanicsCore KratosLinearSolversCore ${CMAKE_DL_LIBS})
-set_target_properties(KratosGeoMechanicsCore PROPERTIES COMPILE_DEFINITIONS "GEO_MECHANICS_APPLICATION=EXPORT,API")
+set_target_properties(KratosGeoMechanicsCore PROPERTIES COMPILE_DEFINITIONS "GEO_MECHANICS_APPLICATION=EXPORT,API" CXX_STANDARD 20)
 
 
 ###############################################################

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_elements/test_integration_schemes.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_elements/test_integration_schemes.cpp
@@ -50,7 +50,7 @@ double SumOfWeights(const Geo::IntegrationPointVectorType& rIntegrationPoints)
     auto weights = std::vector<double>{};
     weights.reserve(rIntegrationPoints.size());
     std::ranges::transform(rIntegrationPoints, std::back_inserter(weights),
-                   [](const auto& rIntegrationPoint) { return rIntegrationPoint.Weight(); });
+                           [](const auto& rIntegrationPoint) { return rIntegrationPoint.Weight(); });
     return std::accumulate(weights.cbegin(), weights.cend(), 0.0);
 }
 

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_elements/test_integration_schemes.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_elements/test_integration_schemes.cpp
@@ -49,7 +49,7 @@ double SumOfWeights(const Geo::IntegrationPointVectorType& rIntegrationPoints)
 {
     auto weights = std::vector<double>{};
     weights.reserve(rIntegrationPoints.size());
-    std::transform(rIntegrationPoints.begin(), rIntegrationPoints.end(), std::back_inserter(weights),
+    std::ranges::transform(rIntegrationPoints, std::back_inserter(weights),
                    [](const auto& rIntegrationPoint) { return rIntegrationPoint.Weight(); });
     return std::accumulate(weights.cbegin(), weights.cend(), 0.0);
 }


### PR DESCRIPTION
Although we only set the c++ version in the subfolder of the GeoMechanicsApplication, it still had an impact on code that was built **after** the GeoMechanicsApplication (which would also be built with C++ 20). 

We fixed it here by solely setting the target properties of the geo lib and test executable, such that there is no impact on other code.