### PR TITLE
Extend InterfaceVectorContainer to Support Mapping between Elements, Conditions, and Geometries

### DIFF
--- a/applications/MappingApplication/custom_utilities/interface_vector_container.cpp
+++ b/applications/MappingApplication/custom_utilities/interface_vector_container.cpp
@@ -36,14 +36,46 @@ template<>
 void VectorContainerType::UpdateSystemVectorFromModelPart(const Variable<double>& rVariable,
                                                           const Kratos::Flags& rMappingOptions)
 {
-    MapperUtilities::UpdateSystemVectorFromModelPart(*mpInterfaceVector, mrModelPart, rVariable, rMappingOptions);
+    switch (mInterfaceEntityType) {
+        case InterfaceEntityType::NODES:
+            MapperUtilities::UpdateSystemVectorFromModelPartNodes(*mpInterfaceVector, mrModelPart, rVariable, rMappingOptions);
+            break;
+
+        case InterfaceEntityType::ELEMENTS:
+            MapperUtilities::UpdateSystemVectorFromModelPartElements(*mpInterfaceVector, mrModelPart, rVariable, rMappingOptions);
+            break;
+
+        case InterfaceEntityType::CONDITIONS:
+            MapperUtilities::UpdateSystemVectorFromModelPartConditions(*mpInterfaceVector, mrModelPart, rVariable, rMappingOptions);
+            break;
+
+        case InterfaceEntityType::GEOMETRIES:
+            MapperUtilities::UpdateSystemVectorFromModelPartGeometries(*mpInterfaceVector, mrModelPart, rVariable, rMappingOptions);
+            break;
+    }
 }
 
 template<>
 void VectorContainerType::UpdateModelPartFromSystemVector(const Variable<double>& rVariable,
                                                           const Kratos::Flags& rMappingOptions)
 {
-    MapperUtilities::UpdateModelPartFromSystemVector(*mpInterfaceVector, mrModelPart, rVariable, rMappingOptions);
+    switch (mInterfaceEntityType) {
+        case InterfaceEntityType::NODES:
+            MapperUtilities::UpdateModelPartNodesFromSystemVector(*mpInterfaceVector, mrModelPart, rVariable, rMappingOptions);
+            break;
+
+        case InterfaceEntityType::ELEMENTS:
+            MapperUtilities::UpdateModelPartElementsFromSystemVector(*mpInterfaceVector, mrModelPart, rVariable, rMappingOptions);
+            break;
+
+        case InterfaceEntityType::CONDITIONS:
+            MapperUtilities::UpdateModelPartConditionsFromSystemVector(*mpInterfaceVector, mrModelPart, rVariable, rMappingOptions);
+            break;
+
+        case InterfaceEntityType::GEOMETRIES:
+            MapperUtilities::UpdateModelPartGeometriesFromSystemVector(*mpInterfaceVector, mrModelPart, rVariable, rMappingOptions);
+            break;
+    }
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////

--- a/applications/MappingApplication/custom_utilities/interface_vector_container.h
+++ b/applications/MappingApplication/custom_utilities/interface_vector_container.h
@@ -49,12 +49,28 @@ public:
 
     typedef Kratos::unique_ptr<TSystemVectorType> TSystemVectorUniquePointerType;
 
+    enum class InterfaceEntityType {
+        NODES,
+        ELEMENTS,
+        CONDITIONS,
+        GEOMETRIES
+    };
+
     ///@}
     ///@name Life Cycle
     ///@{
 
+
     /// Default constructor.
-    explicit InterfaceVectorContainer(ModelPart& rModelPart) : mrModelPart(rModelPart) {}
+    explicit InterfaceVectorContainer(ModelPart& rModelPart)
+        : InterfaceVectorContainer(rModelPart, InterfaceEntityType::NODES)
+    {}
+
+    /// Constructor with entity type
+    InterfaceVectorContainer(ModelPart& rModelPart, InterfaceEntityType EntityType)
+        : mrModelPart(rModelPart)
+        , mInterfaceEntityType(EntityType)
+    {}
 
     /// Destructor.
     virtual ~InterfaceVectorContainer() = default;
@@ -99,8 +115,8 @@ public:
 private:
     ///@name Member Variables
     ///@{
-
     ModelPart& mrModelPart;
+    InterfaceEntityType mInterfaceEntityType = InterfaceEntityType::NODES;
     TSystemVectorUniquePointerType mpInterfaceVector = nullptr;
 
     ///@}

--- a/applications/MappingApplication/custom_utilities/mapper_utilities.h
+++ b/applications/MappingApplication/custom_utilities/mapper_utilities.h
@@ -173,10 +173,6 @@ void UpdateSystemVectorFromGeometricalEntities(
     const std::size_t n_entities = rContainer.size();
     auto it_begin = rContainer.begin();
 
-    KRATOS_ERROR_IF(rVector.size() < n_entities)
-        << "UpdateSystemVectorFromEntities: vector size (" << rVector.size()
-        << ") is smaller than number of entities (" << n_entities << ")!" << std::endl;
-
     const int num_threads = InParallel ? ParallelUtilities::GetNumThreads() : 1;
 
     IndexPartition<std::size_t>(n_entities, num_threads).for_each([&](const std::size_t i){
@@ -322,10 +318,6 @@ void UpdateGeometricalEntitiesFromSystemVector(
 
     const std::size_t n_entities = rContainer.size();
     auto it_begin = rContainer.begin();
-
-    KRATOS_ERROR_IF(rVector.size() < n_entities)
-        << "UpdateGeometricalObjectsFromSystemVector: vector size (" << rVector.size()
-        << ") is smaller than number of entities (" << n_entities << ")!" << std::endl;
 
     const int num_threads = InParallel ? ParallelUtilities::GetNumThreads() : 1;
 

--- a/applications/MappingApplication/custom_utilities/mapper_utilities.h
+++ b/applications/MappingApplication/custom_utilities/mapper_utilities.h
@@ -48,14 +48,14 @@ typedef Kratos::shared_ptr<MapperLocalSystemPointerVector> MapperLocalSystemPoin
 
 using BoundingBoxType = std::array<double, 6>;
 
-static void FillFunction(const NodeType& rNode,
+static void FillFunctionNodes(const NodeType& rNode,
                          const Variable<double>& rVariable,
                          double& rValue)
 {
     rValue = rNode.FastGetSolutionStepValue(rVariable);
 }
 
-static void FillFunctionNonHist(const NodeType& rNode,
+static void FillFunctionNodesNonHist(const NodeType& rNode,
                                 const Variable<double>& rVariable,
                                 double& rValue)
 {
@@ -63,14 +63,14 @@ static void FillFunctionNonHist(const NodeType& rNode,
 }
 
 static inline std::function<void(const NodeType&, const Variable<double>&, double&)>
-GetFillFunction(const Kratos::Flags& rMappingOptions)
+GetFillFunctionForNodes(const Kratos::Flags& rMappingOptions)
 {
     if (rMappingOptions.Is(MapperFlags::FROM_NON_HISTORICAL))
-        return &FillFunctionNonHist;
-    return &FillFunction;
+        return &FillFunctionNodesNonHist;
+    return &FillFunctionNodes;
 }
 
-static void UpdateFunction(NodeType& rNode,
+static void UpdateFunctionNodes(NodeType& rNode,
                            const Variable<double>& rVariable,
                            const double Value,
                            const double Factor)
@@ -78,7 +78,7 @@ static void UpdateFunction(NodeType& rNode,
     rNode.FastGetSolutionStepValue(rVariable) = Value * Factor;
 }
 
-static void UpdateFunctionWithAdd(NodeType& rNode,
+static void UpdateFunctionNodesWithAdd(NodeType& rNode,
                             const Variable<double>& rVariable,
                             const double Value,
                             const double Factor)
@@ -86,7 +86,7 @@ static void UpdateFunctionWithAdd(NodeType& rNode,
     rNode.FastGetSolutionStepValue(rVariable) += Value * Factor;
 }
 
-static void UpdateFunctionNonHist(NodeType& rNode,
+static void UpdateFunctionNodesNonHist(NodeType& rNode,
                             const Variable<double>& rVariable,
                             const double Value,
                             const double Factor)
@@ -94,7 +94,7 @@ static void UpdateFunctionNonHist(NodeType& rNode,
     rNode.SetValue(rVariable, Value * Factor);
 }
 
-static void UpdateFunctionNonHistWithAdd(NodeType& rNode,
+static void UpdateFunctionNodesNonHistWithAdd(NodeType& rNode,
                             const Variable<double>& rVariable,
                             const double Value,
                             const double Factor)
@@ -103,19 +103,33 @@ static void UpdateFunctionNonHistWithAdd(NodeType& rNode,
 }
 
 static inline std::function<void(NodeType&, const Variable<double>&, const double, const double)>
-GetUpdateFunction(const Kratos::Flags& rMappingOptions)
+GetUpdateFunctionForNodes(const Kratos::Flags& rMappingOptions)
 {
     if (rMappingOptions.Is(MapperFlags::ADD_VALUES) && rMappingOptions.Is(MapperFlags::TO_NON_HISTORICAL))
-        return &UpdateFunctionNonHistWithAdd;
+        return &UpdateFunctionNodesNonHistWithAdd;
     if (rMappingOptions.Is(MapperFlags::ADD_VALUES))
-        return &UpdateFunctionWithAdd;
+        return &UpdateFunctionNodesWithAdd;
     if (rMappingOptions.Is(MapperFlags::TO_NON_HISTORICAL))
-        return &UpdateFunctionNonHist;
-    return &UpdateFunction;
+        return &UpdateFunctionNodesNonHist;
+    return &UpdateFunctionNodes;
+}
+
+template<class TEntityType>
+static inline std::function<void(TEntityType&, const Variable<double>&, double, double)>
+GetUpdateFunctionForEntities(const Kratos::Flags& rMappingOptions)
+{
+    if (rMappingOptions.Is(MapperFlags::ADD_VALUES))
+        return [](TEntityType& rEntity, const Variable<double>& rVariable, double value, double factor){
+            rEntity.SetValue(rVariable, rEntity.GetValue(rVariable) + factor * value);
+        };
+
+    return [](TEntityType& rEntity, const Variable<double>& rVariable, double value, double factor){
+        rEntity.SetValue(rVariable, factor * value);
+    };
 }
 
 template<class TVectorType, bool TParallel=true>
-void UpdateSystemVectorFromModelPart(
+void UpdateSystemVectorFromModelPartNodes(
     TVectorType& rVector,
     const ModelPart& rModelPart,
     const Variable<double>& rVariable,
@@ -127,7 +141,7 @@ void UpdateSystemVectorFromModelPart(
     if (!rModelPart.GetCommunicator().GetDataCommunicator().IsDefinedOnThisRank()) return;
 
     // Here we construct a function pointer to not have the if all the time inside the loop
-    const auto fill_fct = MapperUtilities::GetFillFunction(rMappingOptions);
+    const auto fill_fct = MapperUtilities::GetFillFunctionForNodes(rMappingOptions);
 
     const int num_local_nodes = rModelPart.GetCommunicator().LocalMesh().NumberOfNodes();
     const auto nodes_begin = rModelPart.GetCommunicator().LocalMesh().NodesBegin();
@@ -144,8 +158,113 @@ void UpdateSystemVectorFromModelPart(
     KRATOS_CATCH("");
 }
 
+template<class TVectorType, class TContainerType>
+void UpdateSystemVectorFromGeometricalEntities(
+    TVectorType& rVector,
+    const TContainerType& rContainer,
+    const Variable<double>& rVariable,
+    const Kratos::Flags& rMappingOptions,
+    const bool InParallel = true)
+{
+    KRATOS_TRY;
+
+    using EntityType = typename TContainerType::value_type;
+
+    const std::size_t n_entities = rContainer.size();
+    auto it_begin = rContainer.begin();
+
+    KRATOS_ERROR_IF(rVector.size() < n_entities)
+        << "UpdateSystemVectorFromEntities: vector size (" << rVector.size()
+        << ") is smaller than number of entities (" << n_entities << ")!" << std::endl;
+
+    const int num_threads = InParallel ? ParallelUtilities::GetNumThreads() : 1;
+
+    IndexPartition<std::size_t>(n_entities, num_threads).for_each([&](const std::size_t i){
+            const EntityType& r_entity = *(it_begin + i);
+            const double value = r_entity.GetValue(rVariable);
+            rVector[i] = value;  // <-- always assign, no add
+        });
+
+    KRATOS_CATCH("");
+}
+
 template<class TVectorType>
-void UpdateModelPartFromSystemVector(
+void UpdateSystemVectorFromModelPartGeometries(
+    TVectorType& rVector,
+    const ModelPart& rModelPart,
+    const Variable<double>& rVariable,
+    const Kratos::Flags& rMappingOptions,
+    const bool InParallel = true)
+{
+    KRATOS_TRY;
+
+    if (!rModelPart.GetCommunicator().GetDataCommunicator().IsDefinedOnThisRank())
+        return;
+
+    const auto& r_geometries = rModelPart.Geometries();
+
+    UpdateSystemVectorFromGeometricalEntities(
+        rVector,
+        r_geometries,
+        rVariable,
+        rMappingOptions,
+        InParallel);
+
+    KRATOS_CATCH("");
+}
+
+template<class TVectorType>
+void UpdateSystemVectorFromModelPartConditions(
+    TVectorType& rVector,
+    const ModelPart& rModelPart,
+    const Variable<double>& rVariable,
+    const Kratos::Flags& rMappingOptions,
+    const bool InParallel = true)
+{
+    KRATOS_TRY;
+
+    if (!rModelPart.GetCommunicator().GetDataCommunicator().IsDefinedOnThisRank())
+        return;
+
+    const auto& r_local_mesh = rModelPart.GetCommunicator().LocalMesh();
+
+    UpdateSystemVectorFromGeometricalEntities(
+        rVector,
+        r_local_mesh.Conditions(),
+        rVariable,
+        rMappingOptions,
+        InParallel);
+
+    KRATOS_CATCH("");
+}
+
+template<class TVectorType>
+void UpdateSystemVectorFromModelPartElements(
+    TVectorType& rVector,
+    const ModelPart& rModelPart,
+    const Variable<double>& rVariable,
+    const Kratos::Flags& rMappingOptions,
+    const bool InParallel = true)
+{
+    KRATOS_TRY;
+
+    if (!rModelPart.GetCommunicator().GetDataCommunicator().IsDefinedOnThisRank())
+        return;
+
+    const auto& r_local_mesh = rModelPart.GetCommunicator().LocalMesh();
+
+    UpdateSystemVectorFromGeometricalEntities(
+        rVector,
+        r_local_mesh.Elements(),
+        rVariable,
+        rMappingOptions,
+        InParallel);
+
+    KRATOS_CATCH("");
+}
+
+template<class TVectorType>
+void UpdateModelPartNodesFromSystemVector(
     const TVectorType& rVector,
     ModelPart& rModelPart,
     const Variable<double>& rVariable,
@@ -159,7 +278,7 @@ void UpdateModelPartFromSystemVector(
     const double factor = rMappingOptions.Is(MapperFlags::SWAP_SIGN) ? -1.0 : 1.0;
 
     // Here we construct a function pointer to not have the if all the time inside the loop
-    const auto update_fct = std::bind(MapperUtilities::GetUpdateFunction(rMappingOptions),
+    const auto update_fct = std::bind(MapperUtilities::GetUpdateFunctionForNodes(rMappingOptions),
                                         std::placeholders::_1,
                                         std::placeholders::_2,
                                         std::placeholders::_3,
@@ -184,6 +303,101 @@ void UpdateModelPartFromSystemVector(
 
     KRATOS_CATCH("");
 }
+
+template<class TVectorType, class TContainerType>
+void UpdateGeometricalEntitiesFromSystemVector(
+    const TVectorType& rVector,
+    TContainerType& rContainer,
+    const Variable<double>& rVariable,
+    const Kratos::Flags& rMappingOptions,
+    const bool InParallel=true)
+{
+    KRATOS_TRY;
+
+    using EntityType = typename TContainerType::value_type;
+
+    const double factor = rMappingOptions.Is(MapperFlags::SWAP_SIGN) ? -1.0 : 1.0;
+
+    const auto update_fct = MapperUtilities::GetUpdateFunctionForEntities<EntityType>(rMappingOptions);
+
+    const std::size_t n_entities = rContainer.size();
+    auto it_begin = rContainer.begin();
+
+    KRATOS_ERROR_IF(rVector.size() < n_entities)
+        << "UpdateGeometricalObjectsFromSystemVector: vector size (" << rVector.size()
+        << ") is smaller than number of entities (" << n_entities << ")!" << std::endl;
+
+    const int num_threads = InParallel ? ParallelUtilities::GetNumThreads() : 1;
+
+    IndexPartition<std::size_t>(n_entities, num_threads).for_each(
+        [&](const std::size_t i){
+            EntityType& r_obj = *(it_begin + i);
+            update_fct(r_obj, rVariable, rVector[i], factor);
+        });
+
+    KRATOS_CATCH("");
+}
+
+template<class TVectorType>
+void UpdateModelPartConditionsFromSystemVector(
+    const TVectorType& rVector,
+    ModelPart& rModelPart,
+    const Variable<double>& rVariable,
+    const Kratos::Flags& rMappingOptions,
+    const bool InParallel=true)
+{
+    if (!rModelPart.GetCommunicator().GetDataCommunicator().IsDefinedOnThisRank()) return;
+    auto& r_local_mesh = rModelPart.GetCommunicator().LocalMesh();
+
+    UpdateGeometricalEntitiesFromSystemVector(
+        rVector,
+        r_local_mesh.Conditions(),
+        rVariable,
+        rMappingOptions,
+        InParallel);
+}
+
+template<class TVectorType>
+void UpdateModelPartElementsFromSystemVector(
+    const TVectorType& rVector,
+    ModelPart& rModelPart,
+    const Variable<double>& rVariable,
+    const Kratos::Flags& rMappingOptions,
+    const bool InParallel=true)
+{
+    if (!rModelPart.GetCommunicator().GetDataCommunicator().IsDefinedOnThisRank()) return;
+    auto& r_local_mesh = rModelPart.GetCommunicator().LocalMesh();
+
+    UpdateGeometricalEntitiesFromSystemVector(
+        rVector,
+        r_local_mesh.Elements(),
+        rVariable,
+        rMappingOptions,
+        InParallel);
+}
+
+template<class TVectorType>
+void UpdateModelPartGeometriesFromSystemVector(
+    const TVectorType& rVector,
+    ModelPart& rModelPart,
+    const Variable<double>& rVariable,
+    const Kratos::Flags& rMappingOptions,
+    const bool InParallel = true)
+{
+    KRATOS_TRY;
+
+    auto& r_geometries = rModelPart.Geometries();
+
+    UpdateGeometricalEntitiesFromSystemVector(
+        rVector,
+        r_geometries,
+        rVariable,
+        rMappingOptions,
+        InParallel);
+
+    KRATOS_CATCH("");
+}
+
 
 /**
 * @brief Assigning INTERFACE_EQUATION_IDs to the nodes, with and without MPI

--- a/applications/MappingApplication/mpi_extension/custom_utilities/interface_vector_container_mpi.cpp
+++ b/applications/MappingApplication/mpi_extension/custom_utilities/interface_vector_container_mpi.cpp
@@ -33,23 +33,71 @@ typedef InterfaceVectorContainer<SparseSpaceType, DenseSpaceType> VectorContaine
 /* PUBLIC Methods */
 /***********************************************************************************/
 template<>
-void VectorContainerType::UpdateSystemVectorFromModelPart(const Variable<double>& rVariable,
-                                                          const Kratos::Flags& rMappingOptions)
+void VectorContainerType::UpdateSystemVectorFromModelPart(
+    const Variable<double>& rVariable,
+    const Kratos::Flags& rMappingOptions)
 {
-    constexpr bool in_parallel = false; // accessing the trilinos vectors is not threadsafe in the default configuration!
-    MapperUtilities::UpdateSystemVectorFromModelPart((*mpInterfaceVector)[0], mrModelPart, rVariable, rMappingOptions, in_parallel);
+    constexpr bool in_parallel = false; // accessing the Trilinos vectors is not threadsafe in the default configuration!
+
+    auto& r_vector = (*mpInterfaceVector)[0];
+
+    switch (mInterfaceEntityType) {
+        case InterfaceEntityType::NODES:
+            MapperUtilities::UpdateSystemVectorFromModelPartNodes(
+                r_vector, mrModelPart, rVariable, rMappingOptions, in_parallel);
+            break;
+
+        case InterfaceEntityType::ELEMENTS:
+            MapperUtilities::UpdateSystemVectorFromModelPartElements(
+                r_vector, mrModelPart, rVariable, rMappingOptions, in_parallel);
+            break;
+
+        case InterfaceEntityType::CONDITIONS:
+            MapperUtilities::UpdateSystemVectorFromModelPartConditions(
+                r_vector, mrModelPart, rVariable, rMappingOptions, in_parallel);
+            break;
+
+        case InterfaceEntityType::GEOMETRIES:
+            MapperUtilities::UpdateSystemVectorFromModelPartGeometries(
+                r_vector, mrModelPart, rVariable, rMappingOptions, in_parallel);
+            break;
+    }
 }
 
 template<>
-void VectorContainerType::UpdateModelPartFromSystemVector(const Variable<double>& rVariable,
-                                                          const Kratos::Flags& rMappingOptions)
+void VectorContainerType::UpdateModelPartFromSystemVector(
+    const Variable<double>& rVariable,
+    const Kratos::Flags& rMappingOptions)
 {
-    constexpr bool in_parallel = false; // accessing the trilinos vectors is not threadsafe in the default configuration!
-    MapperUtilities::UpdateModelPartFromSystemVector((*mpInterfaceVector)[0], mrModelPart, rVariable, rMappingOptions, in_parallel);
+    constexpr bool in_parallel = false; // accessing the Trilinos vectors is not threadsafe in the default configuration!
+
+    const auto& r_vector = (*mpInterfaceVector)[0];
+
+    switch (mInterfaceEntityType) {
+        case InterfaceEntityType::NODES:
+            MapperUtilities::UpdateModelPartNodesFromSystemVector(
+                r_vector, mrModelPart, rVariable, rMappingOptions, in_parallel);
+            break;
+
+        case InterfaceEntityType::ELEMENTS:
+            MapperUtilities::UpdateModelPartElementsFromSystemVector(
+                r_vector, mrModelPart, rVariable, rMappingOptions, in_parallel);
+            break;
+
+        case InterfaceEntityType::CONDITIONS:
+            MapperUtilities::UpdateModelPartConditionsFromSystemVector(
+                r_vector, mrModelPart, rVariable, rMappingOptions, in_parallel);
+            break;
+
+        case InterfaceEntityType::GEOMETRIES:
+            MapperUtilities::UpdateModelPartGeometriesFromSystemVector(
+                r_vector, mrModelPart, rVariable, rMappingOptions, in_parallel);
+            break;
+    }
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 // Class template instantiation
-template class InterfaceVectorContainer< SparseSpaceType, DenseSpaceType >;
+template class InterfaceVectorContainer<SparseSpaceType, DenseSpaceType>;
 
-}  // namespace Kratos.
+}  // namespace Kratos

--- a/applications/MappingApplication/mpi_extension/custom_utilities/interface_vector_container_mpi.cpp
+++ b/applications/MappingApplication/mpi_extension/custom_utilities/interface_vector_container_mpi.cpp
@@ -33,9 +33,8 @@ typedef InterfaceVectorContainer<SparseSpaceType, DenseSpaceType> VectorContaine
 /* PUBLIC Methods */
 /***********************************************************************************/
 template<>
-void VectorContainerType::UpdateSystemVectorFromModelPart(
-    const Variable<double>& rVariable,
-    const Kratos::Flags& rMappingOptions)
+void VectorContainerType::UpdateSystemVectorFromModelPart(const Variable<double>& rVariable,
+                                                          const Kratos::Flags& rMappingOptions)
 {
     constexpr bool in_parallel = false; // accessing the Trilinos vectors is not threadsafe in the default configuration!
 
@@ -65,9 +64,8 @@ void VectorContainerType::UpdateSystemVectorFromModelPart(
 }
 
 template<>
-void VectorContainerType::UpdateModelPartFromSystemVector(
-    const Variable<double>& rVariable,
-    const Kratos::Flags& rMappingOptions)
+void VectorContainerType::UpdateModelPartFromSystemVector(const Variable<double>& rVariable,
+                                                          const Kratos::Flags& rMappingOptions)
 {
     constexpr bool in_parallel = false; // accessing the Trilinos vectors is not threadsafe in the default configuration!
 


### PR DESCRIPTION
This PR extends the `InterfaceVectorContainer` and the corresponding mapping utilities so that an interface vector can now be built not only from `Nodes`, but also from:
- `Elements`
- `Conditions`
- `Geometries`

The container now holds an  `InterfaceEntityType` enum, and the mapping operations automatically select the correct update routines based on the underlying entity type.

This enables future development of interface-based mappings that operate on arbitrary ModelPart entities (elements, conditions or geometries) in a unified way.

FYI @matekelemen @philbucher 

This PR is related to the following Discussion #13927 