### PR TITLE
[CI] Avoid hardcoded python 3.8 for compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -322,7 +322,7 @@ jobs:
 
     - name: CI configuration
       shell: bash
-      run: python3.8 kratos/python_scripts/testing/ci_utilities.py
+      run: python3 kratos/python_scripts/testing/ci_utilities.py
 
     - name: Build
       run: |
@@ -336,14 +336,14 @@ jobs:
         if [ -f /etc/bashrc ]; then source /etc/bashrc; fi
         export PYTHONPATH=${GITHUB_WORKSPACE}/bin/Custom
         export LD_LIBRARY_PATH=${GITHUB_WORKSPACE}/bin/Custom/libs
-        python3.8 kratos/python_scripts/testing/run_cpp_tests.py
+        python3 kratos/python_scripts/testing/run_cpp_tests.py
 
     - name: Running python tests
       run: |
         if [ -f /etc/bashrc ]; then source /etc/bashrc; fi
         export PYTHONPATH=${GITHUB_WORKSPACE}/bin/Custom
         export LD_LIBRARY_PATH=${GITHUB_WORKSPACE}/bin/Custom/libs
-        python3.8 kratos/python_scripts/testing/run_python_tests.py -l nightly -c python3.8
+        python3 kratos/python_scripts/testing/run_python_tests.py -l nightly -c python3
 
 
   ubuntu-core-without-unity:


### PR DESCRIPTION
**📝 Description**

[Avoid hardcoded python 3.8 for compatibility](https://github.com/KratosMultiphysics/Kratos/commit/95ae05ccc061adbe8ae96579f4034df43263320f), using just `python3` that will work with other versions like `3.10` which is the current version used in Rocky.

**🆕 Changelog**

- [Avoid hardcoded python 3.8 for compatibility](https://github.com/KratosMultiphysics/Kratos/commit/95ae05ccc061adbe8ae96579f4034df43263320f)