### PR TITLE
[GeoMechanicsApplication] Expose missing processes and schemes to GeoMechanicsApplication C++ workflow

### DIFF
--- a/applications/GeoMechanicsApplication/custom_utilities/scheme_factory.hpp
+++ b/applications/GeoMechanicsApplication/custom_utilities/scheme_factory.hpp
@@ -13,8 +13,12 @@
 #pragma once
 
 #include "custom_strategies/schemes/backward_euler_quasistatic_U_Pw_scheme.hpp"
+#include "custom_strategies/schemes/backward_euler_quasistatic_Pw_scheme.hpp"
 #include "custom_strategies/schemes/load_stepping_scheme.hpp"
 #include "custom_strategies/schemes/newmark_dynamic_U_Pw_scheme.hpp"
+#include "custom_strategies/schemes/newmark_quasistatic_damped_U_Pw_scheme.hpp"
+#include "custom_strategies/schemes/newmark_quasistatic_Pw_scheme.hpp"
+#include "custom_strategies/schemes/newmark_quasistatic_U_Pw_scheme.hpp"
 #include "solving_strategies/schemes/scheme.h"
 #include <memory>
 
@@ -34,12 +38,28 @@ public:
         KRATOS_ERROR_IF_NOT(rSolverSettings.Has("solution_type"))
             << "solution_type is not defined, aborting";
 
