### PR TITLE
[Testing] Set `RPATH` of test executables

### DIFF
--- a/cmake_modules/KratosGTest.cmake
+++ b/cmake_modules/KratosGTest.cmake
@@ -24,11 +24,9 @@ macro(kratos_add_gtests)
 
         add_executable("${KRATOS_ADD_GTEST_TARGET}Test" ${KRATOS_ADD_GTEST_SOURCES} ${KRATOS_GTEST_MAIN_SOURCE})
         target_link_libraries("${KRATOS_ADD_GTEST_TARGET}Test" ${KRATOS_ADD_GTEST_TARGET} KratosCoreTestUtilities "${TESTING_MPI_UTILITIES}" GTest::gmock_main)
-        set_target_properties("${KRATOS_ADD_GTEST_TARGET}Test" PROPERTIES COMPILE_DEFINITIONS "KRATOS_TEST_CORE=IMPORT,API")
-
-        # Copy the RPATH of core tests that point to the kratos libs.
-        get_target_property(kratos_core_test_rpath KratosCoreTest INSTALL_RPATH)
-        set_target_properties(${KRATOS_ADD_GTEST_TARGET}Test PROPERTIES INSTALL_RPATH "${kratos_core_test_rpath}")
+        set_target_properties("${KRATOS_ADD_GTEST_TARGET}Test" PROPERTIES
+                              COMPILE_DEFINITIONS "KRATOS_TEST_CORE=IMPORT,API"
+                              INSTALL_RPATH "$ORIGIN/../libs")
 
         target_compile_definitions("${KRATOS_ADD_GTEST_TARGET}Test" PUBLIC GTEST_LINKED_AS_SHARED_LIBRARY)
         install(TARGETS ${KRATOS_ADD_GTEST_TARGET}Test DESTINATION test)

--- a/cmake_modules/KratosGTest.cmake
+++ b/cmake_modules/KratosGTest.cmake
@@ -25,6 +25,11 @@ macro(kratos_add_gtests)
         add_executable("${KRATOS_ADD_GTEST_TARGET}Test" ${KRATOS_ADD_GTEST_SOURCES} ${KRATOS_GTEST_MAIN_SOURCE})
         target_link_libraries("${KRATOS_ADD_GTEST_TARGET}Test" ${KRATOS_ADD_GTEST_TARGET} KratosCoreTestUtilities "${TESTING_MPI_UTILITIES}" GTest::gmock_main)
         set_target_properties("${KRATOS_ADD_GTEST_TARGET}Test" PROPERTIES COMPILE_DEFINITIONS "KRATOS_TEST_CORE=IMPORT,API")
+
+        # Copy the RPATH of core tests that point to the kratos libs.
+        get_target_property(kratos_core_test_rpath KratosCoreTest INSTALL_RPATH)
+        set_target_properties(${KRATOS_ADD_GTEST_TARGET}Test PROPERTIES INSTALL_RPATH "${kratos_core_test_rpath}")
+
         target_compile_definitions("${KRATOS_ADD_GTEST_TARGET}Test" PUBLIC GTEST_LINKED_AS_SHARED_LIBRARY)
         install(TARGETS ${KRATOS_ADD_GTEST_TARGET}Test DESTINATION test)
 

--- a/kratos/CMakeLists.txt
+++ b/kratos/CMakeLists.txt
@@ -79,7 +79,9 @@ if(${KRATOS_BUILD_TESTING} MATCHES ON)
     target_link_libraries(KratosCoreTestUtilities KratosCore GTest::gtest GTest::gmock)
     set_target_properties(KratosCoreTestUtilities PROPERTIES COMPILE_DEFINITIONS "KRATOS_TEST_UTILS=IMPORT,API")
     target_link_libraries(KratosCoreTest PUBLIC KratosCoreTestUtilities GTest::gmock_main)
-    set_target_properties(KratosCoreTest PROPERTIES COMPILE_DEFINITIONS "KRATOS_TEST_CORE=IMPORT,API")
+    set_target_properties(KratosCoreTest PROPERTIES
+                          COMPILE_DEFINITIONS "KRATOS_TEST_CORE=IMPORT,API"
+                          INSTALL_RPATH "$ORIGIN/../libs")
 
     install(TARGETS KratosCoreTestUtilities DESTINATION libs)
     install(TARGETS KratosCoreTest DESTINATION test)


### PR DESCRIPTION
Right now, `run_cpp_tests.py` needs manual fiddling with `LD_LIBRARY_PATH` to run even though we know the directory structure we install to exactly.

This PR sets the `INSTALL_RPATH` of test executables to the library install path so we don't have to manually do it every time we run C++ tests.