### PR TITLE
[ContactStructuralMechanicsApplication] Improve handling of DOF initialization in `ResidualBasedNewtonRaphsonMPCContactStrategy`

### DIFF
--- a/applications/ContactStructuralMechanicsApplication/custom_strategies/custom_strategies/residualbased_newton_raphson_contact_strategy.h
+++ b/applications/ContactStructuralMechanicsApplication/custom_strategies/custom_strategies/residualbased_newton_raphson_contact_strategy.h
@@ -19,7 +19,6 @@
 // Project includes
 #include "contact_structural_mechanics_application_variables.h"
 #include "includes/kratos_parameters.h"
-#include "includes/define.h"
 #include "includes/model_part.h"
 #include "includes/variables.h"
 

--- a/applications/ContactStructuralMechanicsApplication/custom_strategies/custom_strategies/residualbased_newton_raphson_mpc_contact_strategy.h
+++ b/applications/ContactStructuralMechanicsApplication/custom_strategies/custom_strategies/residualbased_newton_raphson_mpc_contact_strategy.h
@@ -19,7 +19,6 @@
 // Project includes
 #include "contact_structural_mechanics_application_variables.h"
 #include "includes/kratos_parameters.h"
-#include "includes/define.h"
 #include "includes/model_part.h"
 #include "includes/variables.h"
 

--- a/applications/ContactStructuralMechanicsApplication/custom_strategies/custom_strategies/residualbased_newton_raphson_mpc_contact_strategy.h
+++ b/applications/ContactStructuralMechanicsApplication/custom_strategies/custom_strategies/residualbased_newton_raphson_mpc_contact_strategy.h
@@ -315,28 +315,30 @@ public:
 
         BaseType::Predict();
 
-        // Getting model part
-        ModelPart& r_model_part = StrategyBaseType::GetModelPart();
-
-        // We get the system
-        TSystemMatrixType& rA = *BaseType::mpA;
-        TSystemVectorType& rDx = *BaseType::mpDx;
-        TSystemVectorType& rb = *BaseType::mpb;
-
-        // We solve the system in order to check the active set once
-        TSparseSpace::SetToZero(rA);
-        TSparseSpace::SetToZero(rDx);
-        TSparseSpace::SetToZero(rb);
-
-        typename TSchemeType::Pointer p_scheme = BaseType::GetScheme();
+        // We get the builder and solver
         typename TBuilderAndSolverType::Pointer p_builder_and_solver = BaseType::GetBuilderAndSolver();
-        p_builder_and_solver->BuildAndSolve(p_scheme, BaseType::GetModelPart(), rA, rDx, rb);
 
-        // Check active set
-        const SizeType echo_level_convergence_criteria = BaseType::mpConvergenceCriteria->GetEchoLevel();
-        BaseType::mpConvergenceCriteria->SetEchoLevel(0);
-        mpMPCContactCriteria->PostCriteria(r_model_part, BaseType::GetBuilderAndSolver()->GetDofSet(), rA, rDx, rb);
-        BaseType::mpConvergenceCriteria->SetEchoLevel(echo_level_convergence_criteria);
+        // Check if the DOF set is initialized
+        if (p_builder_and_solver->GetDofSetIsInitializedFlag()) {
+            // We get the system
+            TSystemMatrixType& rA = *BaseType::mpA;
+            TSystemVectorType& rDx = *BaseType::mpDx;
+            TSystemVectorType& rb = *BaseType::mpb;
+
+            // We solve the system in order to check the active set once
+            TSparseSpace::SetToZero(rA);
+            TSparseSpace::SetToZero(rDx);
+            TSparseSpace::SetToZero(rb);
+
+            typename TSchemeType::Pointer p_scheme = BaseType::GetScheme();
+            p_builder_and_solver->BuildAndSolve(p_scheme, BaseType::GetModelPart(), rA, rDx, rb);
+
+            // Check active set
+            const SizeType echo_level_convergence_criteria = BaseType::mpConvergenceCriteria->GetEchoLevel();
+            BaseType::mpConvergenceCriteria->SetEchoLevel(0);
+            mpMPCContactCriteria->PostCriteria(StrategyBaseType::GetModelPart(), BaseType::GetBuilderAndSolver()->GetDofSet(), rA, rDx, rb);
+            BaseType::mpConvergenceCriteria->SetEchoLevel(echo_level_convergence_criteria);
+        }
 
         KRATOS_CATCH("")
     }


### PR DESCRIPTION
**📝 Description**

Improve handling of DOF initialization in `ResidualBasedNewtonRaphsonMPCContactStrategy`

To be merged in https://github.com/KratosMultiphysics/Kratos/pull/13432

**🆕 Changelog**

- [Improve handling of DOF initialization in `ResidualBasedNewtonRaphsonMPCContactStrategy`](https://github.com/KratosMultiphysics/Kratos/commit/1eada2a114dfdc7b509764d16388eada09e44653)
- [Remove unused include directive from contact strategy headers](https://github.com/KratosMultiphysics/Kratos/commit/d1f5183d8c1ba0edab4b9bec2dc48a6f28acd0fd)