### PR TITLE
[GeoMechanicsApplication] Extract tool for reversing geometry node ids

### DIFF
--- a/applications/GeoMechanicsApplication/custom_geometries/interface_geometry.h
+++ b/applications/GeoMechanicsApplication/custom_geometries/interface_geometry.h
@@ -308,8 +308,7 @@ private:
         // The second side is defined by the second half of the element nodes. However, the
         // nodes must be traversed in opposite direction.
         auto nodes_of_second_side = PointerVector<Node>{begin_of_second_side, points.ptr_end()};
-        GeometryUtilities::ReverseNodes(mMidGeometry->GetGeometryFamily(),
-                                        nodes_of_second_side.ptr_begin(), nodes_of_second_side.ptr_end());
+        GeometryUtilities::ReverseNodes(mMidGeometry->GetGeometryFamily(), nodes_of_second_side);
 
         auto result = GeometriesArrayType{};
         result.push_back(std::make_shared<MidGeometryType>(nodes_of_first_side));

--- a/applications/GeoMechanicsApplication/custom_geometries/interface_geometry.h
+++ b/applications/GeoMechanicsApplication/custom_geometries/interface_geometry.h
@@ -13,6 +13,7 @@
 
 #pragma once
 
+#include "custom_utilities/geometry_utilities.h"
 #include "geometries/geometry.h"
 #include "includes/node.h"
 
@@ -307,17 +308,8 @@ private:
         // The second side is defined by the second half of the element nodes. However, the
         // nodes must be traversed in opposite direction.
         auto nodes_of_second_side = PointerVector<Node>{begin_of_second_side, points.ptr_end()};
-        auto end_of_corner_points = nodes_of_second_side.ptr_begin() + GetNumberOfCornerPoints();
-
-        // For line geometries we want to reverse all 'corner points' of the second side, while
-        // for surfaces we don't change the starting node, but only reverse the order of the rest
-        // of the corner points.
-        auto begin_of_corner_points_to_reverse =
-            mMidGeometry->GetGeometryFamily() == GeometryData::KratosGeometryFamily::Kratos_Linear
-                ? nodes_of_second_side.ptr_begin()
-                : nodes_of_second_side.ptr_begin() + 1;
-        std::reverse(begin_of_corner_points_to_reverse, end_of_corner_points);
-        std::reverse(end_of_corner_points, nodes_of_second_side.ptr_end()); // any high-order nodes
+        GeometryUtilities::ReverseNodes(mMidGeometry->GetGeometryFamily(),
+                                        nodes_of_second_side.ptr_begin(), nodes_of_second_side.ptr_end());
 
         auto result = GeometriesArrayType{};
         result.push_back(std::make_shared<MidGeometryType>(nodes_of_first_side));

--- a/applications/GeoMechanicsApplication/custom_geometries/interface_geometry.h
+++ b/applications/GeoMechanicsApplication/custom_geometries/interface_geometry.h
@@ -317,21 +317,6 @@ private:
         return result;
     }
 
-    [[nodiscard]] std::size_t GetNumberOfCornerPoints() const
-    {
-        switch (mMidGeometry->GetGeometryFamily()) {
-            using enum GeometryData::KratosGeometryFamily;
-        case Kratos_Linear:
-            return 2;
-        case Kratos_Triangle:
-            return 3;
-        case Kratos_Quadrilateral:
-            return 4;
-        default:
-            KRATOS_ERROR << "The geometry family of the mid-geometry is not supported\n";
-        }
-    }
-
     std::unique_ptr<BaseType> mMidGeometry;
 };
 

--- a/applications/GeoMechanicsApplication/custom_geometries/interface_geometry.h
+++ b/applications/GeoMechanicsApplication/custom_geometries/interface_geometry.h
@@ -308,7 +308,8 @@ private:
         // The second side is defined by the second half of the element nodes. However, the
         // nodes must be traversed in opposite direction.
         auto nodes_of_second_side = PointerVector<Node>{begin_of_second_side, points.ptr_end()};
-        GeometryUtilities::ReverseNodes(mMidGeometry->GetGeometryFamily(), nodes_of_second_side);
+        GeometryUtilities::ReverseNodes(nodes_of_second_side, mMidGeometry->GetGeometryFamily(),
+                                        mMidGeometry->GetGeometryOrderType());
 
         auto result = GeometriesArrayType{};
         result.push_back(std::make_shared<MidGeometryType>(nodes_of_first_side));

--- a/applications/GeoMechanicsApplication/custom_utilities/geometry_utilities.cpp
+++ b/applications/GeoMechanicsApplication/custom_utilities/geometry_utilities.cpp
@@ -35,7 +35,7 @@ std::size_t GetNumberOfCornerPoints(GeometryData::KratosGeometryFamily GeometryF
     }
 }
 
