### PR TITLE
[StructuralMechanicsApplication] Avoid conflict `ProcessInfo` usage in `ComputeCenterOfGravityProcess`, `ComputeMassMomentOfInertiaProcess` and `TotalStructuralMassProcess`

### DIFF
--- a/applications/StructuralMechanicsApplication/custom_processes/compute_center_of_gravity_process.cpp
+++ b/applications/StructuralMechanicsApplication/custom_processes/compute_center_of_gravity_process.cpp
@@ -54,7 +54,7 @@ void ComputeCenterOfGravityProcess::Execute()
     KRATOS_INFO("Hint")  << "Check variable CENTER_OF_GRAVITY in the process info in "
                          << "order to access to it at any moment" << std::endl;
 
-    mrThisModelPart.GetProcessInfo()[CENTER_OF_GRAVITY] = center_of_gravity;
+    mrThisModelPart.SetValue(CENTER_OF_GRAVITY, center_of_gravity);
 
     KRATOS_CATCH("")
 } // class ComputeCenterOfGravityProcess

--- a/applications/StructuralMechanicsApplication/custom_processes/compute_mass_moment_of_inertia_process.cpp
+++ b/applications/StructuralMechanicsApplication/custom_processes/compute_mass_moment_of_inertia_process.cpp
@@ -56,7 +56,7 @@ void ComputeMassMomentOfInertiaProcess::Execute()
     KRATOS_INFO("Hint")  << "Check variable MASS_MOMENT_OF_INERTIA in the process info in "
                          << "order to access to it at any moment" << std::endl;
 
-    mrThisModelPart.GetProcessInfo()[MASS_MOMENT_OF_INERTIA] = moment_of_inertia;
+    mrThisModelPart.SetValue(MASS_MOMENT_OF_INERTIA, moment_of_inertia);
 
     KRATOS_CATCH("")
 } // class ComputeMassMomentOfInertiaProcess

--- a/applications/StructuralMechanicsApplication/custom_processes/total_structural_mass_process.cpp
+++ b/applications/StructuralMechanicsApplication/custom_processes/total_structural_mass_process.cpp
@@ -117,7 +117,7 @@ void TotalStructuralMassProcess::Execute()
     KRATOS_INFO("Hint")  << "Check variable NODAL_MASS in the process info in "
                          << "order to access to it at any moment" << std::endl;
 
-    mrThisModelPart.GetProcessInfo()[NODAL_MASS] = total_mass;
+    mrThisModelPart.SetValue(NODAL_MASS, total_mass);
 
     KRATOS_CATCH("")
 

--- a/applications/StructuralMechanicsApplication/tests/test_compute_center_of_gravity.py
+++ b/applications/StructuralMechanicsApplication/tests/test_compute_center_of_gravity.py
@@ -116,7 +116,7 @@ class TestComputeCenterOfGravity(KratosUnittest.TestCase):
 
         cog_process = StructuralMechanicsApplication.ComputeCenterOfGravityProcess(mp)
         cog_process.Execute()
-        center_of_gravity = mp.ProcessInfo[StructuralMechanicsApplication.CENTER_OF_GRAVITY]
+        center_of_gravity = mp.GetValue(StructuralMechanicsApplication.CENTER_OF_GRAVITY)
 
         self.assertAlmostEqual(2.5688903639, center_of_gravity[0])
         self.assertAlmostEqual(0.0, center_of_gravity[1])
@@ -143,7 +143,7 @@ class TestComputeCenterOfGravity(KratosUnittest.TestCase):
 
         cog_process = StructuralMechanicsApplication.ComputeCenterOfGravityProcess(mp)
         cog_process.Execute()
-        center_of_gravity = mp.ProcessInfo[StructuralMechanicsApplication.CENTER_OF_GRAVITY]
+        center_of_gravity = mp.GetValue(StructuralMechanicsApplication.CENTER_OF_GRAVITY)
 
         self.assertAlmostEqual(0.6, center_of_gravity[0])
         self.assertAlmostEqual(0.0, center_of_gravity[1])
@@ -162,7 +162,7 @@ class TestComputeCenterOfGravity(KratosUnittest.TestCase):
 
         cog_process = StructuralMechanicsApplication.ComputeCenterOfGravityProcess(mp)
         cog_process.Execute()
