### PR TITLE
[GeoMechanicsApplication] Improvements for the nodal extrapolation process

### DIFF
--- a/applications/GeoMechanicsApplication/custom_processes/geo_extrapolate_integration_point_values_to_nodes_process.cpp
+++ b/applications/GeoMechanicsApplication/custom_processes/geo_extrapolate_integration_point_values_to_nodes_process.cpp
@@ -126,10 +126,11 @@ void GeoExtrapolateIntegrationPointValuesToNodesProcess::ExecuteFinalizeSolution
     CacheExtrapolationMatricesForElements();
 
     for (const auto& r_model_part : mrModelParts) {
-        block_for_each(r_model_part.get().Elements(), [this](Element& rElement) {
+        block_for_each(r_model_part.get().Elements(),
+                       [this, &r_process_info = r_model_part.get().GetProcessInfo()](Element& rElement) {
             if (rElement.IsActive()) {
                 AddIntegrationPointContributionsForAllVariables(
-                    rElement, GetCachedExtrapolationMatrixFor(rElement));
+                    rElement, GetCachedExtrapolationMatrixFor(rElement), r_process_info);
             }
         });
     }
@@ -167,25 +168,25 @@ const Matrix& GeoExtrapolateIntegrationPointValuesToNodesProcess::GetCachedExtra
 }
 
 void GeoExtrapolateIntegrationPointValuesToNodesProcess::AddIntegrationPointContributionsForAllVariables(
-    Element& rElement, const Matrix& rExtrapolationMatrix) const
+    Element& rElement, const Matrix& rExtrapolationMatrix, const ProcessInfo& rProcessInfo) const
 {
     const auto integration_points_number = GeoElementUtilities::GetNumberOfIntegrationPointsOf(rElement);
 
     for (const auto p_var : mDoubleVariables) {
         AddIntegrationContributionsToNodes(rElement, *p_var, rExtrapolationMatrix,
-                                           integration_points_number, AtomicAdd<double>);
+                                           integration_points_number, rProcessInfo, AtomicAdd<double>);
     }
     for (const auto p_var : mArrayVariables) {
-        AddIntegrationContributionsToNodes(rElement, *p_var, rExtrapolationMatrix,
-                                           integration_points_number, AtomicAdd<double, 3>);
+        AddIntegrationContributionsToNodes(rElement, *p_var, rExtrapolationMatrix, integration_points_number,
+                                           rProcessInfo, AtomicAdd<double, 3>);
     }
     for (const auto p_var : mVectorVariables) {
-        AddIntegrationContributionsToNodes(rElement, *p_var, rExtrapolationMatrix,
-                                           integration_points_number, AtomicAddVector<Vector, Vector>);
+        AddIntegrationContributionsToNodes(rElement, *p_var, rExtrapolationMatrix, integration_points_number,
+                                           rProcessInfo, AtomicAddVector<Vector, Vector>);
     }
     for (const auto p_var : mMatrixVariables) {
-        AddIntegrationContributionsToNodes(rElement, *p_var, rExtrapolationMatrix,
-                                           integration_points_number, AtomicAddMatrix<Matrix, Matrix>);
+        AddIntegrationContributionsToNodes(rElement, *p_var, rExtrapolationMatrix, integration_points_number,
+                                           rProcessInfo, AtomicAddMatrix<Matrix, Matrix>);
     }
 }
 

--- a/applications/GeoMechanicsApplication/custom_processes/geo_extrapolate_integration_point_values_to_nodes_process.cpp
+++ b/applications/GeoMechanicsApplication/custom_processes/geo_extrapolate_integration_point_values_to_nodes_process.cpp
@@ -60,12 +60,6 @@ void GeoExtrapolateIntegrationPointValuesToNodesProcess::FillVariableLists(const
     }
 }
 
