### PR TITLE
[TrilinosApplication] Commenting not compatible test `SuperLUDist` in `Amesos2`.

### DIFF
--- a/applications/TrilinosApplication/tests/test_trilinos_linear_solvers.py
+++ b/applications/TrilinosApplication/tests/test_trilinos_linear_solvers.py
@@ -252,8 +252,9 @@ class TestAmesos2LinearSolvers(TestLinearSolvers):
         with self.subTest('All ranks (MPI_COMM_WORLD)'):
             self._RunParametrized(params_string)
 
-        with self.subTest('SubComm'):
-            self._RunParametrizedWithSubComm(params_string)
+        # NOTE: SuperLUDist apparently is not compatible with subcommunicators
+        # with self.subTest('SubComm'):
+        #     self._RunParametrizedWithSubComm(params_string)
 
     def test_amesos2_mumps(self):
         if( not KratosMultiphysics.TrilinosApplication.Amesos2Solver.HasSolver("amesos2_mumps") ):

--- a/applications/TrilinosApplication/tests/test_trilinos_linear_solvers.py
+++ b/applications/TrilinosApplication/tests/test_trilinos_linear_solvers.py
@@ -336,8 +336,9 @@ class TestAmesos2LinearSolvers(TestLinearSolvers):
         with self.subTest('All ranks (MPI_COMM_WORLD)'):
             self._RunParametrized(params_string)
 
-        with self.subTest('SubComm'):
-            self._RunParametrizedWithSubComm(params_string)
+        # NOTE: SuperLUDist apparently is not compatible with subcommunicators
+        # with self.subTest('SubComm'):
+        #     self._RunParametrizedWithSubComm(params_string)
 
     def test_amesos2_mumps_2(self):
         if( not KratosMultiphysics.TrilinosApplication.Amesos2Solver.HasSolver("amesos2_mumps") ):


### PR DESCRIPTION
**📝 Description**

Commenting not compatible test `SuperLUDist` in `Amesos2`.

`SuperLUDist` apparently is not compatible with subcommunicators with `Amesos2`. It crashes when does the grid size check.

**🆕 Changelog**

- [Commenting not compatible test `SuperLUDist` in `Amesos2`.](https://github.com/KratosMultiphysics/Kratos/commit/46c1c4218e2e703816995db9ca3e97896dae280f)