### PR TITLE
[Core] Make (number of) edges of line geometries complete and consistent with those of other geometries

### DIFF
--- a/kratos/geometries/geometry.h
+++ b/kratos/geometries/geometry.h
@@ -2138,7 +2138,7 @@ public:
     /**
      * @brief This method gives you all edges of this geometry.
      * @details Each returned edge will be a line geometry. The number of points of each edge must match the number of
-     * points of the boundary the geometry. In the special case of inquiring the edges of a line, it will return the
+     * points of the geometry's boundary. In the special case of inquiring the edges of a line, it will return the
      * line itself.
      * @return GeometriesArrayType contains this geometry edges.
      * @see EdgesNumber()

--- a/kratos/geometries/geometry.h
+++ b/kratos/geometries/geometry.h
@@ -2099,8 +2099,15 @@ public:
     ///@{
 
     /**
-     * @brief This method gives you number of all edges of this geometry.
-     * @details For example, for a hexahedron, this would be 12
+     * @brief This method gives you the number of all edges of this geometry.
+     * @details The returned number of edges depends on the shape of the geometry only:
+     * - Any line: 1
+     * - Any triangle: 3
+     * - Any quadrilateral: 4
+     * - Any tetrahedron: 6
+     * - Any hexahedron: 12
+     * - Any wedge: 9
+     * - Any pyramid: 8
      * @return SizeType contains number of this geometry edges.
      * @see EdgesNumber()
      * @see Edges()
@@ -2130,8 +2137,9 @@ public:
 
     /**
      * @brief This method gives you all edges of this geometry.
-     * @details This method will gives you all the edges with one dimension less than this geometry.
-     * For example a triangle would return three lines as its edges or a tetrahedral would return four triangle as its edges but won't return its six edge lines by this method.
+     * @details Each returned edge will be a line geometry. The number of points of each edge must match the number of
+     * points of the boundary the geometry. In the special case of inquiring the edges of a line, it will return the
+     * line itself.
      * @return GeometriesArrayType contains this geometry edges.
      * @see EdgesNumber()
      * @see Edge()

--- a/kratos/geometries/line_2d_2.h
+++ b/kratos/geometries/line_2d_2.h
@@ -676,15 +676,7 @@ public:
     ///@{
 
     /**
-     * @brief This method gives you number of all edges of this geometry.
-     * @details For example, for a hexahedron, this would be 12
-     * @return SizeType contains number of this geometry edges.
-     * @see EdgesNumber()
-     * @see Edges()
-     * @see GenerateEdges()
-     * @see FacesNumber()
-     * @see Faces()
-     * @see GenerateFaces()
+     * @copydoc Geometry::EdgesNumber
      */
     SizeType EdgesNumber() const override
     {
@@ -692,12 +684,7 @@ public:
     }
 
     /**
-     * @brief This method gives you all edges of this geometry.
-     * @details This method will give you all the edges with one dimension less than this geometry.
-     * For example a triangle would return three lines as its edges or a tetrahedral would return four triangles as its edges but won't return its six edge lines by this method.
-     * @return GeometriesArrayType contains this geometry edges.
-     * @see EdgesNumber()
-     * @see Edge()
+     * @copydoc Geometry::GenerateEdges
      */
     GeometriesArrayType GenerateEdges() const override
     {

--- a/kratos/geometries/line_2d_2.h
+++ b/kratos/geometries/line_2d_2.h
@@ -69,95 +69,95 @@ public:
     ///@{
 
     /// Geometry as base class.
-    typedef Geometry<TPointType> BaseType;
+    using BaseType = Geometry<TPointType>;
     using Geometry<TPointType>::ShapeFunctionsValues;
 
     /// Pointer definition of Line2D2
     KRATOS_CLASS_POINTER_DEFINITION( Line2D2 );
 
     /// Type of edge geometry
-    typedef Line2D2<TPointType> EdgeType;
+    using EdgeType = Line2D2<TPointType>;
 
     /** Integration methods implemented in geometry.
     */
-    typedef GeometryData::IntegrationMethod IntegrationMethod;
+    using IntegrationMethod = GeometryData::IntegrationMethod;
 
     /** A Vector of counted pointers to Geometries. Used for
     returning edges of the geometry.
      */
-    typedef typename BaseType::GeometriesArrayType GeometriesArrayType;
+    using GeometriesArrayType = typename BaseType::GeometriesArrayType;
 
     /** Redefinition of template parameter TPointType.
      */
-    typedef TPointType PointType;
+    using PointType = TPointType;
 
     /** Type used for indexing in geometry class.std::size_t used for indexing
     point or integration point access methods and also all other
     methods which need point or integration point index.
     */
-    typedef typename BaseType::IndexType IndexType;
+    using IndexType = typename BaseType::IndexType;
 
 
     /** This typed used to return size or dimension in
     geometry. Dimension, WorkingDimension, PointsNumber and
     ... return this type as their results.
     */
-    typedef typename BaseType::SizeType SizeType;
+    using SizeType = typename BaseType::SizeType;
 
     /** Array of counted pointers to point. This type used to hold
     geometry's points.
     */
-    typedef  typename BaseType::PointsArrayType PointsArrayType;
+    using PointsArrayType = typename BaseType::PointsArrayType;
 
     /** This type used for representing an integration point in
     geometry. This integration point is a point with an
     additional weight component.
     */
-    typedef typename BaseType::IntegrationPointType IntegrationPointType;
+    using IntegrationPointType = typename BaseType::IntegrationPointType;
 
     /** A Vector of IntegrationPointType which used to hold
     integration points related to an integration
     method. IntegrationPoints functions used this type to return
     their results.
     */
-    typedef typename BaseType::IntegrationPointsArrayType IntegrationPointsArrayType;
+    using IntegrationPointsArrayType = typename BaseType::IntegrationPointsArrayType;
 
     /** A Vector of IntegrationPointsArrayType which used to hold
     integration points related to different integration method
     implemented in geometry.
     */
-    typedef typename BaseType::IntegrationPointsContainerType IntegrationPointsContainerType;
+    using IntegrationPointsContainerType = typename BaseType::IntegrationPointsContainerType;
 
     /** A third order tensor used as shape functions' values
     container.
     */
-    typedef typename BaseType::ShapeFunctionsValuesContainerType ShapeFunctionsValuesContainerType;
+    using ShapeFunctionsValuesContainerType = typename BaseType::ShapeFunctionsValuesContainerType;
 
     /** A fourth order tensor used as shape functions' local
     gradients container in geometry.
     */
-    typedef typename BaseType::ShapeFunctionsLocalGradientsContainerType ShapeFunctionsLocalGradientsContainerType;
+    using ShapeFunctionsLocalGradientsContainerType = typename BaseType::ShapeFunctionsLocalGradientsContainerType;
 
     /** A third order tensor to hold jacobian matrices evaluated at
     integration points. Jacobian and InverseOfJacobian functions
     return this type as their result.
     */
-    typedef typename BaseType::JacobiansType JacobiansType;
+    using JacobiansType = typename BaseType::JacobiansType;
 
     /** A third order tensor to hold shape functions' local
     gradients. ShapefunctionsLocalGradients function return this
     type as its result.
     */
-    typedef typename BaseType::ShapeFunctionsGradientsType ShapeFunctionsGradientsType;
+    using ShapeFunctionsGradientsType = typename BaseType::ShapeFunctionsGradientsType;
 
     /** Type of the normal vector used for normal to edges in geometry.
      */
-    typedef typename BaseType::NormalType NormalType;
+    using NormalType = typename BaseType::NormalType;
 
     /**
      * Type of coordinates array
      */
-    typedef typename BaseType::CoordinatesArrayType CoordinatesArrayType;
+    using CoordinatesArrayType = typename BaseType::CoordinatesArrayType;
 
     ///@}
     ///@name Life Cycle

--- a/kratos/geometries/line_2d_2.h
+++ b/kratos/geometries/line_2d_2.h
@@ -675,17 +675,13 @@ public:
     ///@name Edge
     ///@{
 
-    /**
-     * @copydoc Geometry::EdgesNumber
-     */
+    /// @copydoc Geometry::EdgesNumber
     SizeType EdgesNumber() const override
     {
         return 1;
     }
 
-    /**
-     * @copydoc Geometry::GenerateEdges
-     */
+    /// @copydoc Geometry::GenerateEdges
     GeometriesArrayType GenerateEdges() const override
     {
         GeometriesArrayType edges = GeometriesArrayType();

--- a/kratos/geometries/line_2d_2.h
+++ b/kratos/geometries/line_2d_2.h
@@ -693,8 +693,8 @@ public:
 
     /**
      * @brief This method gives you all edges of this geometry.
-     * @details This method will gives you all the edges with one dimension less than this geometry.
-     * For example a triangle would return three lines as its edges or a tetrahedral would return four triangle as its edges but won't return its six edge lines by this method.
+     * @details This method will give you all the edges with one dimension less than this geometry.
+     * For example a triangle would return three lines as its edges or a tetrahedral would return four triangles as its edges but won't return its six edge lines by this method.
      * @return GeometriesArrayType contains this geometry edges.
      * @see EdgesNumber()
      * @see Edge()

--- a/kratos/geometries/line_2d_3.h
+++ b/kratos/geometries/line_2d_3.h
@@ -73,6 +73,9 @@ public:
     /// Pointer definition of Line2D3
     KRATOS_CLASS_POINTER_DEFINITION( Line2D3 );
 
+    /// Type of edge geometry
+    typedef Line2D3<TPointType> EdgeType;
+
     /** Integration methods implemented in geometry.
     */
     typedef GeometryData::IntegrationMethod IntegrationMethod;
@@ -729,6 +732,20 @@ public:
         return 1;
     }
 
+    /**
+     * @brief This method gives you all edges of this geometry.
+     * @details This method will give you all the edges with one dimension less than this geometry.
+     * For example a triangle would return three lines as its edges or a tetrahedral would return four triangle as its edges but won't return its six edge lines by this method.
+     * @return GeometriesArrayType contains this geometry edges.
+     * @see EdgesNumber()
+     * @see Edge()
+     */
+    GeometriesArrayType GenerateEdges() const override
+    {
+        GeometriesArrayType edges;
+        edges.push_back( Kratos::make_shared<EdgeType>( this->pGetPoint( 0 ), this->pGetPoint( 1 ), this->pGetPoint( 2 ) ) );
+        return edges;
+    }
 
     /** FacesNumber
     @return SizeType contains number of this geometry faces.

--- a/kratos/geometries/line_2d_3.h
+++ b/kratos/geometries/line_2d_3.h
@@ -68,94 +68,94 @@ public:
     ///@{
 
     /// Geometry as base class.
-    typedef Geometry<TPointType> BaseType;
+    using BaseType = Geometry<TPointType>;
 
     /// Pointer definition of Line2D3
     KRATOS_CLASS_POINTER_DEFINITION( Line2D3 );
 
     /// Type of edge geometry
-    typedef Line2D3<TPointType> EdgeType;
+    using EdgeType = Line2D3<TPointType>;
 
     /** Integration methods implemented in geometry.
     */
-    typedef GeometryData::IntegrationMethod IntegrationMethod;
+    using IntegrationMethod = GeometryData::IntegrationMethod;
 
     /** A Vector of counted pointers to Geometries. Used for
     returning edges of the geometry.
      */
-    typedef typename BaseType::GeometriesArrayType GeometriesArrayType;
+    using GeometriesArrayType = typename BaseType::GeometriesArrayType;
 
     /** Redefinition of template parameter TPointType.
      */
-    typedef TPointType PointType;
+    using PointType = TPointType;
 
     /** Type used for indexing in geometry class.std::size_t used for indexing
     point or integration point access methods and also all other
     methods which need point or integration point index.
     */
-    typedef typename BaseType::IndexType IndexType;
+    using IndexType = typename BaseType::IndexType;
 
 
     /** This typed used to return size or dimension in
     geometry. Dimension, WorkingDimension, PointsNumber and
     ... return this type as their results.
     */
-    typedef typename BaseType::SizeType SizeType;
+    using SizeType = typename BaseType::SizeType;
 
     /** Array of counted pointers to point. This type used to hold
     geometry's points.
     */
-    typedef  typename BaseType::PointsArrayType PointsArrayType;
+    using PointsArrayType = typename BaseType::PointsArrayType;
 
     /** This type used for representing an integration point in
     geometry. This integration point is a point with an
     additional weight component.
     */
-    typedef typename BaseType::IntegrationPointType IntegrationPointType;
+    using IntegrationPointType = typename BaseType::IntegrationPointType;
 
     /** A Vector of IntegrationPointType which used to hold
     integration points related to an integration
     method. IntegrationPoints functions used this type to return
     their results.
     */
-    typedef typename BaseType::IntegrationPointsArrayType IntegrationPointsArrayType;
+    using IntegrationPointsArrayType = typename BaseType::IntegrationPointsArrayType;
 
     /** A Vector of IntegrationPointsArrayType which used to hold
     integration points related to different integration method
     implemented in geometry.
     */
-    typedef typename BaseType::IntegrationPointsContainerType IntegrationPointsContainerType;
+    using IntegrationPointsContainerType = typename BaseType::IntegrationPointsContainerType;
 
     /** A third order tensor used as shape functions' values
     container.
     */
-    typedef typename BaseType::ShapeFunctionsValuesContainerType ShapeFunctionsValuesContainerType;
+    using ShapeFunctionsValuesContainerType = typename BaseType::ShapeFunctionsValuesContainerType;
 
     /** A fourth order tensor used as shape functions' local
     gradients container in geometry.
     */
-    typedef typename BaseType::ShapeFunctionsLocalGradientsContainerType ShapeFunctionsLocalGradientsContainerType;
+    using ShapeFunctionsLocalGradientsContainerType = typename BaseType::ShapeFunctionsLocalGradientsContainerType;
 
     /** A third order tensor to hold jacobian matrices evaluated at
     integration points. Jacobian and InverseOfJacobian functions
     return this type as their result.
     */
-    typedef typename BaseType::JacobiansType JacobiansType;
+    using JacobiansType = typename BaseType::JacobiansType;
 
     /** A third order tensor to hold shape functions' local
     gradients. ShapefunctionsLocalGradients function return this
     type as its result.
     */
-    typedef typename BaseType::ShapeFunctionsGradientsType ShapeFunctionsGradientsType;
+    using ShapeFunctionsGradientsType = typename BaseType::ShapeFunctionsGradientsType;
 
     /** Type of the normal vector used for normal to edges in geometry.
      */
-    typedef typename BaseType::NormalType NormalType;
+    using NormalType = typename BaseType::NormalType;
 
     /**
      * Type of coordinates array
      */
-    typedef typename BaseType::CoordinatesArrayType CoordinatesArrayType;
+    using CoordinatesArrayType = typename BaseType::CoordinatesArrayType;
 
     ///@}
     ///@name Life Cycle

--- a/kratos/geometries/line_2d_3.h
+++ b/kratos/geometries/line_2d_3.h
@@ -730,7 +730,7 @@ public:
         return 1;
     }
 
