### PR TITLE
[GeoMechanicsApplication] Omit objects when calling a few static functions

### DIFF
--- a/applications/GeoMechanicsApplication/custom_conditions/general_U_Pw_diff_order_condition.cpp
+++ b/applications/GeoMechanicsApplication/custom_conditions/general_U_Pw_diff_order_condition.cpp
@@ -128,7 +128,7 @@ void GeneralUPwDiffOrderCondition::CalculateAll(Vector& rRightHandSideVector, bo
         GetGeometry().IntegrationPoints(this->GetIntegrationMethod());
 
     for (unsigned int PointNumber = 0; PointNumber < IntegrationPoints.size(); PointNumber++) {
-        this->CalculateKinematics(Variables, PointNumber);
+        CalculateKinematics(Variables, PointNumber);
 
         this->CalculateConditionVector(Variables, PointNumber);
 

--- a/applications/GeoMechanicsApplication/custom_elements/small_strain_U_Pw_diff_order_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/small_strain_U_Pw_diff_order_element.cpp
@@ -859,7 +859,7 @@ Vector SmallStrainUPwDiffOrderElement::CalculateInternalForces(ElementVariables&
             rVariables.BiotModulusInverse     = rBiotModuliInverse[integration_point];
             rVariables.IntegrationCoefficient = rIntegrationCoefficients[integration_point];
 
-            this->CalculateAndAddCompressibilityFlow(result, rVariables);
+            CalculateAndAddCompressibilityFlow(result, rVariables);
         }
         for (unsigned int integration_point = 0;
              integration_point < rIntegrationCoefficients.size(); ++integration_point) {
@@ -867,7 +867,7 @@ Vector SmallStrainUPwDiffOrderElement::CalculateInternalForces(ElementVariables&
             rVariables.RelativePermeability   = rRelativePermeabilityValues[integration_point];
             rVariables.IntegrationCoefficient = rIntegrationCoefficients[integration_point];
 
-            this->CalculateAndAddPermeabilityFlow(result, rVariables);
+            CalculateAndAddPermeabilityFlow(result, rVariables);
         }
     }
 
@@ -1278,7 +1278,7 @@ void SmallStrainUPwDiffOrderElement::CalculateAndAddLHS(MatrixType&             
 {
     KRATOS_TRY
 
-    this->CalculateAndAddStiffnessMatrix(rLeftHandSideMatrix, rVariables);
+    CalculateAndAddStiffnessMatrix(rLeftHandSideMatrix, rVariables);
 
     this->CalculateAndAddCouplingMatrix(rLeftHandSideMatrix, rVariables);
 
@@ -1288,7 +1288,7 @@ void SmallStrainUPwDiffOrderElement::CalculateAndAddLHS(MatrixType&             
             rVariables.RelativePermeability, rVariables.IntegrationCoefficient);
         GeoElementUtilities::AssemblePPBlockMatrix(rLeftHandSideMatrix, permeability_matrix);
 
-        this->CalculateAndAddCompressibilityMatrix(rLeftHandSideMatrix, rVariables);
+        CalculateAndAddCompressibilityMatrix(rLeftHandSideMatrix, rVariables);
     }
 
     KRATOS_CATCH("")


### PR DESCRIPTION
**📝 Description**
In a previous PR several methods were made static, but some of the calls to these functions still were done using `this->FunctionName()`. That has been rectified here.
