### PR TITLE
[CORE] Adding new RBF types in the RBFShapeFunctionsUtility class

### DIFF
--- a/kratos/python/add_geometrical_utilities_to_python.cpp
+++ b/kratos/python/add_geometrical_utilities_to_python.cpp
@@ -468,7 +468,14 @@ void AddGeometricalUtilitiesToPython(pybind11::module &m)
         .def_static("CalculateShapeFunctionsAndGradients", &AuxiliaryCalculateMLSShapeFunctionsAndGradients)
         ;
 
-    // Radial Basis FUnctions utility
+    // Radial Basis Functions utility
+    py::enum_<RBFShapeFunctionsUtility::RBFType>(m, "RBFType")
+        .value("InverseMultiquadric", RBFShapeFunctionsUtility::RBFType::InverseMultiquadric)
+        .value("Multiquadric",        RBFShapeFunctionsUtility::RBFType::Multiquadric)
+        .value("Gaussian",            RBFShapeFunctionsUtility::RBFType::Gaussian)
+        .value("ThinPlateSpline",     RBFShapeFunctionsUtility::RBFType::ThinPlateSpline)
+        .value("WendlandC2",          RBFShapeFunctionsUtility::RBFType::WendlandC2);
+
     using DenseQRPointerType = typename RBFShapeFunctionsUtility::DenseQRPointerType;
     py::class_<RBFShapeFunctionsUtility>(m,"RBFShapeFunctionsUtility")
         .def_static("CalculateShapeFunctions", [](const Matrix& rPoints, const array_1d<double,3>& rX, Vector& rN){
@@ -479,7 +486,12 @@ void AddGeometricalUtilitiesToPython(pybind11::module &m)
             return RBFShapeFunctionsUtility::CalculateShapeFunctions(rPoints, rX, h, rN);})
         .def_static("CalculateShapeFunctions", [](const Matrix& rPoints, const array_1d<double,3>& rX, const double h, Vector& rN, DenseQRPointerType pDenseQR){
             return RBFShapeFunctionsUtility::CalculateShapeFunctions(rPoints, rX, h, rN, pDenseQR);})
-        ;
+        .def_static("CalculateShapeFunctions",[](const Matrix& rPoints, const array_1d<double,3>& rX, Vector& rN, DenseQRPointerType pDenseQR, RBFShapeFunctionsUtility::RBFType rbf_type){
+            return RBFShapeFunctionsUtility::CalculateShapeFunctions(rPoints, rX, rN, pDenseQR, rbf_type);
+        })
+        .def_static("CalculateShapeFunctions",[](const Matrix& rPoints, const array_1d<double,3>& rX, const double h, Vector& rN, DenseQRPointerType pDenseQR, RBFShapeFunctionsUtility::RBFType rbf_type){
+            return RBFShapeFunctionsUtility::CalculateShapeFunctions(rPoints, rX, h, rN, pDenseQR, rbf_type);
+        });
 
     // Radial Node Search and MasterSlaveConstraints Assignation Utility
     using NodesContainerType = typename AssignMasterSlaveConstraintsToNeighboursUtility::NodesContainerType;

--- a/kratos/utilities/rbf_shape_functions_utility.cpp
+++ b/kratos/utilities/rbf_shape_functions_utility.cpp
@@ -141,7 +141,6 @@ namespace Kratos
 
         // Initialize the RBF interpolation matrix and RBF interpolated vector
         Matrix A = ZeroMatrix(n_points,n_points);