-template <std::bidirectional_iterator InputIt>
+template <std::random_access_iterator InputIt>
 void ReverseNodes(GeometryData::KratosGeometryFamily GeometryFamily, InputIt Begin, InputIt End)
 {
     // For line geometries we want to reverse all 'corner points', while for surfaces we don't

--- a/applications/GeoMechanicsApplication/custom_utilities/geometry_utilities.cpp
+++ b/applications/GeoMechanicsApplication/custom_utilities/geometry_utilities.cpp
@@ -66,7 +66,7 @@ void ReverseNodes(InputIt                               Begin,
         GeometryFamily == GeometryData::KratosGeometryFamily::Kratos_Linear ? Begin : Begin + 1;
 
     const auto number_of_corner_points = GetNumberOfCornerPoints(GeometryFamily);
-    KRATOS_ERROR_IF(number_of_corner_points > std::distance(Begin, End))
+    KRATOS_ERROR_IF(static_cast<int>(number_of_corner_points) > std::distance(Begin, End))
         << "Number of nodes for reversal is too small for the geometry family and order type "
            "specified.\n";
     auto end_of_corner_points = Begin + number_of_corner_points;
@@ -77,7 +77,7 @@ void ReverseNodes(InputIt                               Begin,
         // For non-line geometries, there could be internal points as well, so we only reverse the
         // edge points here. For line geometries, all remaining points will be edge points.
         const auto number_of_edge_points = GetNumberOfEdgePoints(GeometryFamily, GeometryOrderType);
-        KRATOS_ERROR_IF(number_of_edge_points > std::distance(end_of_corner_points, End))
+        KRATOS_ERROR_IF(static_cast<int>(number_of_edge_points) > std::distance(end_of_corner_points, End))
             << "Number of nodes for reversal is too small for the geometry family and order type "
                "specified.\n";
         end_of_edge_points = end_of_corner_points + number_of_edge_points;

--- a/applications/GeoMechanicsApplication/custom_utilities/geometry_utilities.cpp
+++ b/applications/GeoMechanicsApplication/custom_utilities/geometry_utilities.cpp
@@ -70,19 +70,19 @@ void ReverseNodes(InputIt                               Begin,
         << "Number of nodes for reversal is too small for the geometry family and order type "
            "specified.\n";
     auto end_of_corner_points = Begin + number_of_corner_points;
-
-    const auto number_of_edge_points = GetNumberOfEdgePoints(GeometryFamily, GeometryOrderType);
-    // For line geometries, all remaining points are edge points, while for surfaces there could be
-    // internal points as well.
-    KRATOS_ERROR_IF(number_of_edge_points > std::distance(end_of_corner_points, End) && GeometryFamily != GeometryData::KratosGeometryFamily::Kratos_Linear)
-        << "Number of nodes for reversal is too small for the geometry family and order type "
-           "specified.\n";
-    auto end_of_edge_points =
-        GeometryFamily == GeometryData::KratosGeometryFamily::Kratos_Linear
-            ? End
-            : end_of_corner_points + number_of_edge_points;
-
     std::reverse(begin_of_corner_points, end_of_corner_points);
+
+    auto end_of_edge_points = End;
+    if (GeometryFamily != GeometryData::KratosGeometryFamily::Kratos_Linear) {
+        // For non-line geometries, there could be internal points as well, so we only reverse the
+        // edge points here. For line geometries, all remaining points will be edge points.
+        const auto number_of_edge_points = GetNumberOfEdgePoints(GeometryFamily, GeometryOrderType);
+        KRATOS_ERROR_IF(number_of_edge_points > std::distance(end_of_corner_points, End))
+            << "Number of nodes for reversal is too small for the geometry family and order type "
+               "specified.\n";
+        end_of_edge_points = end_of_corner_points + number_of_edge_points;
+    }
+
     std::reverse(end_of_corner_points, end_of_edge_points);
 }
 

--- a/applications/GeoMechanicsApplication/custom_utilities/geometry_utilities.cpp
+++ b/applications/GeoMechanicsApplication/custom_utilities/geometry_utilities.cpp
@@ -92,10 +92,18 @@ std::vector<std::size_t> GeometryUtilities::GetNodeIdsFromGeometry(const Geometr
 std::vector<std::size_t> GeometryUtilities::GetReversedNodeIdsForGeometryFamily(
     const GeometryData::KratosGeometryFamily& rGeometryFamily, const std::vector<std::size_t>& rInitialNodeIds)
 {
-    auto result               = rInitialNodeIds;
+    auto result = rInitialNodeIds;
+
+    // For line geometries we want to reverse all 'corner points', while for surfaces we don't
+    // change the starting node, but only reverse the order of the rest of the corner points.
+    auto begin_of_corner_points = rGeometryFamily == GeometryData::KratosGeometryFamily::Kratos_Linear
+                                      ? result.begin()
+                                      : result.begin() + 1;
     auto end_of_corner_points = result.begin() + GetNumberOfCornerPoints(rGeometryFamily);
-    std::reverse(result.begin(), end_of_corner_points);
+
+    std::reverse(begin_of_corner_points, end_of_corner_points);
     std::reverse(end_of_corner_points, result.end());
+
     return result;
 }
 

--- a/applications/GeoMechanicsApplication/custom_utilities/geometry_utilities.cpp
+++ b/applications/GeoMechanicsApplication/custom_utilities/geometry_utilities.cpp
@@ -37,7 +37,10 @@ std::size_t GetNumberOfCornerPoints(GeometryData::KratosGeometryFamily GeometryF
 }
 
 template <std::random_access_iterator InputIt>
-void ReverseNodes(GeometryData::KratosGeometryFamily GeometryFamily, InputIt Begin, InputIt End)
+void ReverseNodes(InputIt                               Begin,
+                  InputIt                               End,
+                  GeometryData::KratosGeometryFamily    GeometryFamily,
+                  GeometryData::KratosGeometryOrderType GeometryOrderType)
 {
     // For line geometries we want to reverse all 'corner points', while for surfaces we don't
     // change the starting node, but only reverse the order of the rest of the corner points.
@@ -104,15 +107,18 @@ std::vector<std::size_t> GeometryUtilities::GetNodeIdsFromGeometry(const Geometr
     return result;
 }
 
-void GeometryUtilities::ReverseNodes(GeometryData::KratosGeometryFamily GeometryFamily, PointerVector<Node>& rNodes)
+void GeometryUtilities::ReverseNodes(PointerVector<Node>&                  rNodes,
+                                     GeometryData::KratosGeometryFamily    GeometryFamily,
+                                     GeometryData::KratosGeometryOrderType GeometryOrderType)
 {
-    ::ReverseNodes(GeometryFamily, rNodes.ptr_begin(), rNodes.ptr_end());
+    ::ReverseNodes(rNodes.ptr_begin(), rNodes.ptr_end(), GeometryFamily, GeometryOrderType);
 }
 
-void GeometryUtilities::ReverseNodes(GeometryData::KratosGeometryFamily GeometryFamily,
-                                     std::vector<std::size_t>&          rNodeIds)
+void GeometryUtilities::ReverseNodes(std::vector<std::size_t>&             rNodeIds,
+                                     GeometryData::KratosGeometryFamily    GeometryFamily,
+                                     GeometryData::KratosGeometryOrderType GeometryOrderType)
 {
-    ::ReverseNodes(GeometryFamily, rNodeIds.begin(), rNodeIds.end());
+    ::ReverseNodes(rNodeIds.begin(), rNodeIds.end(), GeometryFamily, GeometryOrderType);
 }
 
 } // namespace Kratos

--- a/applications/GeoMechanicsApplication/custom_utilities/geometry_utilities.cpp
+++ b/applications/GeoMechanicsApplication/custom_utilities/geometry_utilities.cpp
@@ -93,7 +93,9 @@ std::vector<std::size_t> GeometryUtilities::GetReversedNodeIdsForGeometryFamily(
     const GeometryData::KratosGeometryFamily& rGeometryFamily, const std::vector<std::size_t>& rInitialNodeIds)
 {
     auto result = rInitialNodeIds;
-    std::reverse(result.begin(), result.begin() + GetNumberOfCornerPoints(rGeometryFamily));
+    auto end_of_corner_points  = result.begin() + GetNumberOfCornerPoints(rGeometryFamily);
+    std::reverse(result.begin(), end_of_corner_points);
+    std::reverse(end_of_corner_points, result.end());
     return result;
 }
 

--- a/applications/GeoMechanicsApplication/custom_utilities/geometry_utilities.cpp
+++ b/applications/GeoMechanicsApplication/custom_utilities/geometry_utilities.cpp
@@ -67,4 +67,12 @@ std::vector<std::size_t> GeometryUtilities::GetNodeIdsFromGeometry(const Geometr
     return result;
 }
 
+std::vector<std::size_t> GeometryUtilities::GetReversedNodeIdsForGeometryFamily(
+    const GeometryData::KratosGeometryFamily& rGeometryFamily, const std::vector<std::size_t>& rInitialNodeIds)
+{
+    auto result = rInitialNodeIds;
+    std::ranges::reverse(result);
+    return result;
+}
+
 } // namespace Kratos

--- a/applications/GeoMechanicsApplication/custom_utilities/geometry_utilities.cpp
+++ b/applications/GeoMechanicsApplication/custom_utilities/geometry_utilities.cpp
@@ -68,6 +68,11 @@ std::vector<std::size_t> GeometryUtilities::GetNodeIdsFromGeometry(const Geometr
     return result;
 }
 
+void GeometryUtilities::ReverseNodes(GeometryData::KratosGeometryFamily GeometryFamily, PointerVector<Node>& rNodes)
+{
+    ReverseNodes(GeometryFamily, rNodes.ptr_begin(), rNodes.ptr_end());
+}
+
 std::size_t GeometryUtilities::GetNumberOfCornerPoints(const GeometryData::KratosGeometryFamily& rGeometryFamily)
 {
     switch (rGeometryFamily) {

--- a/applications/GeoMechanicsApplication/custom_utilities/geometry_utilities.cpp
+++ b/applications/GeoMechanicsApplication/custom_utilities/geometry_utilities.cpp
@@ -15,27 +15,6 @@
 
 #include <boost/numeric/ublas/assignment.hpp>
 
-namespace
-{
-
-using namespace Kratos;
-
-[[nodiscard]] std::size_t GetNumberOfCornerPoints(const GeometryData::KratosGeometryFamily& rGeometryFamily)
-{
-    switch (rGeometryFamily) {
-        using enum GeometryData::KratosGeometryFamily;
-    case Kratos_Linear:
-        return 2;
-    case Kratos_Triangle:
-        return 3;
-    case Kratos_Quadrilateral:
-        return 4;
-    default:
-        KRATOS_ERROR << "The geometry family of the mid-geometry is not supported\n";
-    }
-}
-} // namespace
-
 namespace Kratos
 {
 
@@ -89,22 +68,19 @@ std::vector<std::size_t> GeometryUtilities::GetNodeIdsFromGeometry(const Geometr
     return result;
 }
 
-std::vector<std::size_t> GeometryUtilities::GetReversedNodeIdsForGeometryFamily(
-    const GeometryData::KratosGeometryFamily& rGeometryFamily, const std::vector<std::size_t>& rInitialNodeIds)
+std::size_t GeometryUtilities::GetNumberOfCornerPoints(const GeometryData::KratosGeometryFamily& rGeometryFamily)
 {
-    auto result = rInitialNodeIds;
-
-    // For line geometries we want to reverse all 'corner points', while for surfaces we don't
-    // change the starting node, but only reverse the order of the rest of the corner points.
-    auto begin_of_corner_points = rGeometryFamily == GeometryData::KratosGeometryFamily::Kratos_Linear
-                                      ? result.begin()
-                                      : result.begin() + 1;
-    auto end_of_corner_points = result.begin() + GetNumberOfCornerPoints(rGeometryFamily);
-
-    std::reverse(begin_of_corner_points, end_of_corner_points);
-    std::reverse(end_of_corner_points, result.end());
-
-    return result;
+    switch (rGeometryFamily) {
+        using enum GeometryData::KratosGeometryFamily;
+    case Kratos_Linear:
+        return 2;
+    case Kratos_Triangle:
+        return 3;
+    case Kratos_Quadrilateral:
+        return 4;
+    default:
+        KRATOS_ERROR << "The geometry family of the mid-geometry is not supported\n";
+    }
 }
 
 } // namespace Kratos

--- a/applications/GeoMechanicsApplication/custom_utilities/geometry_utilities.cpp
+++ b/applications/GeoMechanicsApplication/custom_utilities/geometry_utilities.cpp
@@ -35,7 +35,7 @@ std::size_t GetNumberOfCornerPoints(GeometryData::KratosGeometryFamily GeometryF
     }
 }
 
-template <typename InputIt>
+template <std::bidirectional_iterator InputIt>
 void ReverseNodes(GeometryData::KratosGeometryFamily GeometryFamily, InputIt Begin, InputIt End)
 {
     // For line geometries we want to reverse all 'corner points', while for surfaces we don't

--- a/applications/GeoMechanicsApplication/custom_utilities/geometry_utilities.cpp
+++ b/applications/GeoMechanicsApplication/custom_utilities/geometry_utilities.cpp
@@ -48,8 +48,7 @@ void ReverseNodes(GeometryData::KratosGeometryFamily GeometryFamily, InputIt Beg
     std::reverse(end_of_corner_points, End);
 }
 
-}
-
+} // namespace
 
 namespace Kratos
 {

--- a/applications/GeoMechanicsApplication/custom_utilities/geometry_utilities.cpp
+++ b/applications/GeoMechanicsApplication/custom_utilities/geometry_utilities.cpp
@@ -15,6 +15,42 @@
 
 #include <boost/numeric/ublas/assignment.hpp>
 
+namespace
+{
+
+using namespace Kratos;
+
+std::size_t GetNumberOfCornerPoints(GeometryData::KratosGeometryFamily GeometryFamily)
+{
+    switch (GeometryFamily) {
+        using enum GeometryData::KratosGeometryFamily;
+    case Kratos_Linear:
+        return 2;
+    case Kratos_Triangle:
+        return 3;
+    case Kratos_Quadrilateral:
+        return 4;
+    default:
+        KRATOS_ERROR << "The geometry family of the mid-geometry is not supported\n";
+    }
+}
+
+template <typename InputIt>
+void ReverseNodes(GeometryData::KratosGeometryFamily GeometryFamily, InputIt Begin, InputIt End)
+{
+    // For line geometries we want to reverse all 'corner points', while for surfaces we don't
+    // change the starting node, but only reverse the order of the rest of the corner points.
+    auto begin_of_corner_points =
+        GeometryFamily == GeometryData::KratosGeometryFamily::Kratos_Linear ? Begin : Begin + 1;
+    auto end_of_corner_points = Begin + GetNumberOfCornerPoints(GeometryFamily);
+
+    std::reverse(begin_of_corner_points, end_of_corner_points);
+    std::reverse(end_of_corner_points, End);
+}
+
+}
+
+
 namespace Kratos
 {
 
@@ -70,22 +106,13 @@ std::vector<std::size_t> GeometryUtilities::GetNodeIdsFromGeometry(const Geometr
 
 void GeometryUtilities::ReverseNodes(GeometryData::KratosGeometryFamily GeometryFamily, PointerVector<Node>& rNodes)
 {
-    ReverseNodes(GeometryFamily, rNodes.ptr_begin(), rNodes.ptr_end());
+    ::ReverseNodes(GeometryFamily, rNodes.ptr_begin(), rNodes.ptr_end());
 }
 
-std::size_t GeometryUtilities::GetNumberOfCornerPoints(const GeometryData::KratosGeometryFamily& rGeometryFamily)
+void GeometryUtilities::ReverseNodes(GeometryData::KratosGeometryFamily GeometryFamily,
+                                     std::vector<std::size_t>&          rNodeIds)
 {
-    switch (rGeometryFamily) {
-        using enum GeometryData::KratosGeometryFamily;
-    case Kratos_Linear:
-        return 2;
-    case Kratos_Triangle:
-        return 3;
-    case Kratos_Quadrilateral:
-        return 4;
-    default:
-        KRATOS_ERROR << "The geometry family of the mid-geometry is not supported\n";
-    }
+    ::ReverseNodes(GeometryFamily, rNodeIds.begin(), rNodeIds.end());
 }
 
 } // namespace Kratos

--- a/applications/GeoMechanicsApplication/custom_utilities/geometry_utilities.cpp
+++ b/applications/GeoMechanicsApplication/custom_utilities/geometry_utilities.cpp
@@ -19,6 +19,7 @@ namespace
 {
 
 using namespace Kratos;
+
 [[nodiscard]] std::size_t GetNumberOfCornerPoints(const GeometryData::KratosGeometryFamily& rGeometryFamily)
 {
     switch (rGeometryFamily) {
@@ -33,8 +34,7 @@ using namespace Kratos;
         KRATOS_ERROR << "The geometry family of the mid-geometry is not supported\n";
     }
 }
-}
-
+} // namespace
 
 namespace Kratos
 {
@@ -92,8 +92,8 @@ std::vector<std::size_t> GeometryUtilities::GetNodeIdsFromGeometry(const Geometr
 std::vector<std::size_t> GeometryUtilities::GetReversedNodeIdsForGeometryFamily(
     const GeometryData::KratosGeometryFamily& rGeometryFamily, const std::vector<std::size_t>& rInitialNodeIds)
 {
-    auto result = rInitialNodeIds;
-    auto end_of_corner_points  = result.begin() + GetNumberOfCornerPoints(rGeometryFamily);
+    auto result               = rInitialNodeIds;
+    auto end_of_corner_points = result.begin() + GetNumberOfCornerPoints(rGeometryFamily);
     std::reverse(result.begin(), end_of_corner_points);
     std::reverse(end_of_corner_points, result.end());
     return result;

--- a/applications/GeoMechanicsApplication/custom_utilities/geometry_utilities.cpp
+++ b/applications/GeoMechanicsApplication/custom_utilities/geometry_utilities.cpp
@@ -36,6 +36,24 @@ std::size_t GetNumberOfCornerPoints(GeometryData::KratosGeometryFamily GeometryF
     }
 }
 
+std::size_t GetNumberOfEdgePoints(GeometryData::KratosGeometryFamily    GeometryFamily,
+                                  GeometryData::KratosGeometryOrderType GeometryOrder)
+{
+    switch (GeometryOrder) {
+        using enum GeometryData::KratosGeometryOrderType;
+    case Kratos_Linear_Order:
+        return 0;
+    case Kratos_Quadratic_Order:
+        return GetNumberOfCornerPoints(GeometryFamily);
+    case Kratos_Cubic_Order:
+        return 2 * GetNumberOfCornerPoints(GeometryFamily);
+    default:
+        KRATOS_ERROR
+            << "The specified geometry order type is not supported for getting the number of "
+               "edge points.\n";
+    }
+}
+
 template <std::random_access_iterator InputIt>
 void ReverseNodes(InputIt                               Begin,
                   InputIt                               End,
@@ -48,8 +66,15 @@ void ReverseNodes(InputIt                               Begin,
         GeometryFamily == GeometryData::KratosGeometryFamily::Kratos_Linear ? Begin : Begin + 1;
     auto end_of_corner_points = Begin + GetNumberOfCornerPoints(GeometryFamily);
 
+    // For line geometries, all remaining points are edge points, while for surfaces there could be
+    // internal points as well.
+    auto end_of_edge_points =
+        GeometryFamily == GeometryData::KratosGeometryFamily::Kratos_Linear
+            ? End
+            : end_of_corner_points + GetNumberOfEdgePoints(GeometryFamily, GeometryOrderType);
+
     std::reverse(begin_of_corner_points, end_of_corner_points);
-    std::reverse(end_of_corner_points, End);
+    std::reverse(end_of_corner_points, end_of_edge_points);
 }
 
 } // namespace

--- a/applications/GeoMechanicsApplication/custom_utilities/geometry_utilities.cpp
+++ b/applications/GeoMechanicsApplication/custom_utilities/geometry_utilities.cpp
@@ -64,14 +64,23 @@ void ReverseNodes(InputIt                               Begin,
     // change the starting node, but only reverse the order of the rest of the corner points.
     auto begin_of_corner_points =
         GeometryFamily == GeometryData::KratosGeometryFamily::Kratos_Linear ? Begin : Begin + 1;
-    auto end_of_corner_points = Begin + GetNumberOfCornerPoints(GeometryFamily);
 
+    const auto number_of_corner_points = GetNumberOfCornerPoints(GeometryFamily);
+    KRATOS_ERROR_IF(number_of_corner_points > std::distance(Begin, End))
+        << "Number of nodes for reversal is too small for the geometry family and order type "
+           "specified.\n";
+    auto end_of_corner_points = Begin + number_of_corner_points;
+
+    const auto number_of_edge_points = GetNumberOfEdgePoints(GeometryFamily, GeometryOrderType);
     // For line geometries, all remaining points are edge points, while for surfaces there could be
     // internal points as well.
+    KRATOS_ERROR_IF(number_of_edge_points > std::distance(end_of_corner_points, End) && GeometryFamily != GeometryData::KratosGeometryFamily::Kratos_Linear)
+        << "Number of nodes for reversal is too small for the geometry family and order type "
+           "specified.\n";
     auto end_of_edge_points =
         GeometryFamily == GeometryData::KratosGeometryFamily::Kratos_Linear
             ? End
-            : end_of_corner_points + GetNumberOfEdgePoints(GeometryFamily, GeometryOrderType);
+            : end_of_corner_points + number_of_edge_points;
 
     std::reverse(begin_of_corner_points, end_of_corner_points);
     std::reverse(end_of_corner_points, end_of_edge_points);

--- a/applications/GeoMechanicsApplication/custom_utilities/geometry_utilities.cpp
+++ b/applications/GeoMechanicsApplication/custom_utilities/geometry_utilities.cpp
@@ -10,9 +10,31 @@
 //  Main authors:    Richard Faasse
 //
 #include "geometry_utilities.h"
+#include "geometries/geometry_data.h"
 #include "math_utilities.h"
 
 #include <boost/numeric/ublas/assignment.hpp>
+
+namespace
+{
+
+using namespace Kratos;
+[[nodiscard]] std::size_t GetNumberOfCornerPoints(const GeometryData::KratosGeometryFamily& rGeometryFamily)
+{
+    switch (rGeometryFamily) {
+        using enum GeometryData::KratosGeometryFamily;
+    case Kratos_Linear:
+        return 2;
+    case Kratos_Triangle:
+        return 3;
+    case Kratos_Quadrilateral:
+        return 4;
+    default:
+        KRATOS_ERROR << "The geometry family of the mid-geometry is not supported\n";
+    }
+}
+}
+
 
 namespace Kratos
 {
@@ -71,7 +93,7 @@ std::vector<std::size_t> GeometryUtilities::GetReversedNodeIdsForGeometryFamily(
     const GeometryData::KratosGeometryFamily& rGeometryFamily, const std::vector<std::size_t>& rInitialNodeIds)
 {
     auto result = rInitialNodeIds;
-    std::ranges::reverse(result);
+    std::reverse(result.begin(), result.begin() + GetNumberOfCornerPoints(rGeometryFamily));
     return result;
 }
 

--- a/applications/GeoMechanicsApplication/custom_utilities/geometry_utilities.cpp
+++ b/applications/GeoMechanicsApplication/custom_utilities/geometry_utilities.cpp
@@ -31,7 +31,8 @@ std::size_t GetNumberOfCornerPoints(GeometryData::KratosGeometryFamily GeometryF
     case Kratos_Quadrilateral:
         return 4;
     default:
-        KRATOS_ERROR << "The geometry family of the mid-geometry is not supported\n";
+        KRATOS_ERROR << "The specified geometry family is not supported for getting the number of "
+                        "corner points.\n";
     }
 }
 

--- a/applications/GeoMechanicsApplication/custom_utilities/geometry_utilities.h
+++ b/applications/GeoMechanicsApplication/custom_utilities/geometry_utilities.h
@@ -30,22 +30,19 @@ public:
                                                             const array_1d<double, 3>& rLocalCoordinate);
     static std::vector<std::size_t> GetNodeIdsFromGeometry(const Geometry<Node>& rGeometry);
 
-    [[nodiscard]] static auto GetReversedNodesForGeometryFamily(const GeometryData::KratosGeometryFamily& rGeometryFamily,
-                                                                const auto& rOrderedNodes)
+    template <typename InputIt>
+    [[nodiscard]] static void GetReversedNodesForGeometryFamily(const GeometryData::KratosGeometryFamily& rGeometryFamily,
+                                                                InputIt Begin,
+                                                                InputIt End)
     {
-        auto result = rOrderedNodes;
-
         // For line geometries we want to reverse all 'corner points', while for surfaces we don't
         // change the starting node, but only reverse the order of the rest of the corner points.
-        auto begin_of_corner_points = rGeometryFamily == GeometryData::KratosGeometryFamily::Kratos_Linear
-                                          ? result.begin()
-                                          : result.begin() + 1;
-        auto end_of_corner_points = result.begin() + GetNumberOfCornerPoints(rGeometryFamily);
+        auto begin_of_corner_points =
+            rGeometryFamily == GeometryData::KratosGeometryFamily::Kratos_Linear ? Begin : Begin + 1;
+        auto end_of_corner_points = Begin + GetNumberOfCornerPoints(rGeometryFamily);
 
         std::reverse(begin_of_corner_points, end_of_corner_points);
-        std::reverse(end_of_corner_points, result.end());
-
-        return result;
+        std::reverse(end_of_corner_points, End);
     }
 
 private:

--- a/applications/GeoMechanicsApplication/custom_utilities/geometry_utilities.h
+++ b/applications/GeoMechanicsApplication/custom_utilities/geometry_utilities.h
@@ -29,9 +29,12 @@ public:
     static Matrix Calculate3DRotationMatrixForPlaneGeometry(const Geometry<Node>& rGeometry,
                                                             const array_1d<double, 3>& rLocalCoordinate);
     static std::vector<std::size_t> GetNodeIdsFromGeometry(const Geometry<Node>& rGeometry);
-    static void ReverseNodes(GeometryData::KratosGeometryFamily GeometryFamily, PointerVector<Node>& rNodes);
-    static void ReverseNodes(GeometryData::KratosGeometryFamily GeometryFamily,
-                             std::vector<std::size_t>&          rNodeIds);
+    static void                     ReverseNodes(PointerVector<Node>&                  rNodes,
+                                                 GeometryData::KratosGeometryFamily    GeometryFamily,
+                                                 GeometryData::KratosGeometryOrderType GeometryOrderType);
+    static void                     ReverseNodes(std::vector<std::size_t>&             rNodeIds,
+                                                 GeometryData::KratosGeometryFamily    GeometryFamily,
+                                                 GeometryData::KratosGeometryOrderType GeometryOrderType);
 };
 
 } // namespace Kratos

--- a/applications/GeoMechanicsApplication/custom_utilities/geometry_utilities.h
+++ b/applications/GeoMechanicsApplication/custom_utilities/geometry_utilities.h
@@ -30,7 +30,8 @@ public:
                                                             const array_1d<double, 3>& rLocalCoordinate);
     static std::vector<std::size_t> GetNodeIdsFromGeometry(const Geometry<Node>& rGeometry);
     static void ReverseNodes(GeometryData::KratosGeometryFamily GeometryFamily, PointerVector<Node>& rNodes);
-    static void ReverseNodes(GeometryData::KratosGeometryFamily GeometryFamily, std::vector<std::size_t>& rNodeIds);
+    static void ReverseNodes(GeometryData::KratosGeometryFamily GeometryFamily,
+                             std::vector<std::size_t>&          rNodeIds);
 };
 
 } // namespace Kratos

--- a/applications/GeoMechanicsApplication/custom_utilities/geometry_utilities.h
+++ b/applications/GeoMechanicsApplication/custom_utilities/geometry_utilities.h
@@ -29,6 +29,8 @@ public:
     static Matrix Calculate3DRotationMatrixForPlaneGeometry(const Geometry<Node>& rGeometry,
                                                             const array_1d<double, 3>& rLocalCoordinate);
     static std::vector<std::size_t> GetNodeIdsFromGeometry(const Geometry<Node>& rGeometry);
+    static std::vector<std::size_t> GetReversedNodeIdsForGeometryFamily(
+        const GeometryData::KratosGeometryFamily& rGeometryFamily, const std::vector<std::size_t>& rInitialNodeIds);
 };
 
 } // namespace Kratos

