### PR TITLE
[IgaApplication] import as true geometry a nurbs curve, few improvements

### DIFF
--- a/applications/IgaApplication/custom_modelers/nurbs_geometry_modeler_sbm.cpp
+++ b/applications/IgaApplication/custom_modelers/nurbs_geometry_modeler_sbm.cpp
@@ -138,6 +138,8 @@ void NurbsGeometryModelerSbm::CreateAndAddRegularGrid2D(
         snake_parameters.AddDouble("lambda_outer", mParameters["lambda_outer"].GetDouble());
     if (mParameters.Has("number_of_inner_loops"))
         snake_parameters.AddDouble("number_of_inner_loops", mParameters["number_of_inner_loops"].GetInt());
+    if (mParameters.Has("number_initial_points_if_importing_nurbs"))
+        snake_parameters.AddInt("number_initial_points_if_importing_nurbs", mParameters["number_initial_points_if_importing_nurbs"].GetInt());
 
     // Create the surrogate_sub_model_part for inner and outer
     SnakeSbmProcess snake_sbm_process(*mpModel, snake_parameters);
@@ -255,6 +257,8 @@ void NurbsGeometryModelerSbm::CreateAndAddRegularGrid3D(
         snake_parameters.AddDouble("lambda_outer", mParameters["lambda_outer"].GetDouble());
     if (mParameters.Has("number_of_inner_loops"))
         snake_parameters.AddDouble("number_of_inner_loops", mParameters["number_of_inner_loops"].GetInt());
+    if (mParameters.Has("number_initial_points_if_importing_nurbs"))
+        snake_parameters.AddInt("number_initial_points_if_importing_nurbs", mParameters["number_initial_points_if_importing_nurbs"].GetInt());
     
     KRATOS_ERROR << "The NurbsGeometryModelerSbm is not yet implemented for 3D. " 
         << "Please use the 2D version or implement the 3D version." << std::endl;
@@ -304,6 +308,7 @@ const Parameters NurbsGeometryModelerSbm::GetValidParameters() const
         "lambda_inner": 0.5,
         "lambda_outer": 0.5,
         "number_of_inner_loops": 0,
+        "number_initial_points_if_importing_nurbs": 5000,
         "skin_model_part_inner_initial_name": "skin_model_part_inner_initial",
         "skin_model_part_outer_initial_name": "skin_model_part_outer_initial",
         "skin_model_part_name": "skin_model_part"

--- a/applications/IgaApplication/custom_processes/snake_sbm_process.cpp
+++ b/applications/IgaApplication/custom_processes/snake_sbm_process.cpp
@@ -30,6 +30,7 @@ SnakeSbmProcess::SnakeSbmProcess(
     mLambdaInner = mThisParameters["lambda_inner"].GetDouble();
     mLambdaOuter = mThisParameters["lambda_outer"].GetDouble();
     mNumberOfInnerLoops = mThisParameters["number_of_inner_loops"].GetInt();
+    mNumberInitialPointsIfImportingNurbs = mThisParameters["number_initial_points_if_importing_nurbs"].GetInt();
 
     std::string iga_model_part_name = mThisParameters["model_part_name"].GetString();
     std::string skin_model_part_inner_initial_name = mThisParameters["skin_model_part_inner_initial_name"].GetString();
@@ -62,14 +63,14 @@ void SnakeSbmProcess::CreateTheSnakeCoordinates()
         if (!mpSkinModelPartInnerInitial->HasProperties(0)) mpSkinModelPartInnerInitial->CreateNewProperties(0);
         if (!mpSkinModelPart->HasProperties(0)) mpSkinModelPart->CreateNewProperties(0);
         // template argument IsInnerLoop set true
-        CreateTheSnakeCoordinates<true>(*mpSkinModelPartInnerInitial, mNumberOfInnerLoops, mLambdaInner, mEchoLevel, *mpIgaModelPart, *mpSkinModelPart);
+        CreateTheSnakeCoordinates<true>(*mpSkinModelPartInnerInitial, mNumberOfInnerLoops, mLambdaInner, mEchoLevel, *mpIgaModelPart, *mpSkinModelPart, mNumberInitialPointsIfImportingNurbs);
             
     }
     if (mpSkinModelPartOuterInitial->NumberOfNodes()>0 || mpSkinModelPartOuterInitial->NumberOfGeometries()>0) {
         if (!mpSkinModelPartOuterInitial->HasProperties(0)) mpSkinModelPartOuterInitial->CreateNewProperties(0);
         if (!mpSkinModelPart->HasProperties(0)) mpSkinModelPart->CreateNewProperties(0);
         // template argument IsInnerLoop set false
-        CreateTheSnakeCoordinates<false>(*mpSkinModelPartOuterInitial, 1, mLambdaOuter, mEchoLevel, *mpIgaModelPart, *mpSkinModelPart);
+        CreateTheSnakeCoordinates<false>(*mpSkinModelPartOuterInitial, 1, mLambdaOuter, mEchoLevel, *mpIgaModelPart, *mpSkinModelPart, mNumberInitialPointsIfImportingNurbs);
     }
 }   
 
@@ -82,7 +83,8 @@ void SnakeSbmProcess::CreateTheSnakeCoordinates(
     const double Lambda,
     IndexType EchoLevel,
     ModelPart& rIgaModelPart,
-    ModelPart& rSkinModelPart) 
+    ModelPart& rSkinModelPart,
+    const int NumberInitialPointsIfImportingNurbs) 
 { 
     KRATOS_ERROR_IF(rIgaModelPart.GetValue(KNOT_VECTOR_U).size() == 0) << "::[SnakeSbmProcess]::" 
                 << "The iga model part has KNOT_VECTOR_U of size 0" << std::endl;
@@ -225,13 +227,58 @@ void SnakeSbmProcess::CreateTheSnakeCoordinates(
     }
     else if (rSkinModelPartInitial.Geometries().size()>0) // if the skin model part is defined by nurbs geometries
     {
-        //TODO: decrease the number when the closest point projection for the NURBS is optimized in the IgaSbmModeler
-        const int n_initial_points_for_side = 5000; 
+        // number of sampling points per curve side
+        const int number_initial_points_if_importing_nurbs = NumberInitialPointsIfImportingNurbs; 
         int first_node_id = r_skin_sub_model_part.GetRootModelPart().NumberOfNodes()+1;
         const SizeType n_boundary_curves = rSkinModelPartInitial.NumberOfGeometries();
+
+        // Reorder curves to form a single closed loop: each curve's start must match previous curve's end (within tol)
+        const double tol = 1e-7;
+        std::vector<IndexType> ordered_indices;
+        ordered_indices.reserve(n_boundary_curves);
+        std::vector<bool> used(n_boundary_curves, false);
+
+        // Precompute start/end coordinates for each curve (local t=0 and t=1)
+        std::vector<CoordinatesArrayType> starts(n_boundary_curves), ends(n_boundary_curves);
+        for (IndexType i = 0; i < n_boundary_curves; ++i) {
+            auto p_geom = rSkinModelPartInitial.pGetGeometry(i);
+            NurbsCurveGeometryPointerType p_curve_i = std::dynamic_pointer_cast<Kratos::NurbsCurveGeometry<2, Kratos::PointerVector<Kratos::Node>>>(p_geom);
+            KRATOS_ERROR_IF_NOT(p_curve_i) << "NURBS curve " << i << " not defined in the initial Model Part. Check the importNurbsSbmModeler." << std::endl;
+            CoordinatesArrayType local0 = ZeroVector(3);
+            CoordinatesArrayType local1 = ZeroVector(3); local1[0] = 1.0;
+            starts[i].resize(3,false); ends[i].resize(3,false);
+            p_curve_i->GlobalCoordinates(starts[i], local0);
+            p_curve_i->GlobalCoordinates(ends[i], local1);
+        }
+
+        // Greedy ordering: start from 0 and find next whose start matches current end
+        ordered_indices.push_back(0);
+        used[0] = true;
+        CoordinatesArrayType current_end = ends[0];
+        for (IndexType k = 1; k < n_boundary_curves; ++k) {
+            bool found = false;
+            for (IndexType j = 1; j < n_boundary_curves; ++j) { // j=0 already used
+                if (used[j]) continue;
+                if (norm_2(current_end - starts[j]) <= tol) {
+                    ordered_indices.push_back(j);
+                    used[j] = true;
+                    current_end = ends[j];
+                    found = true;
+                    break;
+                }
+            }
+            KRATOS_ERROR_IF_NOT(found)
+                << "[SnakeSbmProcess] Could not find the next NURBS curve to continue the single closed loop."
+                << " Ensure curves are connected head-to-tail and no reversal is needed." << std::endl;
+        }
+        // Check closure: last end must match first start
+        KRATOS_ERROR_IF(norm_2(current_end - starts[ordered_indices.front()]) > tol)
+            << "[SnakeSbmProcess] The ordered NURBS curves do not form a closed loop (last end != first start)." << std::endl;
+
         bool new_inner_loop = true;
-        for (IndexType i_boundary_curve = 0; i_boundary_curve < n_boundary_curves; i_boundary_curve++) 
+        for (IndexType i_ordered = 0; i_ordered < n_boundary_curves; i_ordered++) 
         {
+            const IndexType i_boundary_curve = ordered_indices[i_ordered];
             NurbsCurveGeometryPointerType p_curve = std::dynamic_pointer_cast<Kratos::NurbsCurveGeometry<2, Kratos::PointerVector<Kratos::Node>>>(rSkinModelPartInitial.pGetGeometry(i_boundary_curve));
             if (!p_curve) 
                 KRATOS_ERROR << "NURBS curve " << i_boundary_curve << " not defined in the initial Model Part. Check the importNurbsSbmModeler." << std::endl;
@@ -273,9 +320,8 @@ void SnakeSbmProcess::CreateTheSnakeCoordinates(
             {
                 const int last_node_id = r_skin_sub_model_part.GetRootModelPart().NumberOfNodes();
                 Node& r_last_node = r_skin_sub_model_part.GetNode(last_node_id);
-                KRATOS_ERROR_IF(norm_2(first_point_coords - r_last_node) > 1e-7)
-                                << "ImportNurbsSbmModeler: error in the json NURBS file. The boundary curves" 
-                                << " are not correctly ordered." << std::endl;
+                KRATOS_ERROR_IF(norm_2(first_point_coords - r_last_node) > tol)
+                                << "[SnakeSbmProcess] NURBS curves reordering failed: expected continuity between curves but points differ by > tol." << std::endl;
 
 
                 // Create two nodes and two conditions for each skin condition
@@ -305,9 +351,9 @@ void SnakeSbmProcess::CreateTheSnakeCoordinates(
             // add the specified number of points
             Vector second_point_local_coord = ZeroVector(3);
             CoordinatesArrayType second_point_coords(3);
-            for (int i = 1; i < n_initial_points_for_side; i++)
+            for (int i = 1; i < number_initial_points_if_importing_nurbs; i++)
             {
-                second_point_local_coord[0] = (double) i/(n_initial_points_for_side-1);
+                second_point_local_coord[0] = (double) i/(number_initial_points_if_importing_nurbs-1);
                 p_curve->GlobalCoordinates(second_point_coords, second_point_local_coord);
                 //***********************************************************
                     // Collect the coordinates of the points

--- a/applications/IgaApplication/custom_processes/snake_sbm_process.h
+++ b/applications/IgaApplication/custom_processes/snake_sbm_process.h
@@ -83,7 +83,8 @@ public:
             "echo_level" : 0,
             "lambda_inner" : 0.5,
             "lambda_outer" : 0.5,
-            "number_of_inner_loops": 0
+            "number_of_inner_loops": 0,
+            "number_initial_points_if_importing_nurbs": 5000
         })" );
 
         return default_parameters;
@@ -97,6 +98,7 @@ private:
     double mLambdaInner;
     double mLambdaOuter;
     std::size_t mNumberOfInnerLoops;
+    int mNumberInitialPointsIfImportingNurbs;
     ModelPart* mpIgaModelPart = nullptr; 
     ModelPart* mpSkinModelPartInnerInitial = nullptr; 
     ModelPart* mpSkinModelPartOuterInitial = nullptr; 
@@ -138,7 +140,8 @@ private:
         const double Lambda,
         IndexType EchoLevel,
         ModelPart& rIgaModelPart,
-        ModelPart& rSkinModelPart 
+        ModelPart& rSkinModelPart,
+        const int NumberInitialPointsIfImportingNurbs
         );
 
     /**

--- a/applications/IgaApplication/tests/import_nurbs_test/square_nurbs_unordered.json
+++ b/applications/IgaApplication/tests/import_nurbs_test/square_nurbs_unordered.json
@@ -1,0 +1,36 @@
+{
+    "Lines": [
+        {
+            "Layer": "top",
+            "Weights": [1, 1],
+            "CPCoordinates": [[1.0, 1.0, 0.0], [0.0, 1.0, 0.0]],
+            "knotVector": [0.0, 0.0, 1.0, 1.0],
+            "id": 3,
+            "pDegree": 1
+        },
+        {
+            "Layer": "right",
+            "Weights": [1, 1],
+            "CPCoordinates": [[1.0, 0.0, 0.0], [1.0, 1.0, 0.0]],
+            "knotVector": [0.0, 0.0, 1.0, 1.0],
+            "id": 2,
+            "pDegree": 1
+        },
+        {
+            "Layer": "bottom",
+            "Weights": [1, 1],
+            "CPCoordinates": [[0.0, 0.0, 0.0], [1.0, 0.0, 0.0]],
+            "knotVector": [0.0, 0.0, 1.0, 1.0],
+            "id": 1,
+            "pDegree": 1
+        },
+        {
+            "Layer": "left",
+            "Weights": [1, 1],
+            "CPCoordinates": [[0.0, 1.0, 0.0], [0.0, 0.0, 0.0]],
+            "knotVector": [0.0, 0.0, 1.0, 1.0],
+            "id": 4,
+            "pDegree": 1
+        }
+    ]
+}

--- a/applications/IgaApplication/tests/test_modelers_sbm.py
+++ b/applications/IgaApplication/tests/test_modelers_sbm.py
@@ -800,6 +800,98 @@ class TestModelersSbm(KratosUnittest.TestCase):
         self.assertEqual(support_model_part.GetConditions()[55].Info(), "\"SbmLaplacianConditionDirichlet\" #55")
         self.assertEqual(support_model_part.GetConditions()[28].Info(), "\"SbmLaplacianConditionNeumann\" #28")
 
+    def test_iga_modeler_outer_sbm_layers_unordered_curves(self):
+        current_model = KratosMultiphysics.Model()
+        modeler_settings = KratosMultiphysics.Parameters("""
+        [
+            {
+            "modeler_name" : "ImportNurbsSbmModeler",
+            "Parameters" : {
+                "input_filename" : "import_nurbs_test/square_nurbs_unordered.json",
+                "model_part_name" : "skinModelPart_outer_initial",
+                "link_layer_to_condition_name": [
+                {
+                    "layer_name" : "bottom",
+                    "condition_name" : "SbmLaplacianConditionDirichlet"
+                },
+                {
+                    "layer_name" : "left",
+                    "condition_name" : "SbmLaplacianConditionDirichlet"
+                },
+                {
+                    "layer_name" : "right",
+                    "condition_name" : "SbmLaplacianConditionNeumann"
+                },
+                {
+                    "layer_name" : "top",
+                    "condition_name" : "SbmLaplacianConditionNeumann"
+                }
+                ]
+                }
+            },                            
+            {
+            "modeler_name": "NurbsGeometryModelerSbm",
+            "Parameters": {
+                    "model_part_name" : "IgaModelPart",
+                    "lower_point_xyz": [-1.0,-1.0,0.0],
+                    "upper_point_xyz": [2.0,2.0,0.0],
+                    "lower_point_uvw": [-1.0,-1.0,0.0],
+                    "upper_point_uvw": [2.0,2.0,0.0],
+                    "polynomial_order" : [1, 1],
+                    "number_of_knot_spans" : [10,10],
+                    "lambda_outer": 0.5,
+                    "number_of_inner_loops": 0,
+                    "skin_model_part_outer_initial_name": "skinModelPart_outer_initial",           
+                    "skin_model_part_name": "skin_model_part"
+                }
+            },
+            {
+                "modeler_name": "IgaModelerSbm",
+                "Parameters": {
+                    "echo_level": 0,
+                    "skin_model_part_name": "skin_model_part",
+                    "analysis_model_part_name": "IgaModelPart",
+                    "element_condition_list": [
+                        {
+                            "geometry_type": "GeometrySurface",
+                            "iga_model_part": "ComputationalDomain",
+                            "type": "element",
+                            "name": "LaplacianIGAElement",
+                            "shape_function_derivatives_order": 3
+                        },
+                        {
+                            "geometry_type": "SurfaceEdge",
+                            "iga_model_part": "SBM_Support_outer",
+                            "type": "condition",
+                            "name": "SbmCondition",
+                            "shape_function_derivatives_order": 3, 
+                            "sbm_parameters": {
+                                "is_inner" : false
+                            }
+                        }
+                    ] // element condition list
+                }
+            }] // iga modeler
+            """)
+
+        iga_model_part = current_model.CreateModelPart("IgaModelPart")
+        iga_model_part.ProcessInfo.SetValue(KratosMultiphysics.DOMAIN_SIZE, 2)
+        
+        run_modelers(current_model, modeler_settings)
+
+        support_model_part = current_model.GetModelPart("IgaModelPart.SBM_Support_outer")
+        computational_model_part = current_model.GetModelPart("IgaModelPart.ComputationalDomain")
+
+        # Expect same results as ordered case: curves are reordered internally
+        self.assertEqual(support_model_part.NumberOfNodes(), 0)
+        self.assertEqual(support_model_part.NumberOfConditions(), 48)
+        self.assertEqual(computational_model_part.NumberOfNodes(), 256)
+        self.assertEqual(computational_model_part.NumberOfConditions(), 0)
+
+        # Spot-check two conditions types to ensure mapping still holds
+        self.assertEqual(support_model_part.GetConditions()[55].Info(), "\"SbmLaplacianConditionDirichlet\" #55")
+        self.assertEqual(support_model_part.GetConditions()[28].Info(), "\"SbmLaplacianConditionNeumann\" #28")
+
 
 if __name__ == '__main__':
     KratosUnittest.main()


### PR DESCRIPTION
📝 Description
Make NURBS SBM import configurable and more robust: add number_initial_points_if_importing_nurbs, wire it through, and ensure boundary curves form a closed loop.

Tags: Enhancement, IgaApplication, Not Api Breaker, Not Mpi
🆕 Changelog

Add number_initial_points_if_importing_nurbs to modeler.
Replace hardcoded sampling with the new parameter.
Reorder NURBS curves into a single closed loop with tolerance checks.