-        double norm_xij;
 
         // Build the RBF interpolation matrix and RBF interpolated vector
         switch (RBFType) {

--- a/kratos/utilities/rbf_shape_functions_utility.cpp
+++ b/kratos/utilities/rbf_shape_functions_utility.cpp
@@ -21,18 +21,37 @@
 
 namespace Kratos
 {
-
     double RBFShapeFunctionsUtility::EvaluateRBF(
         const double x,
-        const double h)
+        const double h,
+        RBFType rbf_type)
     {
-        // Evaluate Inverse multiquadric
-        const double q = x*h;
-        return 1/std::sqrt(1+std::pow(q,2));
-
-        // Evaluate Gaussian function
-        // const double q = x/h;
-        // return std::exp(-0.5*std::pow(q,2));
+         switch (rbf_type)
+        {
+            case RBFType::InverseMultiquadric: {
+                const double q = x * h;
+                return 1.0 / std::sqrt(1.0 + q*q);
+            }
+            case RBFType::Multiquadric: {
+                const double q = x / h;
+                return std::sqrt(1.0 + q*q);
+            }
+            case RBFType::Gaussian: {
+                const double q = x / h;
+                return std::exp(-0.5 * q*q);
+            }
+            case RBFType::ThinPlateSpline: {
+                if (std::abs(x) < 1.0e-12) return 0.0;
+                return x*x * std::log(x*x);
+            }
+            case RBFType::WendlandC2: {
+                const double q = x / h;
+                if (q < 1.0) return std::pow(1.0 - q, 4) * (4.0*q + 1.0);
+                return 0.0;
+            }
+            default:
+                throw std::runtime_error("Unrecognized RBF type");
+        }
     }
 
     void RBFShapeFunctionsUtility::CalculateShapeFunctions(
@@ -59,11 +78,11 @@ namespace Kratos
         // Build the RBF interpolation matrix and RBF interpolated vector
         for (std::size_t i_pt = 0; i_pt < n_points; ++i_pt) {
             for (std::size_t j_pt = 0; j_pt < n_points; ++j_pt) {
-                const double norm_xij = norm_2(row(rPoints,i_pt)-row(rPoints,j_pt));
-                A(i_pt,j_pt) = EvaluateRBF(norm_xij,h);
+                const double norm_xij = norm_2(row(rPoints,i_pt) - row(rPoints,j_pt));
+                A(i_pt,j_pt) = EvaluateRBF(norm_xij,h, RBFShapeFunctionsUtility::RBFType::InverseMultiquadric);
             }
-            const double norm_X =  norm_2(rX-row(rPoints,i_pt));
-            Phi[i_pt] = EvaluateRBF(norm_X,h);
+            const double norm_X =  norm_2(rX - row(rPoints,i_pt));
+            Phi[i_pt] = EvaluateRBF(norm_X, h, RBFShapeFunctionsUtility::RBFType::InverseMultiquadric);
         }
 
         // Obtain the RBF shape functions (N)
@@ -122,7 +141,7 @@ namespace Kratos
         for (std::size_t i_pt = 0; i_pt < n_points; ++i_pt) {
             for (std::size_t j_pt = 0; j_pt < n_points; ++j_pt) {
                 norm_xij = norm_2(row(rPoints,i_pt)-row(rPoints,j_pt));
-                A(i_pt,j_pt) = EvaluateRBF(norm_xij,h);
+                A(i_pt,j_pt) = EvaluateRBF(norm_xij, h, RBFShapeFunctionsUtility::RBFType::InverseMultiquadric);
             }
         }
 
@@ -134,7 +153,7 @@ namespace Kratos
         // Interpolate solution
         for (std::size_t i_pt = 0; i_pt < n_points; ++i_pt) {
             const double norm_xi = norm_2(rX-row(rPoints,i_pt));
-            const double Phi = EvaluateRBF(norm_xi,h);
+            const double Phi = EvaluateRBF(norm_xi, h, RBFShapeFunctionsUtility::RBFType::InverseMultiquadric);
             interpolation += Phi*rN[i_pt];
         }
 
@@ -164,6 +183,27 @@ namespace Kratos
         d /= n_points;
         KRATOS_ERROR_IF(d < 1.0e-12) << "Nearest neighbours distance is close to zero. Check that the cloud points are not overlapping." << std::endl;
         return 1/(0.815*d);// Shape parameter (Only for inverted multiquadratic)
+    }
+
+    // Extracted from: Review of coupling methods for non-matching meshes (https://doi.org/10.1016/j.cma.2006.03.017)
+    double RBFShapeFunctionsUtility::CalculateWendlandC2SupportRadius(const Matrix& rPoints, const double k = 2.5)
+    {
+        const std::size_t n_points = rPoints.size1();
+        KRATOS_ERROR_IF(n_points < 2) << "At least two points are required to estimate spacing." << std::endl;
+
+        double total_distance = 0.0;
+        std::size_t count = 0;
+
+        for (std::size_t i = 0; i < n_points; ++i) {
+            for (std::size_t j = i + 1; j < n_points; ++j) {
+                const double distance = norm_2(row(rPoints, i) - row(rPoints, j));
+                total_distance += distance;
+                ++count;
+            }
+        }
+
+        const double average_spacing = total_distance / count;
+        return k * average_spacing; // Support radius for Wendland C2
     }
 
 }  // namespace Kratos.

--- a/kratos/utilities/rbf_shape_functions_utility.h
+++ b/kratos/utilities/rbf_shape_functions_utility.h
@@ -132,7 +132,7 @@ public:
         const double h,
         Vector& rN,
         DenseQRPointerType pDenseQR = nullptr,