-void GeoExtrapolateIntegrationPointValuesToNodesProcess::Execute()
-{
-    ExecuteBeforeSolutionLoop();
-    ExecuteFinalizeSolutionStep();
-}
-
 void GeoExtrapolateIntegrationPointValuesToNodesProcess::ExecuteBeforeSolutionLoop()
 {
     InitializeAverageVariablesForElements();

--- a/applications/GeoMechanicsApplication/custom_processes/geo_extrapolate_integration_point_values_to_nodes_process.h
+++ b/applications/GeoMechanicsApplication/custom_processes/geo_extrapolate_integration_point_values_to_nodes_process.h
@@ -95,27 +95,23 @@ private:
                                             const Variable<T>& rVariable,
                                             const Matrix&      rExtrapolationMatrix,
                                             SizeType           NumberOfIntegrationPoints,
+                                            const ProcessInfo& rProcessInfo,
                                             const U&           rAtomicAddOperation) const
     {
         auto&          r_geometry = rElement.GetGeometry();
         std::vector<T> values_on_integration_points(NumberOfIntegrationPoints);
-        for (const auto& r_model_part : mrModelParts) {
-            rElement.CalculateOnIntegrationPoints(rVariable, values_on_integration_points,
-                                                  r_model_part.get().GetProcessInfo());
+        rElement.CalculateOnIntegrationPoints(rVariable, values_on_integration_points, rProcessInfo);
 
-            for (IndexType iNode = 0; iNode < r_geometry.PointsNumber(); ++iNode) {
-                // We first initialize the source, which we need to do by getting the first value,
-                // because we don't know the size of the dynamically allocated Vector/Matrix
-                T source = rExtrapolationMatrix(iNode, 0) * values_on_integration_points[0];
-                for (IndexType i_gauss_point = 1;
-                     i_gauss_point < values_on_integration_points.size(); ++i_gauss_point) {
-                    source += rExtrapolationMatrix(iNode, i_gauss_point) *
-                              values_on_integration_points[i_gauss_point];
-                }
-                source /= r_geometry[iNode].GetValue(mrAverageVariable);
-
-                rAtomicAddOperation(r_geometry[iNode].FastGetSolutionStepValue(rVariable), source);
+        for (IndexType iNode = 0; iNode < r_geometry.PointsNumber(); ++iNode) {
+            // We first initialize the source, which we need to do by getting the first value,
+            // because we don't know the size of the dynamically allocated Vector/Matrix
+            T source = rExtrapolationMatrix(iNode, 0) * values_on_integration_points[0];
+            for (IndexType i_gauss_point = 1; i_gauss_point < values_on_integration_points.size(); ++i_gauss_point) {
+                source += rExtrapolationMatrix(iNode, i_gauss_point) * values_on_integration_points[i_gauss_point];
             }
+            source /= r_geometry[iNode].GetValue(mrAverageVariable);
+
+            rAtomicAddOperation(r_geometry[iNode].FastGetSolutionStepValue(rVariable), source);
         }
     }
 
@@ -124,7 +120,9 @@ private:
     [[nodiscard]] bool          ExtrapolationMatrixIsCachedFor(const Element& rElement) const;
     [[nodiscard]] const Matrix& GetCachedExtrapolationMatrixFor(const Element& rElement) const;
 
-    void AddIntegrationPointContributionsForAllVariables(Element& rElement, const Matrix& rExtrapolationMatrix) const;
+    void AddIntegrationPointContributionsForAllVariables(Element&           rElement,
+                                                         const Matrix&      rExtrapolationMatrix,
+                                                         const ProcessInfo& rProcessInfo) const;
 };
 
 } // namespace Kratos.

--- a/applications/GeoMechanicsApplication/custom_processes/geo_extrapolate_integration_point_values_to_nodes_process.h
+++ b/applications/GeoMechanicsApplication/custom_processes/geo_extrapolate_integration_point_values_to_nodes_process.h
@@ -50,7 +50,6 @@ public:
 
     ~GeoExtrapolateIntegrationPointValuesToNodesProcess() override;
 
