### PR TITLE
[Core] Improve `TetrahedralMeshOrientationCheck` logging

### DIFF
--- a/kratos/processes/tetrahedral_mesh_orientation_check.cpp
+++ b/kratos/processes/tetrahedral_mesh_orientation_check.cpp
@@ -157,7 +157,11 @@ void TetrahedralMeshOrientationCheck::Execute()
             const bool switched = this->Orient(r_geometry);
             if (switched) {
                 ++elem_switch_count;
-                ss_elements << "Element number" << it_elem->Id() << " is inverted. Volume: " << r_geometry.DomainSize() << "\n";
+                if (mOptions.Is(DETAILED_INVERTED_ENTITIES_MESSAGE)) {
+                    ss_elements << "Element number: " << it_elem->Id() << " is inverted. Volume: " << r_geometry.DomainSize() << "\n";
+                } else {
+                    ss_elements << "\t" << it_elem->Id() << ",";
+                }
             }
         }
     }
@@ -167,7 +171,11 @@ void TetrahedralMeshOrientationCheck::Execute()
     if (elem_switch_count > 0) {
         out_message << "Mesh orientation check found " << elem_switch_count << " inverted elements.\n";
         if (mOptions.Is(DETAILED_INVERTED_ENTITIES_MESSAGE)) {
-            out_message << ss_elements.str() << "\n";
+            out_message << "The following elements were inverted:\n"
+                        << ss_elements.str();
+        } else {
+            out_message << "The IDs of the inverted elements are:\n"
+                        << ss_elements.str() << "\n";
         }
     } else {
         out_message << "No inverted elements found" << std::endl;
@@ -274,7 +282,11 @@ void TetrahedralMeshOrientationCheck::Execute()
                         r_face_geom(0).swap(r_face_geom(1));
                         face_normal = -face_normal;
                         ++cond_switch_count;
-                        ss_conditions << "Condition number" << (list_conditions[0])->Id() << " is inverted. Area: " << r_face_geom.DomainSize() << "\n";
+                        if (mOptions.Is(DETAILED_INVERTED_ENTITIES_MESSAGE)) {
+                            ss_conditions << "Condition number: " << (list_conditions[0])->Id() << " is inverted. Area: " << r_face_geom.DomainSize() << "\n";
+                        } else {
+                            ss_conditions << "\t" << (list_conditions[0])->Id() << ",";
+                        }
                     }
 
                     if (mOptions.Is(COMPUTE_NODAL_NORMALS)) {
@@ -285,7 +297,7 @@ void TetrahedralMeshOrientationCheck::Execute()
                     }
                     if (mOptions.Is(COMPUTE_CONDITION_NORMALS)) {
                         for (const Condition::Pointer& p_cond : list_conditions) {
-                            p_cond->SetValue(NORMAL, face_normal );
+                            p_cond->SetValue(NORMAL, face_normal);
                         }
                     }
 
@@ -306,7 +318,11 @@ void TetrahedralMeshOrientationCheck::Execute()
     if (cond_switch_count > 0) {
         out_message << "Mesh orientation check found " << cond_switch_count << " inverted conditions.\n";
         if (mOptions.Is(DETAILED_INVERTED_ENTITIES_MESSAGE)) {
-            out_message << ss_conditions.str() << std::endl;
+            out_message << "The following conditions were inverted:\n"
+                        << ss_conditions.str();
+        } else {
+            out_message << "The IDs of the inverted conditions are:\n"
+                        << ss_conditions.str() << "\n";
         }
     } else {
         out_message << "No inverted conditions found" << std::endl;

--- a/kratos/processes/tetrahedral_mesh_orientation_check.cpp
+++ b/kratos/processes/tetrahedral_mesh_orientation_check.cpp
@@ -59,7 +59,7 @@ void TetrahedralMeshOrientationCheck::Execute()
             const bool switched = this->Orient(r_geometry);
             if (switched) {
                 ++elem_switch_count;
-                ss_elements << "Element number" << it_elem->Id() << " is inverted. Volume: " << r_geometry->DomainSize() << "\n";
+                ss_elements << "Element number" << it_elem->Id() << " is inverted. Volume: " << r_geometry.DomainSize() << "\n";
             }
         }
     }
