### PR TITLE
[LinearSolversApplication] Add installation instructions for SuiteSparse on Windows

### DIFF
--- a/applications/LinearSolversApplication/README.md
+++ b/applications/LinearSolversApplication/README.md
@@ -238,3 +238,8 @@ Install the *SuiteSparse* package on your system, and set the `USE_EIGEN_SUITESP
 - MacOS
     - *SuiteSparse* is [available](https://formulae.brew.sh/formula/suite-sparse) on *Homebrew* for both Intel and Apple Silicon machines.
     - `brew install suite-sparse`
+
+- Windows
+  - *SuiteSparse* is available through [*vcpkg*](https://vcpkg.io/en/package/suitesparse) and [*MSYS2*](https://packages.msys2.org/packages/mingw-w64-x86_64-suitesparse) package managers.
+  - `vcpkg install suitesparse suitesparse-spqr suitesparse-umfpack` (remember to add to build script `-DCMAKE_TOOLCHAIN_FILE="vcpkg_path\vcpkg\scripts\buildsystems\vcpkg.cmake"`)
+  - `pacman -S mingw-w64-x86_64-suitesparse`


### PR DESCRIPTION
**📝 Description**

After https://github.com/KratosMultiphysics/Kratos/pull/13587, adding Windows instructions to install *SuiteSparse* on Windows.

**🆕 Changelog**

- [Add installation instructions for *SuiteSparse* on Windows](https://github.com/KratosMultiphysics/Kratos/commit/4973ba227d1fdad3ad3fbf2ea82dd4dc4c3786f5)