--- a/applications/GeoMechanicsApplication/custom_utilities/geometry_utilities.h
+++ b/applications/GeoMechanicsApplication/custom_utilities/geometry_utilities.h
@@ -31,9 +31,9 @@ public:
     static std::vector<std::size_t> GetNodeIdsFromGeometry(const Geometry<Node>& rGeometry);
 
     template <typename InputIt>
-    [[nodiscard]] static void GetReversedNodesForGeometryFamily(const GeometryData::KratosGeometryFamily& rGeometryFamily,
-                                                                InputIt Begin,
-                                                                InputIt End)
+    [[nodiscard]] static void ReverseNodes(const GeometryData::KratosGeometryFamily& rGeometryFamily,
+                                           InputIt Begin,
+                                           InputIt End)
     {
         // For line geometries we want to reverse all 'corner points', while for surfaces we don't
         // change the starting node, but only reverse the order of the rest of the corner points.

--- a/applications/GeoMechanicsApplication/custom_utilities/geometry_utilities.h
+++ b/applications/GeoMechanicsApplication/custom_utilities/geometry_utilities.h
@@ -29,24 +29,8 @@ public:
     static Matrix Calculate3DRotationMatrixForPlaneGeometry(const Geometry<Node>& rGeometry,
                                                             const array_1d<double, 3>& rLocalCoordinate);
     static std::vector<std::size_t> GetNodeIdsFromGeometry(const Geometry<Node>& rGeometry);
-
     static void ReverseNodes(GeometryData::KratosGeometryFamily GeometryFamily, PointerVector<Node>& rNodes);
-
-    template <typename InputIt>
-    static void ReverseNodes(GeometryData::KratosGeometryFamily GeometryFamily, InputIt Begin, InputIt End)
-    {
-        // For line geometries we want to reverse all 'corner points', while for surfaces we don't
-        // change the starting node, but only reverse the order of the rest of the corner points.
-        auto begin_of_corner_points =
-            GeometryFamily == GeometryData::KratosGeometryFamily::Kratos_Linear ? Begin : Begin + 1;
-        auto end_of_corner_points = Begin + GetNumberOfCornerPoints(GeometryFamily);
-
-        std::reverse(begin_of_corner_points, end_of_corner_points);
-        std::reverse(end_of_corner_points, End);
-    }
-
-private:
-    [[nodiscard]] static std::size_t GetNumberOfCornerPoints(const GeometryData::KratosGeometryFamily& rGeometryFamily);
+    static void ReverseNodes(GeometryData::KratosGeometryFamily GeometryFamily, std::vector<std::size_t>& rNodeIds);
 };
 
 } // namespace Kratos

