### PR TITLE
[Core] Fix `AMGCLSolver` in GPU mode

### DIFF
--- a/kratos/linear_solvers/amgcl_solver_impl.hpp
+++ b/kratos/linear_solvers/amgcl_solver_impl.hpp
@@ -548,6 +548,7 @@ void AMGCLSolver<TSparse,TDense>::InitializeSolutionStep(SparseMatrixType& rLhs,
 
         // Construct a GPU-bound shared-memory solver.
         #define KRATOS_MAKE_SHARED_MEMORY_AMGCL_SOLVER(BLOCK_SIZE)                                          \
+            register_vexcl_static_matrix_type<typename TSparse::DataType,BLOCK_SIZE>();                     \
             using BackendType = amgcl::backend::vexcl<typename Impl::template BackendMatrix<BLOCK_SIZE>>;   \
             using SolverType = typename Impl::template MakeSharedMemorySolver<BackendType>::element_type;   \
                                                                                                             \
@@ -564,6 +565,7 @@ void AMGCLSolver<TSparse,TDense>::InitializeSolutionStep(SparseMatrixType& rLhs,
         // Construct a GPU-bound distributed-memory solver.
         #ifdef KRATOS_USING_MPI
             #define KRATOS_MAKE_DISTRIBUTED_AMGCL_SOLVER(BLOCK_SIZE)                                            \
+                register_vexcl_static_matrix_type<typename TSparse::DataType,BLOCK_SIZE>();                     \
                 using BackendType = amgcl::backend::vexcl<typename Impl::template BackendMatrix<BLOCK_SIZE>>;   \
                 using SolverType = typename Impl::template MakeDistributedSolver<BackendType>::element_type;    \
                                                                                                                 \


### PR DESCRIPTION
During refactoring in #13624, I forgot about registering static matrix and vector types on the device side when running `AMGCLSolver` with `"use_gpgpu" : true`. The result was a JIT error at CPU runtime when device kernels are compiled.

This PR adds the missing matrix/vector registration so `AMGCLSolver` can be used in GPU mode again.