### PR TITLE
[GeoMechanicsApplication] Fix C++ settlement workflow inconsistencies

### DIFF
--- a/applications/GeoMechanicsApplication/custom_elements/small_strain_U_Pw_diff_order_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/small_strain_U_Pw_diff_order_element.cpp
@@ -800,9 +800,9 @@ void SmallStrainUPwDiffOrderElement::Calculate(const Variable<Vector>& rVariable
         Variables.NpContainer, Variables.PressureVector);
     const auto degrees_of_saturation = CalculateDegreesOfSaturation(fluid_pressures);
 
-    auto       relative_permeability_values = RetentionLaw::CalculateRelativePermeabilityValues(
+    auto relative_permeability_values = RetentionLaw::CalculateRelativePermeabilityValues(
         mRetentionLawVector, this->GetProperties(), fluid_pressures);
-    const auto permeability_update_factors  = GetOptionalPermeabilityUpdateFactors(strain_vectors);
+    const auto permeability_update_factors = GetOptionalPermeabilityUpdateFactors(strain_vectors);
     std::ranges::transform(permeability_update_factors, relative_permeability_values,
                            relative_permeability_values.begin(), std::multiplies<>{});
     const auto bishop_coefficients = CalculateBishopCoefficients(fluid_pressures);

--- a/applications/GeoMechanicsApplication/custom_elements/small_strain_U_Pw_diff_order_element.hpp
+++ b/applications/GeoMechanicsApplication/custom_elements/small_strain_U_Pw_diff_order_element.hpp
@@ -270,7 +270,6 @@ private:
 
     void load(Serializer& rSerializer) override;
 
-
     Vector CalculateInternalForces(ElementVariables&          Variables,
                                    const std::vector<Matrix>& b_matrices,
                                    const std::vector<double>& integration_coefficients,

--- a/applications/GeoMechanicsApplication/custom_workflows/dgeosettlement.cpp
+++ b/applications/GeoMechanicsApplication/custom_workflows/dgeosettlement.cpp
@@ -215,10 +215,6 @@ int KratosGeoSettlement::RunStage(const std::filesystem::path&            rWorki
             process->ExecuteInitialize();
         }
 
-        for (const auto& process : processes) {
-            process->ExecuteBeforeSolutionLoop();
-        }
-
         if (mpTimeLoopExecutor) {
             mpTimeLoopExecutor->SetCancelDelegate(rShouldCancel);
             mpTimeLoopExecutor->SetProgressDelegate(rProgressDelegate);

--- a/applications/GeoMechanicsApplication/custom_workflows/time_loop_executor.hpp
+++ b/applications/GeoMechanicsApplication/custom_workflows/time_loop_executor.hpp
@@ -85,7 +85,7 @@ public:
     }
 
 private:
-    void CallExecuteBeforeSolutionLoopOnProcesses()
+    void CallExecuteBeforeSolutionLoopOnProcesses() const
     {
         for (const auto& r_process_observable : mProcessObservables) {
             auto p_process = r_process_observable.lock();

--- a/applications/GeoMechanicsApplication/custom_workflows/time_loop_executor.hpp
+++ b/applications/GeoMechanicsApplication/custom_workflows/time_loop_executor.hpp
@@ -44,8 +44,8 @@ public:
 
     void SetProcessObservables(const std::vector<std::weak_ptr<Process>>& rProcessObservables) override
     {
-        mTimeStepExecutor->SetProcessObservables(rProcessObservables);
         mProcessObservables = rProcessObservables;
+        mTimeStepExecutor->SetProcessObservables(rProcessObservables);
     }
 
     void SetTimeIncrementor(std::unique_ptr<TimeIncrementor> pTimeIncrementor) override

--- a/applications/GeoMechanicsApplication/custom_workflows/time_loop_executor.hpp
+++ b/applications/GeoMechanicsApplication/custom_workflows/time_loop_executor.hpp
@@ -69,6 +69,8 @@ public:
             // clone without end time, the end time is overwritten anyway
             mStrategyWrapper->CloneTimeStep();
             NewEndState = RunCycleLoop(NewEndState);
+            KRATOS_ERROR_IF_NOT(NewEndState.Converged())
+                << "The calculation exited without converging.\n";
             mStrategyWrapper->ComputeIncrementalDisplacementField();
             mStrategyWrapper->AccumulateTotalDisplacementField();
             mStrategyWrapper->FinalizeSolutionStep();

--- a/applications/GeoMechanicsApplication/custom_workflows/time_loop_executor.hpp
+++ b/applications/GeoMechanicsApplication/custom_workflows/time_loop_executor.hpp
@@ -62,10 +62,7 @@ public:
     std::vector<TimeStepEndState> Run(const TimeStepEndState& EndState) override
     {
         mStrategyWrapper->Initialize();
-        for (const auto& process_observable : mProcessObservables) {
-            auto process = process_observable.lock();
-            if (process) process->ExecuteBeforeSolutionLoop();
-        }
+        CallExecuteBeforeSolutionLoopOnProcesses();
 
         std::vector<TimeStepEndState> result;
         TimeStepEndState              NewEndState = EndState;
@@ -88,6 +85,14 @@ public:
     }
 
 private:
+    void CallExecuteBeforeSolutionLoopOnProcesses()
+    {
+        for (const auto& r_process_observable : mProcessObservables) {
+            auto p_process = r_process_observable.lock();
+            if (p_process) p_process->ExecuteBeforeSolutionLoop();
+        }
+    }
+
     TimeStepEndState RunCycle(double PreviousTime)
     {
         // Setting the time and time increment may be needed for the processes

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_elements/test_pw_element.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_elements/test_pw_element.cpp
@@ -265,7 +265,8 @@ KRATOS_TEST_CASE_IN_SUITE(TransientPwLineElement_ReturnsTheExpectedLeftHandSideA
                                        Defaults::relative_tolerance)
 }
 
-void CommonChecksForLineAndDomainElements(intrusive_ptr<Element> pElement, const ProcessInfo& dummy_process_info = ProcessInfo{})
+void CommonChecksForLineAndDomainElements(intrusive_ptr<Element> pElement,
+                                          const ProcessInfo&     dummy_process_info = ProcessInfo{})
 {
     KRATOS_EXPECT_EXCEPTION_IS_THROWN(pElement->Check(dummy_process_info),
                                       "DENSITY_WATER does not exist in the material properties at "
@@ -522,7 +523,8 @@ KRATOS_TEST_CASE_IN_SUITE(TransientPwLineElement_IntegrationMethod, KratosGeoMec
     KRATOS_EXPECT_EQ(p_integration_method, expected_integration_method);
 }
 
-KRATOS_TEST_CASE_IN_SUITE(TransientPwLineElement_CheckThrowsOnFaultyInputForSurfaceElement, KratosGeoMechanicsFastSuiteWithoutKernel)
+KRATOS_TEST_CASE_IN_SUITE(TransientPwLineElement_CheckThrowsOnFaultyInputForSurfaceElement,
+                          KratosGeoMechanicsFastSuiteWithoutKernel)
 {
     // Arrange
     using enum CalculationContribution;

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_workflows/test_time_loop_executor.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_workflows/test_time_loop_executor.cpp
@@ -82,19 +82,19 @@ public:
     MOCK_METHOD(void, Predict, (), (override));
 
     MOCK_METHOD(void, ComputeIncrementalDisplacementField, (), (override));
-    MOCK_METHOD(void, AccumulateTotalDisplacementField,(), (override));
+    MOCK_METHOD(void, AccumulateTotalDisplacementField, (), (override));
 
     MOCK_METHOD(void, CloneTimeStep, (), (override));
     MOCK_METHOD(void, RestorePositionsAndDOFVectorToStartOfStep, (), (override));
     MOCK_METHOD(std::size_t, GetNumberOfIterations, (), (const, override));
 
-    MOCK_METHOD(void, InitializeOutput,(), (override));
-    MOCK_METHOD(void, FinalizeOutput,(), (override));
+    MOCK_METHOD(void, InitializeOutput, (), (override));
+    MOCK_METHOD(void, FinalizeOutput, (), (override));
 
 private:
     Model                 mModel;
-    ModelPart*            mpModelPart                                  = nullptr;
-    std::size_t           mCountOutputProcessCalled                    = 0;
+    ModelPart*            mpModelPart               = nullptr;
+    std::size_t           mCountOutputProcessCalled = 0;
     std::function<void()> mOutputProcessCallback;
 };
 
@@ -141,7 +141,8 @@ TimeStepEndState MakeConvergedStepState()
     return result;
 }
 
-void RunTwoTimeStepsWithFixedNumberOfCycles(std::size_t WantedNumOfCyclesPerStep, const std::shared_ptr<DummySolverStrategy>& rpSolver)
+void RunTwoTimeStepsWithFixedNumberOfCycles(std::size_t WantedNumOfCyclesPerStep,
+                                            const std::shared_ptr<DummySolverStrategy>& rpSolver)
 {
     TimeLoopExecutor executor;
     executor.SetTimeIncrementor(std::make_unique<FixedCyclesTimeIncrementor>(WantedNumOfCyclesPerStep));

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_workflows/test_time_loop_executor.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_workflows/test_time_loop_executor.cpp
@@ -37,8 +37,6 @@ public:
         ON_CALL(*this, SolveSolutionStep()).WillByDefault(testing::Return(TimeStepEndState::ConvergenceState::converged));
     }
 
-    MOCK_METHOD(std::size_t, GetNumberOfIterations, (), (const, override));
-
     [[nodiscard]] double GetEndTime() const override { return mpModelPart->GetProcessInfo()[TIME]; }
 
     void SetEndTime(double EndTime) override { mpModelPart->GetProcessInfo()[TIME] = EndTime; }
@@ -60,11 +58,10 @@ public:
 
     void IncrementStepNumber() override { ++mpModelPart->GetProcessInfo()[STEP]; }
 
-    MOCK_METHOD(void, CloneTimeStep, (), (override));
-
-    MOCK_METHOD(void, RestorePositionsAndDOFVectorToStartOfStep, (), (override));
-
-    MOCK_METHOD(void, AccumulateTotalDisplacementField,(), (override));
+    void SetOutputProcessCallback(std::function<void()> Callback)
+    {
+        mOutputProcessCallback = std::move(Callback);
+    }
 
     void OutputProcess() override
     {
@@ -72,44 +69,32 @@ public:
         if (mOutputProcessCallback) mOutputProcessCallback();
     }
 
-    [[nodiscard]] std::size_t GetCountInitializeOutputCalled() const
-    {
-        return mCountInitializeOutputCalled;
-    }
-
     [[nodiscard]] std::size_t GetCountOutputProcessCalled() const
     {
         return mCountOutputProcessCalled;
     }
 
-    [[nodiscard]] std::size_t GetCountFinalizeOutputCalled() const
-    {
-        return mCountFinalizeOutputCalled;
-    }
-
-    MOCK_METHOD(void, InitializeOutput,(), (override));
-
-    MOCK_METHOD(void, Predict, (), (override));
-    MOCK_METHOD(void, InitializeSolutionStep, (), (override));
     MOCK_METHOD(void, Initialize, (), (override));
-    MOCK_METHOD(void, ComputeIncrementalDisplacementField, (), (override));
+    MOCK_METHOD(void, InitializeSolutionStep, (), (override));
     MOCK_METHOD(TimeStepEndState::ConvergenceState, SolveSolutionStep, (), (override));
-
     MOCK_METHOD(void, FinalizeSolutionStep, (), (override));
 
-    MOCK_METHOD(void, FinalizeOutput,(), (override));
+    MOCK_METHOD(void, Predict, (), (override));
 
-    void SetOutputProcessCallback(std::function<void()> Callback)
-    {
-        mOutputProcessCallback = std::move(Callback);
-    }
+    MOCK_METHOD(void, ComputeIncrementalDisplacementField, (), (override));
+    MOCK_METHOD(void, AccumulateTotalDisplacementField,(), (override));
+
+    MOCK_METHOD(void, CloneTimeStep, (), (override));
+    MOCK_METHOD(void, RestorePositionsAndDOFVectorToStartOfStep, (), (override));
+    MOCK_METHOD(std::size_t, GetNumberOfIterations, (), (const, override));
+
+    MOCK_METHOD(void, InitializeOutput,(), (override));
+    MOCK_METHOD(void, FinalizeOutput,(), (override));
 
 private:
     Model                 mModel;
     ModelPart*            mpModelPart                                  = nullptr;
-    std::size_t           mCountInitializeOutputCalled                 = 0;
     std::size_t           mCountOutputProcessCalled                    = 0;
-    std::size_t           mCountFinalizeOutputCalled                   = 0;
     std::function<void()> mOutputProcessCallback;
 };
 

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_workflows/test_time_loop_executor.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_workflows/test_time_loop_executor.cpp
@@ -64,17 +64,7 @@ public:
 
     MOCK_METHOD(void, RestorePositionsAndDOFVectorToStartOfStep, (), (override));
 
-    [[nodiscard]] bool IsRestoreCalled() const { return mIsRestoreCalled; }
-
-    void AccumulateTotalDisplacementField() override
-    {
-        ++mCountAccumulateTotalDisplacementFieldCalled;
-    }
-
-    [[nodiscard]] std::size_t GetCountAccumulateTotalDisplacementFieldCalled() const
-    {
-        return mCountAccumulateTotalDisplacementFieldCalled;
-    }
+    MOCK_METHOD(void, AccumulateTotalDisplacementField,(), (override));
 
     void OutputProcess() override
     {
@@ -117,9 +107,7 @@ public:
 private:
     Model                 mModel;
     ModelPart*            mpModelPart                                  = nullptr;
-    bool                  mIsRestoreCalled                             = false;
     std::size_t           mCountInitializeOutputCalled                 = 0;
-    std::size_t           mCountAccumulateTotalDisplacementFieldCalled = 0;
     std::size_t           mCountOutputProcessCalled                    = 0;
     std::size_t           mCountFinalizeOutputCalled                   = 0;
     std::function<void()> mOutputProcessCallback;
@@ -320,9 +308,9 @@ KRATOS_TEST_CASE_IN_SUITE(ExpectRestoreCalledForTwoCycles, KratosGeoMechanicsFas
 KRATOS_TEST_CASE_IN_SUITE(ExpectDisplacementFieldUpdateForEveryStep, KratosGeoMechanicsFastSuiteWithoutKernel)
 {
     auto solver_strategy = std::make_shared<DummySolverStrategy>();
-    RunFixedCycleTimeLoop(1, solver_strategy);
 
-    KRATOS_EXPECT_EQ(2, solver_strategy->GetCountAccumulateTotalDisplacementFieldCalled());
+    EXPECT_CALL(*solver_strategy, AccumulateTotalDisplacementField).Times(2);
+    RunFixedCycleTimeLoop(1, solver_strategy);
 }
 
 KRATOS_TEST_CASE_IN_SUITE(ExpectOutputProcessCalledForEveryStep, KratosGeoMechanicsFastSuiteWithoutKernel)

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_workflows/test_time_loop_executor.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_workflows/test_time_loop_executor.cpp
@@ -141,7 +141,7 @@ TimeStepEndState MakeConvergedStepState()
     return result;
 }
 
-void RunFixedCycleTimeLoop(std::size_t WantedNumOfCyclesPerStep, const std::shared_ptr<DummySolverStrategy>& rpSolver)
+void RunTwoTimeStepsWithFixedNumberOfCycles(std::size_t WantedNumOfCyclesPerStep, const std::shared_ptr<DummySolverStrategy>& rpSolver)
 {
     TimeLoopExecutor executor;
     executor.SetTimeIncrementor(std::make_unique<FixedCyclesTimeIncrementor>(WantedNumOfCyclesPerStep));
@@ -259,7 +259,7 @@ KRATOS_TEST_CASE_IN_SUITE(ExpectOneCyclePerStepWhenUsingAPrescribedTimeIncrement
 KRATOS_TEST_CASE_IN_SUITE(ExpectEndTimeToBeSetOnSolverStrategyAfterRunningAStepLoop, KratosGeoMechanicsFastSuiteWithoutKernel)
 {
     auto solver_strategy = std::make_shared<DummySolverStrategy>();
-    RunFixedCycleTimeLoop(1, solver_strategy);
+    RunTwoTimeStepsWithFixedNumberOfCycles(1, solver_strategy);
 
     KRATOS_EXPECT_DOUBLE_EQ(1.0, solver_strategy->GetEndTime());
     KRATOS_EXPECT_DOUBLE_EQ(0.5, solver_strategy->GetTimeIncrement());
@@ -271,7 +271,7 @@ KRATOS_TEST_CASE_IN_SUITE(ExpectATimeStepCloneAtStartOfStep, KratosGeoMechanicsF
     auto solver_strategy = std::make_shared<DummySolverStrategy>();
 
     EXPECT_CALL(*solver_strategy, CloneTimeStep).Times(testing::AtLeast(1));
-    RunFixedCycleTimeLoop(1, solver_strategy);
+    RunTwoTimeStepsWithFixedNumberOfCycles(1, solver_strategy);
 }
 
 KRATOS_TEST_CASE_IN_SUITE(ExpectNoRestoreCalledForOneCycle, KratosGeoMechanicsFastSuiteWithoutKernel)
@@ -279,7 +279,7 @@ KRATOS_TEST_CASE_IN_SUITE(ExpectNoRestoreCalledForOneCycle, KratosGeoMechanicsFa
     auto solver_strategy = std::make_shared<DummySolverStrategy>();
 
     EXPECT_CALL(*solver_strategy, RestorePositionsAndDOFVectorToStartOfStep).Times(0);
-    RunFixedCycleTimeLoop(1, solver_strategy);
+    RunTwoTimeStepsWithFixedNumberOfCycles(1, solver_strategy);
 }
 
 KRATOS_TEST_CASE_IN_SUITE(ExpectRestoreCalledForTwoCycles, KratosGeoMechanicsFastSuiteWithoutKernel)
@@ -287,7 +287,7 @@ KRATOS_TEST_CASE_IN_SUITE(ExpectRestoreCalledForTwoCycles, KratosGeoMechanicsFas
     auto solver_strategy = std::make_shared<DummySolverStrategy>();
 
     EXPECT_CALL(*solver_strategy, RestorePositionsAndDOFVectorToStartOfStep).Times(testing::AtLeast(1));
-    RunFixedCycleTimeLoop(2, solver_strategy);
+    RunTwoTimeStepsWithFixedNumberOfCycles(2, solver_strategy);
 }
 
 KRATOS_TEST_CASE_IN_SUITE(ExpectDisplacementFieldUpdateForEveryStep, KratosGeoMechanicsFastSuiteWithoutKernel)
@@ -295,7 +295,7 @@ KRATOS_TEST_CASE_IN_SUITE(ExpectDisplacementFieldUpdateForEveryStep, KratosGeoMe
     auto solver_strategy = std::make_shared<DummySolverStrategy>();
 
     EXPECT_CALL(*solver_strategy, AccumulateTotalDisplacementField).Times(2);
-    RunFixedCycleTimeLoop(1, solver_strategy);
+    RunTwoTimeStepsWithFixedNumberOfCycles(1, solver_strategy);
 }
 
 KRATOS_TEST_CASE_IN_SUITE(ExpectOutputProcessCalledForEveryStep, KratosGeoMechanicsFastSuiteWithoutKernel)

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_workflows/test_time_loop_executor.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_workflows/test_time_loop_executor.cpp
@@ -76,10 +76,6 @@ public:
         return mCountAccumulateTotalDisplacementFieldCalled;
     }
 
-    void ComputeIncrementalDisplacementField() override
-    {
-        // intentionally empty
-    }
 
     void OutputProcess() override
     {
@@ -107,23 +103,13 @@ public:
         return mCountFinalizeOutputCalled;
     }
 
-    void Initialize() override
-    {
-        // intentionally empty
-    }
 
     void InitializeOutput() override { ++mCountInitializeOutputCalled; }
 
-    void InitializeSolutionStep() override
-    {
-        // intentionally empty
-    }
-
-    void Predict() override
-    {
-        // intentionally empty
-    }
-
+    MOCK_METHOD(void, Predict, (), (override));
+    MOCK_METHOD(void, InitializeSolutionStep,(), (override));
+    MOCK_METHOD(void, Initialize,(), (override));
+    MOCK_METHOD(void, ComputeIncrementalDisplacementField,(), (override));
     MOCK_METHOD(TimeStepEndState::ConvergenceState, SolveSolutionStep, (), (override));
 
     void FinalizeSolutionStep() override { ++mCountFinalizeSolutionStepCalled; }

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_workflows/test_time_loop_executor.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_workflows/test_time_loop_executor.cpp
@@ -36,7 +36,7 @@ public:
         ON_CALL(*this, SolveSolutionStep()).WillByDefault(testing::Return(TimeStepEndState::ConvergenceState::converged));
     }
 
-    [[nodiscard]] std::size_t GetNumberOfIterations() const override { return 1; }
+    MOCK_METHOD(std::size_t, GetNumberOfIterations,(), (const, override));
 
     [[nodiscard]] double GetEndTime() const override { return mpModelPart->GetProcessInfo()[TIME]; }
 
@@ -93,11 +93,6 @@ public:
         return mCountOutputProcessCalled;
     }
 
-    [[nodiscard]] std::size_t GetCountFinalizeSolutionStepCalled() const
-    {
-        return mCountFinalizeSolutionStepCalled;
-    }
-
     [[nodiscard]] std::size_t GetCountFinalizeOutputCalled() const
     {
         return mCountFinalizeOutputCalled;
@@ -111,7 +106,7 @@ public:
     MOCK_METHOD(void, ComputeIncrementalDisplacementField, (), (override));
     MOCK_METHOD(TimeStepEndState::ConvergenceState, SolveSolutionStep, (), (override));
 
-    void FinalizeSolutionStep() override { ++mCountFinalizeSolutionStepCalled; }
+    MOCK_METHOD(void, FinalizeSolutionStep, (), (override));
 
     void FinalizeOutput() override { ++mCountFinalizeOutputCalled; }
 
@@ -128,7 +123,6 @@ private:
     std::size_t           mCountInitializeOutputCalled                 = 0;
     std::size_t           mCountAccumulateTotalDisplacementFieldCalled = 0;
     std::size_t           mCountOutputProcessCalled                    = 0;
-    std::size_t           mCountFinalizeSolutionStepCalled             = 0;
     std::size_t           mCountFinalizeOutputCalled                   = 0;
     std::function<void()> mOutputProcessCallback;
 };
@@ -352,8 +346,9 @@ KRATOS_TEST_CASE_IN_SUITE(ExpectFinalizeSolutionStepCalledOnceForEveryStep, Krat
     auto solver_strategy = std::make_shared<DummySolverStrategy>();
     executor.SetSolverStrategyWrapper(solver_strategy);
 
+    EXPECT_CALL(*solver_strategy, FinalizeSolutionStep).Times(2);
     const auto step_states = executor.Run(TimeStepEndState{});
-    KRATOS_EXPECT_EQ(step_states.size(), solver_strategy->GetCountFinalizeSolutionStepCalled());
+    KRATOS_EXPECT_EQ(2, step_states.size());
 }
 
 KRATOS_TEST_CASE_IN_SUITE(ExpectOutputIsInitializedAndFinalizedWhenRunCompletesOk, KratosGeoMechanicsFastSuiteWithoutKernel)


### PR DESCRIPTION
**📝 Description**
This PR fixes the two found issues in the settlement workflow with respect to the python workflow:
- The workflow does not always exit when there is non-convergence
- The order of execution for process functions is different. ExecuteBeforeSolutionLoop is called before the solving strategy initialize, while in python it's done the other way around. This leads to issues in the C++ workflow.

**🆕 Changelog**
Please summarize the changes in one list to generate the changelog:
E.g.
- Added a throw when a solution step does not converge (in a set number of cycles)
- Added process `ExecuteBeforeSolutionLoop` to the time loop executor and removed it from the KratosGeoSettlement class.
- Refactored the DummySolvingStrategy (used in the related unit tests) such that it uses GMock functionality instead of manual spy/mock functionality.