--- a/applications/GeoMechanicsApplication/custom_utilities/geometry_utilities.h
+++ b/applications/GeoMechanicsApplication/custom_utilities/geometry_utilities.h
@@ -29,8 +29,27 @@ public:
     static Matrix Calculate3DRotationMatrixForPlaneGeometry(const Geometry<Node>& rGeometry,
                                                             const array_1d<double, 3>& rLocalCoordinate);
     static std::vector<std::size_t> GetNodeIdsFromGeometry(const Geometry<Node>& rGeometry);
-    static std::vector<std::size_t> GetReversedNodeIdsForGeometryFamily(
-        const GeometryData::KratosGeometryFamily& rGeometryFamily, const std::vector<std::size_t>& rInitialNodeIds);
+
+    [[nodiscard]] static auto GetReversedNodesForGeometryFamily(const GeometryData::KratosGeometryFamily& rGeometryFamily,
+                                                                const auto& rOrderedNodes)
+    {
+        auto result = rOrderedNodes;
+
+        // For line geometries we want to reverse all 'corner points', while for surfaces we don't
+        // change the starting node, but only reverse the order of the rest of the corner points.
+        auto begin_of_corner_points = rGeometryFamily == GeometryData::KratosGeometryFamily::Kratos_Linear
+                                          ? result.begin()
+                                          : result.begin() + 1;
+        auto end_of_corner_points = result.begin() + GetNumberOfCornerPoints(rGeometryFamily);
+
+        std::reverse(begin_of_corner_points, end_of_corner_points);
+        std::reverse(end_of_corner_points, result.end());
+
+        return result;
+    }
+
+private:
+    [[nodiscard]] static std::size_t GetNumberOfCornerPoints(const GeometryData::KratosGeometryFamily& rGeometryFamily);
 };
 
 } // namespace Kratos