-     /// @copydoc Geometry::GenerateEdges
+    /// @copydoc Geometry::GenerateEdges
     GeometriesArrayType GenerateEdges() const override
     {
         GeometriesArrayType edges;

--- a/kratos/geometries/line_2d_3.h
+++ b/kratos/geometries/line_2d_3.h
@@ -724,17 +724,13 @@ public:
     ///@name Edges and faces
     ///@{
 
-    /** EdgesNumber
-    * @copydoc Geometry::EdgesNumber
-    */
+    /// @copydoc Geometry::EdgesNumber
     SizeType EdgesNumber() const override
     {
         return 1;
     }
 
-    /**
-     * @copydoc Geometry::GenerateEdges
-     */
+     /// @copydoc Geometry::GenerateEdges
     GeometriesArrayType GenerateEdges() const override
     {
         GeometriesArrayType edges;

--- a/kratos/geometries/line_2d_3.h
+++ b/kratos/geometries/line_2d_3.h
@@ -725,7 +725,7 @@ public:
     ///@{
 
     /** EdgesNumber
-    @return SizeType contains number of this geometry edges.
+    * @copydoc Geometry::EdgesNumber
     */
     SizeType EdgesNumber() const override
     {
@@ -733,12 +733,7 @@ public:
     }
 
     /**
-     * @brief This method gives you all edges of this geometry.
-     * @details This method will give you all the edges with one dimension less than this geometry.
-     * For example a triangle would return three lines as its edges or a tetrahedral would return four triangles as its edges but won't return its six edge lines by this method.
-     * @return GeometriesArrayType contains this geometry edges.
-     * @see EdgesNumber()
-     * @see Edge()
+     * @copydoc Geometry::GenerateEdges
      */
     GeometriesArrayType GenerateEdges() const override
     {

--- a/kratos/geometries/line_2d_3.h
+++ b/kratos/geometries/line_2d_3.h
@@ -735,7 +735,7 @@ public:
     /**
      * @brief This method gives you all edges of this geometry.
      * @details This method will give you all the edges with one dimension less than this geometry.
-     * For example a triangle would return three lines as its edges or a tetrahedral would return four triangle as its edges but won't return its six edge lines by this method.
+     * For example a triangle would return three lines as its edges or a tetrahedral would return four triangles as its edges but won't return its six edge lines by this method.
      * @return GeometriesArrayType contains this geometry edges.
      * @see EdgesNumber()
      * @see Edge()

--- a/kratos/geometries/line_2d_3.h
+++ b/kratos/geometries/line_2d_3.h
@@ -726,7 +726,7 @@ public:
     */
     SizeType EdgesNumber() const override
     {
-        return 2;
+        return 1;
     }
 
 

--- a/kratos/geometries/line_2d_4.h
+++ b/kratos/geometries/line_2d_4.h
@@ -72,6 +72,9 @@ public:
     /// Pointer definition of Line2D4
     KRATOS_CLASS_POINTER_DEFINITION(Line2D4);
 
+    /// Type of edge geometry
+    typedef Line2D4<TPointType> EdgeType;
+
     /** Integration methods implemented in geometry.
     */
     typedef GeometryData::IntegrationMethod IntegrationMethod;
@@ -687,6 +690,21 @@ public:
     SizeType EdgesNumber() const override
     {
         return 1;
+    }
+
+    /**
+     * @brief This method gives you all edges of this geometry.
+     * @details This method will give you all the edges with one dimension less than this geometry.
+     * For example a triangle would return three lines as its edges or a tetrahedral would return four triangle as its edges but won't return its six edge lines by this method.
+     * @return GeometriesArrayType contains this geometry edges.
+     * @see EdgesNumber()
+     * @see Edge()
+     */
+    GeometriesArrayType GenerateEdges() const override
+    {
+        GeometriesArrayType edges;
+        edges.push_back( Kratos::make_shared<EdgeType>( this->pGetPoint( 0 ), this->pGetPoint( 1 ), this->pGetPoint( 2 ), this->pGetPoint( 3 ) ) );
+        return edges;
     }
 
     /** FacesNumber

--- a/kratos/geometries/line_2d_4.h
+++ b/kratos/geometries/line_2d_4.h
@@ -67,93 +67,93 @@ public:
     ///@{
 
     /// Geometry as base class.
-    typedef Geometry<TPointType> BaseType;
+    using BaseType = Geometry<TPointType>;
 
     /// Pointer definition of Line2D4
     KRATOS_CLASS_POINTER_DEFINITION(Line2D4);
 
     /// Type of edge geometry
-    typedef Line2D4<TPointType> EdgeType;
+    using EdgeType = Line2D4<TPointType>;
 
     /** Integration methods implemented in geometry.
     */
-    typedef GeometryData::IntegrationMethod IntegrationMethod;
+    using IntegrationMethod = GeometryData::IntegrationMethod;
 
     /** A Vector of counted pointers to Geometries. Used for
     returning edges of the geometry.
      */
-    typedef typename BaseType::GeometriesArrayType GeometriesArrayType;
+    using GeometriesArrayType = typename BaseType::GeometriesArrayType;
 
     /** Redefinition of template parameter TPointType.
      */
-    typedef TPointType PointType;
+    using PointType = TPointType;
 
     /** Type used for indexing in geometry class.std::size_t used for indexing
     point or integration point access methods and also all other
     methods which need point or integration point index.
     */
-    typedef typename BaseType::IndexType IndexType;
+    using IndexType = typename BaseType::IndexType;
 
     /** This typed used to return size or dimension in
     geometry. Dimension, WorkingDimension, PointsNumber and
     ... return this type as their results.
     */
-    typedef typename BaseType::SizeType SizeType;
+    using SizeType = typename BaseType::SizeType;
 
     /** Array of counted pointers to point. This type used to hold
     geometry's points.
     */
-    typedef  typename BaseType::PointsArrayType PointsArrayType;
+    using PointsArrayType = typename BaseType::PointsArrayType;
 
     /** This type used for representing an integration point in
     geometry. This integration point is a point with an
     additional weight component.
     */
-    typedef typename BaseType::IntegrationPointType IntegrationPointType;
+    using IntegrationPointType = typename BaseType::IntegrationPointType;
 
     /** A Vector of IntegrationPointType which used to hold
     integration points related to an integration
     method. IntegrationPoints functions used this type to return
     their results.
     */
-    typedef typename BaseType::IntegrationPointsArrayType IntegrationPointsArrayType;
+    using IntegrationPointsArrayType = typename BaseType::IntegrationPointsArrayType;
 
     /** A Vector of IntegrationPointsArrayType which used to hold
     integration points related to different integration method
     implemented in geometry.
     */
-    typedef typename BaseType::IntegrationPointsContainerType IntegrationPointsContainerType;
+    using IntegrationPointsContainerType = typename BaseType::IntegrationPointsContainerType;
 
     /** A third order tensor used as shape functions' values
     container.
     */
-    typedef typename BaseType::ShapeFunctionsValuesContainerType ShapeFunctionsValuesContainerType;
+    using ShapeFunctionsValuesContainerType = typename BaseType::ShapeFunctionsValuesContainerType;
 
     /** A fourth order tensor used as shape functions' local
     gradients container in geometry.
     */
-    typedef typename BaseType::ShapeFunctionsLocalGradientsContainerType ShapeFunctionsLocalGradientsContainerType;
+    using ShapeFunctionsLocalGradientsContainerType = typename BaseType::ShapeFunctionsLocalGradientsContainerType;
 
     /** A third order tensor to hold jacobian matrices evaluated at
     integration points. Jacobian and InverseOfJacobian functions
     return this type as their result.
     */
-    typedef typename BaseType::JacobiansType JacobiansType;
+    using JacobiansType = typename BaseType::JacobiansType;
 
     /** A third order tensor to hold shape functions' local
     gradients. ShapefunctionsLocalGradients function return this
     type as its result.
     */
-    typedef typename BaseType::ShapeFunctionsGradientsType ShapeFunctionsGradientsType;
+    using ShapeFunctionsGradientsType = typename BaseType::ShapeFunctionsGradientsType;
 
     /** Type of the normal vector used for normal to edges in geometry.
      */
-    typedef typename BaseType::NormalType NormalType;
+    using NormalType = typename BaseType::NormalType;
 
     /**
      * Type of coordinates array
      */
-    typedef typename BaseType::CoordinatesArrayType CoordinatesArrayType;
+    using CoordinatesArrayType = typename BaseType::CoordinatesArrayType;
 
     ///@}
     ///@name Life Cycle

--- a/kratos/geometries/line_2d_4.h
+++ b/kratos/geometries/line_2d_4.h
@@ -695,7 +695,7 @@ public:
     /**
      * @brief This method gives you all edges of this geometry.
      * @details This method will give you all the edges with one dimension less than this geometry.
-     * For example a triangle would return three lines as its edges or a tetrahedral would return four triangle as its edges but won't return its six edge lines by this method.
+     * For example a triangle would return three lines as its edges or a tetrahedral would return four triangles as its edges but won't return its six edge lines by this method.
      * @return GeometriesArrayType contains this geometry edges.
      * @see EdgesNumber()
      * @see Edge()

--- a/kratos/geometries/line_2d_4.h
+++ b/kratos/geometries/line_2d_4.h
@@ -712,7 +712,7 @@ public:
      */
     SizeType FacesNumber() const override
     {
-        return EdgesNumber();
+        return 0;
     }
 
     ///@}

--- a/kratos/geometries/line_2d_4.h
+++ b/kratos/geometries/line_2d_4.h
@@ -685,7 +685,7 @@ public:
     }
 
     /** EdgesNumber
-     * @return SizeType contains number of this geometry edges.
+     * @copydoc Geometry::EdgesNumber
      */
     SizeType EdgesNumber() const override
     {
@@ -693,12 +693,7 @@ public:
     }
 
     /**
-     * @brief This method gives you all edges of this geometry.
-     * @details This method will give you all the edges with one dimension less than this geometry.
-     * For example a triangle would return three lines as its edges or a tetrahedral would return four triangles as its edges but won't return its six edge lines by this method.
-     * @return GeometriesArrayType contains this geometry edges.
-     * @see EdgesNumber()
-     * @see Edge()
+     * @copydoc Geometry::GenerateEdges
      */
     GeometriesArrayType GenerateEdges() const override
     {

--- a/kratos/geometries/line_2d_4.h
+++ b/kratos/geometries/line_2d_4.h
@@ -684,17 +684,13 @@ public:
         return std::sqrt(std::pow(J(0, 0), 2) + std::pow(J(1, 0), 2));
     }
 
-    /** EdgesNumber
-     * @copydoc Geometry::EdgesNumber
-     */
+    /// @copydoc Geometry::EdgesNumber
     SizeType EdgesNumber() const override
     {
         return 1;
     }
 
-    /**
-     * @copydoc Geometry::GenerateEdges
-     */
+    /// @copydoc Geometry::GenerateEdges
     GeometriesArrayType GenerateEdges() const override
     {
         GeometriesArrayType edges;

--- a/kratos/geometries/line_2d_4.h
+++ b/kratos/geometries/line_2d_4.h
@@ -686,7 +686,7 @@ public:
      */
     SizeType EdgesNumber() const override
     {
-        return 2;
+        return 1;
     }
 
     /** FacesNumber

--- a/kratos/geometries/line_2d_5.h
+++ b/kratos/geometries/line_2d_5.h
@@ -716,7 +716,7 @@ namespace Kratos
          */
         SizeType FacesNumber() const override
         {
-            return EdgesNumber();
+            return 0;
         }
 
         ///@}

--- a/kratos/geometries/line_2d_5.h
+++ b/kratos/geometries/line_2d_5.h
@@ -67,93 +67,93 @@ namespace Kratos
         ///@{
 
         /// Geometry as base class.
-        typedef Geometry<TPointType> BaseType;
+        using BaseType = Geometry<TPointType>;
 
         /// Pointer definition of Line2D5
         KRATOS_CLASS_POINTER_DEFINITION(Line2D5);
 
         /// Type of edge geometry
-        typedef Line2D5<TPointType> EdgeType;
+        using EdgeType = Line2D5<TPointType>;
 
         /** Integration methods implemented in geometry.
         */
-        typedef GeometryData::IntegrationMethod IntegrationMethod;
+        using IntegrationMethod = GeometryData::IntegrationMethod;
 
         /** A Vector of counted pointers to Geometries. Used for
         returning edges of the geometry.
          */
-        typedef typename BaseType::GeometriesArrayType GeometriesArrayType;
+        using GeometriesArrayType = typename BaseType::GeometriesArrayType;
 
         /** Redefinition of template parameter TPointType.
          */
-        typedef TPointType PointType;
+        using PointType = TPointType;
 
         /** Type used for indexing in geometry class.std::size_t used for indexing
         point or integration point access methods and also all other
         methods which need point or integration point index.
         */
-        typedef typename BaseType::IndexType IndexType;
+        using IndexType = typename BaseType::IndexType;
 
         /** This typed used to return size or dimension in
         geometry. Dimension, WorkingDimension, PointsNumber and
         ... return this type as their results.
         */
-        typedef typename BaseType::SizeType SizeType;
+        using SizeType = typename BaseType::SizeType;
 
         /** Array of counted pointers to point. This type used to hold
         geometry's points.
         */
-        typedef  typename BaseType::PointsArrayType PointsArrayType;
+        using PointsArrayType = typename BaseType::PointsArrayType;
 
         /** This type used for representing an integration point in
         geometry. This integration point is a point with an
         additional weight component.
         */
-        typedef typename BaseType::IntegrationPointType IntegrationPointType;
+        using IntegrationPointType = typename BaseType::IntegrationPointType;
 
         /** A Vector of IntegrationPointType which used to hold
         integration points related to an integration
         method. IntegrationPoints functions used this type to return
         their results.
         */
-        typedef typename BaseType::IntegrationPointsArrayType IntegrationPointsArrayType;
+        using IntegrationPointsArrayType = typename BaseType::IntegrationPointsArrayType;
 
         /** A Vector of IntegrationPointsArrayType which used to hold
         integration points related to different integration method
         implemented in geometry.
         */
-        typedef typename BaseType::IntegrationPointsContainerType IntegrationPointsContainerType;
+        using IntegrationPointsContainerType = typename BaseType::IntegrationPointsContainerType;
 
         /** A third order tensor used as shape functions' values
         container.
         */
-        typedef typename BaseType::ShapeFunctionsValuesContainerType ShapeFunctionsValuesContainerType;
+        using ShapeFunctionsValuesContainerType = typename BaseType::ShapeFunctionsValuesContainerType;
 
         /** A fourth order tensor used as shape functions' local
         gradients container in geometry.
         */
-        typedef typename BaseType::ShapeFunctionsLocalGradientsContainerType ShapeFunctionsLocalGradientsContainerType;
+        using ShapeFunctionsLocalGradientsContainerType = typename BaseType::ShapeFunctionsLocalGradientsContainerType;
 
         /** A third order tensor to hold jacobian matrices evaluated at
         integration points. Jacobian and InverseOfJacobian functions
         return this type as their result.
         */
-        typedef typename BaseType::JacobiansType JacobiansType;
+        using JacobiansType = typename BaseType::JacobiansType;
 
         /** A third order tensor to hold shape functions' local
         gradients. ShapefunctionsLocalGradients function return this
         type as its result.
         */
-        typedef typename BaseType::ShapeFunctionsGradientsType ShapeFunctionsGradientsType;
+        using ShapeFunctionsGradientsType = typename BaseType::ShapeFunctionsGradientsType;
 
         /** Type of the normal vector used for normal to edges in geometry.
          */
-        typedef typename BaseType::NormalType NormalType;
+        using NormalType = typename BaseType::NormalType;
 
         /**
          * Type of coordinates array
          */
-        typedef typename BaseType::CoordinatesArrayType CoordinatesArrayType;
+        using CoordinatesArrayType = typename BaseType::CoordinatesArrayType;
 
         ///@}
         ///@name Life Cycle

--- a/kratos/geometries/line_2d_5.h
+++ b/kratos/geometries/line_2d_5.h
@@ -699,7 +699,7 @@ namespace Kratos
         /**
          * @brief This method gives you all edges of this geometry.
          * @details This method will give you all the edges with one dimension less than this geometry.
-         * For example a triangle would return three lines as its edges or a tetrahedral would return four triangle as its edges but won't return its six edge lines by this method.
+         * For example a triangle would return three lines as its edges or a tetrahedral would return four triangles as its edges but won't return its six edge lines by this method.
          * @return GeometriesArrayType contains this geometry edges.
          * @see EdgesNumber()
          * @see Edge()

--- a/kratos/geometries/line_2d_5.h
+++ b/kratos/geometries/line_2d_5.h
@@ -690,7 +690,7 @@ namespace Kratos
          */
         SizeType EdgesNumber() const override
         {
-            return 2;
+            return 1;
         }
 
         /** FacesNumber

--- a/kratos/geometries/line_2d_5.h
+++ b/kratos/geometries/line_2d_5.h
@@ -689,7 +689,7 @@ namespace Kratos
         }
 
         /** EdgesNumber
-         * @return SizeType contains number of this geometry edges.
+         * @copydoc Geometry::EdgesNumber
          */
         SizeType EdgesNumber() const override
         {
@@ -697,12 +697,7 @@ namespace Kratos
         }
 
         /**
-         * @brief This method gives you all edges of this geometry.
-         * @details This method will give you all the edges with one dimension less than this geometry.
-         * For example a triangle would return three lines as its edges or a tetrahedral would return four triangles as its edges but won't return its six edge lines by this method.
-         * @return GeometriesArrayType contains this geometry edges.
-         * @see EdgesNumber()
-         * @see Edge()
+         * @copydoc Geometry::GenerateEdges
          */
         GeometriesArrayType GenerateEdges() const override
         {

--- a/kratos/geometries/line_2d_5.h
+++ b/kratos/geometries/line_2d_5.h
@@ -72,6 +72,9 @@ namespace Kratos
         /// Pointer definition of Line2D5
         KRATOS_CLASS_POINTER_DEFINITION(Line2D5);
 
+        /// Type of edge geometry
+        typedef Line2D5<TPointType> EdgeType;
+
         /** Integration methods implemented in geometry.
         */
         typedef GeometryData::IntegrationMethod IntegrationMethod;
@@ -691,6 +694,21 @@ namespace Kratos
         SizeType EdgesNumber() const override
         {
             return 1;
+        }
+
+        /**
+         * @brief This method gives you all edges of this geometry.
+         * @details This method will give you all the edges with one dimension less than this geometry.
+         * For example a triangle would return three lines as its edges or a tetrahedral would return four triangle as its edges but won't return its six edge lines by this method.
+         * @return GeometriesArrayType contains this geometry edges.
+         * @see EdgesNumber()
+         * @see Edge()
+         */
+        GeometriesArrayType GenerateEdges() const override
+        {
+            GeometriesArrayType edges;
+            edges.push_back( Kratos::make_shared<EdgeType>( this->pGetPoint( 0 ), this->pGetPoint( 1 ), this->pGetPoint( 2 ), this->pGetPoint( 3 ), this->pGetPoint( 4 ) ) );
+            return edges;
         }
 
         /** FacesNumber

--- a/kratos/geometries/line_2d_5.h
+++ b/kratos/geometries/line_2d_5.h
@@ -688,17 +688,13 @@ namespace Kratos
             return std::sqrt(std::pow(J(0, 0), 2) + std::pow(J(1, 0), 2));
         }
 
-        /** EdgesNumber
-         * @copydoc Geometry::EdgesNumber
-         */
+        /// @copydoc Geometry::EdgesNumber
         SizeType EdgesNumber() const override
         {
             return 1;
         }
 
-        /**
-         * @copydoc Geometry::GenerateEdges
-         */
+        /// @copydoc Geometry::GenerateEdges
         GeometriesArrayType GenerateEdges() const override
         {
             GeometriesArrayType edges;

--- a/kratos/geometries/line_3d_2.h
+++ b/kratos/geometries/line_3d_2.h
@@ -743,8 +743,8 @@ public:
 
     /**
      * @brief This method gives you all edges of this geometry.
-     * @details This method will gives you all the edges with one dimension less than this geometry.
-     * For example a triangle would return three lines as its edges or a tetrahedral would return four triangle as its edges but won't return its six edge lines by this method.
+     * @details This method will give you all the edges with one dimension less than this geometry.
+     * For example a triangle would return three lines as its edges or a tetrahedral would return four triangles as its edges but won't return its six edge lines by this method.
      * @return GeometriesArrayType contains this geometry edges.
      * @see EdgesNumber()
      * @see Edge()

--- a/kratos/geometries/line_3d_2.h
+++ b/kratos/geometries/line_3d_2.h
@@ -69,95 +69,95 @@ public:
     ///@{
 
     /// Geometry as base class.
-    typedef Geometry<TPointType> BaseType;
+    using BaseType = Geometry<TPointType>;
     using Geometry<TPointType>::ShapeFunctionsValues;
 
     /// Pointer definition of Line3D2
     KRATOS_CLASS_POINTER_DEFINITION( Line3D2 );
 
     /// Type of edge geometry
-    typedef Line3D2<TPointType> EdgeType;
+    using EdgeType = Line3D2<TPointType>;
 
     /** Integration methods implemented in geometry.
     */
-    typedef GeometryData::IntegrationMethod IntegrationMethod;
+    using IntegrationMethod = GeometryData::IntegrationMethod;
 
     /** A Vector of counted pointers to Geometries. Used for
     returning edges of the geometry.
      */
-    typedef typename BaseType::GeometriesArrayType GeometriesArrayType;
+    using GeometriesArrayType = typename BaseType::GeometriesArrayType;
 
     /** Redefinition of template parameter TPointType.
      */
-    typedef TPointType PointType;
+    using PointType = TPointType;
 
     /** Type used for indexing in geometry class.std::size_t used for indexing
     point or integration point access methods and also all other
     methods which need point or integration point index.
     */
-    typedef typename BaseType::IndexType IndexType;
+    using IndexType = typename BaseType::IndexType;
 
 
     /** This typed used to return size or dimension in
     geometry. Dimension, WorkingDimension, PointsNumber and
     ... return this type as their results.
     */
-    typedef typename BaseType::SizeType SizeType;
+    using SizeType = typename BaseType::SizeType;
 
     /** Array of counted pointers to point. This type used to hold
     geometry's points.
     */
-    typedef  typename BaseType::PointsArrayType PointsArrayType;
+    using PointsArrayType = typename BaseType::PointsArrayType;
 
     /** This type used for representing an integration point in
     geometry. This integration point is a point with an
     additional weight component.
     */
-    typedef typename BaseType::IntegrationPointType IntegrationPointType;
+    using IntegrationPointType = typename BaseType::IntegrationPointType;
 
     /** A Vector of IntegrationPointType which used to hold
     integration points related to an integration
     method. IntegrationPoints functions used this type to return
     their results.
     */
-    typedef typename BaseType::IntegrationPointsArrayType IntegrationPointsArrayType;
+    using IntegrationPointsArrayType = typename BaseType::IntegrationPointsArrayType;
 
     /** A Vector of IntegrationPointsArrayType which used to hold
     integration points related to different integration method
     implemented in geometry.
     */
-    typedef typename BaseType::IntegrationPointsContainerType IntegrationPointsContainerType;
+    using IntegrationPointsContainerType = typename BaseType::IntegrationPointsContainerType;
 
     /** A third order tensor used as shape functions' values
     container.
     */
-    typedef typename BaseType::ShapeFunctionsValuesContainerType ShapeFunctionsValuesContainerType;
+    using ShapeFunctionsValuesContainerType = typename BaseType::ShapeFunctionsValuesContainerType;
 
     /** A fourth order tensor used as shape functions' local
     gradients container in geometry.
     */
-    typedef typename BaseType::ShapeFunctionsLocalGradientsContainerType ShapeFunctionsLocalGradientsContainerType;
+    using ShapeFunctionsLocalGradientsContainerType = typename BaseType::ShapeFunctionsLocalGradientsContainerType;
 
     /** A third order tensor to hold jacobian matrices evaluated at
     integration points. Jacobian and InverseOfJacobian functions
     return this type as their result.
     */
-    typedef typename BaseType::JacobiansType JacobiansType;
+    using JacobiansType = typename BaseType::JacobiansType;
 
     /** A third order tensor to hold shape functions' local
     gradients. ShapefunctionsLocalGradients function return this
     type as its result.
     */
-    typedef typename BaseType::ShapeFunctionsGradientsType ShapeFunctionsGradientsType;
+    using ShapeFunctionsGradientsType = typename BaseType::ShapeFunctionsGradientsType;
 
     /** Type of the normal vector used for normal to edges in geometry.
      */
-    typedef typename BaseType::NormalType NormalType;
+    using NormalType = typename BaseType::NormalType;
 
     /**
      * Type of coordinates array
      */
-    typedef typename BaseType::CoordinatesArrayType CoordinatesArrayType;
+    using CoordinatesArrayType = typename BaseType::CoordinatesArrayType;
 
     ///@}
     ///@name Life Cycle

--- a/kratos/geometries/line_3d_2.h
+++ b/kratos/geometries/line_3d_2.h
@@ -725,17 +725,13 @@ public:
     ///@name Edge
     ///@{
 
-    /**
-     * @copydoc Geometry::EdgesNumber
-     */
+    /// @copydoc Geometry::EdgesNumber
     SizeType EdgesNumber() const override
     {
         return 1;
     }
 
-    /**
-     * @copydoc Geometry::GenerateEdges
-     */
+    /// @copydoc Geometry::GenerateEdges
     GeometriesArrayType GenerateEdges() const override
     {
         GeometriesArrayType edges = GeometriesArrayType();

--- a/kratos/geometries/line_3d_2.h
+++ b/kratos/geometries/line_3d_2.h
@@ -726,15 +726,7 @@ public:
     ///@{
 
     /**
-     * @brief This method gives you number of all edges of this geometry.
-     * @details For example, for a hexahedron, this would be 12
-     * @return SizeType contains number of this geometry edges.
-     * @see EdgesNumber()
-     * @see Edges()
-     * @see GenerateEdges()
-     * @see FacesNumber()
-     * @see Faces()
-     * @see GenerateFaces()
+     * @copydoc Geometry::EdgesNumber
      */
     SizeType EdgesNumber() const override
     {
@@ -742,12 +734,7 @@ public:
     }
 
     /**
-     * @brief This method gives you all edges of this geometry.
-     * @details This method will give you all the edges with one dimension less than this geometry.
-     * For example a triangle would return three lines as its edges or a tetrahedral would return four triangles as its edges but won't return its six edge lines by this method.
-     * @return GeometriesArrayType contains this geometry edges.
-     * @see EdgesNumber()
-     * @see Edge()
+     * @copydoc Geometry::GenerateEdges
      */
     GeometriesArrayType GenerateEdges() const override
     {

--- a/kratos/geometries/line_3d_3.h
+++ b/kratos/geometries/line_3d_3.h
@@ -75,6 +75,9 @@ public:
     /// Pointer definition of Line3D3
     KRATOS_CLASS_POINTER_DEFINITION( Line3D3 );
 
+    /// Type of edge geometry
+    typedef Line3D3<TPointType> EdgeType;
+
     /** Integration methods implemented in geometry.
     */
     typedef GeometryData::IntegrationMethod IntegrationMethod;
@@ -482,6 +485,21 @@ public:
     SizeType EdgesNumber() const override
     {
         return 1;
+    }
+
+    /**
+     * @brief This method gives you all edges of this geometry.
+     * @details This method will give you all the edges with one dimension less than this geometry.
+     * For example a triangle would return three lines as its edges or a tetrahedral would return four triangle as its edges but won't return its six edge lines by this method.
+     * @return GeometriesArrayType contains this geometry edges.
+     * @see EdgesNumber()
+     * @see Edge()
+     */
+    GeometriesArrayType GenerateEdges() const override
+    {
+        GeometriesArrayType edges;
+        edges.push_back( Kratos::make_shared<EdgeType>( this->pGetPoint( 0 ), this->pGetPoint( 1 ), this->pGetPoint( 2 ) ) );
+        return edges;
     }
 
     SizeType FacesNumber() const override

--- a/kratos/geometries/line_3d_3.h
+++ b/kratos/geometries/line_3d_3.h
@@ -481,7 +481,7 @@ public:
     */
     SizeType EdgesNumber() const override
     {
-        return 2;
+        return 1;
     }
 
     SizeType FacesNumber() const override

--- a/kratos/geometries/line_3d_3.h
+++ b/kratos/geometries/line_3d_3.h
@@ -479,17 +479,13 @@ public:
     ///@name Edges and faces
     ///@{
 
-    /** EdgesNumber
-    * @copydoc Geometry::EdgesNumber
-    */
+    /// @copydoc Geometry::EdgesNumber
     SizeType EdgesNumber() const override
     {
         return 1;
     }
 
-    /**
-     * @copydoc Geometry::GenerateEdges
-     */
+    /// @copydoc Geometry::GenerateEdges
     GeometriesArrayType GenerateEdges() const override
     {
         GeometriesArrayType edges;

--- a/kratos/geometries/line_3d_3.h
+++ b/kratos/geometries/line_3d_3.h
@@ -70,94 +70,94 @@ public:
     ///@{
 
     /// Geometry as base class.
-    typedef Geometry<TPointType> BaseType;
+    using BaseType = Geometry<TPointType>;
 
     /// Pointer definition of Line3D3
     KRATOS_CLASS_POINTER_DEFINITION( Line3D3 );
 
     /// Type of edge geometry
-    typedef Line3D3<TPointType> EdgeType;
+    using EdgeType = Line3D3<TPointType>;
 
     /** Integration methods implemented in geometry.
     */
-    typedef GeometryData::IntegrationMethod IntegrationMethod;
+    using IntegrationMethod = GeometryData::IntegrationMethod;
 
     /** A Vector of counted pointers to Geometries. Used for
     returning edges of the geometry.
      */
-    typedef typename BaseType::GeometriesArrayType GeometriesArrayType;
+    using GeometriesArrayType = typename BaseType::GeometriesArrayType;
 
     /** Redefinition of template parameter TPointType.
      */
-    typedef TPointType PointType;
+    using PointType = TPointType;
 
     /** Type used for indexing in geometry class.std::size_t used for indexing
     point or integration point access methods and also all other
     methods which need point or integration point index.
     */
-    typedef typename BaseType::IndexType IndexType;
+    using IndexType = typename BaseType::IndexType;
 
 
     /** This typed used to return size or dimension in
     geometry. Dimension, WorkingDimension, PointsNumber and
     ... return this type as their results.
     */
-    typedef typename BaseType::SizeType SizeType;
+    using SizeType = typename BaseType::SizeType;
 
     /** Array of counted pointers to point. This type used to hold
     geometry's points.
     */
-    typedef  typename BaseType::PointsArrayType PointsArrayType;
+    using PointsArrayType = typename BaseType::PointsArrayType;
 
     /** This type used for representing an integration point in
     geometry. This integration point is a point with an
     additional weight component.
     */
-    typedef typename BaseType::IntegrationPointType IntegrationPointType;
+    using IntegrationPointType = typename BaseType::IntegrationPointType;
 
     /** A Vector of IntegrationPointType which used to hold
     integration points related to an integration
     method. IntegrationPoints functions used this type to return
     their results.
     */
-    typedef typename BaseType::IntegrationPointsArrayType IntegrationPointsArrayType;
+    using IntegrationPointsArrayType = typename BaseType::IntegrationPointsArrayType;
 
     /** A Vector of IntegrationPointsArrayType which used to hold
     integration points related to different integration method
     implemented in geometry.
     */
-    typedef typename BaseType::IntegrationPointsContainerType IntegrationPointsContainerType;
+    using IntegrationPointsContainerType = typename BaseType::IntegrationPointsContainerType;
 
     /** A third order tensor used as shape functions' values
     container.
     */
-    typedef typename BaseType::ShapeFunctionsValuesContainerType ShapeFunctionsValuesContainerType;
+    using ShapeFunctionsValuesContainerType = typename BaseType::ShapeFunctionsValuesContainerType;
 
     /** A fourth order tensor used as shape functions' local
     gradients container in geometry.
     */
-    typedef typename BaseType::ShapeFunctionsLocalGradientsContainerType ShapeFunctionsLocalGradientsContainerType;
+    using ShapeFunctionsLocalGradientsContainerType = typename BaseType::ShapeFunctionsLocalGradientsContainerType;
 
     /** A third order tensor to hold jacobian matrices evaluated at
     integration points. Jacobian and InverseOfJacobian functions
     return this type as their result.
     */
-    typedef typename BaseType::JacobiansType JacobiansType;
+    using JacobiansType = typename BaseType::JacobiansType;
 
     /** A third order tensor to hold shape functions' local
     gradients. ShapefunctionsLocalGradients function return this
     type as its result.
     */
-    typedef typename BaseType::ShapeFunctionsGradientsType ShapeFunctionsGradientsType;
+    using ShapeFunctionsGradientsType = typename BaseType::ShapeFunctionsGradientsType;
 
     /** Type of the normal vector used for normal to edges in geometry.
      */
-    typedef typename BaseType::NormalType NormalType;
+    using NormalType = typename BaseType::NormalType;
 
     /**
      * Type of coordinates array
      */
-    typedef typename BaseType::CoordinatesArrayType CoordinatesArrayType;
+    using CoordinatesArrayType = typename BaseType::CoordinatesArrayType;
 
     ///@}
     ///@name Life Cycle

--- a/kratos/geometries/line_3d_3.h
+++ b/kratos/geometries/line_3d_3.h
@@ -480,7 +480,7 @@ public:
     ///@{
 
     /** EdgesNumber
-    @return SizeType contains number of this geometry edges.
+    * @copydoc Geometry::EdgesNumber
     */
     SizeType EdgesNumber() const override
     {
@@ -488,12 +488,7 @@ public:
     }
 
     /**
-     * @brief This method gives you all edges of this geometry.
-     * @details This method will give you all the edges with one dimension less than this geometry.
-     * For example a triangle would return three lines as its edges or a tetrahedral would return four triangles as its edges but won't return its six edge lines by this method.
-     * @return GeometriesArrayType contains this geometry edges.
-     * @see EdgesNumber()
-     * @see Edge()
+     * @copydoc Geometry::GenerateEdges
      */
     GeometriesArrayType GenerateEdges() const override
     {

--- a/kratos/geometries/line_3d_3.h
+++ b/kratos/geometries/line_3d_3.h
@@ -490,7 +490,7 @@ public:
     /**
      * @brief This method gives you all edges of this geometry.
      * @details This method will give you all the edges with one dimension less than this geometry.
-     * For example a triangle would return three lines as its edges or a tetrahedral would return four triangle as its edges but won't return its six edge lines by this method.
+     * For example a triangle would return three lines as its edges or a tetrahedral would return four triangles as its edges but won't return its six edge lines by this method.
      * @return GeometriesArrayType contains this geometry edges.
      * @see EdgesNumber()
      * @see Edge()

--- a/kratos/tests/cpp_tests/geometries/test_line_2d_2.cpp
+++ b/kratos/tests/cpp_tests/geometries/test_line_2d_2.cpp
@@ -66,7 +66,6 @@ namespace Testing {
     }
 
     /** Checks if the number of edges is correct.
-    * Checks if the number of edges is correct.
     */
     KRATOS_TEST_CASE_IN_SUITE(Line2D2EdgesNumber, KratosCoreGeometriesFastSuite) {
         auto geom = GeneratePointsUnitXDirectionLine2D2();
@@ -74,7 +73,6 @@ namespace Testing {
     }
 
     /** Checks if the edges are correct.
-    * Checks if the edges are correct.
     */
     KRATOS_TEST_CASE_IN_SUITE(Line2D2Edges, KratosCoreGeometriesFastSuite) {
         auto p_geom = GeneratePointsUnitXDirectionLine2D2();
@@ -87,7 +85,6 @@ namespace Testing {
     }
 
     /** Checks if the number of faces is correct.
-    * Checks if the number of faces is correct.
     */
     KRATOS_TEST_CASE_IN_SUITE(Line2D2FacesNumber, KratosCoreGeometriesFastSuite) {
         auto geom = GeneratePointsUnitXDirectionLine2D2();

--- a/kratos/tests/cpp_tests/geometries/test_line_2d_3.cpp
+++ b/kratos/tests/cpp_tests/geometries/test_line_2d_3.cpp
@@ -79,7 +79,6 @@ namespace {
 }
 
     /** Checks if the number of edges is correct.
-    * Checks if the number of edges is correct.
     */
     KRATOS_TEST_CASE_IN_SUITE(Line2D3EdgesNumber, KratosCoreGeometriesFastSuite) {
         auto p_geometry = GeneratePointsUnitXDirectionLine2D3();
@@ -100,7 +99,6 @@ namespace {
     }
 
     /** Checks if the number of faces is correct.
-    * Checks if the number of faces is correct.
     */
     KRATOS_TEST_CASE_IN_SUITE(Line2D3FacesNumber, KratosCoreGeometriesFastSuite) {
         auto p_geometry = GeneratePointsUnitXDirectionLine2D3();

--- a/kratos/tests/cpp_tests/geometries/test_line_2d_3.cpp
+++ b/kratos/tests/cpp_tests/geometries/test_line_2d_3.cpp
@@ -86,6 +86,19 @@ namespace {
         KRATOS_EXPECT_EQ(p_geometry->EdgesNumber(), 1);
     }
 
+    /** Checks if the edges are correct.
+    */
+    KRATOS_TEST_CASE_IN_SUITE(Line2D3Edges, KratosCoreGeometriesFastSuite) {
+        auto p_geom = GeneratePointsUnitXDirectionLine2D3();
+
+        const auto& r_edges = p_geom->GenerateEdges();
+        ASSERT_EQ(r_edges.size(), 1);
+        for (std::size_t i = 0; i < r_edges.front().PointsNumber(); ++i) {
+            KRATOS_EXPECT_NEAR(r_edges.front()[i].X(), (p_geom->pGetPoint(i))->X(), TOLERANCE);
+            KRATOS_EXPECT_NEAR(r_edges.front()[i].Y(), (p_geom->pGetPoint(i))->Y(), TOLERANCE);
+        }
+    }
+
     /** Checks if the number of faces is correct.
     * Checks if the number of faces is correct.
     */

--- a/kratos/tests/cpp_tests/geometries/test_line_2d_3.cpp
+++ b/kratos/tests/cpp_tests/geometries/test_line_2d_3.cpp
@@ -83,7 +83,7 @@ namespace {
     */
     KRATOS_TEST_CASE_IN_SUITE(Line2D3EdgesNumber, KratosCoreGeometriesFastSuite) {
         auto p_geometry = GeneratePointsUnitXDirectionLine2D3();
-        KRATOS_EXPECT_EQ(p_geometry->EdgesNumber(), 2);
+        KRATOS_EXPECT_EQ(p_geometry->EdgesNumber(), 1);
     }
 
     /** Checks if the number of faces is correct.

--- a/kratos/tests/cpp_tests/geometries/test_line_2d_4.cpp
+++ b/kratos/tests/cpp_tests/geometries/test_line_2d_4.cpp
@@ -104,7 +104,6 @@ namespace Testing {
     }
 
     /** Checks if the number of faces is correct.
-    * Checks if the number of faces is correct.
     */
     KRATOS_TEST_CASE_IN_SUITE(Line2D4FacesNumber, KratosCoreGeometriesFastSuite) {
         auto p_geometry = GeneratePointsUnitXDirectionLine2D4();

--- a/kratos/tests/cpp_tests/geometries/test_line_2d_4.cpp
+++ b/kratos/tests/cpp_tests/geometries/test_line_2d_4.cpp
@@ -84,11 +84,23 @@ namespace Testing {
     }
 
     /** Checks if the number of edges is correct.
-    * Checks if the number of edges is correct.
     */
     KRATOS_TEST_CASE_IN_SUITE(Line2D4EdgesNumber, KratosCoreGeometriesFastSuite) {
         auto p_geometry = GeneratePointsUnitXDirectionLine2D4();
         KRATOS_EXPECT_EQ(p_geometry->EdgesNumber(), 1);
+    }
+
+    /** Checks if the edges are correct.
+    */
+    KRATOS_TEST_CASE_IN_SUITE(Line2D4Edges, KratosCoreGeometriesFastSuite) {
+        auto p_geom = GeneratePointsUnitXDirectionLine2D4();
+
+        const auto& r_edges = p_geom->GenerateEdges();
+        ASSERT_EQ(r_edges.size(), 1);
+        for (std::size_t i = 0; i < r_edges.front().PointsNumber(); ++i) {
+            KRATOS_EXPECT_NEAR(r_edges.front()[i].X(), (p_geom->pGetPoint(i))->X(), TOLERANCE);
+            KRATOS_EXPECT_NEAR(r_edges.front()[i].Y(), (p_geom->pGetPoint(i))->Y(), TOLERANCE);
+        }
     }
 
     /** Checks if the number of faces is correct.

--- a/kratos/tests/cpp_tests/geometries/test_line_2d_4.cpp
+++ b/kratos/tests/cpp_tests/geometries/test_line_2d_4.cpp
@@ -88,7 +88,7 @@ namespace Testing {
     */
     KRATOS_TEST_CASE_IN_SUITE(Line2D4EdgesNumber, KratosCoreGeometriesFastSuite) {
         auto p_geometry = GeneratePointsUnitXDirectionLine2D4();
-        KRATOS_EXPECT_EQ(p_geometry->EdgesNumber(), 2);
+        KRATOS_EXPECT_EQ(p_geometry->EdgesNumber(), 1);
     }
 
     /** Checks if the number of faces is correct.

--- a/kratos/tests/cpp_tests/geometries/test_line_2d_4.cpp
+++ b/kratos/tests/cpp_tests/geometries/test_line_2d_4.cpp
@@ -108,7 +108,7 @@ namespace Testing {
     */
     KRATOS_TEST_CASE_IN_SUITE(Line2D4FacesNumber, KratosCoreGeometriesFastSuite) {
         auto p_geometry = GeneratePointsUnitXDirectionLine2D4();
-        KRATOS_EXPECT_EQ(p_geometry->FacesNumber(), 2);
+        KRATOS_EXPECT_EQ(p_geometry->FacesNumber(), 0);
     }
 
     /** Checks if the length of the line is calculated correctly.

--- a/kratos/tests/cpp_tests/geometries/test_line_2d_5.cpp
+++ b/kratos/tests/cpp_tests/geometries/test_line_2d_5.cpp
@@ -93,7 +93,7 @@ namespace Testing {
     */
     KRATOS_TEST_CASE_IN_SUITE(Line2D5EdgesNumber, KratosCoreGeometriesFastSuite) {
         auto p_geometry = GeneratePointsUnitXDirectionLine2D5();
-        KRATOS_EXPECT_EQ(p_geometry->EdgesNumber(), 2);
+        KRATOS_EXPECT_EQ(p_geometry->EdgesNumber(), 1);
     }
 
     /** Checks if the number of faces is correct.

--- a/kratos/tests/cpp_tests/geometries/test_line_2d_5.cpp
+++ b/kratos/tests/cpp_tests/geometries/test_line_2d_5.cpp
@@ -89,11 +89,23 @@ namespace Testing {
     }
 
     /** Checks if the number of edges is correct.
-    * Checks if the number of edges is correct.
     */
     KRATOS_TEST_CASE_IN_SUITE(Line2D5EdgesNumber, KratosCoreGeometriesFastSuite) {
         auto p_geometry = GeneratePointsUnitXDirectionLine2D5();
         KRATOS_EXPECT_EQ(p_geometry->EdgesNumber(), 1);
+    }
+
+    /** Checks if the edges are correct.
+    */
+    KRATOS_TEST_CASE_IN_SUITE(Line2D5Edges, KratosCoreGeometriesFastSuite) {
+        auto p_geom = GeneratePointsUnitXDirectionLine2D5();
+
+        const auto& r_edges = p_geom->GenerateEdges();
+        ASSERT_EQ(r_edges.size(), 1);
+        for (std::size_t i = 0; i < r_edges.front().PointsNumber(); ++i) {
+            KRATOS_EXPECT_NEAR(r_edges.front()[i].X(), (p_geom->pGetPoint(i))->X(), TOLERANCE);
+            KRATOS_EXPECT_NEAR(r_edges.front()[i].Y(), (p_geom->pGetPoint(i))->Y(), TOLERANCE);
+        }
     }
 
     /** Checks if the number of faces is correct.

--- a/kratos/tests/cpp_tests/geometries/test_line_2d_5.cpp
+++ b/kratos/tests/cpp_tests/geometries/test_line_2d_5.cpp
@@ -109,7 +109,6 @@ namespace Testing {
     }
 
     /** Checks if the number of faces is correct.
-    * Checks if the number of faces is correct.
     */
     KRATOS_TEST_CASE_IN_SUITE(Line2D5FacesNumber, KratosCoreGeometriesFastSuite) {
         auto p_geometry = GeneratePointsUnitXDirectionLine2D5();

--- a/kratos/tests/cpp_tests/geometries/test_line_2d_5.cpp
+++ b/kratos/tests/cpp_tests/geometries/test_line_2d_5.cpp
@@ -113,7 +113,7 @@ namespace Testing {
     */
     KRATOS_TEST_CASE_IN_SUITE(Line2D5FacesNumber, KratosCoreGeometriesFastSuite) {
         auto p_geometry = GeneratePointsUnitXDirectionLine2D5();
-        KRATOS_EXPECT_EQ(p_geometry->FacesNumber(), 2);
+        KRATOS_EXPECT_EQ(p_geometry->FacesNumber(), 0);
     }
 
     /** Checks if the length of the line is calculated correctly.

--- a/kratos/tests/cpp_tests/geometries/test_line_3d_2.cpp
+++ b/kratos/tests/cpp_tests/geometries/test_line_3d_2.cpp
@@ -65,7 +65,6 @@ namespace Testing {
     }
 
     /** Checks if the number of edges is correct.
-    * Checks if the number of edges is correct.
     */
     KRATOS_TEST_CASE_IN_SUITE(Line3D2EdgesNumber, KratosCoreGeometriesFastSuite) {
         Geometry<Point>::Pointer p_geom = GeneratePointsUnitXDirectionLine3D2();
@@ -73,7 +72,6 @@ namespace Testing {
     }
 
     /** Checks if the edges are correct.
-    * Checks if the edges are correct.
     */
     KRATOS_TEST_CASE_IN_SUITE(Line3D2Edges, KratosCoreGeometriesFastSuite) {
         auto p_geom = GeneratePointsUnitXDirectionLine3D2();
@@ -86,7 +84,6 @@ namespace Testing {
     }
 
     /** Checks if the number of faces is correct.
-    * Checks if the number of faces is correct.
     */
     KRATOS_TEST_CASE_IN_SUITE(Line3D2FacesNumber, KratosCoreGeometriesFastSuite) {
         Geometry<Point>::Pointer p_geom = GeneratePointsUnitXDirectionLine3D2();

--- a/kratos/tests/cpp_tests/geometries/test_line_3d_3.cpp
+++ b/kratos/tests/cpp_tests/geometries/test_line_3d_3.cpp
@@ -84,7 +84,7 @@ namespace {
 */
 KRATOS_TEST_CASE_IN_SUITE(Line3D3EdgesNumber, KratosCoreGeometriesFastSuite) {
     auto p_geometry = GeneratePointsUnitXDirectionLine3D3();
-    KRATOS_EXPECT_EQ(p_geometry->EdgesNumber(), 2);
+    KRATOS_EXPECT_EQ(p_geometry->EdgesNumber(), 1);
 }
 
 /** Checks if the number of faces is correct.

--- a/kratos/tests/cpp_tests/geometries/test_line_3d_3.cpp
+++ b/kratos/tests/cpp_tests/geometries/test_line_3d_3.cpp
@@ -86,8 +86,8 @@ KRATOS_TEST_CASE_IN_SUITE(Line3D3EdgesNumber, KratosCoreGeometriesFastSuite) {
     KRATOS_EXPECT_EQ(p_geometry->EdgesNumber(), 1);
 }
 
-    /** Checks if the edges are correct.
-        */
+/** Checks if the edges are correct.
+*/
 KRATOS_TEST_CASE_IN_SUITE(Line3D3Edges, KratosCoreGeometriesFastSuite) {
     auto p_geom = GeneratePointsUnitXDirectionLine3D3();
 
@@ -100,7 +100,6 @@ KRATOS_TEST_CASE_IN_SUITE(Line3D3Edges, KratosCoreGeometriesFastSuite) {
 }
 
 /** Checks if the number of faces is correct.
-* Checks if the number of faces is correct.
 */
 KRATOS_TEST_CASE_IN_SUITE(Line3D3FacesNumber, KratosCoreGeometriesFastSuite) {
     auto p_geometry = GeneratePointsUnitXDirectionLine3D3();

--- a/kratos/tests/cpp_tests/geometries/test_line_3d_3.cpp
+++ b/kratos/tests/cpp_tests/geometries/test_line_3d_3.cpp
@@ -80,11 +80,23 @@ namespace {
 }
 
 /** Checks if the number of edges is correct.
-* Checks if the number of edges is correct.
 */
 KRATOS_TEST_CASE_IN_SUITE(Line3D3EdgesNumber, KratosCoreGeometriesFastSuite) {
     auto p_geometry = GeneratePointsUnitXDirectionLine3D3();
     KRATOS_EXPECT_EQ(p_geometry->EdgesNumber(), 1);
+}
+
+    /** Checks if the edges are correct.
+        */
+KRATOS_TEST_CASE_IN_SUITE(Line3D3Edges, KratosCoreGeometriesFastSuite) {
+    auto p_geom = GeneratePointsUnitXDirectionLine3D3();
+
+    const auto& r_edges = p_geom->GenerateEdges();
+    ASSERT_EQ(r_edges.size(), 1);
+    for (std::size_t i = 0; i < r_edges.front().PointsNumber(); ++i) {
+        KRATOS_EXPECT_NEAR(r_edges.front()[i].X(), (p_geom->pGetPoint(i))->X(), TOLERANCE);
+        KRATOS_EXPECT_NEAR(r_edges.front()[i].Y(), (p_geom->pGetPoint(i))->Y(), TOLERANCE);
+    }
 }
 
 /** Checks if the number of faces is correct.


### PR DESCRIPTION
**📝 Description**
This PR aims at making the (number of) edges of line geometries complete and consistent with those of other geometries. When looking at other geometries (e.g. triangles or quadrilaterals), the number of edges corresponds to the number of sides of the geometry. For instance, for triangles that would always be 3, regardless of the order of the shape functions (and hence the number of intermediate nodes on a side). For line geometries, however, this was inconsistent. For instance, when inquiring the number of edges of a 3-point line geometry, the returned value would be 2. However, that is not the number of edges of the geometry, but the number of line segments that make up the side (or edge). For line geometries, to be consistent with other geometries, the returned value should always be 1.

In addition, several line geometries lacked an `override` of `GenerateEdges`, which yielded an error when attempting to inquire the edges of such a line geometry (raised by the base class, which said that an `override` had to be provided).

The modified code as well as the newly added code is covered by unit tests.

Note that we have attempted to mimic the existing coding style.

**🆕 Changelog**
- Added `EdgeType` aliases to class templates `Line2D3`, `Line2D4`, `Line2D5`, and `Line3D3`, since these were missing.
- All line geometries now return 1 when inquiring the number of edges (i.e. when calling member `EdgesNumber`). This is in line with how other geometries define an edge.
- Added implementations of member `GenerateEdges` to class templates `Line2D3`, `Line2D4`, `Line2D5`, and `Line3D3`, since these were missing, too. In all cases, the returned geometry is identical to the line geometry itself.
- Corrected the implementations of `FacesNumber` of class templates `Line2D4` and `Line2D5` (i.e. when calling member `FacesNumber`). They now both return 0, since a line geometry doesn't have any faces. Note that this implementation is in line with those of the other line geometries.
- Based on the above listed changes, a few unit tests had to be corrected. Furthermore, new unit tests have been added to cover the new code.
- Avoid duplication of documentation by using `@copydoc`, as suggested by @matekelemen.
- Use the modern way of defining type aliases. That is, occurrences of `typedef` have been replaced by `using`, as suggested by @matekelemen.
- Removed some duplicated comments.
