### PR TITLE
[Core] Fix `FallbackLinearSolver` tests

### DIFF
--- a/kratos/tests/cpp_tests/linear_solvers/test_fallback_linear_solver.cpp
+++ b/kratos/tests/cpp_tests/linear_solvers/test_fallback_linear_solver.cpp
@@ -98,6 +98,7 @@ KRATOS_TEST_CASE_IN_SUITE(FallbackLinearSolverConstructorSolvers, KratosCoreFast
     for (std::size_t i = 0; i < size; ++i) {
         A.push_back(i, i, 1.0);
     }
+    A.set_filled(size + 1, size);
     VectorType b(size);
     VectorType x(size);
 
@@ -124,6 +125,7 @@ KRATOS_TEST_CASE_IN_SUITE(FallbackLinearSolverConstructorParameters, KratosCoreF
     for (std::size_t i = 0; i < size; ++i) {
         A.push_back(i, i, 1.0);
     }
+    A.set_filled(size + 1, size);
     VectorType b(size);
     VectorType x(size);
 

--- a/kratos/tests/cpp_tests/linear_solvers/test_fallback_linear_solver.cpp
+++ b/kratos/tests/cpp_tests/linear_solvers/test_fallback_linear_solver.cpp
@@ -87,7 +87,8 @@ KRATOS_TEST_CASE_IN_SUITE(FallbackLinearSolverConstructorSolvers, KratosCoreFast
     // Create the solvers
     auto p_solver1 = Kratos::make_shared<DummyLinearSolverType>();
     Parameters amgcl_parameters = Parameters(R"({
-        "solver_type": "amgcl"
+        "solver_type": "amgcl",
+        "block_size" : 3
     })");
     auto p_solver2 = LinearSolverFactoryType().Create(amgcl_parameters);
 
@@ -134,7 +135,8 @@ KRATOS_TEST_CASE_IN_SUITE(FallbackLinearSolverConstructorParameters, KratosCoreF
         "solver_type": "fallback_linear_solver",
         "solvers"    : [
             {
-                "solver_type": "amgcl"
+                "solver_type": "amgcl",
+                "block_size" : 3
             },
             {
                 "solver_type": "skyline_lu_factorization"


### PR DESCRIPTION
~~LHS matrices were left in an invalid state after inserting elements into them, leading to randomly failed tests (e.g. in #13955).~~

This wasn't the problem, but #13624 introducing a slight behavior change. Namely, if
- `"block_size"` wasn't explicitly specified AND
- `ProvideAdditionalData` was never called

=> the solver defaults to a `"block_size"` of `1`, when before #13624 it defaulted to `3`.