### PR TITLE
[Core] Added cmake transition flags

### DIFF
--- a/scripts/ninja_configure.bat
+++ b/scripts/ninja_configure.bat
@@ -42,6 +42,7 @@ cmake -G"Ninja"                                                         ^
 -H"%KRATOS_SOURCE%"                                                     ^
 -B"%KRATOS_BUILD%/%KRATOS_BUILD_TYPE%"                                  ^
 -DCMAKE_BUILD_TYPE=%KRATOS_BUILD_TYPE%                                  ^
+-DCMAKE_POLICY_VERSION_MINIMUM=3.5                                      ^
 -DCMAKE_PDB_OUTPUT_DIRECTORY=%KRATOS_BUILD%\%KRATOS_BUILD_TYPE%/PDB     ^
 -DUSE_EIGEN_MKL=OFF                                                     ^
 -DKRATOS_GENERATE_PYTHON_STUBS=ON

--- a/scripts/standard_configure.bat
+++ b/scripts/standard_configure.bat
@@ -42,8 +42,9 @@ rem set KRATOS_PARALLEL_BUILD_FLAG=/MP4
 rem Configure
 @echo on
 cmake -G"Visual Studio 16 2019" -H"%KRATOS_SOURCE%" -B"%KRATOS_BUILD%\%KRATOS_BUILD_TYPE%"          ^
--DUSE_EIGEN_MKL=OFF                                                                                 ^
 -DCMAKE_CXX_FLAGS=" %KRATOS_PARALLEL_BUILD_FLAG% "                                                  ^
+-DCMAKE_POLICY_VERSION_MINIMUM=3.5                                                                  ^
+-DUSE_EIGEN_MKL=OFF                                                                                 ^
 -DKRATOS_GENERATE_PYTHON_STUBS=ON
 
 rem Build

--- a/scripts/standard_configure.sh
+++ b/scripts/standard_configure.sh
@@ -45,6 +45,7 @@ rm -rf "${KRATOS_BUILD}/${KRATOS_BUILD_TYPE}/CMakeFiles"
 # Configure
 cmake -H"${KRATOS_SOURCE}" -B"${KRATOS_BUILD}/${KRATOS_BUILD_TYPE}" \
 -DUSE_MPI=OFF                                                       \
+-DCMAKE_POLICY_VERSION_MINIMUM=3.5                                  \
 -DUSE_EIGEN_MKL=OFF                                                 \
 -DKRATOS_GENERATE_PYTHON_STUBS=ON
 

--- a/scripts/standard_configure_MINGW.sh
+++ b/scripts/standard_configure_MINGW.sh
@@ -41,6 +41,7 @@ cmake ..                                                                        
 -DCMAKE_BUILD_TYPE="${KRATOS_BUILD_TYPE}"                                                           \
 -DCMAKE_EXE_LINKER_FLAGS="-s"                                                                       \
 -DCMAKE_SHARED_LINKER_FLAGS="-s"                                                                    \
+-DCMAKE_POLICY_VERSION_MINIMUM=3.5                                                                  \
 -H"${KRATOS_SOURCE}"                                                                                \
 -B"${KRATOS_BUILD}/${KRATOS_BUILD_TYPE}"                                                            \
 -DUSE_MPI=OFF                                                                                       \

--- a/scripts/standard_configure_MINGW_UCRT64.sh
+++ b/scripts/standard_configure_MINGW_UCRT64.sh
@@ -56,6 +56,7 @@ cmake ..                                                                        
 -DCMAKE_C_FLAGS=${CMAKE_C_FLAGS}                                                                    \
 -DCMAKE_CXX_FLAGS="${KRATOS_CMAKE_CXX_FLAGS} ${CMAKE_CXX_FLAGS}"                                    \
 -DCMAKE_EXPORT_COMPILE_COMMANDS=${CMAKE_EXPORT_COMPILE_COMMANDS}                                    \
+-DCMAKE_POLICY_VERSION_MINIMUM=3.5                                                                  \
 -DKRATOS_BUILD_TESTING=ON                                                                           \
 -DKRATOS_SHARED_MEMORY_PARALLELIZATION="${KRATOS_SHARED_MEMORY_PARALLELIZATION}"                    \
 -DUSE_EIGEN_MKL=OFF

--- a/scripts/standard_configure_intel_llvm.bat
+++ b/scripts/standard_configure_intel_llvm.bat
@@ -50,8 +50,9 @@ cmake                                              ^
 -G "%CMAKE_GENERATOR%"                             ^
 -H"%KRATOS_SOURCE%"                                ^
 -B"%KRATOS_BUILD%\%KRATOS_BUILD_TYPE%"             ^
--DUSE_EIGEN_MKL=OFF                                ^
 -DCMAKE_CXX_FLAGS=" %KRATOS_PARALLEL_BUILD_FLAG% " ^
+-DCMAKE_POLICY_VERSION_MINIMUM=3.5                 ^
+-DUSE_EIGEN_MKL=OFF                                ^
 -DKRATOS_GENERATE_PYTHON_STUBS=ON
 
 rem Build

--- a/scripts/standard_configure_mac.sh
+++ b/scripts/standard_configure_mac.sh
@@ -45,6 +45,7 @@ rm -rf "${KRATOS_BUILD}/${KRATOS_BUILD_TYPE}/CMakeFiles"
 # Configure
 /Applications/CMake.app/Contents/bin/cmake -H"${KRATOS_SOURCE}" -B"${KRATOS_BUILD}/${KRATOS_BUILD_TYPE}"    \
  -DCMAKE_CXX_FLAGS="${CMAKE_CXX_FLAGS} -msse3 -std=c++11 -L/usr/local/opt/llvm/lib"                         \
+ -DCMAKE_POLICY_VERSION_MINIMUM=3.5                                                                         \
  -DCMAKE_C_FLAGS="${CMAKE_C_FLAGS} -msse3 -L/usr/local/opt/llvm/lib"                                        \
  -DUSE_EIGEN_MKL=OFF                                                                                        \
  -DKRATOS_GENERATE_PYTHON_STUBS=ON


### PR DESCRIPTION
**📝 Description**
Added transition flags until we move to 4.0. This is motivated by the release of VisualStudio 2026 which only has a generator in CMake 4.0. Most of users will start using this from now on.

Flags are the same as the ones we use in the CI.