@@ -173,7 +173,7 @@ void TetrahedralMeshOrientationCheck::Execute()
                         r_face_geom(0).swap(r_face_geom(1));
                         face_normal = -face_normal;
                         ++cond_switch_count;
-                        ss_conditions << "Condition number" << (list_conditions[0])->Id() << " is inverted. Area: " << r_face_geom->DomainSize() << "\n";
+                        ss_conditions << "Condition number" << (list_conditions[0])->Id() << " is inverted. Area: " << r_face_geom.DomainSize() << "\n";
                     }
 
                     if(mrOptions.Is(COMPUTE_NODAL_NORMALS)) {

--- a/kratos/processes/tetrahedral_mesh_orientation_check.h
+++ b/kratos/processes/tetrahedral_mesh_orientation_check.h
@@ -4,16 +4,14 @@
 //   _|\_\_|  \__,_|\__|\___/ ____/
 //                   Multi-Physics
 //
-//  License:           BSD License
-//                          Kratos default license: kratos/license.txt
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
 //
 //  Main authors:    Pooyan Dadvand
 //                   Riccardo Rossi
 //
-//
 
-#ifndef KRATOS_TETRAHEDRAL_MESH_ORIENTATION_CHECK_H
-#define KRATOS_TETRAHEDRAL_MESH_ORIENTATION_CHECK_H
+#pragma once
 
 // System includes
 
@@ -29,12 +27,6 @@ namespace Kratos
 {
 ///@name Type Definitions
 ///@{
-
-/// The definition of the node
-typedef Node NodeType;
-
-/// The definition of the geometry
-typedef Geometry<NodeType> GeometryType;
 
 ///@}
 ///@name Kratos Classes
@@ -56,7 +48,7 @@ public:
     ///@name Type Definitions
     ///@{
 
-    //DEFINITION OF FLAGS TO CONTROL THE BEHAVIOUR
+    // DEFINITION OF FLAGS TO CONTROL THE BEHAVIOUR
     KRATOS_DEFINE_LOCAL_FLAG(ASSIGN_NEIGHBOUR_ELEMENTS_TO_CONDITIONS);
     KRATOS_DEFINE_LOCAL_FLAG(COMPUTE_NODAL_NORMALS);
     KRATOS_DEFINE_LOCAL_FLAG(COMPUTE_CONDITION_NORMALS);
@@ -67,45 +59,48 @@ public:
     KRATOS_CLASS_POINTER_DEFINITION(TetrahedralMeshOrientationCheck);
 
     /// The definition of the index type
-    typedef std::size_t IndexType;
+    using IndexType = std::size_t;
 
     /// The definition of the size type
-    typedef std::size_t SizeType;
+    using SizeType = std::size_t ;
 
-    /// Definition of the node type
-    typedef Node NodeType;
-
-    // Definition of the geometry
-    typedef Geometry<NodeType> GeometryType;
+    /// Definition of the geometry
+    using GeometryType = Geometry<Node>;
 
     ///@}
     ///@name Life Cycle
     ///@{
 
-    /// Constructor for TetrahedralMeshOrientationCheck Process
     /**
+     * @brief Constructor for TetrahedralMeshOrientationCheck Process
      * @param rModelPart The model part to check.
      * @param ThrowErrors If true, an error will be thrown if the input model part contains malformed elements or conditions.
+     * @param Options The flags to be set
      */
     TetrahedralMeshOrientationCheck(
         ModelPart& rModelPart,
         bool ThrowErrors,
-        const Flags options = COMPUTE_NODAL_NORMALS.AsFalse() | COMPUTE_CONDITION_NORMALS.AsFalse() | ASSIGN_NEIGHBOUR_ELEMENTS_TO_CONDITIONS.AsFalse() | ALLOW_REPEATED_CONDITIONS.AsFalse()
+        const Flags Options = COMPUTE_NODAL_NORMALS.AsFalse() | COMPUTE_CONDITION_NORMALS.AsFalse() | ASSIGN_NEIGHBOUR_ELEMENTS_TO_CONDITIONS.AsFalse() | ALLOW_REPEATED_CONDITIONS.AsFalse()
         ):  Process(),
             mrModelPart(rModelPart),
             mThrowErrors(ThrowErrors), //to be changed to a flag
-            mrOptions(options)
+            mrOptions(Options)
 
     {
     }
 
+    /**
+     * @brief Constructor for TetrahedralMeshOrientationCheck Process (simplified)
+     * @param rModelPart The model part to check.
+     * @param Options The flags to be set
+     */
     TetrahedralMeshOrientationCheck(
         ModelPart& rModelPart,
-        const Flags options = COMPUTE_NODAL_NORMALS.AsFalse() | COMPUTE_CONDITION_NORMALS.AsFalse() | ASSIGN_NEIGHBOUR_ELEMENTS_TO_CONDITIONS.AsFalse() | ALLOW_REPEATED_CONDITIONS.AsFalse()
+        const Flags Options = COMPUTE_NODAL_NORMALS.AsFalse() | COMPUTE_CONDITION_NORMALS.AsFalse() | ASSIGN_NEIGHBOUR_ELEMENTS_TO_CONDITIONS.AsFalse() | ALLOW_REPEATED_CONDITIONS.AsFalse()
         ):  Process(),
             mrModelPart(rModelPart),
             mThrowErrors(false),
-            mrOptions(options)
+            mrOptions(Options)
     {
     }
 
@@ -126,23 +121,27 @@ public:
     ///@name Operations
     ///@{
 
-
-    /// Check elements to make sure that their jacobian is positive and conditions to ensure that their face normals point outwards
+    /**
+     * @brief Checks elements for positive Jacobian and conditions for outward-pointing normals.
+     * @details This method iterates through all tetrahedral elements in the `ModelPart` to verify that their Jacobian is positive,
+     * which ensures they are not inverted. It also checks that the face normals of all conditions point outwards from the mesh.
+     * If the `ThrowErrors` flag is set in the constructor, an exception will be thrown upon finding an invalid element or condition.
+     */
     void Execute() override;
 
+    /**
+     * @brief Swaps the orientation of all tetrahedral elements in the mesh.
+     * @details This method reverses the connectivity (node order) of every tetrahedral element and condition in the `ModelPart`.
+     * This is useful for correcting the global orientation of a mesh.
+     */
     void SwapAll();
 
+    /**
+     * @brief Swaps the orientation of elements with a negative Jacobian.
+     * @details This method is specifically designed to correct inverted elements. It iterates through the elements, and if an element's
+     * Jacobian is found to be negative, its connectivity is reversed to correct its orientation and ensure a positive Jacobian.
+     */
     void SwapNegativeElements();
-
-    ///@}
-    ///@name Access
-    ///@{
-
-
-    ///@}
-    ///@name Inquiry
-    ///@{
-
 
     ///@}
     ///@name Input and output
@@ -166,17 +165,12 @@ public:
         this->PrintInfo(rOStream);
     }
 
-
     ///@}
-    ///@name Friends
+protected:
+    ///@name Operations
     ///@{
 
-
-    ///@}
-
-protected:
-
-/**
+    /**
      * @brief tells if the element is linear or higher order
      * @param rGeometry The element geometry
      * @return true if linear, false if not
@@ -211,9 +205,6 @@ protected:
      */
     SizeType NumberOfNodesInEachBoundary(const GeometryType& rGeometry);
 
-
-
-
     /**
      * @brief Finds the nodes of each of the boundaries of the element
      * @param rGeometry The element geometry
@@ -221,11 +212,10 @@ protected:
      */
     void NodesOfBoundaries(const GeometryType& rGeometry, DenseMatrix<int>& rNodesIds);
 
-
+    ///@}
 private:
     ///@name Static Member Variables
     ///@{
-
 
     ///@}
     ///@name Member Variables
@@ -239,6 +229,13 @@ private:
     ///@name Private Operations
     ///@{
 
+    /**
+     * @brief Checks the orientation of a given geometry and corrects it if necessary.
+     * @param rGeom The geometry whose orientation is to be checked.
+     * @return `true` if the geometry was originally correctly oriented or was successfully corrected; `false` otherwise.
+     * @details This method verifies if the geometry has a positive volume (or "Jacobian" for elements). If the volume is found to be negative, the method
+     * attempts to reverse the connectivity of the geometry (e.g., swapping node indices) to correct its orientation.
+     */
     bool Orient(GeometryType& rGeom);
 
     ///@}
@@ -256,14 +253,12 @@ private:
 }; // Class Process
 
 ///@}