--- a/applications/GeoMechanicsApplication/custom_utilities/geometry_utilities.h
+++ b/applications/GeoMechanicsApplication/custom_utilities/geometry_utilities.h
@@ -30,16 +30,16 @@ public:
                                                             const array_1d<double, 3>& rLocalCoordinate);
     static std::vector<std::size_t> GetNodeIdsFromGeometry(const Geometry<Node>& rGeometry);
 
+    static void ReverseNodes(GeometryData::KratosGeometryFamily GeometryFamily, PointerVector<Node>& rNodes);
+
     template <typename InputIt>
-    [[nodiscard]] static void ReverseNodes(const GeometryData::KratosGeometryFamily& rGeometryFamily,
-                                           InputIt Begin,
-                                           InputIt End)
+    static void ReverseNodes(GeometryData::KratosGeometryFamily GeometryFamily, InputIt Begin, InputIt End)
     {
         // For line geometries we want to reverse all 'corner points', while for surfaces we don't
         // change the starting node, but only reverse the order of the rest of the corner points.
         auto begin_of_corner_points =
-            rGeometryFamily == GeometryData::KratosGeometryFamily::Kratos_Linear ? Begin : Begin + 1;
-        auto end_of_corner_points = Begin + GetNumberOfCornerPoints(rGeometryFamily);
+            GeometryFamily == GeometryData::KratosGeometryFamily::Kratos_Linear ? Begin : Begin + 1;
+        auto end_of_corner_points = Begin + GetNumberOfCornerPoints(GeometryFamily);
 
         std::reverse(begin_of_corner_points, end_of_corner_points);
         std::reverse(end_of_corner_points, End);

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_utilities/test_geometry_utilities.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_utilities/test_geometry_utilities.cpp
@@ -317,6 +317,10 @@ INSTANTIATE_TEST_CASE_P(
                                       GeometryData::KratosGeometryOrderType::Kratos_Quadratic_Order,
                                       std::vector<std::size_t>{1, 2, 3, 4, 5, 6},
                                       std::vector<std::size_t>{1, 3, 2, 6, 5, 4}),
+                      std::make_tuple(GeometryData::KratosGeometryFamily::Kratos_Triangle,
+                                      GeometryData::KratosGeometryOrderType::Kratos_Cubic_Order,
+                                      std::vector<std::size_t>{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
+                                      std::vector<std::size_t>{1, 3, 2, 9, 8, 7, 6, 5, 4, 10}),
                       std::make_tuple(GeometryData::KratosGeometryFamily::Kratos_Quadrilateral,
                                       GeometryData::KratosGeometryOrderType::Kratos_Linear_Order,
                                       std::vector<std::size_t>{1, 2, 3, 4},
@@ -324,6 +328,10 @@ INSTANTIATE_TEST_CASE_P(
                       std::make_tuple(GeometryData::KratosGeometryFamily::Kratos_Quadrilateral,
                                       GeometryData::KratosGeometryOrderType::Kratos_Quadratic_Order,
                                       std::vector<std::size_t>{1, 2, 3, 4, 5, 6, 7, 8},
-                                      std::vector<std::size_t>{1, 4, 3, 2, 8, 7, 6, 5})));
+                                      std::vector<std::size_t>{1, 4, 3, 2, 8, 7, 6, 5}),
+                      std::make_tuple(GeometryData::KratosGeometryFamily::Kratos_Quadrilateral,
+                                      GeometryData::KratosGeometryOrderType::Kratos_Quadratic_Order,
+                                      std::vector<std::size_t>{1, 2, 3, 4, 5, 6, 7, 8, 9},
+                                      std::vector<std::size_t>{1, 4, 3, 2, 8, 7, 6, 5, 9})));
 
 } // namespace Kratos::Testing

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_utilities/test_geometry_utilities.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_utilities/test_geometry_utilities.cpp
@@ -287,8 +287,8 @@ TEST_P(LinearGeometryFamiliesReverseFixture, GeometryUtilities_CorrectlyReverses
 {
     const auto [geometry_family, initial_ids, expected_reversed_ids] = GetParam();
 
-    const auto reversed_ids =
-        GeometryUtilities::GetReversedNodesForGeometryFamily(geometry_family, initial_ids);
+    auto reversed_ids = initial_ids;
+        GeometryUtilities::GetReversedNodesForGeometryFamily(geometry_family, reversed_ids.begin(), reversed_ids.end());
 
     KRATOS_EXPECT_VECTOR_EQ(reversed_ids, expected_reversed_ids);
 }

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_utilities/test_geometry_utilities.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_utilities/test_geometry_utilities.cpp
@@ -288,7 +288,7 @@ TEST_P(LinearGeometryFamiliesReverseFixture, GeometryUtilities_CorrectlyReverses
     const auto [geometry_family, initial_ids, expected_reversed_ids] = GetParam();
 
     const auto reversed_ids =
-        GeometryUtilities::GetReversedNodeIdsForGeometryFamily(geometry_family, initial_ids);
+        GeometryUtilities::GetReversedNodesForGeometryFamily(geometry_family, initial_ids);
 
     KRATOS_EXPECT_VECTOR_EQ(reversed_ids, expected_reversed_ids);
 }

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_utilities/test_geometry_utilities.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_utilities/test_geometry_utilities.cpp
@@ -278,13 +278,13 @@ KRATOS_TEST_CASE_IN_SUITE(GeometryUtilities_ReturnsCorrectNodeIds, KratosGeoMech
     KRATOS_EXPECT_VECTOR_EQ(node_ids, std::vector({1, 3, 42, 314}));
 }
 
-class LinearGeometryFamiliesReverseFixture
+class GeometryFamiliesReverseFixture
     : public ::testing::TestWithParam<
           std::tuple<GeometryData::KratosGeometryFamily, GeometryData::KratosGeometryOrderType, std::vector<std::size_t>, std::vector<std::size_t>>>
 {
 };
 
-TEST_P(LinearGeometryFamiliesReverseFixture, GeometryUtilities_CorrectlyReversesNodeIds)
+TEST_P(GeometryFamiliesReverseFixture, GeometryUtilities_CorrectlyReversesNodeIds)
 {
     const auto& [geometry_family, geometry_order, initial_ids, expected_reversed_ids] = GetParam();
 
@@ -296,7 +296,7 @@ TEST_P(LinearGeometryFamiliesReverseFixture, GeometryUtilities_CorrectlyReverses
 
 INSTANTIATE_TEST_CASE_P(
     KratosGeoMechanicsFastSuiteWithoutKernel,
-    LinearGeometryFamiliesReverseFixture,
+    GeometryFamiliesReverseFixture,
     ::testing::Values(std::make_tuple(GeometryData::KratosGeometryFamily::Kratos_Linear,
                                       GeometryData::KratosGeometryOrderType::Kratos_Linear_Order,
                                       std::vector<std::size_t>{1, 2},
@@ -333,5 +333,44 @@ INSTANTIATE_TEST_CASE_P(
                                       GeometryData::KratosGeometryOrderType::Kratos_Quadratic_Order,
                                       std::vector<std::size_t>{1, 2, 3, 4, 5, 6, 7, 8, 9},
                                       std::vector<std::size_t>{1, 4, 3, 2, 8, 7, 6, 5, 9})));
+
+class ReverseThrowsWhenNumberOfNodeIdsIsTooSmall
+    : public ::testing::TestWithParam<std::tuple<GeometryData::KratosGeometryFamily, GeometryData::KratosGeometryOrderType, std::vector<std::size_t>>>
+{
+};
+
+TEST_P(ReverseThrowsWhenNumberOfNodeIdsIsTooSmall, GeometryUtilities_ThrowsWhenNumberOfNodeIdsIsTooSmall)
+{
+    const auto& [geometry_family, geometry_order, initial_ids] = GetParam();
+
+    auto reversed_ids = initial_ids;
+
+    const auto expected_message = "Number of nodes for reversal is too small for the geometry "
+                                  "family and order type specified.";
+    KRATOS_EXPECT_EXCEPTION_IS_THROWN(
+        GeometryUtilities::ReverseNodes(reversed_ids, geometry_family, geometry_order), expected_message);
+}
+
+INSTANTIATE_TEST_CASE_P(
+    KratosGeoMechanicsFastSuiteWithoutKernel,
+    ReverseThrowsWhenNumberOfNodeIdsIsTooSmall,
+    ::testing::Values(std::make_tuple(GeometryData::KratosGeometryFamily::Kratos_Linear,
+                                      GeometryData::KratosGeometryOrderType::Kratos_Linear_Order,
+                                      std::vector<std::size_t>{1}),
+                      std::make_tuple(GeometryData::KratosGeometryFamily::Kratos_Triangle,
+                                      GeometryData::KratosGeometryOrderType::Kratos_Linear_Order,
+                                      std::vector<std::size_t>{1, 2}),
+                      std::make_tuple(GeometryData::KratosGeometryFamily::Kratos_Triangle,
+                                      GeometryData::KratosGeometryOrderType::Kratos_Quadratic_Order,
+                                      std::vector<std::size_t>{1, 2, 3, 4, 5}),
+                      std::make_tuple(GeometryData::KratosGeometryFamily::Kratos_Triangle,
+                                      GeometryData::KratosGeometryOrderType::Kratos_Cubic_Order,
+                                      std::vector<std::size_t>{1, 2, 3, 4, 5, 6, 7, 8}),
+                      std::make_tuple(GeometryData::KratosGeometryFamily::Kratos_Quadrilateral,
+                                      GeometryData::KratosGeometryOrderType::Kratos_Linear_Order,
+                                      std::vector<std::size_t>{1, 2, 3}),
+                      std::make_tuple(GeometryData::KratosGeometryFamily::Kratos_Quadrilateral,
+                                      GeometryData::KratosGeometryOrderType::Kratos_Quadratic_Order,
+                                      std::vector<std::size_t>{1, 2, 3, 4, 5, 6, 7})));
 
 } // namespace Kratos::Testing

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_utilities/test_geometry_utilities.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_utilities/test_geometry_utilities.cpp
@@ -279,16 +279,17 @@ KRATOS_TEST_CASE_IN_SUITE(GeometryUtilities_ReturnsCorrectNodeIds, KratosGeoMech
 }
 
 class LinearGeometryFamiliesReverseFixture
-    : public ::testing::TestWithParam<std::tuple<GeometryData::KratosGeometryFamily, std::vector<std::size_t>, std::vector<std::size_t>>>
+    : public ::testing::TestWithParam<
+          std::tuple<GeometryData::KratosGeometryFamily, GeometryData::KratosGeometryOrderType, std::vector<std::size_t>, std::vector<std::size_t>>>
 {
 };
 
 TEST_P(LinearGeometryFamiliesReverseFixture, GeometryUtilities_CorrectlyReversesNodeIds)
 {
-    const auto& [geometry_family, initial_ids, expected_reversed_ids] = GetParam();
+    const auto& [geometry_family, geometry_order, initial_ids, expected_reversed_ids] = GetParam();
 
     auto reversed_ids = initial_ids;
-    GeometryUtilities::ReverseNodes(geometry_family, reversed_ids);
+    GeometryUtilities::ReverseNodes(reversed_ids, geometry_family, geometry_order);
 
     KRATOS_EXPECT_VECTOR_EQ(reversed_ids, expected_reversed_ids);
 }
@@ -297,24 +298,31 @@ INSTANTIATE_TEST_CASE_P(
     KratosGeoMechanicsFastSuiteWithoutKernel,
     LinearGeometryFamiliesReverseFixture,
     ::testing::Values(std::make_tuple(GeometryData::KratosGeometryFamily::Kratos_Linear,
+                                      GeometryData::KratosGeometryOrderType::Kratos_Linear_Order,
                                       std::vector<std::size_t>{1, 2},
                                       std::vector<std::size_t>{2, 1}),
                       std::make_tuple(GeometryData::KratosGeometryFamily::Kratos_Linear,
+                                      GeometryData::KratosGeometryOrderType::Kratos_Quadratic_Order,
                                       std::vector<std::size_t>{1, 2, 3},
                                       std::vector<std::size_t>{2, 1, 3}),
                       std::make_tuple(GeometryData::KratosGeometryFamily::Kratos_Linear,
+                                      GeometryData::KratosGeometryOrderType::Kratos_Cubic_Order,
                                       std::vector<std::size_t>{1, 2, 3, 4},
                                       std::vector<std::size_t>{2, 1, 4, 3}),
                       std::make_tuple(GeometryData::KratosGeometryFamily::Kratos_Triangle,
+                                      GeometryData::KratosGeometryOrderType::Kratos_Linear_Order,
                                       std::vector<std::size_t>{1, 2, 3},
                                       std::vector<std::size_t>{1, 3, 2}),
                       std::make_tuple(GeometryData::KratosGeometryFamily::Kratos_Triangle,
+                                      GeometryData::KratosGeometryOrderType::Kratos_Quadratic_Order,
                                       std::vector<std::size_t>{1, 2, 3, 4, 5, 6},
                                       std::vector<std::size_t>{1, 3, 2, 6, 5, 4}),
                       std::make_tuple(GeometryData::KratosGeometryFamily::Kratos_Quadrilateral,
+                                      GeometryData::KratosGeometryOrderType::Kratos_Linear_Order,
                                       std::vector<std::size_t>{1, 2, 3, 4},
                                       std::vector<std::size_t>{1, 4, 3, 2}),
                       std::make_tuple(GeometryData::KratosGeometryFamily::Kratos_Quadrilateral,
+                                      GeometryData::KratosGeometryOrderType::Kratos_Quadratic_Order,
                                       std::vector<std::size_t>{1, 2, 3, 4, 5, 6, 7, 8},
                                       std::vector<std::size_t>{1, 4, 3, 2, 8, 7, 6, 5})));
 

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_utilities/test_geometry_utilities.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_utilities/test_geometry_utilities.cpp
@@ -288,7 +288,7 @@ TEST_P(LinearGeometryFamiliesReverseFixture, GeometryUtilities_CorrectlyReverses
     const auto [geometry_family, initial_ids, expected_reversed_ids] = GetParam();
 
     auto reversed_ids = initial_ids;
-        GeometryUtilities::GetReversedNodesForGeometryFamily(geometry_family, reversed_ids.begin(), reversed_ids.end());
+    GeometryUtilities::ReverseNodes(geometry_family, reversed_ids.begin(), reversed_ids.end());
 
     KRATOS_EXPECT_VECTOR_EQ(reversed_ids, expected_reversed_ids);
 }

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_utilities/test_geometry_utilities.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_utilities/test_geometry_utilities.cpp
@@ -288,7 +288,7 @@ TEST_P(LinearGeometryFamiliesReverseFixture, GeometryUtilities_CorrectlyReverses
     const auto [geometry_family, initial_ids, expected_reversed_ids] = GetParam();
 
     auto reversed_ids = initial_ids;
-    GeometryUtilities::ReverseNodes(geometry_family, reversed_ids.begin(), reversed_ids.end());
+    GeometryUtilities::ReverseNodes(geometry_family, reversed_ids);
 
     KRATOS_EXPECT_VECTOR_EQ(reversed_ids, expected_reversed_ids);
 }

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_utilities/test_geometry_utilities.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_utilities/test_geometry_utilities.cpp
@@ -297,7 +297,8 @@ INSTANTIATE_TEST_CASE_P(KratosGeoMechanicsFastSuiteWithoutKernel,
                         LinearGeometryFamiliesReverseFixture,
                         ::testing::Values(
                             std::make_tuple(std::vector<std::size_t>{1, 2}, std::vector<std::size_t>{2, 1}),
-                            std::make_tuple(std::vector<std::size_t>{1, 2, 3}, std::vector<std::size_t>{2, 1, 3})
+                            std::make_tuple(std::vector<std::size_t>{1, 2, 3}, std::vector<std::size_t>{2, 1, 3}),
+                            std::make_tuple(std::vector<std::size_t>{1, 2, 3, 4}, std::vector<std::size_t>{2, 1, 4, 3})
                         ));
 
 } // namespace Kratos::Testing

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_utilities/test_geometry_utilities.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_utilities/test_geometry_utilities.cpp
@@ -307,15 +307,15 @@ INSTANTIATE_TEST_CASE_P(
                                       std::vector<std::size_t>{2, 1, 4, 3}),
                       std::make_tuple(GeometryData::KratosGeometryFamily::Kratos_Triangle,
                                       std::vector<std::size_t>{1, 2, 3},
-                                      std::vector<std::size_t>{3, 2, 1}),
+                                      std::vector<std::size_t>{1, 3, 2}),
                       std::make_tuple(GeometryData::KratosGeometryFamily::Kratos_Triangle,
                                       std::vector<std::size_t>{1, 2, 3, 4, 5, 6},
-                                      std::vector<std::size_t>{3, 2, 1, 6, 5, 4}),
+                                      std::vector<std::size_t>{1, 3, 2, 6, 5, 4}),
                       std::make_tuple(GeometryData::KratosGeometryFamily::Kratos_Quadrilateral,
                                       std::vector<std::size_t>{1, 2, 3, 4},
-                                      std::vector<std::size_t>{4, 3, 2, 1}),
+                                      std::vector<std::size_t>{1, 4, 3, 2}),
                       std::make_tuple(GeometryData::KratosGeometryFamily::Kratos_Quadrilateral,
                                       std::vector<std::size_t>{1, 2, 3, 4, 5, 6, 7, 8},
-                                      std::vector<std::size_t>{4, 3, 2, 1, 8, 7, 6, 5})));
+                                      std::vector<std::size_t>{1, 4, 3, 2, 8, 7, 6, 5})));
 
 } // namespace Kratos::Testing

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_utilities/test_geometry_utilities.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_utilities/test_geometry_utilities.cpp
@@ -278,15 +278,25 @@ KRATOS_TEST_CASE_IN_SUITE(GeometryUtilities_ReturnsCorrectNodeIds, KratosGeoMech
     KRATOS_EXPECT_VECTOR_EQ(node_ids, std::vector({1, 3, 42, 314}));
 }
 