-        const RBFType rbf_type = RBFType::InverseMultiquadric);
+        const RBFType RBFType = RBFType::InverseMultiquadric);
 
     /**
      * @brief Calculates the RBF shape function values
@@ -147,7 +147,7 @@ public:
         const array_1d<double,3>& rX,
         Vector& rN,
         DenseQRPointerType pDenseQR = nullptr,
-        const RBFType rbf_type = RBFType::InverseMultiquadric);
+        const RBFType RBFType = RBFType::InverseMultiquadric);
 
     /**
      * @brief Calculates the RBF shape function values
@@ -165,7 +165,7 @@ public:
         const double h,
         Vector& rN,
         Vector& rY,
-        const RBFType rbf_type = RBFType::InverseMultiquadric);
+        const RBFType RBFType = RBFType::InverseMultiquadric);
 
     static double CalculateInverseMultiquadricShapeParameter(const Matrix& rPoints);
 
@@ -220,19 +220,6 @@ private:
 
         return h;
     }
-
-    static std::function<double(double)> CreatePhi(const RBFType type, const double h) {
-        switch (type) {
-            case RBFType::InverseMultiquadric: { InverseMultiquadric f{h}; return [f](double r){return f(r);}; }
-            case RBFType::Multiquadric:       { Multiquadric f{h};       return [f](double r){return f(r);}; }
-            case RBFType::Gaussian:           { Gaussian f{h};           return [f](double r){return f(r);}; }
-            case RBFType::ThinPlateSpline:    { ThinPlateSpline f{};     return [f](double r){return f(r);}; }
-            case RBFType::WendlandC2:         { WendlandC2 f{h};         return [f](double r){return f(r);}; }
-        }
-        InverseMultiquadric f{h};
-        return [f](double r){return f(r);};
-    }
-
     ///@}
 };
 

--- a/kratos/utilities/rbf_shape_functions_utility.h
+++ b/kratos/utilities/rbf_shape_functions_utility.h
@@ -69,17 +69,53 @@ public:
     ///@name Operations
     ///@{
 
-    /**
-     * @brief Calculate the RBF value
-     * This function evaluates the Gaussian RBF for a norm
-     * @param x Norm of RBF argument (i.e. norm of radial vector)
-     * @param h Gaussian radius
-     * @return double The RBF value
-     */
-    static double EvaluateRBF(
-        const double x,
-        const double h,
-        RBFType rbf_type);
+    /// Inverse Multiquadric RBF
+    struct InverseMultiquadric{
+        double h;                      
+        double operator()(double r) const {
+            const double q = h * r;
+            return 1.0 / std::sqrt(1.0 + q * q);
+        }
+    };
+
+    /// Multiquadric RBF
+    struct Multiquadric{
+        double h;                      
+        double operator()(double r) const {
+            const double q = r / h;
+            return std::sqrt(1.0 + q * q);
+        }
+    };
+
+    /// Gaussian RBF
+    struct Gaussian{
+        double h;                      
+        double operator()(double r) const {
+            const double q = r / h;
+            return std::exp(-0.5 * q * q);
+        }
+    };
+
+    /// Thin Plate Spline RBF
+    struct ThinPlateSpline {
+        double operator()(double r) const {
+            if (r < 1.0e-12)
+                return 0.0; 
+            const double r2 = r * r;
+            return r2 * std::log(r2);
+        }
+    };
+
+    /// Wendland C2 RBF
+    struct WendlandC2 {
+        double h;                      
+        double operator()(double r) const {
+            const double q = r / h;
+            if (q >= 1.0)
+                return 0.0;
+            return std::pow(1.0 - q, 4) * (4.0 * q + 1.0); // (1-q)^4 * (4q+1)
+        }
+    };
 
     /**
      * @brief Calculates the RBF shape function values

--- a/kratos/utilities/rbf_shape_functions_utility.h
+++ b/kratos/utilities/rbf_shape_functions_utility.h
@@ -7,7 +7,7 @@
 //  License:		 BSD License
 //					 Kratos default license: kratos/license.txt
 //
-//  Main authors:    Sebastian Ares de Parga
+//  Main authors:    Sebastian Ares de Parga, Juan I. Camarotti
 //
 
 #if !defined(KRATOS_rbf_shape_functions_utility_H_INCLUDED)
@@ -49,6 +49,14 @@ public:
     /// Kratos core QR decomposition type
     using KratosCoreQRType = DenseHouseholderQRDecomposition<DenseSpace>;
 
+    enum class RBFType {
+        InverseMultiquadric,
+        Multiquadric,
+        Gaussian,
+        ThinPlateSpline,
+        WendlandC2
+    };
+
     ///@}
     ///@name Life Cycle
     ///@{
@@ -70,7 +78,8 @@ public:
      */
     static double EvaluateRBF(
         const double x,
-        const double h);
+        const double h,
+        RBFType rbf_type);
 
     /**
      * @brief Calculates the RBF shape function values
@@ -119,14 +128,16 @@ public:
         Vector& rN,
         Vector& rY);
 
+    static double CalculateInverseMultiquadricShapeParameter(const Matrix& rPoints);
+
+    static double CalculateWendlandC2SupportRadius(const Matrix& rPoints, const double k);
+
     ///@}
 private:
     ///@name Unaccessible methods
     ///@{
 
     RBFShapeFunctionsUtility(){};
-
-    static double CalculateInverseMultiquadricShapeParameter(const Matrix& rPoints);
 
     ///@}
 };


### PR DESCRIPTION
**Description** 

This PR extends the `RBFShapeFunctionsUtility` class  to include several additional Radial Basis Function (RBF) formulations commonly used for interpolation and mapping in multi-physics applications (e.g., FSI coupling).

**Related PR** 
#13917 