### PR TITLE
[CMake] Remove API-breaking change messages from CMakeLists older than 2 years

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -722,12 +722,6 @@ endforeach()
 message("\n***********************************************************************\n")
 
 message("\nList of upcoming API-breaking and behavior changes:")
-message("\t Geometry 'Dimension' removed: https://github.com/KratosMultiphysics/Kratos/pull/10977")
-message("\t Geometry old projection methods deprecation: https://github.com/KratosMultiphysics/Kratos/pull/9024")
-message("\t Geometry old closest point methods deprecation: https://github.com/KratosMultiphysics/Kratos/pull/9243")
-message("\t Model 'CreateModelPart' behavior change (no error thrown if model part exists): https://github.com/KratosMultiphysics/Kratos/pull/9598")
-message("\t Make GetIntegrationMethod method of Condition const: https://github.com/KratosMultiphysics/Kratos/pull/9769")
-message("\t Behavior change of ModelPart.GetProperties (MeshIndex removed): https://github.com/KratosMultiphysics/Kratos/pull/9774")
 message("\t Behavior change of Testing. Please ensure you use KRATOS_EXPECT for testing instead of KRATOS_CHECK")
 message("\t Removal of misused EXTENDED_GAUSS integration rules and unification across geometries: https://github.com/KratosMultiphysics/Kratos/pull/13444")
 


### PR DESCRIPTION
**📝 Description**

Removed several messages regarding API-breaking changes and deprecations from the CMakeLists.txt file if these are older than 2 years.

**🆕 Changelog**

- [Remove API-breaking change messages from CMakeLists older than 2 years](https://github.com/KratosMultiphysics/Kratos/commit/d2a422255d1b6d5569749d08544256ab445b2dd6)