-KRATOS_TEST_CASE_IN_SUITE(GeometryUtilities_CorrectlyReversesNodeIdsForLinearGeometryFamilies,
-                          KratosGeoMechanicsFastSuiteWithoutKernel)
+class LinearGeometryFamiliesReverseFixture : public ::testing::TestWithParam<std::tuple<std::vector<std::size_t>, std::vector<std::size_t>>>
 {
-    const auto               geometry_family = GeometryData::KratosGeometryFamily::Kratos_Linear;
-    std::vector<std::size_t> node_ids        = {1, 2};
 
-    const auto reversed_ids = GeometryUtilities::GetReversedNodeIdsForGeometryFamily(geometry_family, node_ids);
+};
 
-    KRATOS_EXPECT_VECTOR_EQ(reversed_ids, std::vector({2, 1}));
+TEST_P(LinearGeometryFamiliesReverseFixture, GeometryUtilities_CorrectlyReversesNodeIds)
+{
+    const auto [initial_ids, expected_reversed_ids] = GetParam();
+    const auto geometry_family = GeometryData::KratosGeometryFamily::Kratos_Linear;
+
+    const auto reversed_ids = GeometryUtilities::GetReversedNodeIdsForGeometryFamily(geometry_family, initial_ids);
+
+    KRATOS_EXPECT_VECTOR_EQ(reversed_ids, expected_reversed_ids);
 }
