### PR TITLE
[GeoMechanicsApplication] Used std::move for objects that are passed by value and used only once

### DIFF
--- a/applications/GeoMechanicsApplication/custom_conditions/axisymmetric_line_normal_fluid_flux_2D_diff_order_condition.cpp
+++ b/applications/GeoMechanicsApplication/custom_conditions/axisymmetric_line_normal_fluid_flux_2D_diff_order_condition.cpp
@@ -27,14 +27,14 @@ AxisymmetricLineNormalFluidFlux2DDiffOrderCondition::AxisymmetricLineNormalFluid
 // Constructor 1
 AxisymmetricLineNormalFluidFlux2DDiffOrderCondition::AxisymmetricLineNormalFluidFlux2DDiffOrderCondition(
     IndexType NewId, GeometryType::Pointer pGeometry)
-    : LineNormalFluidFlux2DDiffOrderCondition(NewId, pGeometry)
+    : LineNormalFluidFlux2DDiffOrderCondition(NewId, std::move(pGeometry))
 {
 }
 
 // Constructor 2
 AxisymmetricLineNormalFluidFlux2DDiffOrderCondition::AxisymmetricLineNormalFluidFlux2DDiffOrderCondition(
     IndexType NewId, GeometryType::Pointer pGeometry, PropertiesType::Pointer pProperties)
-    : LineNormalFluidFlux2DDiffOrderCondition(NewId, pGeometry, pProperties)
+    : LineNormalFluidFlux2DDiffOrderCondition(NewId, std::move(pGeometry), std::move(pProperties))
 {
 }
 

--- a/applications/GeoMechanicsApplication/custom_conditions/axisymmetric_line_normal_load_2D_diff_order_condition.cpp
+++ b/applications/GeoMechanicsApplication/custom_conditions/axisymmetric_line_normal_load_2D_diff_order_condition.cpp
@@ -27,14 +27,14 @@ AxisymmetricLineNormalLoad2DDiffOrderCondition::AxisymmetricLineNormalLoad2DDiff
 // Constructor 1
 AxisymmetricLineNormalLoad2DDiffOrderCondition::AxisymmetricLineNormalLoad2DDiffOrderCondition(
     IndexType NewId, GeometryType::Pointer pGeometry)
-    : LineNormalLoad2DDiffOrderCondition(NewId, pGeometry)
+    : LineNormalLoad2DDiffOrderCondition(NewId, std::move(pGeometry))
 {
 }
 
 // Constructor 2
 AxisymmetricLineNormalLoad2DDiffOrderCondition::AxisymmetricLineNormalLoad2DDiffOrderCondition(
     IndexType NewId, GeometryType::Pointer pGeometry, PropertiesType::Pointer pProperties)
-    : LineNormalLoad2DDiffOrderCondition(NewId, pGeometry, pProperties)
+    : LineNormalLoad2DDiffOrderCondition(NewId, std::move(pGeometry), std::move(pProperties))
 {
 }
 

--- a/applications/GeoMechanicsApplication/custom_conditions/line_load_2D_diff_order_condition.cpp
+++ b/applications/GeoMechanicsApplication/custom_conditions/line_load_2D_diff_order_condition.cpp
@@ -24,7 +24,7 @@ LineLoad2DDiffOrderCondition::LineLoad2DDiffOrderCondition() : GeneralUPwDiffOrd
 
 // Constructor 1
 LineLoad2DDiffOrderCondition::LineLoad2DDiffOrderCondition(IndexType NewId, GeometryType::Pointer pGeometry)
-    : GeneralUPwDiffOrderCondition(NewId, pGeometry)
+    : GeneralUPwDiffOrderCondition(NewId, std::move(pGeometry))
 {
 }
 
