### PR TITLE
[LinearSolversApplication] Remove duplicated `#pragma once` in `MKLUtilities`

### DIFF
--- a/applications/LinearSolversApplication/custom_utilities/mkl_utilities.cpp
+++ b/applications/LinearSolversApplication/custom_utilities/mkl_utilities.cpp
@@ -10,8 +10,6 @@
 //  Main authors:    Vicente Mataix Ferrandiz
 //
 
-#pragma once
-
 // System includes
 
 // External includes


### PR DESCRIPTION
**📝 Description**

Remove duplicated `#pragma once` in `MKLUtilities`.

**🆕 Changelog**

- [Remove duplicated `#pragma once` in `MKLUtilities`](https://github.com/KratosMultiphysics/Kratos/commit/41154a3fad2c1dcb5d70cbbfcde7a0d89ad23eef)