+
+INSTANTIATE_TEST_CASE_P(KratosGeoMechanicsFastSuiteWithoutKernel,
+                        LinearGeometryFamiliesReverseFixture,
+                        ::testing::Values(
+                            std::make_tuple(std::vector<std::size_t>{1, 2}, std::vector<std::size_t>{2, 1})
+                        ));
 
 } // namespace Kratos::Testing

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_utilities/test_geometry_utilities.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_utilities/test_geometry_utilities.cpp
@@ -293,16 +293,29 @@ TEST_P(LinearGeometryFamiliesReverseFixture, GeometryUtilities_CorrectlyReverses
     KRATOS_EXPECT_VECTOR_EQ(reversed_ids, expected_reversed_ids);
 }
 
-INSTANTIATE_TEST_CASE_P(KratosGeoMechanicsFastSuiteWithoutKernel,
-                        LinearGeometryFamiliesReverseFixture,
-                        ::testing::Values(std::make_tuple(GeometryData::KratosGeometryFamily::Kratos_Linear,
-                                                          std::vector<std::size_t>{1, 2},
-                                                          std::vector<std::size_t>{2, 1}),
-                                          std::make_tuple(GeometryData::KratosGeometryFamily::Kratos_Linear,
-                                                          std::vector<std::size_t>{1, 2, 3},
-                                                          std::vector<std::size_t>{2, 1, 3}),
-                                          std::make_tuple(GeometryData::KratosGeometryFamily::Kratos_Linear,
-                                                          std::vector<std::size_t>{1, 2, 3, 4},
-                                                          std::vector<std::size_t>{2, 1, 4, 3})));
+INSTANTIATE_TEST_CASE_P(
+    KratosGeoMechanicsFastSuiteWithoutKernel,
+    LinearGeometryFamiliesReverseFixture,
+    ::testing::Values(std::make_tuple(GeometryData::KratosGeometryFamily::Kratos_Linear,
+                                      std::vector<std::size_t>{1, 2},
+                                      std::vector<std::size_t>{2, 1}),
+                      std::make_tuple(GeometryData::KratosGeometryFamily::Kratos_Linear,
+                                      std::vector<std::size_t>{1, 2, 3},
+                                      std::vector<std::size_t>{2, 1, 3}),
+                      std::make_tuple(GeometryData::KratosGeometryFamily::Kratos_Linear,
+                                      std::vector<std::size_t>{1, 2, 3, 4},
+                                      std::vector<std::size_t>{2, 1, 4, 3}),
+                      std::make_tuple(GeometryData::KratosGeometryFamily::Kratos_Triangle,
+                                      std::vector<std::size_t>{1, 2, 3},
+                                      std::vector<std::size_t>{3, 2, 1}),
+                      std::make_tuple(GeometryData::KratosGeometryFamily::Kratos_Triangle,
+                                      std::vector<std::size_t>{1, 2, 3, 4, 5, 6},
+                                      std::vector<std::size_t>{3, 2, 1, 6, 5, 4}),
+                      std::make_tuple(GeometryData::KratosGeometryFamily::Kratos_Quadrilateral,
+                                      std::vector<std::size_t>{1, 2, 3, 4},
+                                      std::vector<std::size_t>{4, 3, 2, 1}),
+                      std::make_tuple(GeometryData::KratosGeometryFamily::Kratos_Quadrilateral,
+                                      std::vector<std::size_t>{1, 2, 3, 4, 5, 6, 7, 8},
+                                      std::vector<std::size_t>{4, 3, 2, 1, 8, 7, 6, 5})));
 
 } // namespace Kratos::Testing

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_utilities/test_geometry_utilities.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_utilities/test_geometry_utilities.cpp
@@ -285,7 +285,7 @@ class LinearGeometryFamiliesReverseFixture
 
 TEST_P(LinearGeometryFamiliesReverseFixture, GeometryUtilities_CorrectlyReversesNodeIds)
 {
-    const auto [geometry_family, initial_ids, expected_reversed_ids] = GetParam();
+    const auto& [geometry_family, initial_ids, expected_reversed_ids] = GetParam();
 
     auto reversed_ids = initial_ids;
     GeometryUtilities::ReverseNodes(geometry_family, reversed_ids);

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_utilities/test_geometry_utilities.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_utilities/test_geometry_utilities.cpp
@@ -279,14 +279,13 @@ KRATOS_TEST_CASE_IN_SUITE(GeometryUtilities_ReturnsCorrectNodeIds, KratosGeoMech
 }
 
 class LinearGeometryFamiliesReverseFixture
-    : public ::testing::TestWithParam<std::tuple<std::vector<std::size_t>, std::vector<std::size_t>>>
+    : public ::testing::TestWithParam<std::tuple<GeometryData::KratosGeometryFamily, std::vector<std::size_t>, std::vector<std::size_t>>>
 {
 };
 
 TEST_P(LinearGeometryFamiliesReverseFixture, GeometryUtilities_CorrectlyReversesNodeIds)
 {
-    const auto [initial_ids, expected_reversed_ids] = GetParam();
-    const auto geometry_family = GeometryData::KratosGeometryFamily::Kratos_Linear;
+    const auto [geometry_family, initial_ids, expected_reversed_ids] = GetParam();
 
     const auto reversed_ids =
         GeometryUtilities::GetReversedNodeIdsForGeometryFamily(geometry_family, initial_ids);
@@ -294,12 +293,16 @@ TEST_P(LinearGeometryFamiliesReverseFixture, GeometryUtilities_CorrectlyReverses
     KRATOS_EXPECT_VECTOR_EQ(reversed_ids, expected_reversed_ids);
 }
 
-INSTANTIATE_TEST_CASE_P(
-    KratosGeoMechanicsFastSuiteWithoutKernel,
-    LinearGeometryFamiliesReverseFixture,
-    ::testing::Values(std::make_tuple(std::vector<std::size_t>{1, 2}, std::vector<std::size_t>{2, 1}),
-                      std::make_tuple(std::vector<std::size_t>{1, 2, 3}, std::vector<std::size_t>{2, 1, 3}),
-                      std::make_tuple(std::vector<std::size_t>{1, 2, 3, 4},
-                                      std::vector<std::size_t>{2, 1, 4, 3})));
+INSTANTIATE_TEST_CASE_P(KratosGeoMechanicsFastSuiteWithoutKernel,
+                        LinearGeometryFamiliesReverseFixture,
+                        ::testing::Values(std::make_tuple(GeometryData::KratosGeometryFamily::Kratos_Linear,
+                                                          std::vector<std::size_t>{1, 2},
+                                                          std::vector<std::size_t>{2, 1}),
+                                          std::make_tuple(GeometryData::KratosGeometryFamily::Kratos_Linear,
+                                                          std::vector<std::size_t>{1, 2, 3},
+                                                          std::vector<std::size_t>{2, 1, 3}),
+                                          std::make_tuple(GeometryData::KratosGeometryFamily::Kratos_Linear,
+                                                          std::vector<std::size_t>{1, 2, 3, 4},
+                                                          std::vector<std::size_t>{2, 1, 4, 3})));
 
 } // namespace Kratos::Testing

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_utilities/test_geometry_utilities.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_utilities/test_geometry_utilities.cpp
@@ -296,7 +296,8 @@ TEST_P(LinearGeometryFamiliesReverseFixture, GeometryUtilities_CorrectlyReverses
 INSTANTIATE_TEST_CASE_P(KratosGeoMechanicsFastSuiteWithoutKernel,
                         LinearGeometryFamiliesReverseFixture,
                         ::testing::Values(
-                            std::make_tuple(std::vector<std::size_t>{1, 2}, std::vector<std::size_t>{2, 1})
+                            std::make_tuple(std::vector<std::size_t>{1, 2}, std::vector<std::size_t>{2, 1}),
+                            std::make_tuple(std::vector<std::size_t>{1, 2, 3}, std::vector<std::size_t>{2, 1, 3})
                         ));
 
 } // namespace Kratos::Testing

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_utilities/test_geometry_utilities.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_utilities/test_geometry_utilities.cpp
@@ -278,9 +278,9 @@ KRATOS_TEST_CASE_IN_SUITE(GeometryUtilities_ReturnsCorrectNodeIds, KratosGeoMech
     KRATOS_EXPECT_VECTOR_EQ(node_ids, std::vector({1, 3, 42, 314}));
 }
 
-class LinearGeometryFamiliesReverseFixture : public ::testing::TestWithParam<std::tuple<std::vector<std::size_t>, std::vector<std::size_t>>>
+class LinearGeometryFamiliesReverseFixture
+    : public ::testing::TestWithParam<std::tuple<std::vector<std::size_t>, std::vector<std::size_t>>>
 {
-
 };
 
 TEST_P(LinearGeometryFamiliesReverseFixture, GeometryUtilities_CorrectlyReversesNodeIds)
@@ -288,17 +288,18 @@ TEST_P(LinearGeometryFamiliesReverseFixture, GeometryUtilities_CorrectlyReverses
     const auto [initial_ids, expected_reversed_ids] = GetParam();
     const auto geometry_family = GeometryData::KratosGeometryFamily::Kratos_Linear;
 
-    const auto reversed_ids = GeometryUtilities::GetReversedNodeIdsForGeometryFamily(geometry_family, initial_ids);
+    const auto reversed_ids =
+        GeometryUtilities::GetReversedNodeIdsForGeometryFamily(geometry_family, initial_ids);
 
     KRATOS_EXPECT_VECTOR_EQ(reversed_ids, expected_reversed_ids);
 }
 
-INSTANTIATE_TEST_CASE_P(KratosGeoMechanicsFastSuiteWithoutKernel,
-                        LinearGeometryFamiliesReverseFixture,
-                        ::testing::Values(
-                            std::make_tuple(std::vector<std::size_t>{1, 2}, std::vector<std::size_t>{2, 1}),
-                            std::make_tuple(std::vector<std::size_t>{1, 2, 3}, std::vector<std::size_t>{2, 1, 3}),
-                            std::make_tuple(std::vector<std::size_t>{1, 2, 3, 4}, std::vector<std::size_t>{2, 1, 4, 3})
-                        ));
+INSTANTIATE_TEST_CASE_P(
+    KratosGeoMechanicsFastSuiteWithoutKernel,
+    LinearGeometryFamiliesReverseFixture,
+    ::testing::Values(std::make_tuple(std::vector<std::size_t>{1, 2}, std::vector<std::size_t>{2, 1}),
+                      std::make_tuple(std::vector<std::size_t>{1, 2, 3}, std::vector<std::size_t>{2, 1, 3}),
+                      std::make_tuple(std::vector<std::size_t>{1, 2, 3, 4},
+                                      std::vector<std::size_t>{2, 1, 4, 3})));
 
 } // namespace Kratos::Testing

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_utilities/test_geometry_utilities.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_utilities/test_geometry_utilities.cpp
@@ -12,6 +12,7 @@
 
 #include "custom_geometries/interface_geometry.h"
 #include "custom_utilities/geometry_utilities.h"
