### PR TITLE
Change linear_solver.h to add a call to Clear()

### DIFF
--- a/kratos/linear_solvers/linear_solver.h
+++ b/kratos/linear_solvers/linear_solver.h
@@ -149,6 +149,7 @@ public:
         this->InitializeSolutionStep(rA, rX, rB);
         const auto status = this->PerformSolutionStep(rA, rX, rB);
         this->FinalizeSolutionStep(rA, rX, rB);
+        this->Clear();
         return status;
     }
 


### PR DESCRIPTION
This is needed as the latest change would otherwise imply a behaviour change with the linear solver not being cleaned up after calling solve!

**📝 Description**
adds call to Clear in Solve to ensure that everything is properly cleaned up after calling Solve.
If the user wants to  retain something, than it should call separately InitializeSolutionStep, PerformSolutionStep, FinalizeSolutionStep and Clear

Please mark the PR with appropriate tags: 
- Api Breaker, Mpi, etc...

**🆕 Changelog**