@@ -32,7 +32,7 @@ LineLoad2DDiffOrderCondition::LineLoad2DDiffOrderCondition(IndexType NewId, Geom
 LineLoad2DDiffOrderCondition::LineLoad2DDiffOrderCondition(IndexType               NewId,
                                                            GeometryType::Pointer   pGeometry,
                                                            PropertiesType::Pointer pProperties)
-    : GeneralUPwDiffOrderCondition(NewId, pGeometry, pProperties)
+    : GeneralUPwDiffOrderCondition(NewId, std::move(pGeometry), std::move(pProperties))
 {
 }
 

--- a/applications/GeoMechanicsApplication/custom_conditions/line_normal_fluid_flux_2D_diff_order_condition.cpp
+++ b/applications/GeoMechanicsApplication/custom_conditions/line_normal_fluid_flux_2D_diff_order_condition.cpp
@@ -30,14 +30,14 @@ LineNormalFluidFlux2DDiffOrderCondition::LineNormalFluidFlux2DDiffOrderCondition
 // Constructor 1
 LineNormalFluidFlux2DDiffOrderCondition::LineNormalFluidFlux2DDiffOrderCondition(IndexType NewId,
                                                                                  GeometryType::Pointer pGeometry)
-    : LineLoad2DDiffOrderCondition(NewId, pGeometry)
+    : LineLoad2DDiffOrderCondition(NewId, std::move(pGeometry))
 {
 }
 
 // Constructor 2
 LineNormalFluidFlux2DDiffOrderCondition::LineNormalFluidFlux2DDiffOrderCondition(
     IndexType NewId, GeometryType::Pointer pGeometry, PropertiesType::Pointer pProperties)
-    : LineLoad2DDiffOrderCondition(NewId, pGeometry, pProperties)
+    : LineLoad2DDiffOrderCondition(NewId, std::move(pGeometry), std::move(pProperties))
 {
 }
 

--- a/applications/GeoMechanicsApplication/custom_conditions/line_normal_load_2D_diff_order_condition.cpp
+++ b/applications/GeoMechanicsApplication/custom_conditions/line_normal_load_2D_diff_order_condition.cpp
@@ -30,7 +30,7 @@ LineNormalLoad2DDiffOrderCondition::LineNormalLoad2DDiffOrderCondition()
 
 // Constructor 1
 LineNormalLoad2DDiffOrderCondition::LineNormalLoad2DDiffOrderCondition(IndexType NewId, GeometryType::Pointer pGeometry)
-    : LineLoad2DDiffOrderCondition(NewId, pGeometry)
+    : LineLoad2DDiffOrderCondition(NewId, std::move(pGeometry))
 {
 }
 
@@ -38,7 +38,7 @@ LineNormalLoad2DDiffOrderCondition::LineNormalLoad2DDiffOrderCondition(IndexType
 LineNormalLoad2DDiffOrderCondition::LineNormalLoad2DDiffOrderCondition(IndexType NewId,
                                                                        GeometryType::Pointer pGeometry,
                                                                        PropertiesType::Pointer pProperties)
-    : LineLoad2DDiffOrderCondition(NewId, pGeometry, pProperties)
+    : LineLoad2DDiffOrderCondition(NewId, std::move(pGeometry), std::move(pProperties))
 {
 }
 

--- a/applications/GeoMechanicsApplication/custom_conditions/surface_load_3D_diff_order_condition.cpp
+++ b/applications/GeoMechanicsApplication/custom_conditions/surface_load_3D_diff_order_condition.cpp
@@ -27,7 +27,7 @@ SurfaceLoad3DDiffOrderCondition::SurfaceLoad3DDiffOrderCondition() : GeneralUPwD
 
 // Constructor 1
 SurfaceLoad3DDiffOrderCondition::SurfaceLoad3DDiffOrderCondition(IndexType NewId, GeometryType::Pointer pGeometry)
-    : GeneralUPwDiffOrderCondition(NewId, pGeometry)
+    : GeneralUPwDiffOrderCondition(NewId, std::move(pGeometry))
 {
 }
 
@@ -35,7 +35,7 @@ SurfaceLoad3DDiffOrderCondition::SurfaceLoad3DDiffOrderCondition(IndexType NewId
 SurfaceLoad3DDiffOrderCondition::SurfaceLoad3DDiffOrderCondition(IndexType             NewId,
                                                                  GeometryType::Pointer pGeometry,
                                                                  PropertiesType::Pointer pProperties)
-    : GeneralUPwDiffOrderCondition(NewId, pGeometry, pProperties)
+    : GeneralUPwDiffOrderCondition(NewId, std::move(pGeometry), std::move(pProperties))
 {
 }
 

--- a/applications/GeoMechanicsApplication/custom_conditions/surface_normal_fluid_flux_3D_diff_order_condition.cpp
+++ b/applications/GeoMechanicsApplication/custom_conditions/surface_normal_fluid_flux_3D_diff_order_condition.cpp
@@ -30,14 +30,14 @@ SurfaceNormalFluidFlux3DDiffOrderCondition::SurfaceNormalFluidFlux3DDiffOrderCon
 // Constructor 1
 SurfaceNormalFluidFlux3DDiffOrderCondition::SurfaceNormalFluidFlux3DDiffOrderCondition(IndexType NewId,
                                                                                        GeometryType::Pointer pGeometry)
-    : SurfaceLoad3DDiffOrderCondition(NewId, pGeometry)
+    : SurfaceLoad3DDiffOrderCondition(NewId, std::move(pGeometry))
 {
 }
 
 // Constructor 2
 SurfaceNormalFluidFlux3DDiffOrderCondition::SurfaceNormalFluidFlux3DDiffOrderCondition(
     IndexType NewId, GeometryType::Pointer pGeometry, PropertiesType::Pointer pProperties)
-    : SurfaceLoad3DDiffOrderCondition(NewId, pGeometry, pProperties)
+    : SurfaceLoad3DDiffOrderCondition(NewId, std::move(pGeometry), std::move(pProperties))
 {
 }
 

--- a/applications/GeoMechanicsApplication/custom_conditions/surface_normal_load_3D_diff_order_condition.cpp
+++ b/applications/GeoMechanicsApplication/custom_conditions/surface_normal_load_3D_diff_order_condition.cpp
@@ -32,7 +32,7 @@ SurfaceNormalLoad3DDiffOrderCondition::SurfaceNormalLoad3DDiffOrderCondition()
 // Constructor 1
 SurfaceNormalLoad3DDiffOrderCondition::SurfaceNormalLoad3DDiffOrderCondition(IndexType NewId,
                                                                              GeometryType::Pointer pGeometry)
-    : SurfaceLoad3DDiffOrderCondition(NewId, pGeometry)
+    : SurfaceLoad3DDiffOrderCondition(NewId, std::move(pGeometry))
 {
 }
 
@@ -40,7 +40,7 @@ SurfaceNormalLoad3DDiffOrderCondition::SurfaceNormalLoad3DDiffOrderCondition(Ind
 SurfaceNormalLoad3DDiffOrderCondition::SurfaceNormalLoad3DDiffOrderCondition(IndexType NewId,
                                                                              GeometryType::Pointer pGeometry,
                                                                              PropertiesType::Pointer pProperties)
-    : SurfaceLoad3DDiffOrderCondition(NewId, pGeometry, pProperties)
+    : SurfaceLoad3DDiffOrderCondition(NewId, std::move(pGeometry), std::move(pProperties))
 {
 }
 

--- a/applications/GeoMechanicsApplication/custom_elements/geo_cr_beam_element_linear_2D2N.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/geo_cr_beam_element_linear_2D2N.cpp
@@ -23,14 +23,14 @@
 namespace Kratos
 {
 GeoCrBeamElementLinear2D2N::GeoCrBeamElementLinear2D2N(IndexType NewId, GeometryType::Pointer pGeometry)
-    : CrBeamElementLinear2D2N(NewId, pGeometry)
+    : CrBeamElementLinear2D2N(NewId, std::move(pGeometry))
 {
 }
 
 GeoCrBeamElementLinear2D2N::GeoCrBeamElementLinear2D2N(IndexType               NewId,
                                                        GeometryType::Pointer   pGeometry,
                                                        PropertiesType::Pointer pProperties)
-    : CrBeamElementLinear2D2N(NewId, pGeometry, pProperties)
+    : CrBeamElementLinear2D2N(NewId, std::move(pGeometry), std::move(pProperties))
 {
 }
 

--- a/applications/GeoMechanicsApplication/custom_workflows/dgeoflow.cpp
+++ b/applications/GeoMechanicsApplication/custom_workflows/dgeoflow.cpp
@@ -384,8 +384,8 @@ int KratosExecute::ExecuteWithPiping(ModelPart&                rModelPart,
         KRATOS_ERROR << "No river boundary found.";
     }
 
-    FindCriticalHead(rModelPart, rGidOutputSettings, rCriticalHeadInfo, pOutput, rKratosLogBuffer,
-                     p_river_boundary, pSolvingStrategy, rCallBackFunctions);
+    FindCriticalHead(rModelPart, rGidOutputSettings, rCriticalHeadInfo, std::move(pOutput),
+                     rKratosLogBuffer, p_river_boundary, pSolvingStrategy, rCallBackFunctions);
 
     WriteCriticalHeadResultToFile();
 
@@ -529,7 +529,7 @@ void KratosExecute::HandleCleanUp(const CallBackFunctions& rCallBackFunctions,
                                   const std::stringstream& rKratosLogBuffer)
 {
     rCallBackFunctions.LogCallback(rKratosLogBuffer.str().c_str());
-    Logger::RemoveOutput(pOutput);
+    Logger::RemoveOutput(std::move(pOutput));
     ResetModelParts();
 }
 

--- a/applications/GeoMechanicsApplication/custom_workflows/dgeosettlement.cpp
+++ b/applications/GeoMechanicsApplication/custom_workflows/dgeosettlement.cpp
@@ -313,7 +313,7 @@ void KratosGeoSettlement::FlushLoggingOutput(const std::function<void(const char
                                              const std::stringstream& rKratosLogBuffer)
 {
     rLogCallback(rKratosLogBuffer.str().c_str());
-    Logger::RemoveOutput(pLoggerOutput);
+    Logger::RemoveOutput(std::move(pLoggerOutput));
 }
 
 const InputUtility* KratosGeoSettlement::GetInterfaceInputUtility() const

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_processes/test_geo_extrapolate_integration_point_values_to_nodes_process.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_processes/test_geo_extrapolate_integration_point_values_to_nodes_process.cpp
@@ -29,7 +29,7 @@ public:
     KRATOS_CLASS_INTRUSIVE_POINTER_DEFINITION(StubElementForNodalExtrapolationTest);
 
     StubElementForNodalExtrapolationTest(IndexType NewId, GeometryType::Pointer pGeometry)
-        : Element(NewId, pGeometry)
+        : Element(NewId, std::move(pGeometry))
     {
     }
 

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_strategies/test_geo_mechanics_newton_rapson_erosion_processs_strategy.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_strategies/test_geo_mechanics_newton_rapson_erosion_processs_strategy.cpp
@@ -39,7 +39,7 @@ public:
                                                         typename TBuilderAndSolverType::Pointer pNewBuilderAndSolver,
                                                         Parameters& rParameters)
         : GeoMechanicsNewtonRaphsonErosionProcessStrategy<TSparseSpace, TDenseSpace, TLinearSolver>(
-              rModelPart, pScheme, pNewConvergenceCriteria, pNewBuilderAndSolver, rParameters),
+              rModelPart, std::move(pScheme), std::move(pNewConvergenceCriteria), std::move(pNewBuilderAndSolver), rParameters),
           mrModelPart(rModelPart)
     {
     }

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_strategies/test_geomechanics_time_integration_scheme.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_strategies/test_geomechanics_time_integration_scheme.cpp
@@ -170,12 +170,12 @@ public:
 
     void AddComponent(ModelPart::ElementType::Pointer element)
     {
-        GetModelPart().AddElement(element);
+        GetModelPart().AddElement(std::move(element));
     }
 
     void AddComponent(ModelPart::ConditionType::Pointer condition)
     {
-        GetModelPart().AddCondition(condition);
+        GetModelPart().AddCondition(std::move(condition));
     }
 
     ModelPart& GetModelPart() { return mModel.GetModelPart("dummy"); }


### PR DESCRIPTION
As per clang-tidy report, this fixes ~35 issues.