-
 ///@name Type Definitions
 ///@{
 
 ///@}
 ///@name Input and output
 ///@{
-
 
 /// input stream function
 inline std::istream& operator >> (std::istream& rIStream,
@@ -281,9 +276,4 @@ inline std::ostream& operator << (std::ostream& rOStream,
 }
 ///@}
 
-
-
 } // namespace Kratos
-
-
-#endif // KRATOS_TETRAHEDRAL_MESH_ORIENTATION_PROCESS_H

--- a/kratos/python/add_processes_to_python.cpp
+++ b/kratos/python/add_processes_to_python.cpp
@@ -302,14 +302,19 @@ void  AddProcessesToPython(pybind11::module& m)
     ;
 
     auto orientation_check_interface = py::class_<TetrahedralMeshOrientationCheck, TetrahedralMeshOrientationCheck::Pointer, Process>(m,"TetrahedralMeshOrientationCheck")
-            .def(py::init<ModelPart&, bool>())
-            .def(py::init<ModelPart&, bool, Kratos::Flags>())
+            .def(py::init<ModelPart&, const bool>()) // NOTE: LEGACY CONSTRUCTOR
+            .def(py::init<ModelPart&, const bool, Kratos::Flags>()) // NOTE: LEGACY CONSTRUCTOR
+            .def(py::init<Model&, Parameters>())
     .def("SwapAll",&TetrahedralMeshOrientationCheck::SwapAll)
     .def("SwapNegativeElements",&TetrahedralMeshOrientationCheck::SwapNegativeElements)
     ;