-        center_of_gravity = mp.ProcessInfo[StructuralMechanicsApplication.CENTER_OF_GRAVITY]
+        center_of_gravity = mp.GetValue(StructuralMechanicsApplication.CENTER_OF_GRAVITY)
 
         self.assertAlmostEqual(0.0723057, center_of_gravity[0])
         self.assertAlmostEqual(0.0517395, center_of_gravity[1])
@@ -181,7 +181,7 @@ class TestComputeCenterOfGravity(KratosUnittest.TestCase):
 
         cog_process = StructuralMechanicsApplication.ComputeCenterOfGravityProcess(mp)
         cog_process.Execute()
-        center_of_gravity = mp.ProcessInfo[StructuralMechanicsApplication.CENTER_OF_GRAVITY]
+        center_of_gravity = mp.GetValue(StructuralMechanicsApplication.CENTER_OF_GRAVITY)
 
         self.assertAlmostEqual(0.0723057, center_of_gravity[0])
         self.assertAlmostEqual(0.0517395, center_of_gravity[1])
@@ -210,7 +210,7 @@ class TestComputeCenterOfGravity(KratosUnittest.TestCase):
 
         cog_process = StructuralMechanicsApplication.ComputeCenterOfGravityProcess(mp)
         cog_process.Execute()
-        center_of_gravity = mp.ProcessInfo[StructuralMechanicsApplication.CENTER_OF_GRAVITY]
+        center_of_gravity = mp.GetValue(StructuralMechanicsApplication.CENTER_OF_GRAVITY)
 
         self.assertAlmostEqual(0.6416666667, center_of_gravity[0])
         self.assertAlmostEqual(0.5729166667, center_of_gravity[1])

--- a/applications/StructuralMechanicsApplication/tests/test_compute_mass_moment_of_inertia.py
+++ b/applications/StructuralMechanicsApplication/tests/test_compute_mass_moment_of_inertia.py
@@ -134,7 +134,7 @@ class TestComputeMassMomentOfInertia(KratosUnittest.TestCase):
 
         moi_process = StructuralMechanicsApplication.ComputeMassMomentOfInertiaProcess(mp, p1, p2)
         moi_process.Execute()
-        moment_of_inertia = mp.ProcessInfo[StructuralMechanicsApplication.MASS_MOMENT_OF_INERTIA]
+        moment_of_inertia = mp.GetValue(StructuralMechanicsApplication.MASS_MOMENT_OF_INERTIA)
         self.assertAlmostEqual(364.5648, moment_of_inertia)
 
     def test_beam_moi(self):
@@ -158,7 +158,7 @@ class TestComputeMassMomentOfInertia(KratosUnittest.TestCase):
         p2 = KratosMultiphysics.Point(0.6, 2.0, 0.0)
         moi_process = StructuralMechanicsApplication.ComputeMassMomentOfInertiaProcess(mp, p1, p2)
         moi_process.Execute()
-        moment_of_inertia = mp.ProcessInfo[StructuralMechanicsApplication.MASS_MOMENT_OF_INERTIA]
+        moment_of_inertia = mp.GetValue(StructuralMechanicsApplication.MASS_MOMENT_OF_INERTIA)
         self.assertAlmostEqual(11.3028466, moment_of_inertia)
 
     def test_shell_moi(self):
@@ -177,7 +177,7 @@ class TestComputeMassMomentOfInertia(KratosUnittest.TestCase):
 
         moi_process = StructuralMechanicsApplication.ComputeMassMomentOfInertiaProcess(mp, p1, p2)
         moi_process.Execute()
-        moment_of_inertia = mp.ProcessInfo[StructuralMechanicsApplication.MASS_MOMENT_OF_INERTIA]
+        moment_of_inertia = mp.GetValue(StructuralMechanicsApplication.MASS_MOMENT_OF_INERTIA)
 
         self.assertAlmostEqual(0.044, moment_of_inertia)
 
@@ -196,7 +196,7 @@ class TestComputeMassMomentOfInertia(KratosUnittest.TestCase):
         p2 = KratosMultiphysics.Point(0.5, 0.25, 1.0)
         moi_process = StructuralMechanicsApplication.ComputeMassMomentOfInertiaProcess(mp, p1, p2)
         moi_process.Execute()
-        moment_of_inertia = mp.ProcessInfo[StructuralMechanicsApplication.MASS_MOMENT_OF_INERTIA]
+        moment_of_inertia = mp.GetValue(StructuralMechanicsApplication.MASS_MOMENT_OF_INERTIA)
 
         self.assertAlmostEqual(1.4762, moment_of_inertia)
 
