### PR TITLE
[LinearSolvers] Insert `MKL` to `Registry` if supported

### DIFF
--- a/applications/LinearSolversApplication/linear_solvers_application.cpp
+++ b/applications/LinearSolversApplication/linear_solvers_application.cpp
@@ -51,15 +51,6 @@ void KratosLinearSolversApplication::Register()
         Registry::AddItem<std::string>("libraries.eigen");
     }
 
-    #if defined USE_EIGEN_MKL
-    MKLVersion mkl_version;
-    mkl_get_version(&mkl_version);
-    KRATOS_INFO("") << "Using Intel MKL version "
-                    << mkl_version.MajorVersion << "." << mkl_version.MinorVersion << "." << mkl_version.UpdateVersion
-                    << " build " << mkl_version.Build << std::endl
-                    << "MKL processor: " << mkl_version.Processor << std::endl;
-    #endif
-
     RegisterDenseLinearSolvers();
 
     using complex = std::complex<double>;
@@ -85,6 +76,19 @@ void KratosLinearSolversApplication::Register()
     KRATOS_REGISTER_LINEAR_SOLVER("sparse_cg", SparseCGFactory);
 
 #if defined USE_EIGEN_MKL
+
+    {
+        MKLVersion mkl_version;
+        mkl_get_version(&mkl_version);
+        KRATOS_INFO("") << "Using Intel MKL version "
+                        << mkl_version.MajorVersion << "." << mkl_version.MinorVersion << "." << mkl_version.UpdateVersion
+                        << " build " << mkl_version.Build << std::endl
+                        << "MKL processor: " << mkl_version.Processor << std::endl;
+    }
+
+    if (!Registry::HasItem("libraries.mkl")) {
+        Registry::AddItem<std::string>("libraries.mkl");
+    }
 
     // Pardiso LU Solver
     using PardisoLUType = EigenDirectSolver<EigenPardisoLUSolver<double>>;

