### PR TITLE
[Core] Expose `PointerVectorSet::back` to python

### DIFF
--- a/kratos/python/containers_interface.h
+++ b/kratos/python/containers_interface.h
@@ -100,7 +100,7 @@ public:
 
     void CreateInterface(pybind11::module& m, std::string ContainerName)
     {
-        auto bindings = py::class_<TContainerType, typename TContainerType::Pointer  >(m,ContainerName.c_str())
+        py::class_<TContainerType, typename TContainerType::Pointer  >(m,ContainerName.c_str())
         .def(py::init<>())
         .def("__len__",      [](TContainerType& self){return self.size();} )
         .def("__contains__", [](TContainerType& self, const typename TContainerType::value_type& value){return (self.find(value.Id()) != self.end());} )

--- a/kratos/python/containers_interface.h
+++ b/kratos/python/containers_interface.h
@@ -53,7 +53,7 @@ class MapInterface
 
     MapInterface(){};
     virtual ~MapInterface(){};
-   
+
     void CreateInterface(pybind11::module& m, std::string ContainerName)
     {
         py::class_<TContainerType, typename TContainerType::Pointer  >(m,ContainerName.c_str())
@@ -68,7 +68,7 @@ class MapInterface
         ;
     }
 };
-  
+
 template< class TContainerType >
 class PointerVectorPythonInterface
 {
@@ -100,7 +100,7 @@ public:
 
     void CreateInterface(pybind11::module& m, std::string ContainerName)
     {
-        py::class_<TContainerType, typename TContainerType::Pointer  >(m,ContainerName.c_str())
+        auto bindings = py::class_<TContainerType, typename TContainerType::Pointer  >(m,ContainerName.c_str())
         .def(py::init<>())
         .def("__len__",      [](TContainerType& self){return self.size();} )
         .def("__contains__", [](TContainerType& self, const typename TContainerType::value_type& value){return (self.find(value.Id()) != self.end());} )
@@ -110,7 +110,11 @@ public:
         .def("__getitem__",  [](TContainerType& self, unsigned int i){return self(i);} )
         .def("__iter__",     [](TContainerType& self){return py::make_iterator(self.ptr_begin(), self.ptr_end());},  py::keep_alive<0,1>())  //TODO: decide if here we should use ptr_iterators or iterators
         .def("append",       [](TContainerType& self, typename TContainerType::pointer value){self.push_back(value);}  )
-        .def("clear",        [](TContainerType& self){self.clear();} )
+        .def("clear",        [](TContainerType& self){self.clear();})
+        .def("back",         [](TContainerType& rThis){
+            KRATOS_ERROR_IF(rThis.empty()) << "attempting to call \"back()\" on an empty container.";
+            return *(rThis.ptr_end() - 1);
+        })
         ;
     }
 };


### PR DESCRIPTION
The fastest way of finding a node/element/condition ID that's not used yet is by finding the upper bound of existing ones. Since we don't support index-based searches in `PointerVectorSet`, `back` is a reasonable alternative.