### PR TITLE
[IGA] Fix refinement modeler

### DIFF
--- a/applications/IgaApplication/custom_modelers/refinement_modeler.cpp
+++ b/applications/IgaApplication/custom_modelers/refinement_modeler.cpp
@@ -92,7 +92,10 @@ namespace Kratos
                             PointsRefined, KnotsURefined, WeightsRefined);
 
                         // Recreate nodes in model part to ensure correct assignment of dofs
-                        IndexType node_id = (r_model_part.NodesEnd() - 1)->Id() + 1;
+                        VariableUtils().SetFlag(TO_ERASE, true, r_model_part.Nodes());
+                        r_model_part.RemoveNodesFromAllLevels(TO_ERASE);
+                        IndexType node_id = 1;
+
                         for (IndexType i = 0; i < PointsRefined.size(); ++i) {
                             if (PointsRefined(i)->Id() == 0) {
                                 PointsRefined(i) = r_model_part.CreateNewNode(node_id, PointsRefined[i][0], PointsRefined[i][1], PointsRefined[i][2]);
@@ -133,7 +136,10 @@ namespace Kratos
                             PointsRefined, KnotsVRefined, WeightsRefined);
 
                         // Recreate nodes in model part to ensure correct assignment of dofs
-                        IndexType node_id = (r_model_part.NodesEnd() - 1)->Id() + 1;
+                        VariableUtils().SetFlag(TO_ERASE, true, r_model_part.Nodes());
+                        r_model_part.RemoveNodesFromAllLevels(TO_ERASE);
+                        IndexType node_id = 1;
+
                         for (IndexType i = 0; i < PointsRefined.size(); ++i) {
                             if (PointsRefined(i)->Id() == 0) {
                                 PointsRefined(i) = r_model_part.CreateNewNode(node_id, PointsRefined[i][0], PointsRefined[i][1], PointsRefined[i][2]);
@@ -182,7 +188,10 @@ namespace Kratos
                             PointsRefined, KnotsURefined, WeightsRefined);
 
                         // Recreate nodes in model part to ensure correct assignment of dofs
-                        IndexType node_id = (r_model_part.NodesEnd() - 1)->Id() + 1;
+                        VariableUtils().SetFlag(TO_ERASE, true, r_model_part.Nodes());
+                        r_model_part.RemoveNodesFromAllLevels(TO_ERASE);
+                        IndexType node_id = 1;
+                        
                         for (IndexType i = 0; i < PointsRefined.size(); ++i) {
                             if (PointsRefined(i)->Id() == 0) {
                                 PointsRefined(i) = r_model_part.CreateNewNode(node_id, PointsRefined[i][0], PointsRefined[i][1], PointsRefined[i][2]);
@@ -231,7 +240,10 @@ namespace Kratos
                         PointsRefined, KnotsVRefined, WeightsRefined);
 
                     // Recreate nodes in model part to ensure correct assignment of dofs
-                    IndexType node_id = (r_model_part.NodesEnd() - 1)->Id() + 1;
+                    VariableUtils().SetFlag(TO_ERASE, true, r_model_part.Nodes());
+                    r_model_part.RemoveNodesFromAllLevels(TO_ERASE);
+                    IndexType node_id = 1;
+
                     for (IndexType i = 0; i < PointsRefined.size(); ++i) {
                         if (PointsRefined(i)->Id() == 0) {
                             PointsRefined(i) = r_model_part.CreateNewNode(node_id, PointsRefined[i][0], PointsRefined[i][1], PointsRefined[i][2]);

--- a/applications/IgaApplication/custom_modelers/refinement_modeler.h
+++ b/applications/IgaApplication/custom_modelers/refinement_modeler.h
@@ -23,6 +23,7 @@
 
 #include "geometries/nurbs_shape_function_utilities/nurbs_surface_refinement_utilities.h"
 #include "geometries/nurbs_surface_geometry.h"
+#include "utilities/variable_utils.h"
 
 namespace Kratos
 {

--- a/applications/IgaApplication/tests/modeler_tests/h_refinements.iga.json
+++ b/applications/IgaApplication/tests/modeler_tests/h_refinements.iga.json
@@ -5,7 +5,8 @@
       "geometry_type": "NurbsSurface",
       "model_part_name": "IgaModelPart",
       "parameters": {
-        "insert_nb_per_span_u": 2
+        "insert_nb_per_span_u": 2,
+        "insert_nb_per_span_v": 1
       }
     }
   ]

--- a/applications/IgaApplication/tests/modeler_tests/k_refinements.iga.json
+++ b/applications/IgaApplication/tests/modeler_tests/k_refinements.iga.json
@@ -1,0 +1,15 @@
+{
+  "refinements": [
+    {
+      "brep_ids": [ 1 ],
+      "geometry_type": "NurbsSurface",
+      "model_part_name": "IgaModelPart",
+      "parameters": {
+        "insert_nb_per_span_u": 2,
+        "insert_nb_per_span_v": 1,
+        "increase_degree_u": 1,
+        "increase_degree_v": 1
+      }
+    }
+  ]
+}

--- a/applications/IgaApplication/tests/modeler_tests/p_refinements.iga.json
+++ b/applications/IgaApplication/tests/modeler_tests/p_refinements.iga.json
@@ -1,0 +1,13 @@
+{
+  "refinements": [
+    {
+      "brep_ids": [ 1 ],
+      "geometry_type": "NurbsSurface",
+      "model_part_name": "IgaModelPart",
+      "parameters": {
+        "increase_degree_u": 1,
+        "increase_degree_v": 1
+      }
+    }
+  ]
+}

--- a/applications/IgaApplication/tests/test_modelers.py
+++ b/applications/IgaApplication/tests/test_modelers.py
@@ -67,7 +67,7 @@ class TestModelers(KratosUnittest.TestCase):
         self.assertEqual(support_2_Variation_model_part.GetNodes()[5].Id, 5)
         self.assertEqual(support_2_Variation_model_part.GetNodes()[6].Id, 6)
 
-    def test_RefinementModeler(self):
+    def test_RefinementModeler_mesh(self):
         current_model = KratosMultiphysics.Model()
         modelers_list = KratosMultiphysics.Parameters(
         """ [{
@@ -80,7 +80,7 @@ class TestModelers(KratosUnittest.TestCase):
             "modeler_name": "RefinementModeler",
             "Parameters": {
                 "echo_level":  0,
-                "refinements_file_name": "modeler_tests/refinements.iga.json"
+                "refinements_file_name": "modeler_tests/h_refinements.iga.json"
             } }] """ )
 
         run_modelers(current_model, modelers_list)
@@ -88,8 +88,56 @@ class TestModelers(KratosUnittest.TestCase):
         model_part = current_model.GetModelPart("IgaModelPart")
 
         # Check if all needed node are within the model parts
-        self.assertEqual(model_part.NumberOfNodes(), 40)
-        self.assertEqual(model_part.GetGeometry(1).GetGeometryPart(KratosMultiphysics.Geometry.BACKGROUND_GEOMETRY_INDEX).PointsNumber(), 28)
+        self.assertEqual(model_part.NumberOfNodes(), 42)
+        self.assertEqual(model_part.GetGeometry(1).GetGeometryPart(KratosMultiphysics.Geometry.BACKGROUND_GEOMETRY_INDEX).PointsNumber(), 42)
+    
+    def test_RefinementModeler_polynomial(self):
+        current_model = KratosMultiphysics.Model()
+        modelers_list = KratosMultiphysics.Parameters(
+        """ [{
+            "modeler_name": "CadIoModeler",
+            "Parameters": {
+                "echo_level": 0,
+                "cad_model_part_name": "IgaModelPart",
+                "geometry_file_name": "modeler_tests/surface_geometry.cad.json"
+            } }, {
+            "modeler_name": "RefinementModeler",
+            "Parameters": {
+                "echo_level":  0,
+                "refinements_file_name": "modeler_tests/p_refinements.iga.json"
+            } }] """ )
+
+        run_modelers(current_model, modelers_list)
+
+        model_part = current_model.GetModelPart("IgaModelPart")
+
+        # Check if all needed node are within the model parts
+        self.assertEqual(model_part.NumberOfNodes(), 30)
+        self.assertEqual(model_part.GetGeometry(1).GetGeometryPart(KratosMultiphysics.Geometry.BACKGROUND_GEOMETRY_INDEX).PointsNumber(), 30)
+    
+    def test_RefinementModeler_both(self):
+        current_model = KratosMultiphysics.Model()
+        modelers_list = KratosMultiphysics.Parameters(
+        """ [{
+            "modeler_name": "CadIoModeler",
+            "Parameters": {
+                "echo_level": 0,
+                "cad_model_part_name": "IgaModelPart",
+                "geometry_file_name": "modeler_tests/surface_geometry.cad.json"
+            } }, {
+            "modeler_name": "RefinementModeler",
+            "Parameters": {
+                "echo_level":  0,
+                "refinements_file_name": "modeler_tests/k_refinements.iga.json"
+            } }] """ )
+
+        run_modelers(current_model, modelers_list)
+
+        model_part = current_model.GetModelPart("IgaModelPart")
+
+        # Check if all needed node are within the model parts
+        self.assertEqual(model_part.NumberOfNodes(), 72)
+        self.assertEqual(model_part.GetGeometry(1).GetGeometryPart(KratosMultiphysics.Geometry.BACKGROUND_GEOMETRY_INDEX).PointsNumber(), 72)
 
     def test_nurbs_geometry_2d_modeler_control_points(self):
         current_model = KratosMultiphysics.Model()


### PR DESCRIPTION
**📝 Description**
This PR resolves an issue in the IGA refinement modeler where existing nodes were not removed from the model part after refinement. As a result, the model contained redundant nodes, and the `Ids` of newly created nodes continued from the old numbering. This fix ensures that outdated nodes are properly removed and new nodes receive consistent and correct `Ids` values.

Additional tests for the refinement modeler have also been added.

CC: @juancamarotti 