--- a/kratos/sources/kernel.cpp
+++ b/kratos/sources/kernel.cpp
@@ -26,13 +26,13 @@
 
 namespace Kratos {
 
-Kernel::Kernel() 
-    : mpKratosCoreApplication(Kratos::make_shared<KratosApplication>(std::string("KratosMultiphysics"))) 
+Kernel::Kernel()
+    : mpKratosCoreApplication(Kratos::make_shared<KratosApplication>(std::string("KratosMultiphysics")))
 {
     Initialize();
 }
 
-Kernel::Kernel(bool IsDistributedRun) 
+Kernel::Kernel(bool IsDistributedRun)
         : mpKratosCoreApplication(Kratos::make_shared<KratosApplication>(std::string("KratosMultiphysics")))
 {
     // Distributed run definition
@@ -63,11 +63,7 @@ void Kernel::Initialize() {
 
     // Import the Kratos core application (if not already imported)
     if (!IsImported("KratosMultiphysics")) {
-        // Boost is always available
-        if (!Registry::HasItem("libraries.boost")) {
-            Registry::AddItem<std::string>("libraries.boost");
-
-            // When using the nonfree version of TRIANGLE, add it to the list of libraries
+        // When using the nonfree version of TRIANGLE, add it to the list of libraries
         #if USE_TRIANGLE_NONFREE_TPL
             Registry::AddItem<std::string>("libraries.triangle");
         #else
@@ -90,20 +86,20 @@ void Kernel::Initialize() {
             Registry::AddItem<std::string>("libraries.benchmark");
         #endif
 
-            // Add the libraries that are always available
-            Registry::AddItem<std::string>("libraries.amgcl");
-            Registry::AddItem<std::string>("libraries.clipper");
-            Registry::AddItem<std::string>("libraries.concurrentqueue");
-            Registry::AddItem<std::string>("libraries.ghc");
-            Registry::AddItem<std::string>("libraries.gidpost");
-            Registry::AddItem<std::string>("libraries.intrusive_ptr");
-            Registry::AddItem<std::string>("libraries.json");
-            Registry::AddItem<std::string>("libraries.pybind11");
-            Registry::AddItem<std::string>("libraries.span");
-            Registry::AddItem<std::string>("libraries.tinyexpr");
-            Registry::AddItem<std::string>("libraries.vexcl");
-            Registry::AddItem<std::string>("libraries.zlib");
-        }
+        // Add the libraries that are always available
+        Registry::AddItem<std::string>("libraries.amgcl");
+        Registry::AddItem<std::string>("libraries.boost");
+        Registry::AddItem<std::string>("libraries.clipper");
+        Registry::AddItem<std::string>("libraries.concurrentqueue");
+        Registry::AddItem<std::string>("libraries.ghc");
+        Registry::AddItem<std::string>("libraries.gidpost");
+        Registry::AddItem<std::string>("libraries.intrusive_ptr");
+        Registry::AddItem<std::string>("libraries.json");
+        Registry::AddItem<std::string>("libraries.pybind11");
+        Registry::AddItem<std::string>("libraries.span");
+        Registry::AddItem<std::string>("libraries.tinyexpr");
+        Registry::AddItem<std::string>("libraries.vexcl");
+        Registry::AddItem<std::string>("libraries.zlib");
 
         // Import core application
         this->ImportApplication(mpKratosCoreApplication);

--- a/kratos/sources/kernel.cpp
+++ b/kratos/sources/kernel.cpp
@@ -26,13 +26,13 @@
 
 namespace Kratos {
 
-Kernel::Kernel()
-    : mpKratosCoreApplication(Kratos::make_shared<KratosApplication>(std::string("KratosMultiphysics")))
+Kernel::Kernel() 
+    : mpKratosCoreApplication(Kratos::make_shared<KratosApplication>(std::string("KratosMultiphysics"))) 
 {
     Initialize();
 }
 
-Kernel::Kernel(bool IsDistributedRun)
+Kernel::Kernel(bool IsDistributedRun) 
         : mpKratosCoreApplication(Kratos::make_shared<KratosApplication>(std::string("KratosMultiphysics")))
 {
     // Distributed run definition
@@ -63,7 +63,11 @@ void Kernel::Initialize() {
 
     // Import the Kratos core application (if not already imported)
     if (!IsImported("KratosMultiphysics")) {
-        // When using the nonfree version of TRIANGLE, add it to the list of libraries
+        // Boost is always available
+        if (!Registry::HasItem("libraries.boost")) {
+            Registry::AddItem<std::string>("libraries.boost");
+
+            // When using the nonfree version of TRIANGLE, add it to the list of libraries
         #if USE_TRIANGLE_NONFREE_TPL
             Registry::AddItem<std::string>("libraries.triangle");
         #else
@@ -86,20 +90,20 @@ void Kernel::Initialize() {
             Registry::AddItem<std::string>("libraries.benchmark");
         #endif
 
-        // Add the libraries that are always available
-        Registry::AddItem<std::string>("libraries.amgcl");
-        Registry::AddItem<std::string>("libraries.boost");
-        Registry::AddItem<std::string>("libraries.clipper");
-        Registry::AddItem<std::string>("libraries.concurrentqueue");
-        Registry::AddItem<std::string>("libraries.ghc");
-        Registry::AddItem<std::string>("libraries.gidpost");
-        Registry::AddItem<std::string>("libraries.intrusive_ptr");
-        Registry::AddItem<std::string>("libraries.json");
-        Registry::AddItem<std::string>("libraries.pybind11");
-        Registry::AddItem<std::string>("libraries.span");
-        Registry::AddItem<std::string>("libraries.tinyexpr");
-        Registry::AddItem<std::string>("libraries.vexcl");
-        Registry::AddItem<std::string>("libraries.zlib");
+            // Add the libraries that are always available
+            Registry::AddItem<std::string>("libraries.amgcl");
+            Registry::AddItem<std::string>("libraries.clipper");
+            Registry::AddItem<std::string>("libraries.concurrentqueue");
+            Registry::AddItem<std::string>("libraries.ghc");
+            Registry::AddItem<std::string>("libraries.gidpost");
+            Registry::AddItem<std::string>("libraries.intrusive_ptr");
+            Registry::AddItem<std::string>("libraries.json");
+            Registry::AddItem<std::string>("libraries.pybind11");
+            Registry::AddItem<std::string>("libraries.span");
+            Registry::AddItem<std::string>("libraries.tinyexpr");
+            Registry::AddItem<std::string>("libraries.vexcl");
+            Registry::AddItem<std::string>("libraries.zlib");
+        }
 
         // Import core application
         this->ImportApplication(mpKratosCoreApplication);


### PR DESCRIPTION
The `Registry` is supposed to list all external libraries used by core as well as imported libraries under the `libraries` key. However, `MKL` was missing.

This PR can help with programmatic detection of `MKL` support at runtime. FYI @AlejandroCornejo #13831

