### PR TITLE
[Structural] Replace private member variables in `CrBeamElement`s

### DIFF
--- a/applications/StructuralMechanicsApplication/custom_elements/beam_elements/cr_beam_element_3D2N.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/beam_elements/cr_beam_element_3D2N.cpp
@@ -112,6 +112,7 @@ CrBeamElement3D2N::CrBeamElement3D2N(IndexType NewId,
     constexpr double quaternion_sca_a = 1.0;
     constexpr double quaternion_sca_b = 1.0;
 
+    std::fill(internal_variables.begin(), internal_variables.end(), 0.0);
     internal_variables[2 * msElementSize + 2 * msDimension]     = quaternion_sca_a;
     internal_variables[2 * msElementSize + 2 * msDimension + 1] = quaternion_sca_b;
 
@@ -138,9 +139,7 @@ CrBeamElement3D2N::Create(IndexType NewId, GeometryType::Pointer pGeom,
 void CrBeamElement3D2N::EquationIdVector(EquationIdVectorType& rResult,
         const ProcessInfo& rCurrentProcessInfo) const
 {
-    if (rResult.size() != msElementSize) {
-        rResult.resize(msElementSize);
-    }
+    rResult.resize(msElementSize);
 
     for (int i = 0; i < msNumberOfNodes; ++i) {
         int index = i * msNumberOfNodes * msDimension;
@@ -159,10 +158,7 @@ void CrBeamElement3D2N::EquationIdVector(EquationIdVectorType& rResult,
 void CrBeamElement3D2N::GetDofList(DofsVectorType& rElementalDofList,
                                    const ProcessInfo& rCurrentProcessInfo) const
 {
-
-    if (rElementalDofList.size() != msElementSize) {
-        rElementalDofList.resize(msElementSize);
-    }
+    rElementalDofList.resize(msElementSize);
 
     for (int i = 0; i < msNumberOfNodes; ++i) {
         int index = i * msNumberOfNodes * msDimension;
@@ -182,9 +178,7 @@ void CrBeamElement3D2N::GetSecondDerivativesVector(Vector& rValues, int Step) co
 {
 
     KRATOS_TRY
-    if (rValues.size() != msElementSize) {
-        rValues.resize(msElementSize, false);
-    }
+    rValues.resize(msElementSize, false);
 
     for (int i = 0; i < msNumberOfNodes; ++i) {
         int index = i * msDimension * 2;
@@ -226,9 +220,7 @@ void CrBeamElement3D2N::GetFirstDerivativesVector(Vector& rValues, int Step) con
 {
 
     KRATOS_TRY
-    if (rValues.size() != msElementSize) {
-        rValues.resize(msElementSize, false);
-    }
+    rValues.resize(msElementSize, false);
 
     for (int i = 0; i < msNumberOfNodes; ++i) {
         int index = i * msDimension * 2;

--- a/applications/StructuralMechanicsApplication/custom_elements/beam_elements/cr_beam_element_3D2N.hpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/beam_elements/cr_beam_element_3D2N.hpp
@@ -33,16 +33,8 @@ namespace Kratos
 
 class KRATOS_API(STRUCTURAL_MECHANICS_APPLICATION) CrBeamElement3D2N : public Element
 {
-protected:
-    //const values
-    static constexpr int msNumberOfNodes = 2;
-    static constexpr int msDimension = 3;
-    static constexpr unsigned int msLocalSize = msNumberOfNodes * msDimension;
-    static constexpr unsigned int msElementSize = msLocalSize * 2;
-
 public:
     KRATOS_CLASS_INTRUSIVE_POINTER_DEFINITION(CrBeamElement3D2N);
-
 
     typedef Element BaseType;
     typedef BaseType::GeometryType GeometryType;
@@ -54,6 +46,11 @@ public:
     typedef BaseType::VectorType VectorType;
     typedef BaseType::EquationIdVectorType EquationIdVectorType;
     typedef BaseType::DofsVectorType DofsVectorType;
+
+    static constexpr int msNumberOfNodes = 2;
+    static constexpr int msDimension = 3;
+    static constexpr unsigned int msLocalSize = msNumberOfNodes * msDimension;
+    static constexpr unsigned int msElementSize = msLocalSize * 2;
 
     CrBeamElement3D2N() {};
     CrBeamElement3D2N(IndexType NewId, GeometryType::Pointer pGeometry);
@@ -312,22 +309,9 @@ public:
     const Parameters GetSpecifications() const override;
 
 private:
-
-
-    Vector mDeformationCurrentIteration = ZeroVector(msElementSize);
-    Vector mDeformationPreviousIteration = ZeroVector(msElementSize);
-    Vector mQuaternionVEC_A = ZeroVector(msDimension);
-    Vector mQuaternionVEC_B = ZeroVector(msDimension);
-    double mQuaternionSCA_A = 1.00;
-    double mQuaternionSCA_B = 1.00;
-
-
-
-
     friend class Serializer;
     void save(Serializer& rSerializer) const override;
     void load(Serializer& rSerializer) override;
-
 };
 
 

--- a/applications/StructuralMechanicsApplication/custom_elements/beam_elements/cr_beam_element_3D2N.hpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/beam_elements/cr_beam_element_3D2N.hpp
@@ -52,13 +52,12 @@ public:
     static constexpr unsigned int msLocalSize = msNumberOfNodes * msDimension;
     static constexpr unsigned int msElementSize = msLocalSize * 2;
 
-    CrBeamElement3D2N() {};
+    CrBeamElement3D2N();
+
     CrBeamElement3D2N(IndexType NewId, GeometryType::Pointer pGeometry);
+
     CrBeamElement3D2N(IndexType NewId, GeometryType::Pointer pGeometry,
                       PropertiesType::Pointer pProperties);
-
-
-    ~CrBeamElement3D2N() override;
 
     /**
     * @brief Creates a new element


### PR DESCRIPTION
Private member variables prevent resetting earlier states of an analysis efficiently. This PR moves them to the `Element`'s `DataValueContainer`.

- [ ] `CrBeamElement2D2N`
- [ ] `CrBeamElement2D3N`
- [x] `CrBeamElement3D2N`
- [ ] `CrBeamElement3D3N`
- [ ] `CrBeamElementLinear2D2N`
- [ ] `CrBeamElementLinear3D2N`