-        if (rSolverSettings["scheme_type"].GetString() == "Backward_Euler" &&
-            rSolverSettings["solution_type"].GetString() == "Quasi-Static") {
-            return std::make_shared<BackwardEulerQuasistaticUPwScheme<TSparseSpace, TDenseSpace>>();
+        const auto scheme_type   = rSolverSettings["scheme_type"].GetString();
+        const auto solution_type = rSolverSettings["solution_type"].GetString();
+        
+        // Determine the solver type (Pw or U_Pw)
+        std::string solver_type = "U_Pw";
+        if (rSolverSettings.Has("solver_type")) {
+            solver_type = rSolverSettings["solver_type"].GetString();
         }
 
-        if (rSolverSettings["scheme_type"].GetString() == "Newmark") {
+        // Backward Euler schemes
+        if (scheme_type == "Backward_Euler") {
+            if (solution_type == "Quasi-Static") {
+                if (solver_type == "Pw") {
+                    return std::make_shared<BackwardEulerQuasistaticPwScheme<TSparseSpace, TDenseSpace>>();
+                }
+                // Default to U-Pw scheme
+                return std::make_shared<BackwardEulerQuasistaticUPwScheme<TSparseSpace, TDenseSpace>>();
+            }
+        }
+
+        // Newmark schemes
+        if (scheme_type == "Newmark") {
             KRATOS_ERROR_IF_NOT(rSolverSettings.Has("newmark_beta"))
                 << "'newmark_beta' is not defined, aborting";
             KRATOS_ERROR_IF_NOT(rSolverSettings.Has("newmark_gamma"))
@@ -50,25 +70,39 @@ public:
             const auto beta  = rSolverSettings["newmark_beta"].GetDouble();
             const auto gamma = rSolverSettings["newmark_gamma"].GetDouble();
             const auto theta = rSolverSettings["newmark_theta"].GetDouble();
-            if (rSolverSettings["solution_type"].GetString() == "dynamic") {
+
+            if (solution_type == "dynamic") {
                 return std::make_shared<NewmarkDynamicUPwScheme<TSparseSpace, TDenseSpace>>(beta, gamma, theta);
             }
-            if (rSolverSettings["solution_type"].GetString() == "Quasi-Static") {
-                return std::make_shared<NewmarkQuasistaticUPwScheme<TSparseSpace, TDenseSpace>>(
-                    beta, gamma, theta);
+            
+            if (solution_type == "Quasi-Static") {
+                if (solver_type == "Pw") {
+                    return std::make_shared<NewmarkQuasistaticPwScheme<TSparseSpace, TDenseSpace>>(theta);
+                }
+
+                const auto rayleigh_m = rSolverSettings.Has("rayleigh_m") ? rSolverSettings["rayleigh_m"].GetDouble() : 0.0;
+                const auto rayleigh_k = rSolverSettings.Has("rayleigh_k") ? rSolverSettings["rayleigh_k"].GetDouble() : 0.0;
+
+                if (rayleigh_m < 1.0e-20 && rayleigh_k < 1.0e-20) {
+                    return std::make_shared<NewmarkQuasistaticUPwScheme<TSparseSpace, TDenseSpace>>(
+                        beta, gamma, theta);
+                } else {
+                    return std::make_shared<NewmarkQuasistaticDampedUPwScheme<TSparseSpace, TDenseSpace>>(
+                        beta, gamma, theta);
+                }
             }
         }
 
-        if (rSolverSettings["solution_type"].GetString() == "static") {
-            if (rSolverSettings["scheme_type"].GetString() == "load_stepping") {
+        // Static schemes
+        if (solution_type == "static") {
+            if (scheme_type == "load_stepping") {
                 return std::make_shared<LoadSteppingScheme<TSparseSpace, TDenseSpace>>();
             }
             return std::make_shared<GeoMechanicsStaticScheme<TSparseSpace, TDenseSpace>>();
         }
 
-        KRATOS_ERROR << "Specified combination of solution_type ("
-                     << rSolverSettings["solution_type"].GetString() << ") and scheme_type ("
-                     << rSolverSettings["scheme_type"].GetString() << ") is not supported, aborting";
+        KRATOS_ERROR << "Specified combination of solution_type (" << solution_type
+                     << ") and scheme_type (" << scheme_type << ") is not supported, aborting";
     }
 };
 

--- a/applications/GeoMechanicsApplication/custom_workflows/dgeosettlement.cpp
+++ b/applications/GeoMechanicsApplication/custom_workflows/dgeosettlement.cpp
@@ -26,6 +26,18 @@
 #include "custom_processes/apply_vector_constraint_table_process.h"
 #include "custom_processes/fix_water_pressures_above_phreatic_line.h"
 #include "custom_processes/set_parameter_field_process.hpp"
+#include "custom_processes/apply_c_phi_reduction_process.h"
+#include "custom_processes/apply_component_table_process.h"
+#include "custom_processes/apply_constant_interpolate_line_pressure_process.hpp"
+#include "custom_processes/apply_constant_phreatic_multi_line_pressure_process.h"
+#include "custom_processes/apply_final_stresses_of_previous_stage_to_initial_state.h"
+#include "custom_processes/apply_initial_uniform_stress_field.h"
+#include "custom_processes/apply_write_result_scalar_process.hpp"
+#include "custom_processes/calculate_incremental_motion_process.h"
+#include "custom_processes/calculate_total_motion_process.h"
+#include "custom_processes/geo_apply_constant_scalar_value_process.h"
+#include "custom_processes/set_absorbing_boundary_parameters_process.hpp"
+#include "custom_processes/set_multiple_moving_loads.h"
 
 #include "adaptive_time_incrementor.h"
 #include "custom_processes/deactivate_conditions_on_inactive_elements_process.h"
@@ -163,6 +175,25 @@ void KratosGeoSettlement::InitializeProcessFactory()
                                 MakeCreatorWithModelFor<GeoExtrapolateIntegrationPointValuesToNodesProcess>());
     mProcessFactory->AddCreator("FixWaterPressuresAbovePhreaticLineProcess",
                                 MakeCreatorFor<FixWaterPressuresAbovePhreaticLineProcess>());
+    mProcessFactory->AddCreator("ApplyComponentTableProcess",
+                                MakeCreatorFor<ApplyComponentTableProcess>());
+    mProcessFactory->AddCreator("ApplyConstantPhreaticMultiLinePressureProcess",
+                                MakeCreatorFor<ApplyConstantPhreaticMultiLinePressureProcess>());
+    mProcessFactory->AddCreator("ApplyFinalStressesOfPreviousStageToInitialState",
+                                MakeCreatorWithModelFor<ApplyFinalStressesOfPreviousStageToInitialState>());
+    mProcessFactory->AddCreator("ApplyInitialUniformStressField", MakeCreatorFor<ApplyInitialUniformStressField>());
+    mProcessFactory->AddCreator("ApplyWriteScalarProcess", MakeCreatorFor<ApplyWriteScalarProcess>());
+    mProcessFactory->AddCreator("CalculateIncrementalMotionProcess",
+                                MakeCreatorFor<CalculateIncrementalMotionProcess>());
+    mProcessFactory->AddCreator("CalculateTotalMotionProcess", MakeCreatorFor<CalculateTotalMotionProcess>());
+    mProcessFactory->AddCreator("GeoApplyConstantScalarValueProcess",
+                                MakeCreatorFor<GeoApplyConstantScalarValueProcess>());
+    mProcessFactory->AddCreator("SetMultipleMovingLoadsProcess", MakeCreatorFor<SetMultipleMovingLoadsProcess>());
+    mProcessFactory->AddCreator("ApplyCPhiReductionProcess", MakeCreatorWithModelFor<ApplyCPhiReductionProcess>());
+    mProcessFactory->AddCreator("ApplyConstantInterpolateLinePressureProcess",
+                                MakeCreatorFor<ApplyConstantInterpolateLinePressureProcess>());
+    mProcessFactory->AddCreator("SetAbsorbingBoundaryParametersProcess",
+                                MakeCreatorFor<SetAbsorbingBoundaryParametersProcess>());
     mProcessFactory->SetCallBackWhenProcessIsUnknown([](const std::string& rProcessName) {
         KRATOS_ERROR << "Unexpected process (" << rProcessName << "), calculation is aborted";
     });

--- a/applications/GeoMechanicsApplication/custom_workflows/dgeosettlement.cpp
+++ b/applications/GeoMechanicsApplication/custom_workflows/dgeosettlement.cpp
@@ -19,25 +19,25 @@
 #include "structural_mechanics_application.h"
 #include "time_loop_executor_interface.h"
 
+#include "custom_processes/apply_c_phi_reduction_process.h"
+#include "custom_processes/apply_component_table_process.h"
+#include "custom_processes/apply_constant_interpolate_line_pressure_process.h"
+#include "custom_processes/apply_constant_phreatic_multi_line_pressure_process.h"
 #include "custom_processes/apply_excavation_process.h"
+#include "custom_processes/apply_final_stresses_of_previous_stage_to_initial_state.h"
+#include "custom_processes/apply_initial_uniform_stress_field.h"
 #include "custom_processes/apply_k0_procedure_process.h"
 #include "custom_processes/apply_normal_load_table_process.h"
 #include "custom_processes/apply_scalar_constraint_table_process.h"
 #include "custom_processes/apply_vector_constraint_table_process.h"
-#include "custom_processes/fix_water_pressures_above_phreatic_line.h"
-#include "custom_processes/set_parameter_field_process.hpp"
-#include "custom_processes/apply_c_phi_reduction_process.h"
-#include "custom_processes/apply_component_table_process.h"
-#include "custom_processes/apply_constant_interpolate_line_pressure_process.hpp"
-#include "custom_processes/apply_constant_phreatic_multi_line_pressure_process.h"
-#include "custom_processes/apply_final_stresses_of_previous_stage_to_initial_state.h"
-#include "custom_processes/apply_initial_uniform_stress_field.h"
-#include "custom_processes/apply_write_result_scalar_process.hpp"
+#include "custom_processes/apply_write_result_scalar_process.h"
 #include "custom_processes/calculate_incremental_motion_process.h"
 #include "custom_processes/calculate_total_motion_process.h"
+#include "custom_processes/fix_water_pressures_above_phreatic_line.h"
 #include "custom_processes/geo_apply_constant_scalar_value_process.h"
-#include "custom_processes/set_absorbing_boundary_parameters_process.hpp"
+#include "custom_processes/set_absorbing_boundary_parameters_process.h"
 #include "custom_processes/set_multiple_moving_loads.h"
+#include "custom_processes/set_parameter_field_process.hpp"
 
 #include "adaptive_time_incrementor.h"
 #include "custom_processes/deactivate_conditions_on_inactive_elements_process.h"
@@ -175,21 +175,23 @@ void KratosGeoSettlement::InitializeProcessFactory()
                                 MakeCreatorWithModelFor<GeoExtrapolateIntegrationPointValuesToNodesProcess>());
     mProcessFactory->AddCreator("FixWaterPressuresAbovePhreaticLineProcess",
                                 MakeCreatorFor<FixWaterPressuresAbovePhreaticLineProcess>());
-    mProcessFactory->AddCreator("ApplyComponentTableProcess",
-                                MakeCreatorFor<ApplyComponentTableProcess>());
+    mProcessFactory->AddCreator("ApplyComponentTableProcess", MakeCreatorFor<ApplyComponentTableProcess>());
     mProcessFactory->AddCreator("ApplyConstantPhreaticMultiLinePressureProcess",
                                 MakeCreatorFor<ApplyConstantPhreaticMultiLinePressureProcess>());
     mProcessFactory->AddCreator("ApplyFinalStressesOfPreviousStageToInitialState",
                                 MakeCreatorWithModelFor<ApplyFinalStressesOfPreviousStageToInitialState>());
-    mProcessFactory->AddCreator("ApplyInitialUniformStressField", MakeCreatorFor<ApplyInitialUniformStressField>());
+    mProcessFactory->AddCreator("ApplyInitialUniformStressField",
+                                MakeCreatorFor<ApplyInitialUniformStressField>());
     mProcessFactory->AddCreator("ApplyWriteScalarProcess", MakeCreatorFor<ApplyWriteScalarProcess>());
     mProcessFactory->AddCreator("CalculateIncrementalMotionProcess",
                                 MakeCreatorFor<CalculateIncrementalMotionProcess>());
     mProcessFactory->AddCreator("CalculateTotalMotionProcess", MakeCreatorFor<CalculateTotalMotionProcess>());
     mProcessFactory->AddCreator("GeoApplyConstantScalarValueProcess",
                                 MakeCreatorFor<GeoApplyConstantScalarValueProcess>());
-    mProcessFactory->AddCreator("SetMultipleMovingLoadsProcess", MakeCreatorFor<SetMultipleMovingLoadsProcess>());
-    mProcessFactory->AddCreator("ApplyCPhiReductionProcess", MakeCreatorWithModelFor<ApplyCPhiReductionProcess>());
+    mProcessFactory->AddCreator("SetMultipleMovingLoadsProcess",
+                                MakeCreatorFor<SetMultipleMovingLoadsProcess>());
+    mProcessFactory->AddCreator("ApplyCPhiReductionProcess",
+                                MakeCreatorWithModelFor<ApplyCPhiReductionProcess>());
     mProcessFactory->AddCreator("ApplyConstantInterpolateLinePressureProcess",
                                 MakeCreatorFor<ApplyConstantInterpolateLinePressureProcess>());
     mProcessFactory->AddCreator("SetAbsorbingBoundaryParametersProcess",

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_utilities/test_scheme_factory.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_utilities/test_scheme_factory.cpp
@@ -84,4 +84,175 @@ KRATOS_TEST_CASE_IN_SUITE(CreateScheme_ReturnsCorrectScheme_ForBackwardEulerQuas
     KRATOS_EXPECT_NE(backward_euler_scheme, nullptr);
 }
 
+KRATOS_TEST_CASE_IN_SUITE(CreateScheme_ReturnsCorrectScheme_ForBackwardEulerQuasiStaticPw,
+                          KratosGeoMechanicsFastSuiteWithoutKernel)
+{
+    const auto parameters =
+        R"(
+    {
+        "scheme_type" : "Backward_Euler",
+        "solution_type" : "Quasi-Static",
+        "solver_type" : "Pw"
+    }
+    )";
+
+    const auto scheme = SchemeFactoryType::Create(Parameters{parameters});
+    const auto backward_euler_scheme =
+        dynamic_cast<const BackwardEulerQuasistaticPwScheme<SparseSpaceType, LocalSpaceType>*>(
+            scheme.get());
+
+    KRATOS_EXPECT_NE(backward_euler_scheme, nullptr);
+}
+
+KRATOS_TEST_CASE_IN_SUITE(CreateScheme_ReturnsCorrectScheme_ForNewmarkDynamic,
+                          KratosGeoMechanicsFastSuiteWithoutKernel)
+{
+    const auto parameters =
+        R"(
+    {
+        "scheme_type" : "Newmark",
+        "solution_type" : "dynamic",
+        "newmark_beta" : 0.25,
+        "newmark_gamma" : 0.5,
+        "newmark_theta" : 0.5
+    }
+    )";
+
+    const auto scheme = SchemeFactoryType::Create(Parameters{parameters});
+    const auto newmark_scheme =
+        dynamic_cast<const NewmarkDynamicUPwScheme<SparseSpaceType, LocalSpaceType>*>(
+            scheme.get());
+
+    KRATOS_EXPECT_NE(newmark_scheme, nullptr);
+}
+
+KRATOS_TEST_CASE_IN_SUITE(CreateScheme_ReturnsCorrectScheme_ForNewmarkQuasiStaticUndamped,
+                          KratosGeoMechanicsFastSuiteWithoutKernel)
+{
+    const auto parameters =
+        R"(
+    {
+        "scheme_type" : "Newmark",
+        "solution_type" : "Quasi-Static",
+        "newmark_beta" : 0.25,
+        "newmark_gamma" : 0.5,
+        "newmark_theta" : 0.5
+    }
+    )";
+
+    const auto scheme = SchemeFactoryType::Create(Parameters{parameters});
+    const auto newmark_scheme =
+        dynamic_cast<const NewmarkQuasistaticUPwScheme<SparseSpaceType, LocalSpaceType>*>(
+            scheme.get());
+
+    KRATOS_EXPECT_NE(newmark_scheme, nullptr);
+}
+
+KRATOS_TEST_CASE_IN_SUITE(CreateScheme_ReturnsCorrectScheme_ForNewmarkQuasiStaticDamped,
+                          KratosGeoMechanicsFastSuiteWithoutKernel)
+{
+    const auto parameters =
+        R"(
+    {
+        "scheme_type" : "Newmark",
+        "solution_type" : "Quasi-Static",
+        "newmark_beta" : 0.25,
+        "newmark_gamma" : 0.5,
+        "newmark_theta" : 0.5,
+        "rayleigh_m" : 0.1
+    }
+    )";
+
+    const auto scheme = SchemeFactoryType::Create(Parameters{parameters});
+    const auto newmark_scheme =
+        dynamic_cast<const NewmarkQuasistaticDampedUPwScheme<SparseSpaceType, LocalSpaceType>*>(
+            scheme.get());
+
+    KRATOS_EXPECT_NE(newmark_scheme, nullptr);
+}
+
+KRATOS_TEST_CASE_IN_SUITE(CreateScheme_ReturnsCorrectScheme_ForNewmarkQuasiStaticDampedWithK,
+                          KratosGeoMechanicsFastSuiteWithoutKernel)
+{
+    const auto parameters =
+        R"(
+    {
+        "scheme_type" : "Newmark",
+        "solution_type" : "Quasi-Static",
+        "newmark_beta" : 0.25,
+        "newmark_gamma" : 0.5,
+        "newmark_theta" : 0.5,
+        "rayleigh_k" : 1.0e-5
+    }
+    )";
+
+    const auto scheme = SchemeFactoryType::Create(Parameters{parameters});
+    const auto newmark_scheme =
+        dynamic_cast<const NewmarkQuasistaticDampedUPwScheme<SparseSpaceType, LocalSpaceType>*>(
+            scheme.get());
+
+    KRATOS_EXPECT_NE(newmark_scheme, nullptr);
+}
+
+KRATOS_TEST_CASE_IN_SUITE(CreateScheme_ReturnsCorrectScheme_ForNewmarkQuasiStaticPw,
+                          KratosGeoMechanicsFastSuiteWithoutKernel)
+{
+    const auto parameters =
+        R"(
+    {
+        "scheme_type" : "Newmark",
+        "solution_type" : "Quasi-Static",
+        "newmark_beta" : 0.25,
+        "newmark_gamma" : 0.5,
+        "newmark_theta" : 0.5,
+        "solver_type" : "Pw"
+    }
+    )";
+
+    const auto scheme = SchemeFactoryType::Create(Parameters{parameters});
+    const auto newmark_scheme =
+        dynamic_cast<const NewmarkQuasistaticPwScheme<SparseSpaceType, LocalSpaceType>*>(
+            scheme.get());
+
+    KRATOS_EXPECT_NE(newmark_scheme, nullptr);
+}
+
+KRATOS_TEST_CASE_IN_SUITE(CreateScheme_ReturnsCorrectScheme_ForStaticLoadStepping,
+                          KratosGeoMechanicsFastSuiteWithoutKernel)
+{
+    const auto parameters =
+        R"(
+    {
+        "scheme_type" : "load_stepping",
+        "solution_type" : "static"
+    }
+    )";
+
+    const auto scheme = SchemeFactoryType::Create(Parameters{parameters});
+    const auto load_stepping_scheme =
+        dynamic_cast<const LoadSteppingScheme<SparseSpaceType, LocalSpaceType>*>(
+            scheme.get());
+
+    KRATOS_EXPECT_NE(load_stepping_scheme, nullptr);
+}
+
+KRATOS_TEST_CASE_IN_SUITE(CreateScheme_ReturnsCorrectScheme_ForStaticDefault,
+                          KratosGeoMechanicsFastSuiteWithoutKernel)
+{
+    const auto parameters =
+        R"(
+    {
+        "scheme_type" : "some_scheme",
+        "solution_type" : "static"
+    }
+    )";
+
+    const auto scheme = SchemeFactoryType::Create(Parameters{parameters});
+    const auto static_scheme =
+        dynamic_cast<const GeoMechanicsStaticScheme<SparseSpaceType, LocalSpaceType>*>(
+            scheme.get());
+
+    KRATOS_EXPECT_NE(static_scheme, nullptr);
+}
+
 } // namespace Kratos::Testing


