### PR TITLE
[GeoMechanicsApplication] Add a unit test for the Mohr-Coulomb model that covers HIGHEST_PRINCIPAL_STRESSES as averaging type

### DIFF
--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_constitutive/test_mohr_coulomb_with_tension_cutoff.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_constitutive/test_mohr_coulomb_with_tension_cutoff.cpp
@@ -192,6 +192,11 @@ KRATOS_TEST_CASE_IN_SUITE(MohrCoulombWithTensionCutOff_CalculateMaterialResponse
     constexpr auto tolerance = 2.0e-10;
     KRATOS_EXPECT_VECTOR_NEAR(CalculateMappedStressVector(cauchy_stress_vector, parameters, law),
                               expected_cauchy_stress_vector, tolerance);
+
+    cauchy_stress_vector <<= 12.0, -12.0, -16.0, 0.0;
+    expected_cauchy_stress_vector <<= 6.78245195822, -13.3912259791, -13.3912259791, 0.0;
+    KRATOS_EXPECT_VECTOR_NEAR(CalculateMappedStressVector(cauchy_stress_vector, parameters, law),
+                              expected_cauchy_stress_vector, tolerance);
 }
 
 KRATOS_TEST_CASE_IN_SUITE(MohrCoulombWithTensionCutOff_CalculateMaterialResponseCauchyAtCornerReturnZone,

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_constitutive/test_mohr_coulomb_with_tension_cutoff.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_constitutive/test_mohr_coulomb_with_tension_cutoff.cpp
@@ -191,13 +191,13 @@ KRATOS_TEST_CASE_IN_SUITE(MohrCoulombWithTensionCutOff_CalculateMaterialResponse
     cauchy_stress_vector <<= 12.0, 10.0, -16.0, 0.0;
     expected_cauchy_stress_vector <<= 7.806379130008, 7.806379130008, -9.61275826001616129, 0.0;
     KRATOS_EXPECT_VECTOR_NEAR(CalculateMappedStressVector(cauchy_stress_vector, parameters, law),
-                              expected_cauchy_stress_vector, Defaults::absolute_tolerance * 2.0e2);
+                              expected_cauchy_stress_vector, Defaults::absolute_tolerance * 1.0e3);
 
     // HIGHEST_PRINCIPAL_STRESSES as averaging type
     cauchy_stress_vector <<= 12.0, -12.0, -16.0, 0.0;
     expected_cauchy_stress_vector <<= 6.78245195822, -13.3912259791, -13.3912259791, 0.0;
     KRATOS_EXPECT_VECTOR_NEAR(CalculateMappedStressVector(cauchy_stress_vector, parameters, law),
-                              expected_cauchy_stress_vector, Defaults::absolute_tolerance * 1.0e2);
+                              expected_cauchy_stress_vector, Defaults::absolute_tolerance * 1.0e3);
 }
 
 KRATOS_TEST_CASE_IN_SUITE(MohrCoulombWithTensionCutOff_CalculateMaterialResponseCauchyAtCornerReturnZone,

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_constitutive/test_mohr_coulomb_with_tension_cutoff.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_constitutive/test_mohr_coulomb_with_tension_cutoff.cpp
@@ -187,16 +187,17 @@ KRATOS_TEST_CASE_IN_SUITE(MohrCoulombWithTensionCutOff_CalculateMaterialResponse
     KRATOS_EXPECT_VECTOR_NEAR(CalculateMappedStressVector(cauchy_stress_vector, parameters, law),
                               expected_cauchy_stress_vector, Defaults::absolute_tolerance);
 
+    // LOWEST_PRINCIPAL_STRESSES as averaging type
     cauchy_stress_vector <<= 12.0, 10.0, -16.0, 0.0;
     expected_cauchy_stress_vector <<= 7.806379130008, 7.806379130008, -9.61275826001616129, 0.0;
-    constexpr auto tolerance = 2.0e-10;
     KRATOS_EXPECT_VECTOR_NEAR(CalculateMappedStressVector(cauchy_stress_vector, parameters, law),
-                              expected_cauchy_stress_vector, tolerance);
+                              expected_cauchy_stress_vector, Defaults::absolute_tolerance * 2.0e2);
 
+    // HIGHEST_PRINCIPAL_STRESSES as averaging type
     cauchy_stress_vector <<= 12.0, -12.0, -16.0, 0.0;
     expected_cauchy_stress_vector <<= 6.78245195822, -13.3912259791, -13.3912259791, 0.0;
     KRATOS_EXPECT_VECTOR_NEAR(CalculateMappedStressVector(cauchy_stress_vector, parameters, law),
-                              expected_cauchy_stress_vector, tolerance);
+                              expected_cauchy_stress_vector, Defaults::absolute_tolerance * 1.0e2);
 }
 
 KRATOS_TEST_CASE_IN_SUITE(MohrCoulombWithTensionCutOff_CalculateMaterialResponseCauchyAtCornerReturnZone,


### PR DESCRIPTION
**📝 Description**
Code coverage analysis has revealed that the averaging type HIGHEST_PRINCIPAL_STRESSES is not covered by our unit tests. In other words, we have no way to validate that the associated code works as expected (using the unit tests). We should add at least uni test to cover the corresponding code.

See the code coverage analysis result of file custom_constitutive/coulomb_yield_surface.cpp (lines 137-139).


**🆕 Changelog**
- Added unit test 
