### PR TITLE
[GeoMechanicsApplication] Fixed some issues in the constitutive laws

### DIFF
--- a/applications/GeoMechanicsApplication/custom_constitutive/coulomb_with_tension_cut_off_impl.cpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/coulomb_with_tension_cut_off_impl.cpp
@@ -111,8 +111,7 @@ bool CoulombWithTensionCutOffImpl::IsAdmissibleSigmaTau(const Vector& rTrialSigm
     return coulomb_yield_function_value < coulomb_tolerance && tension_yield_function_value < tension_tolerance;
 }
 
-Vector CoulombWithTensionCutOffImpl::DoReturnMapping(const Properties& rProperties,
-                                                     const Vector&     rTrialSigmaTau,
+Vector CoulombWithTensionCutOffImpl::DoReturnMapping(const Vector& rTrialSigmaTau,
                                                      CoulombYieldSurface::CoulombAveragingType AveragingType) const
 {
     const auto apex = CalculateApex(mCoulombYieldSurface.GetFrictionAngleInRadians(),

--- a/applications/GeoMechanicsApplication/custom_constitutive/coulomb_with_tension_cut_off_impl.h
+++ b/applications/GeoMechanicsApplication/custom_constitutive/coulomb_with_tension_cut_off_impl.h
@@ -31,8 +31,7 @@ public:
     explicit CoulombWithTensionCutOffImpl(const Properties& rMaterialProperties);
 
     [[nodiscard]] bool   IsAdmissibleSigmaTau(const Vector& rTrialSigmaTau) const;
-    [[nodiscard]] Vector DoReturnMapping(const Properties& rProperties,
-                                         const Vector&     rTrialSigmaTau,
+    [[nodiscard]] Vector DoReturnMapping(const Vector& rTrialSigmaTau,
                                          CoulombYieldSurface::CoulombAveragingType AveragingType) const;
 
 private:

--- a/applications/GeoMechanicsApplication/custom_constitutive/coulomb_yield_surface.cpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/coulomb_yield_surface.cpp
@@ -88,8 +88,8 @@ CoulombYieldSurface::CoulombYieldSurface()
     InitializeKappaDependentFunctions();
 }
 
-CoulombYieldSurface::CoulombYieldSurface(Properties MaterialProperties)
-    : mMaterialProperties{std::move(MaterialProperties)}
+CoulombYieldSurface::CoulombYieldSurface(const Properties& rMaterialProperties)
+    : mMaterialProperties{rMaterialProperties}
 {
     // For backward compatibility, if no hardening type is given, we assume no hardening at all
     if (!mMaterialProperties.Has(GEO_COULOMB_HARDENING_TYPE)) {

--- a/applications/GeoMechanicsApplication/custom_constitutive/coulomb_yield_surface.h
+++ b/applications/GeoMechanicsApplication/custom_constitutive/coulomb_yield_surface.h
@@ -58,7 +58,6 @@ private:
     KappaDependentFunction mFrictionAngleCalculator;
     KappaDependentFunction mCohesionCalculator;
     KappaDependentFunction mDilatancyAngleCalculator;
-
 }; // Class CoulombYieldSurface
 
 } // namespace Kratos

--- a/applications/GeoMechanicsApplication/custom_constitutive/coulomb_yield_surface.h
+++ b/applications/GeoMechanicsApplication/custom_constitutive/coulomb_yield_surface.h
@@ -36,7 +36,7 @@ public:
     };
 
     CoulombYieldSurface();
-    explicit CoulombYieldSurface(Properties MaterialProperties);
+    explicit CoulombYieldSurface(const Properties& rMaterialProperties);
 
     [[nodiscard]] double GetFrictionAngleInRadians() const;
     [[nodiscard]] double GetCohesion() const;

--- a/applications/GeoMechanicsApplication/custom_constitutive/interface_coulomb_with_tension_cut_off.cpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/interface_coulomb_with_tension_cut_off.cpp
@@ -139,7 +139,7 @@ void InterfaceCoulombWithTensionCutOff::CalculateMaterialResponseCauchy(Paramete
 
     if (!mCoulombWithTensionCutOffImpl.IsAdmissibleSigmaTau(trial_sigma_tau)) {
         mapped_sigma_tau = mCoulombWithTensionCutOffImpl.DoReturnMapping(
-            r_properties, trial_sigma_tau, CoulombYieldSurface::CoulombAveragingType::NO_AVERAGING);
+            trial_sigma_tau, CoulombYieldSurface::CoulombAveragingType::NO_AVERAGING);
         if (negative) mapped_sigma_tau[1] *= -1.0;
     }
 

--- a/applications/GeoMechanicsApplication/custom_constitutive/mohr_coulomb_with_tension_cutoff.cpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/mohr_coulomb_with_tension_cutoff.cpp
@@ -209,7 +209,7 @@ void MohrCoulombWithTensionCutOff::CalculateMaterialResponseCauchy(ConstitutiveL
         mStressVector = trial_stress_vector;
     } else {
         auto mapped_sigma_tau = mCoulombWithTensionCutOffImpl.DoReturnMapping(
-            r_properties, trial_sigma_tau, CoulombYieldSurface::CoulombAveragingType::NO_AVERAGING);
+            trial_sigma_tau, CoulombYieldSurface::CoulombAveragingType::NO_AVERAGING);
         auto mapped_principal_stress_vector = StressStrainUtilities::TransformSigmaTauToPrincipalStresses(
             mapped_sigma_tau, principal_trial_stress_vector);
 
@@ -221,8 +221,7 @@ void MohrCoulombWithTensionCutOff::CalculateMaterialResponseCauchy(ConstitutiveL
                 AveragePrincipalStressComponents(principal_trial_stress_vector, averaging_type);
             trial_sigma_tau = StressStrainUtilities::TransformPrincipalStressesToSigmaTau(
                 averaged_principal_trial_stress_vector);
-            mapped_sigma_tau = mCoulombWithTensionCutOffImpl.DoReturnMapping(
-                r_properties, trial_sigma_tau, averaging_type);
+            mapped_sigma_tau = mCoulombWithTensionCutOffImpl.DoReturnMapping(trial_sigma_tau, averaging_type);
             mapped_principal_stress_vector = StressStrainUtilities::TransformSigmaTauToPrincipalStresses(
                 mapped_sigma_tau, averaged_principal_trial_stress_vector);
             mapped_principal_stress_vector[1] =

--- a/applications/GeoMechanicsApplication/custom_constitutive/windows.hpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/windows.hpp
@@ -1,8 +1,8 @@
-// including windows.h adds some undesirable macros. Here, min and max macros are deactivated.
+// including Windows.h adds some undesirable macros. Here, min and max macros are deactivated.
 #ifdef NOMINMAX
-#include <windows.h>
+#include <Windows.h>
 #else
 #define NOMINMAX
-#include <windows.h>
+#include <Windows.h>
 #undef NOMINMAX
 #endif


### PR DESCRIPTION
**📝 Description**
This PR resolves some issues in the constitutive laws of GeoMechanicsApplication that were found by SonarQube.

**🆕 Changelog**
- Removed an unused function parameter.
- Pass a `Properties` instance by reference-to-const rather than by value to a constructor, since a `Properties` instance cannot be moved (when attempting to move it, it will be copied).
- Removed a redundant blank line.
- Corrected the case of a filename of a Windows-only header.

Note that the issues regarding move operations need to be resolved separately, since they require changes in the Kratos Core.