+#include "geometries/geometry_data.h"
 #include "tests/cpp_tests/geo_mechanics_fast_suite.h"
 
 #include <boost/numeric/ublas/assignment.hpp>
@@ -275,6 +276,17 @@ KRATOS_TEST_CASE_IN_SUITE(GeometryUtilities_ReturnsCorrectNodeIds, KratosGeoMech
     const auto node_ids = GeometryUtilities::GetNodeIdsFromGeometry(geometry);
 
     KRATOS_EXPECT_VECTOR_EQ(node_ids, std::vector({1, 3, 42, 314}));
+}
+
+KRATOS_TEST_CASE_IN_SUITE(GeometryUtilities_CorrectlyReversesNodeIdsForLinearGeometryFamilies,
+                          KratosGeoMechanicsFastSuiteWithoutKernel)
+{
+    const auto               geometry_family = GeometryData::KratosGeometryFamily::Kratos_Linear;
+    std::vector<std::size_t> node_ids        = {1, 2};
+
+    const auto reversed_ids = GeometryUtilities::GetReversedNodeIdsForGeometryFamily(geometry_family, node_ids);
+
+    KRATOS_EXPECT_VECTOR_EQ(reversed_ids, std::vector({2, 1}));
 }
 
 } // namespace Kratos::Testing


### PR DESCRIPTION
**📝 Description**
This PR extracts a tool that can reverse the nodes of a geometry depending on its geometry family (lines, triangles or quads are supported). The tool is unit-tested and re-used in the interface geometry (where we already did this reversal).

This extraction is a needed step for finding neighbours, where depending on the case, we need to also search 'reversed' boundaries (and thus need a tool to reverse the nodes of a geometry).
