### PR TITLE
[GeoMechanicsApplication] Replace the reading of material parameters in Mohr-Coulomb, to be from the yield surface

### DIFF
--- a/applications/GeoMechanicsApplication/custom_constitutive/coulomb_with_tension_cut_off_impl.cpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/coulomb_with_tension_cut_off_impl.cpp
@@ -118,20 +118,20 @@ Vector CoulombWithTensionCutOffImpl::DoReturnMapping(const Properties& rProperti
                                                      const Vector&     rTrialSigmaTau,
                                                      CoulombYieldSurface::CoulombAveragingType AveragingType) const
 {
-    const auto apex = CalculateApex(ConstitutiveLawUtilities::GetFrictionAngleInRadians(rProperties),
-                                    ConstitutiveLawUtilities::GetCohesion(rProperties));
+    const auto apex =
+        CalculateApex(mCoulombYieldSurface.GetFrictionAngleInRad(), mCoulombYieldSurface.GetCohesion());
 
-    if (IsStressAtTensionApexReturnZone(rTrialSigmaTau, rProperties[GEO_TENSILE_STRENGTH], apex)) {
-        return ReturnStressAtTensionApexReturnZone(rProperties[GEO_TENSILE_STRENGTH]);
+    if (IsStressAtTensionApexReturnZone(rTrialSigmaTau, mTensionCutOff.GetTensileStrength(), apex)) {
+        return ReturnStressAtTensionApexReturnZone(mTensionCutOff.GetTensileStrength());
     }
 
-    const auto corner_point = CalculateCornerPoint(
-        ConstitutiveLawUtilities::GetFrictionAngleInRadians(rProperties),
-        ConstitutiveLawUtilities::GetCohesion(rProperties), rProperties[GEO_TENSILE_STRENGTH]);
-    if (IsStressAtTensionCutoffReturnZone(rTrialSigmaTau, rProperties[GEO_TENSILE_STRENGTH], apex, corner_point)) {
+    const auto corner_point =
+        CalculateCornerPoint(mCoulombYieldSurface.GetFrictionAngleInRad(),
+                             mCoulombYieldSurface.GetCohesion(), mTensionCutOff.GetTensileStrength());
+    if (IsStressAtTensionCutoffReturnZone(rTrialSigmaTau, mTensionCutOff.GetTensileStrength(), apex, corner_point)) {
         return ReturnStressAtTensionCutoffReturnZone(
             rTrialSigmaTau, mTensionCutOff.DerivativeOfFlowFunction(rTrialSigmaTau),
-            rProperties[GEO_TENSILE_STRENGTH]);
+            mTensionCutOff.GetTensileStrength());
     }
 
     if (IsStressAtCornerReturnZone(
@@ -143,8 +143,7 @@ Vector CoulombWithTensionCutOffImpl::DoReturnMapping(const Properties& rProperti
     // Regular failure region
     return ReturnStressAtRegularFailureZone(
         rTrialSigmaTau, mCoulombYieldSurface.DerivativeOfFlowFunction(rTrialSigmaTau, AveragingType),
-        ConstitutiveLawUtilities::GetFrictionAngleInRadians(rProperties),
-        ConstitutiveLawUtilities::GetCohesion(rProperties));
+        mCoulombYieldSurface.GetFrictionAngleInRad(), mCoulombYieldSurface.GetCohesion());
 }
 
 void CoulombWithTensionCutOffImpl::save(Serializer& rSerializer) const

--- a/applications/GeoMechanicsApplication/custom_constitutive/coulomb_with_tension_cut_off_impl.cpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/coulomb_with_tension_cut_off_impl.cpp
@@ -119,14 +119,14 @@ Vector CoulombWithTensionCutOffImpl::DoReturnMapping(const Properties& rProperti
                                                      CoulombYieldSurface::CoulombAveragingType AveragingType) const
 {
     const auto apex =
-        CalculateApex(mCoulombYieldSurface.GetFrictionAngleInRad(), mCoulombYieldSurface.GetCohesion());
+        CalculateApex(mCoulombYieldSurface.GetFrictionAngleInRadians(), mCoulombYieldSurface.GetCohesion());
 
     if (IsStressAtTensionApexReturnZone(rTrialSigmaTau, mTensionCutOff.GetTensileStrength(), apex)) {
         return ReturnStressAtTensionApexReturnZone(mTensionCutOff.GetTensileStrength());
     }
 
     const auto corner_point =
-        CalculateCornerPoint(mCoulombYieldSurface.GetFrictionAngleInRad(),
+        CalculateCornerPoint(mCoulombYieldSurface.GetFrictionAngleInRadians(),
                              mCoulombYieldSurface.GetCohesion(), mTensionCutOff.GetTensileStrength());
     if (IsStressAtTensionCutoffReturnZone(rTrialSigmaTau, mTensionCutOff.GetTensileStrength(), apex, corner_point)) {
         return ReturnStressAtTensionCutoffReturnZone(
@@ -143,7 +143,7 @@ Vector CoulombWithTensionCutOffImpl::DoReturnMapping(const Properties& rProperti
     // Regular failure region
     return ReturnStressAtRegularFailureZone(
         rTrialSigmaTau, mCoulombYieldSurface.DerivativeOfFlowFunction(rTrialSigmaTau, AveragingType),
-        mCoulombYieldSurface.GetFrictionAngleInRad(), mCoulombYieldSurface.GetCohesion());
+        mCoulombYieldSurface.GetFrictionAngleInRadians(), mCoulombYieldSurface.GetCohesion());
 }
 
 void CoulombWithTensionCutOffImpl::save(Serializer& rSerializer) const

--- a/applications/GeoMechanicsApplication/custom_constitutive/coulomb_yield_surface.cpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/coulomb_yield_surface.cpp
@@ -25,6 +25,12 @@ CoulombYieldSurface::CoulombYieldSurface(double FrictionAngleInRad, double Cohes
 {
 }
 
+double CoulombYieldSurface::GetFrictionAngleInRad() const { return mFrictionAngle; }
+
+double CoulombYieldSurface::GetCohesion() const { return mCohesion; }
+
+double CoulombYieldSurface::GetDilatationAngleInRad() const { return mDilatationAngle; }
+
 double CoulombYieldSurface::YieldFunctionValue(const Vector& rSigmaTau) const
 {
     return rSigmaTau[1] + rSigmaTau[0] * std::sin(mFrictionAngle) - mCohesion * std::cos(mFrictionAngle);

--- a/applications/GeoMechanicsApplication/custom_constitutive/coulomb_yield_surface.cpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/coulomb_yield_surface.cpp
@@ -25,11 +25,11 @@ CoulombYieldSurface::CoulombYieldSurface(double FrictionAngleInRad, double Cohes
 {
 }
 
-double CoulombYieldSurface::GetFrictionAngleInRad() const { return mFrictionAngle; }
+double CoulombYieldSurface::GetFrictionAngleInRadians() const { return mFrictionAngle; }
 
 double CoulombYieldSurface::GetCohesion() const { return mCohesion; }
 
-double CoulombYieldSurface::GetDilatationAngleInRad() const { return mDilatationAngle; }
+double CoulombYieldSurface::GetDilatationAngleInRadians() const { return mDilatationAngle; }
 
 double CoulombYieldSurface::YieldFunctionValue(const Vector& rSigmaTau) const
 {

--- a/applications/GeoMechanicsApplication/custom_constitutive/coulomb_yield_surface.h
+++ b/applications/GeoMechanicsApplication/custom_constitutive/coulomb_yield_surface.h
@@ -34,9 +34,9 @@ public:
 
     CoulombYieldSurface(double FrictionAngleInRad, double Cohesion, double DilatationAngleInRad);
 
-    double GetFrictionAngleInRad() const;
-    double GetCohesion() const;
-    double GetDilatationAngleInRad() const;
+    [[nodiscard]] double GetFrictionAngleInRadians() const;
+    [[nodiscard]] double GetCohesion() const;
+    [[nodiscard]] double GetDilatationAngleInRadians() const;
 
     [[nodiscard]] double YieldFunctionValue(const Vector& rSigmaTau) const override;
     [[nodiscard]] Vector DerivativeOfFlowFunction(const Vector&) const override;

--- a/applications/GeoMechanicsApplication/custom_constitutive/coulomb_yield_surface.h
+++ b/applications/GeoMechanicsApplication/custom_constitutive/coulomb_yield_surface.h
@@ -34,6 +34,10 @@ public:
 
     CoulombYieldSurface(double FrictionAngleInRad, double Cohesion, double DilatationAngleInRad);
 
+    double GetFrictionAngleInRad() const;
+    double GetCohesion() const;
+    double GetDilatationAngleInRad() const;
+
     [[nodiscard]] double YieldFunctionValue(const Vector& rSigmaTau) const override;
     [[nodiscard]] Vector DerivativeOfFlowFunction(const Vector&) const override;
     [[nodiscard]] Vector DerivativeOfFlowFunction(const Vector&, CoulombAveragingType AveragingType) const;

--- a/applications/GeoMechanicsApplication/custom_constitutive/tension_cutoff.cpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/tension_cutoff.cpp
@@ -21,6 +21,8 @@ namespace Kratos
 {
 TensionCutoff::TensionCutoff(double TensileStrength) : mTensileStrength{TensileStrength} {}
 
+double TensionCutoff::GetTensileStrength() const { return mTensileStrength; }
+
 double TensionCutoff::YieldFunctionValue(const Vector& rSigmaTau) const
 {
     auto principal_stress_vector = Vector{ZeroVector{3}};

--- a/applications/GeoMechanicsApplication/custom_constitutive/tension_cutoff.h
+++ b/applications/GeoMechanicsApplication/custom_constitutive/tension_cutoff.h
@@ -28,6 +28,8 @@ public:
 
     explicit TensionCutoff(double TensileStrength);
 
+    double GetTensileStrength() const;
+
     [[nodiscard]] double YieldFunctionValue(const Vector& rSigmaTau) const override;
     [[nodiscard]] Vector DerivativeOfFlowFunction(const Vector&) const override;
 

--- a/applications/GeoMechanicsApplication/custom_constitutive/tension_cutoff.h
+++ b/applications/GeoMechanicsApplication/custom_constitutive/tension_cutoff.h
@@ -28,7 +28,7 @@ public:
 
     explicit TensionCutoff(double TensileStrength);
 
-    double GetTensileStrength() const;
+    [[nodiscard]] double GetTensileStrength() const;
 
     [[nodiscard]] double YieldFunctionValue(const Vector& rSigmaTau) const override;
     [[nodiscard]] Vector DerivativeOfFlowFunction(const Vector&) const override;


### PR DESCRIPTION
**📝 Description**
The reading and passing the material parameters is done from the constitutiva law. However, the yield surface includes the same information as member variables.

We find it is:
- Safer to read these variables from the yield surface. If in the future some changes will implemented to the constitutive law, and the variables deviate (for some reasons), then the yield surface does not change its behaviour.

- It is easier to extend to include hardening/softening (the material parameters to be not constant).
This can be done by adding getter in yield surface

**🆕 Changelog**
- Added Get's to columb and tensile surfaces
- modified MC, in DoReturnMapping.