### PR DESCRIPTION
**📝 Description**
This PR enhances the GeoMechanicsApplication by adding missing process registrations in the dgeosettlement workflow and expanding scheme factory support for additional scheme variants.

This change allows the dgeosettlement workflow to act more as the generic c++ interface for running geo models in Kratos. This will be applied in the cloud runner PoC through GiD.

**🆕 Changelog**
Added registrations for the following processes:
- `ApplyComponentTableProcess`
- `ApplyConstantPhreaticMultiLinePressureProcess`
- `ApplyFinalStressesOfPreviousStageToInitialState`
- `ApplyInitialUniformStressField`
- `CalculateIncrementalMotionProcess`
- `CalculateTotalMotionProcess`
- `GeoApplyConstantScalarValueProcess`
- `SetMultipleMovingLoadsProcess`
- `ApplyWriteScalarProcess`
- `ApplyCPhiReductionProcess`
- `ApplyConstantInterpolateLinePressureProcess`
- `SetAbsorbingBoundaryParametersProcess`

Added support for 7 scheme variants:
- `BackwardEulerQuasistaticUPwScheme` - Backward Euler with U-Pw coupling
- `BackwardEulerQuasistaticPwScheme` - Backward Euler with water pressure only
- `NewmarkDynamicUPwScheme` - Newmark dynamic analysis
- `NewmarkQuasistaticUPwScheme` - Newmark Quasi-Static undamped
- `NewmarkQuasistaticDampedUPwScheme` - Newmark Quasi-Static with damping
- `NewmarkQuasistaticPwScheme` - Newmark Quasi-Static water pressure only
- `LoadSteppingScheme` - Load stepping for static analysis
- `GeoMechanicsStaticScheme` - Standard static analysis