### PR TITLE
[OptApp ] fixing l2 norm Convergence conflicting with acii output

### DIFF
--- a/applications/OptimizationApplication/python_scripts/convergence_criteria/l2_conv_criterion.py
+++ b/applications/OptimizationApplication/python_scripts/convergence_criteria/l2_conv_criterion.py
@@ -1,6 +1,6 @@
 import typing
-import numpy
 import KratosMultiphysics as Kratos
+import KratosMultiphysics.OptimizationApplication as KratosOA
 from KratosMultiphysics.OptimizationApplication.utilities.optimization_problem import OptimizationProblem
 from KratosMultiphysics.OptimizationApplication.utilities.component_data_view import ComponentDataView
 from KratosMultiphysics.OptimizationApplication.utilities.optimization_problem_utilities import GetComponentHavingDataByFullName
@@ -57,7 +57,7 @@ class L2ConvCriterion(ConvergenceCriterion):
         if not hasattr(field, "Evaluate"):
             raise RuntimeError(f"The value represented by {self.__field_name} is not a field.")
 
-        self.__norm = numpy.linalg.norm(field.Evaluate().flatten())
+        self.__norm = KratosOA.ExpressionUtils.NormL2(field)
         self.__conv = self.__norm <= self.__tolerance
         self.__component_data_view.GetBufferedData().SetValue(self.__field_name.split(':')[0] + "_l2_norm", self.__norm)
         return self.__conv


### PR DESCRIPTION
**📝 Description**

This pull request refactors the L2 convergence criterion implementation in `l2_conv_criterion.py` to use Kratos Optimization Application utilities for norm calculation. The old version was flattening the vector and causing the ASCII output process to crash. 