-    void                           Execute() override;
     void                           ExecuteBeforeSolutionLoop() override;
     void                           ExecuteFinalizeSolutionStep() override;
     void                           ExecuteFinalize() override;

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_processes/test_geo_extrapolate_integration_point_values_to_nodes_process.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_processes/test_geo_extrapolate_integration_point_values_to_nodes_process.cpp
@@ -159,7 +159,6 @@ KRATOS_TEST_CASE_IN_SUITE(TestExtrapolationProcess_ExtrapolatesCorrectlyForConst
     GeoExtrapolateIntegrationPointValuesToNodesProcess process(model, parameters);
     process.ExecuteBeforeSolutionLoop();
     process.ExecuteFinalizeSolutionStep();
-    process.ExecuteFinalize();
 
     for (auto& node : model_part.Nodes()) {
         KRATOS_EXPECT_NEAR(node.FastGetSolutionStepValue(HYDRAULIC_HEAD), 1.0, 1e-6);
@@ -192,7 +191,6 @@ KRATOS_TEST_CASE_IN_SUITE(TestExtrapolationProcess_ExtrapolatesCorrectlyForTwoCo
     GeoExtrapolateIntegrationPointValuesToNodesProcess process(model, parameters);
     process.ExecuteBeforeSolutionLoop();
     process.ExecuteFinalizeSolutionStep();
-    process.ExecuteFinalize();
 
     std::vector<double> expected_values = {1.0, 1.5, 1.5, 1.0, 2.0, 2.0};
     std::vector<double> actual_values;
@@ -231,7 +229,6 @@ KRATOS_TEST_CASE_IN_SUITE(TestExtrapolationProcess_ExtrapolatesCorrectlyForLinea
     GeoExtrapolateIntegrationPointValuesToNodesProcess process(model, parameters);
     process.ExecuteBeforeSolutionLoop();
     process.ExecuteFinalizeSolutionStep();
-    process.ExecuteFinalize();
 
     std::vector<double> expected_values = {-1, 0, 1, -1, -1, 1};
     std::vector<double> actual_values;
@@ -272,7 +269,6 @@ KRATOS_TEST_CASE_IN_SUITE(TestExtrapolationProcess_ExtrapolatesCorrectlyForLinea
     GeoExtrapolateIntegrationPointValuesToNodesProcess process(model, parameters);
     process.ExecuteBeforeSolutionLoop();
     process.ExecuteFinalizeSolutionStep();
-    process.ExecuteFinalize();
 
     std::vector<double> expected_values = {-1, 0, 1, -1, -1, 1};
     std::vector<double> actual_values;
@@ -314,7 +310,6 @@ KRATOS_TEST_CASE_IN_SUITE(TestExtrapolationProcess_ExtrapolatesMatrixCorrectlyFo
     GeoExtrapolateIntegrationPointValuesToNodesProcess process(model, parameters);
     process.ExecuteBeforeSolutionLoop();
     process.ExecuteFinalizeSolutionStep();
-    process.ExecuteFinalize();
 
     std::vector<Matrix> expected_values = {ScalarMatrix(3, 3, -1), ScalarMatrix(3, 3, 0),
                                            ScalarMatrix(3, 3, 1),  ScalarMatrix(3, 3, -1),
@@ -361,7 +356,6 @@ KRATOS_TEST_CASE_IN_SUITE(TestExtrapolationProcess_ExtrapolatesVectorCorrectlyFo
     GeoExtrapolateIntegrationPointValuesToNodesProcess process(model, parameters);
     process.ExecuteBeforeSolutionLoop();
     process.ExecuteFinalizeSolutionStep();
-    process.ExecuteFinalize();
 
     std::vector<Vector> expected_values = {ScalarVector(6, -1), ScalarVector(6, 0),
                                            ScalarVector(6, 1),  ScalarVector(6, -1),
@@ -408,7 +402,6 @@ KRATOS_TEST_CASE_IN_SUITE(TestExtrapolationProcess_ExtrapolatesArrayCorrectlyFor
     GeoExtrapolateIntegrationPointValuesToNodesProcess process(model, parameters);
     process.ExecuteBeforeSolutionLoop();
     process.ExecuteFinalizeSolutionStep();
-    process.ExecuteFinalize();
 
     std::vector<Vector>              expected_values = {ScalarVector(3, -1), ScalarVector(3, 0),
                                                         ScalarVector(3, 1),  ScalarVector(3, -1),

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_processes/test_geo_extrapolate_integration_point_values_to_nodes_process.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_processes/test_geo_extrapolate_integration_point_values_to_nodes_process.cpp
@@ -155,7 +155,9 @@ KRATOS_TEST_CASE_IN_SUITE(TestExtrapolationProcess_ExtrapolatesCorrectlyForConst
     })");
 
     GeoExtrapolateIntegrationPointValuesToNodesProcess process(model, parameters);
-    process.Execute();
+    process.ExecuteBeforeSolutionLoop();
+    process.ExecuteFinalizeSolutionStep();
+    process.ExecuteFinalize();
 
     for (auto& node : model_part.Nodes()) {
         KRATOS_EXPECT_NEAR(node.FastGetSolutionStepValue(HYDRAULIC_HEAD), 1.0, 1e-6);
@@ -186,7 +188,9 @@ KRATOS_TEST_CASE_IN_SUITE(TestExtrapolationProcess_ExtrapolatesCorrectlyForTwoCo
     })");
 
     GeoExtrapolateIntegrationPointValuesToNodesProcess process(model, parameters);
-    process.Execute();
+    process.ExecuteBeforeSolutionLoop();
+    process.ExecuteFinalizeSolutionStep();
+    process.ExecuteFinalize();
 
     std::vector<double> expected_values = {1.0, 1.5, 1.5, 1.0, 2.0, 2.0};
     std::vector<double> actual_values;
@@ -223,7 +227,9 @@ KRATOS_TEST_CASE_IN_SUITE(TestExtrapolationProcess_ExtrapolatesCorrectlyForLinea
          "list_of_variables"          : ["HYDRAULIC_HEAD"]
      })");
     GeoExtrapolateIntegrationPointValuesToNodesProcess process(model, parameters);
-    process.Execute();
+    process.ExecuteBeforeSolutionLoop();
+    process.ExecuteFinalizeSolutionStep();
+    process.ExecuteFinalize();
 
     std::vector<double> expected_values = {-1, 0, 1, -1, -1, 1};
     std::vector<double> actual_values;
@@ -263,7 +269,9 @@ KRATOS_TEST_CASE_IN_SUITE(TestExtrapolationProcess_ExtrapolatesMatrixCorrectlyFo
      })");
 
     GeoExtrapolateIntegrationPointValuesToNodesProcess process(model, parameters);
-    process.Execute();
+    process.ExecuteBeforeSolutionLoop();
+    process.ExecuteFinalizeSolutionStep();
+    process.ExecuteFinalize();
 
     std::vector<Matrix> expected_values = {ScalarMatrix(3, 3, -1), ScalarMatrix(3, 3, 0),
                                            ScalarMatrix(3, 3, 1),  ScalarMatrix(3, 3, -1),
@@ -308,7 +316,9 @@ KRATOS_TEST_CASE_IN_SUITE(TestExtrapolationProcess_ExtrapolatesVectorCorrectlyFo
      })");
 
     GeoExtrapolateIntegrationPointValuesToNodesProcess process(model, parameters);
-    process.Execute();
+    process.ExecuteBeforeSolutionLoop();
+    process.ExecuteFinalizeSolutionStep();
+    process.ExecuteFinalize();
 
     std::vector<Vector> expected_values = {ScalarVector(6, -1), ScalarVector(6, 0),
                                            ScalarVector(6, 1),  ScalarVector(6, -1),
@@ -353,7 +363,9 @@ KRATOS_TEST_CASE_IN_SUITE(TestExtrapolationProcess_ExtrapolatesArrayCorrectlyFor
      })");
 
     GeoExtrapolateIntegrationPointValuesToNodesProcess process(model, parameters);
-    process.Execute();
+    process.ExecuteBeforeSolutionLoop();
+    process.ExecuteFinalizeSolutionStep();
+    process.ExecuteFinalize();
 
     std::vector<Vector>              expected_values = {ScalarVector(3, -1), ScalarVector(3, 0),
                                                         ScalarVector(3, 1),  ScalarVector(3, -1),


### PR DESCRIPTION
**📝 Description**
This PR fixes a bug in the nodal extrapolation process where the number of provided model parts (even if they are empty) had an impact on the smoothed nodal values. In addition, the override of member `Execute` has been removed since it was used by unit tests only.

**🆕 Changelog**
- Removed an inner loop over the provided model parts that should not have been there.
- Added a unit test that demonstrates that if unrelated (empty) model parts are added to the `"model_part_name_list"`, it no longer has an impact on the smoothed nodal values.
- Removed member `GeoExtrapolateIntegrationPointValuesToNodesProcess::Execute`, since it was called by unit tests only. By explicitly stating which members are supposed to be called in which order, using the nodal extrapolation process has been documented more clearly by the unit tests.
