### PR TITLE
[Meshing] Check conditions for SPLIT_ELEMENT flags in local refine tetra mesh on boundary only

### DIFF
--- a/applications/MeshingApplication/custom_utilities/local_refine_tetrahedra_mesh_only_on_boundaries.hpp
+++ b/applications/MeshingApplication/custom_utilities/local_refine_tetrahedra_mesh_only_on_boundaries.hpp
@@ -84,6 +84,21 @@ public:
             }
         }
 
+        // check for conditions with SPLIT_ELEMENT flag to refine the corresponding edges
+        for (auto& r_cond: rThisModelPart.Conditions()) {
+            if (r_cond.GetValue(SPLIT_ELEMENT)) {
+                Condition::GeometryType& r_geom = r_cond.GetGeometry(); // Nodes of the condition
+                for (unsigned int i = 0; i < r_geom.size(); i++) {
+                    int index_i = mMapNodeIdToPos[r_geom[i].Id()];  
+                    for (unsigned int j = 0; j < r_geom.size(); j++) {
+                        int index_j = mMapNodeIdToPos[r_geom[j].Id()];
+                        if (index_j > index_i) {
+                            rCoord(index_i, index_j) = -2;
+                        }
+                    }
+                }
+            }
+        }
 
         KRATOS_CATCH("");
     }

--- a/applications/MeshingApplication/tests/test_local_refine_only_on_boundaries.py
+++ b/applications/MeshingApplication/tests/test_local_refine_only_on_boundaries.py
@@ -53,5 +53,38 @@ class TestLocalRefineOnlyOnBoundaries(KratosUnittest.TestCase):
         self.assertEqual(current_model["main_model_part.MainPart.Wall_BC.Wall1"].NumberOfConditions(), 360)
         self.assertEqual(current_model["main_model_part.MainPart.Wall_BC.Wall1"].NumberOfElements(), 0)
 
+    def test_refine_on_boundary_edges_by_marking_conditions(self):
+
+        # create model part
+        current_model = KratosMultiphysics.Model()
+        main_model_part_2 = current_model.CreateModelPart("main_model_part_2")
+        main_model_part_2.ProcessInfo.SetValue(KratosMultiphysics.DOMAIN_SIZE, 3)
+        main_model_part_2.AddNodalSolutionStepVariable(KratosMultiphysics.DISTANCE)
+
+        # import mdpa
+        file_path = os.path.dirname(os.path.realpath(__file__))
+        KratosMultiphysics.ModelPartIO(file_path + "/cube_with_5_faces").ReadModelPart(main_model_part_2)
+
+        # flag conditions on boundary to refine
+        for cond in main_model_part_2.Conditions:
+            cond.SetValue(KratosMultiphysics.SPLIT_ELEMENT,True)
+
+        #refining
+        KratosMultiphysics.FindNodalNeighboursProcess(main_model_part_2).Execute()
+        refine_on_reference = False
+        interpolate_internal_variables = True
+        MeshingApplication.LocalRefineTetrahedraMeshOnlyOnBoundaries(main_model_part_2).LocalRefineMesh( refine_on_reference, interpolate_internal_variables)
+        
+        #checking
+        refined_vol = self._ComputeVolume(main_model_part_2.Elements)
+        self.assertAlmostEqual(refined_vol, 1.0, 12)
+        self.assertEqual(main_model_part_2.NumberOfElements(), 517)
+        self.assertEqual(current_model["main_model_part_2.MainPart.VolumeParts.Body1"].NumberOfConditions(), 0)
+        self.assertEqual(current_model["main_model_part_2.MainPart.VolumeParts.Body1"].NumberOfElements(), 517)
+        self.assertEqual(main_model_part_2.NumberOfNodes(), 205)
+        self.assertEqual(main_model_part_2.NumberOfConditions(), 360)
+        self.assertEqual(current_model["main_model_part_2.MainPart.Wall_BC.Wall1"].NumberOfConditions(), 360)
+        self.assertEqual(current_model["main_model_part_2.MainPart.Wall_BC.Wall1"].NumberOfElements(), 0)
+
 if __name__ == '__main__':
     KratosUnittest.main()


### PR DESCRIPTION
Added loop over conditions to check for SPLIT_ELEMENT.
If SPLIT_ELEMENT is found on a condition, mark all edges for refinement.