@@ -228,7 +228,7 @@ class TestComputeMassMomentOfInertia(KratosUnittest.TestCase):
         p2 = KratosMultiphysics.Point(0.4, 0.25, 1.0)
         moi_process = StructuralMechanicsApplication.ComputeMassMomentOfInertiaProcess(mp,p1,p2)
         moi_process.Execute()
-        moment_of_inertia = mp.ProcessInfo[StructuralMechanicsApplication.MASS_MOMENT_OF_INERTIA]
+        moment_of_inertia = mp.GetValue(StructuralMechanicsApplication.MASS_MOMENT_OF_INERTIA)
 
         self.assertAlmostEqual(0.021, moment_of_inertia)
 

--- a/applications/StructuralMechanicsApplication/tests/test_mass_calculation.py
+++ b/applications/StructuralMechanicsApplication/tests/test_mass_calculation.py
@@ -124,7 +124,7 @@ class TestMassCalculation(KratosUnittest.TestCase):
 
         self.__CheckElementalMasses(mp, expected_elemental_masses_by_id)
 
-        total_mass = mp.ProcessInfo[KratosMultiphysics.NODAL_MASS]
+        total_mass = mp.GetValue(KratosMultiphysics.NODAL_MASS)
         self.assertAlmostEqual(sum(expected_elemental_masses_by_id.values()), total_mass)
 
     def test_beam_mass(self):
@@ -162,7 +162,7 @@ class TestMassCalculation(KratosUnittest.TestCase):
         }
         self.__CheckElementalMasses(mp, expected_elemental_masses_by_id)
 
-        total_mass = mp.ProcessInfo[KratosMultiphysics.NODAL_MASS]
+        total_mass = mp.GetValue(KratosMultiphysics.NODAL_MASS)
         self.assertAlmostEqual(sum(expected_elemental_masses_by_id.values()), total_mass)
 
     def test_shell_mass(self):
@@ -187,7 +187,7 @@ class TestMassCalculation(KratosUnittest.TestCase):
         }
         self.__CheckElementalMasses(mp, expected_elemental_masses_by_id)
 
-        total_mass = mp.ProcessInfo[KratosMultiphysics.NODAL_MASS]
+        total_mass = mp.GetValue(KratosMultiphysics.NODAL_MASS)
         self.assertAlmostEqual(sum(expected_elemental_masses_by_id.values()), total_mass)
 
     def test_orthotropic_shell_mass(self):
@@ -212,7 +212,7 @@ class TestMassCalculation(KratosUnittest.TestCase):
         }
         self.__CheckElementalMasses(mp, expected_elemental_masses_by_id)
 
-        total_mass = mp.ProcessInfo[KratosMultiphysics.NODAL_MASS]
+        total_mass = mp.GetValue(KratosMultiphysics.NODAL_MASS)
         self.assertAlmostEqual(sum(expected_elemental_masses_by_id.values()), total_mass)
 
     def test_solid_mass(self):
@@ -246,7 +246,7 @@ class TestMassCalculation(KratosUnittest.TestCase):
         }
         self.__CheckElementalMasses(mp, expected_elemental_masses_by_id)
 
-        total_mass = mp.ProcessInfo[KratosMultiphysics.NODAL_MASS]
+        total_mass = mp.GetValue(KratosMultiphysics.NODAL_MASS)
         self.assertAlmostEqual(sum(expected_elemental_masses_by_id.values()), total_mass)
 
     def __CheckElementalMasses(self, model_part, expected_elemental_masses_by_id):


### PR DESCRIPTION
**📝 Description**

Avoid conflict `ProcessInfo` usage in `ComputeCenterOfGravityProcess`, `ComputeMassMomentOfInertiaProcess` and `TotalStructuralMassProcess`.

Fixes https://github.com/KratosMultiphysics/Kratos/issues/14050

**🆕 Changelog**

- [Avoid conflict `ProcessInfo` usage in `ComputeCenterOfGravityProcess`](https://github.com/KratosMultiphysics/Kratos/commit/6deb5de738f7d7338e6297468a7873b92eddaded)
- [Avoid conflict `ProcessInfo` usage in `ComputeMassMomentOfInertiaProcess`](https://github.com/KratosMultiphysics/Kratos/commit/6aad4f989f5f3417e218d1a7347bc31de710b32d)
- [Avoid conflict `ProcessInfo` usage in `TotalStructuralMassProcess`](https://github.com/KratosMultiphysics/Kratos/commit/ab81729007048db661020faf5f64dd4aed274ccc)
