### PR TITLE
[CMake] Missing custom setting for `PYTHON_LIBRARY`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -394,6 +394,11 @@ if(DEFINED ENV{PYTHON_EXECUTABLE})
   set(PYTHON_EXECUTABLE $ENV{PYTHON_EXECUTABLE})
 endif(DEFINED ENV{PYTHON_EXECUTABLE})
 
+# Try to use python library from env variable
+if(DEFINED ENV{PYTHON_LIBRARY})
+  set(PYTHON_LIBRARY $ENV{PYTHON_LIBRARY})
+endif(DEFINED ENV{PYTHON_LIBRARY})
+
 include(pybind11Tools)
 
 # Reset pybind11 config and remove -LTO since it gives multiple problems.


### PR DESCRIPTION
**📝 Description**

Missing custom setting for `PYTHON_LIBRARY`.

**🆕 Changelog**

- [Missing custom setting for `PYTHON_LIBRARY`](https://github.com/KratosMultiphysics/Kratos/commit/e174015551ccd46e929207ca4e2d2f03af42a2ca)
