### PR TITLE
[GeoMechanicsApplications] Made setting material params in the coulomb yield surface thread safe

### DIFF
--- a/applications/GeoMechanicsApplication/custom_constitutive/coulomb_yield_surface.cpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/coulomb_yield_surface.cpp
@@ -80,10 +80,10 @@ namespace Kratos
 
 CoulombYieldSurface::CoulombYieldSurface()
 {
-    mMaterialProperties[GEO_COULOMB_HARDENING_TYPE] = "None";
-    mMaterialProperties[GEO_FRICTION_ANGLE]         = 0.0;
-    mMaterialProperties[GEO_COHESION]               = 0.0;
-    mMaterialProperties[GEO_DILATANCY_ANGLE]        = 0.0;
+    mMaterialProperties.SetValue(GEO_COULOMB_HARDENING_TYPE, "None");
+    mMaterialProperties.SetValue(GEO_FRICTION_ANGLE, 0.0);
+    mMaterialProperties.SetValue(GEO_COHESION, 0.0);
+    mMaterialProperties.SetValue(GEO_DILATANCY_ANGLE, 0.0);
 
     InitializeKappaDependentFunctions();
 }
@@ -93,7 +93,7 @@ CoulombYieldSurface::CoulombYieldSurface(const Properties& rMaterialProperties)
 {
     // For backward compatibility, if no hardening type is given, we assume no hardening at all
     if (!mMaterialProperties.Has(GEO_COULOMB_HARDENING_TYPE)) {
-        mMaterialProperties[GEO_COULOMB_HARDENING_TYPE] = "None";
+        mMaterialProperties.SetValue(GEO_COULOMB_HARDENING_TYPE, "None");
     }
 
     InitializeKappaDependentFunctions();


### PR DESCRIPTION
Used the SetValue function instead of the getter. When a property doesn't exist yet, the getter is not threadsafe and results in a debug error in our small integration test suite:
<img width="1358" height="151" alt="image" src="https://github.com/user-attachments/assets/1fdfab3b-55ab-4108-b7fb-43d965cf88a1" />

The throw happens here: https://github.com/KratosMultiphysics/Kratos/blob/master/kratos/containers/data_value_container.h#L271-L274

_**Note: The reason we don't see this in any pipeline, is the you need to run in debug and with OpenMP enabled to encounter it**_

