### PR TITLE
[Core] Add methods to compute bounding boxes with tolerance to `SearchUtilities`

### DIFF
--- a/kratos/utilities/search_utilities.cpp
+++ b/kratos/utilities/search_utilities.cpp
@@ -48,6 +48,36 @@ void SearchUtilities::ComputeBoundingBoxesWithTolerance(
 /***********************************************************************************/
 /***********************************************************************************/
 
+void SearchUtilities::ComputeBoundingBoxesWithTolerance(
+    const std::vector<BoundingBox<Point>>& rBoundingBoxes,
+    const double Tolerance,
+    std::vector<BoundingBox<Point>>& rBoundingBoxesWithTolerance
+    )
+{
+    const SizeType size_vec = rBoundingBoxes.size();
+
+    if (rBoundingBoxesWithTolerance.size() != size_vec) {
+        rBoundingBoxesWithTolerance.resize(size_vec);
+    }
+
+    // Apply Tolerances
+    for (IndexType i = 0; i < size_vec; i++) {
+        const auto& r_bounding_box = rBoundingBoxes[i];
+        const auto& r_min_point = r_bounding_box.GetMinPoint();
+        const auto& r_max_point = r_bounding_box.GetMaxPoint();
+        auto& r_bb_with_tolerance = rBoundingBoxesWithTolerance[i];
+        auto& r_min_point_with_tolerance = r_bb_with_tolerance.GetMinPoint();
+        auto& r_max_point_with_tolerance = r_bb_with_tolerance.GetMaxPoint();
+        for (unsigned int j = 0; j < 3; ++j) {
+            r_min_point_with_tolerance[j] = r_min_point[j] - Tolerance;
+            r_max_point_with_tolerance[j] = r_max_point[j] + Tolerance;
+        }
+    }
+}
+
+/***********************************************************************************/
+/***********************************************************************************/
+
 void SearchUtilities::ComputeBoundingBoxesWithToleranceCheckingNullBB(
     const std::vector<double>& rBoundingBoxes,
     const double Tolerance,
@@ -73,6 +103,44 @@ void SearchUtilities::ComputeBoundingBoxesWithToleranceCheckingNullBB(
 
         for (IndexType i=1; i<size_vec; i+=2) {
             rBoundingBoxesWithTolerance[i] = rBoundingBoxes[i] - Tolerance;
+        }
+    }
+}
+
+/***********************************************************************************/
+/***********************************************************************************/
+
+void SearchUtilities::ComputeBoundingBoxesWithToleranceCheckingNullBB(
+    const std::vector<BoundingBox<Point>>& rBoundingBoxes,
+    const double Tolerance,
+    std::vector<BoundingBox<Point>>& rBoundingBoxesWithTolerance
+    )
+{
+    const SizeType size_vec = rBoundingBoxes.size();
+
+    if (rBoundingBoxesWithTolerance.size() != size_vec) {
+        rBoundingBoxesWithTolerance.resize(size_vec);
+    }
+
+    // Apply Tolerances if the BB is not null
+    const double zero_tolerance = std::numeric_limits<double>::epsilon();
+    const auto& r_first_bb = rBoundingBoxes[0];
+    const auto& r_first_bb_min_point = r_first_bb.GetMinPoint();
+    const auto& r_first_bb_max_point = r_first_bb.GetMaxPoint();
+    if (std::abs(r_first_bb_max_point[0] - r_first_bb_min_point[0]) > zero_tolerance && 
+        std::abs(r_first_bb_max_point[1] - r_first_bb_min_point[1]) > zero_tolerance &&
+        std::abs(r_first_bb_max_point[2] - r_first_bb_min_point[2]) > zero_tolerance) {
+        for (IndexType i = 0; i < size_vec; i++) {
+            const auto& r_bounding_box = rBoundingBoxes[i];
+            const auto& r_min_point = r_bounding_box.GetMinPoint();
+            const auto& r_max_point = r_bounding_box.GetMaxPoint();
+            auto& r_bb_with_tolerance = rBoundingBoxesWithTolerance[i];
+            auto& r_min_point_with_tolerance = r_bb_with_tolerance.GetMinPoint();
+            auto& r_max_point_with_tolerance = r_bb_with_tolerance.GetMaxPoint();
+            for (unsigned int j = 0; j < 3; ++j) {
+                r_min_point_with_tolerance[j] = r_min_point[j] - Tolerance;
+                r_max_point_with_tolerance[j] = r_max_point[j] + Tolerance;
+            }
         }
     }
 }

--- a/kratos/utilities/search_utilities.h
+++ b/kratos/utilities/search_utilities.h
@@ -261,6 +261,18 @@ public:
         );
 
     /**
+     * @brief Compute the bounding boxes of the given bounding boxes from a given tolerance
+     * @param rBoundingBoxes The bounding boxes
+     * @param Tolerance The tolerance
+     * @param rBoundingBoxesWithTolerance The resulting bounding boxes with the applied tolerance
+     */
+    static void ComputeBoundingBoxesWithTolerance(
+        const std::vector<BoundingBox<Point>>& rBoundingBoxes,
+        const double Tolerance,
+        std::vector<BoundingBox<Point>>& rBoundingBoxesWithTolerance
+        );
+
+    /**
      * @brief Compute the bounding boxes of the given bounding boxes from a given tolerance, additionally checking if the bounding boxes are initialized
      * @details This method is used when the bounding boxes are not initialized
      * @param rBoundingBoxes The bounding boxes
@@ -271,6 +283,19 @@ public:
         const std::vector<double>& rBoundingBoxes,
         const double Tolerance,
         std::vector<double>& rBoundingBoxesWithTolerance
+        );
+
+    /**
+     * @brief Compute the bounding boxes of the given bounding boxes from a given tolerance, additionally checking if the bounding boxes are initialized
+     * @details This method is used when the bounding boxes are not initialized
+     * @param rBoundingBoxes The bounding boxes
+     * @param Tolerance The tolerance
+     * @param rBoundingBoxesWithTolerance The resulting bounding boxes with the applied tolerance
+     */
+    static void ComputeBoundingBoxesWithToleranceCheckingNullBB(
+        const std::vector<BoundingBox<Point>>& rBoundingBoxes,
+        const double Tolerance,
+        std::vector<BoundingBox<Point>>& rBoundingBoxesWithTolerance
         );
 
     /**


### PR DESCRIPTION
**📝 Description**

Add methods to compute bounding boxes with tolerance to `SearchUtilities`.

**🆕 Changelog**

- [Add methods to compute bounding boxes with tolerance](https://github.com/KratosMultiphysics/Kratos/commit/0bddfc107851ae65a0b55041de92505b357867df)
