### PR TITLE
[FastPR][Core] Add IsThreadSafe to sparse graphs

### DIFF
--- a/kratos/containers/sparse_contiguous_row_graph.h
+++ b/kratos/containers/sparse_contiguous_row_graph.h
@@ -419,6 +419,7 @@ public:
     ///@name Inquiry
     ///@{
 
+    static constexpr bool IsThreadSafe = true;
 
     ///@}
     ///@name Input and output

--- a/kratos/containers/sparse_graph.h
+++ b/kratos/containers/sparse_graph.h
@@ -406,6 +406,7 @@ public:
     ///@name Inquiry
     ///@{
 
+    static constexpr bool IsThreadSafe = false;
 
     ///@}
     ///@name Input and output


### PR DESCRIPTION
**📝 Description**
Adds a `static constexpr bool` to indicate if the sparse graphs are whether threadsafe or not.
