### PR TITLE
[CompressiblePotentialFlowApplication] Change the use of vacuum velocity limiter

### DIFF
--- a/applications/CompressiblePotentialFlowApplication/custom_utilities/potential_flow_utilities.cpp
+++ b/applications/CompressiblePotentialFlowApplication/custom_utilities/potential_flow_utilities.cpp
@@ -379,7 +379,9 @@ double ComputePerturbationCompressiblePressureCoefficient(const Element& rElemen
     const double v_inf_2 = inner_prod(free_stream_velocity, free_stream_velocity);
     const double M_inf_2 = M_inf * M_inf;
     double v_2 = inner_prod(velocity, velocity);
-    const double vacuum_velocity_squared = ComputeVacuumVelocitySquared(rCurrentProcessInfo);
+    // compute max velocity allowed by limit Mach number
+    const double vacuum_velocity_squared = ComputeMaximumVelocitySquared<Dim, NumNodes>(rCurrentProcessInfo);
+    // const double vacuum_velocity_squared = ComputeVacuumVelocitySquared(rCurrentProcessInfo);
     if( v_2 > vacuum_velocity_squared){
         v_2 = vacuum_velocity_squared;
     }

--- a/applications/CompressiblePotentialFlowApplication/tests/cpp_tests/test_potential_flow_utilities.cpp
+++ b/applications/CompressiblePotentialFlowApplication/tests/cpp_tests/test_potential_flow_utilities.cpp
@@ -37,6 +37,7 @@ void GenerateTestingElement(ModelPart& rModelPart) {
     rModelPart.GetProcessInfo()[FREE_STREAM_MACH] = 0.6;
     rModelPart.GetProcessInfo()[HEAT_CAPACITY_RATIO] = 1.4;
     rModelPart.GetProcessInfo()[SOUND_VELOCITY] = 340.0;
+    rModelPart.GetProcessInfo()[MACH_LIMIT] = 1.73205080756887729;
 
     BoundedVector<double, 3> free_stream_velocity = ZeroVector(3);
     free_stream_velocity(0) = rModelPart.GetProcessInfo().GetValue(FREE_STREAM_MACH) *
@@ -333,7 +334,7 @@ KRATOS_TEST_CASE_IN_SUITE(ComputePerturbationCompressiblePressureCoefficientClam
         PotentialFlowUtilities::ComputePerturbationCompressiblePressureCoefficient<2, 3>(
             *p_element, r_current_process_info);
 
-    const double reference_pressure_coefficient = -3.968253968253968;
+    const double reference_pressure_coefficient = -2.99132886677513;
     const double tolerance = 1e-15;
 
     KRATOS_ERROR_IF(!(std::abs(pressure_coefficient - reference_pressure_coefficient) < tolerance))


### PR DESCRIPTION
**📝 Description**
This PR changes the use of the vacuum velocity limiter by a limiter based on the Limit Mach number that provides lower numerical values ​​avoiding those that generate NAN solution regions.

**🆕 Changelog**
- Changed velocity reference from vacuum_velocity to maximum_velocity as a limiter
- Updated cpp test
