### PR TITLE
[TrilinosApplication] Add `gfortran` linking to `KratosTrilinosCore` library

### DIFF
--- a/applications/TrilinosApplication/CMakeLists.txt
+++ b/applications/TrilinosApplication/CMakeLists.txt
@@ -68,7 +68,11 @@ endif(${KRATOS_BUILD_TESTING} MATCHES ON)
 # ###############################################################
 ## TrilinosApplication core library (C++ parts)
 add_library( KratosTrilinosCore SHARED ${KRATOS_TRILINOS_APPLICATION_CORE_SOURCES} )
-target_link_libraries(KratosTrilinosCore PUBLIC KratosCore KratosMPICore ${TRILINOS_LIBRARIES} -lgfortran)
+if (${TRILINOS_REQUIRES_LINKING_FORTRAN})
+    target_link_libraries(KratosTrilinosCore PUBLIC KratosCore KratosMPICore ${TRILINOS_LIBRARIES} -lgfortran)
+else()
+    target_link_libraries(KratosTrilinosCore PUBLIC KratosCore KratosMPICore ${TRILINOS_LIBRARIES})
+endif()
 set_target_properties( KratosTrilinosCore PROPERTIES COMPILE_DEFINITIONS "TRILINOS_APPLICATION=EXPORT,API")
 
 target_include_directories(KratosTrilinosCore SYSTEM PUBLIC ${TRILINOS_INCLUDE_DIR})

--- a/applications/TrilinosApplication/CMakeLists.txt
+++ b/applications/TrilinosApplication/CMakeLists.txt
@@ -67,12 +67,12 @@ endif(${KRATOS_BUILD_TESTING} MATCHES ON)
 
 # ###############################################################
 ## TrilinosApplication core library (C++ parts)
-add_library( KratosTrilinosCore SHARED ${KRATOS_TRILINOS_APPLICATION_CORE_SOURCES} )
-if (${TRILINOS_REQUIRES_LINKING_FORTRAN})
-    target_link_libraries(KratosTrilinosCore PUBLIC KratosCore KratosMPICore ${TRILINOS_LIBRARIES} -lgfortran)
-else()
-    target_link_libraries(KratosTrilinosCore PUBLIC KratosCore KratosMPICore ${TRILINOS_LIBRARIES})
+set(TRILINOS_LINK_LIBS KratosCore KratosMPICore ${TRILINOS_LIBRARIES})
+if (${TRILINOS_APPLICATION_LINK_GFORTRAN})
+    set(TRILINOS_LINK_LIBS ${TRILINOS_LINK_LIBS} -lgfortran)
 endif()
+add_library( KratosTrilinosCore SHARED ${KRATOS_TRILINOS_APPLICATION_CORE_SOURCES} )
+target_link_libraries(KratosTrilinosCore PUBLIC ${TRILINOS_LINK_LIBS})
 set_target_properties( KratosTrilinosCore PROPERTIES COMPILE_DEFINITIONS "TRILINOS_APPLICATION=EXPORT,API")
 
 target_include_directories(KratosTrilinosCore SYSTEM PUBLIC ${TRILINOS_INCLUDE_DIR})

--- a/applications/TrilinosApplication/CMakeLists.txt
+++ b/applications/TrilinosApplication/CMakeLists.txt
@@ -68,7 +68,7 @@ endif(${KRATOS_BUILD_TESTING} MATCHES ON)
 # ###############################################################
 ## TrilinosApplication core library (C++ parts)
 add_library( KratosTrilinosCore SHARED ${KRATOS_TRILINOS_APPLICATION_CORE_SOURCES} )
-target_link_libraries(KratosTrilinosCore PUBLIC KratosCore KratosMPICore ${TRILINOS_LIBRARIES} )
+target_link_libraries(KratosTrilinosCore PUBLIC KratosCore KratosMPICore ${TRILINOS_LIBRARIES} -lgfortran)
 set_target_properties( KratosTrilinosCore PROPERTIES COMPILE_DEFINITIONS "TRILINOS_APPLICATION=EXPORT,API")
 
 target_include_directories(KratosTrilinosCore SYSTEM PUBLIC ${TRILINOS_INCLUDE_DIR})


### PR DESCRIPTION
**📝 Description**

Compilation may fail depending of the dependencies management and Trilinos appplication may require to link to fortran.

**🆕 Changelog**

- [Add `gfortran` linking to `KratosTrilinosCore` library](https://github.com/KratosMultiphysics/Kratos/commit/6039d0caa107bee4f675699143c1b65e37e0c96f)