+    orientation_check_interface.attr("THROW_ERRORS") = &TetrahedralMeshOrientationCheck::THROW_ERRORS;
     orientation_check_interface.attr("ASSIGN_NEIGHBOUR_ELEMENTS_TO_CONDITIONS") = &TetrahedralMeshOrientationCheck::ASSIGN_NEIGHBOUR_ELEMENTS_TO_CONDITIONS;
     orientation_check_interface.attr("COMPUTE_NODAL_NORMALS") = &TetrahedralMeshOrientationCheck::COMPUTE_NODAL_NORMALS;
     orientation_check_interface.attr("COMPUTE_CONDITION_NORMALS") = &TetrahedralMeshOrientationCheck::COMPUTE_CONDITION_NORMALS;
+    orientation_check_interface.attr("MAKE_VOLUMES_POSITIVE") = &TetrahedralMeshOrientationCheck::MAKE_VOLUMES_POSITIVE;
+    orientation_check_interface.attr("ALLOW_REPEATED_CONDITIONS") = &TetrahedralMeshOrientationCheck::ALLOW_REPEATED_CONDITIONS;
+    orientation_check_interface.attr("DETAILED_INVERTED_ENTITIES_MESSAGE") = &TetrahedralMeshOrientationCheck::DETAILED_INVERTED_ENTITIES_MESSAGE;
 
     py::class_<VariationalDistanceCalculationProcess<2,SparseSpaceType,LocalSpaceType,LinearSolverType>, VariationalDistanceCalculationProcess<2,SparseSpaceType,LocalSpaceType,LinearSolverType>::Pointer, Process>(m,"VariationalDistanceCalculationProcess2D")
             .def(py::init<Model&, LinearSolverType::Pointer, Parameters>())


### PR DESCRIPTION
**📝 Description**

Improve `TetrahedralMeshOrientationCheck` logging. Right now we just know that certain number of elements are inverted, but [we don't know](https://i.pinimg.com/originals/9b/e4/2b/9be42b0833940b44b2e15dd61438588d.gif) which elements are inverted.

**🆕 Changelog**

- [Improve `TetrahedralMeshOrientationCheck` logging](https://github.com/KratosMultiphysics/Kratos/commit/d9cd46317b90de11b655796c3454d3067bfe3471)
