### PR TITLE
Added calculate and unit tests to interface.

### DIFF
--- a/applications/GeoMechanicsApplication/custom_elements/interface_element.h
+++ b/applications/GeoMechanicsApplication/custom_elements/interface_element.h
@@ -62,6 +62,10 @@ public:
                                       std::vector<ConstitutiveLaw::Pointer>&    rOutput,
                                       const ProcessInfo&) override;
     using Element::CalculateOnIntegrationPoints;
+
+    void Calculate(const Variable<Vector>& rVariable, Vector& rOutput, const ProcessInfo& rProcessInfo) override;
+    using Element::Calculate;
+
     void GetDofList(DofsVectorType& rElementalDofList, const ProcessInfo&) const override;
     void Initialize(const ProcessInfo& rCurrentProcessInfo) override;
     int  Check(const ProcessInfo& rCurrentProcessInfo) const override;

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_elements/test_interface_element.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_elements/test_interface_element.cpp
@@ -566,16 +566,17 @@ KRATOS_TEST_CASE_IN_SUITE(LineInterfaceElement_RightHandSideEqualsMinusInternalF
     Vector actual_external_forces_vector;
     element.Calculate(EXTERNAL_FORCES_VECTOR, actual_external_forces_vector, ProcessInfo{});
     // Assert
-    auto expected_external_forces_vector = Vector{8,0.0};
-    KRATOS_EXPECT_VECTOR_RELATIVE_NEAR(actual_external_forces_vector, expected_external_forces_vector, Defaults::relative_tolerance)
+    const auto expected_external_forces_vector = Vector{8, 0.0};
+    KRATOS_EXPECT_VECTOR_RELATIVE_NEAR(actual_external_forces_vector,
+                                       expected_external_forces_vector, Defaults::relative_tolerance)
 
     // Act
     Vector actual_internal_forces_vector;
     element.Calculate(INTERNAL_FORCES_VECTOR, actual_internal_forces_vector, ProcessInfo{});
     // Assert
-    auto expected_internal_forces_vector = Vector{- expected_right_hand_side};
-    KRATOS_EXPECT_VECTOR_RELATIVE_NEAR(actual_internal_forces_vector, expected_internal_forces_vector, Defaults::relative_tolerance)
-
+    auto expected_internal_forces_vector = Vector{(-1.0) * expected_right_hand_side};
+    KRATOS_EXPECT_VECTOR_RELATIVE_NEAR(actual_internal_forces_vector,
+                                       expected_internal_forces_vector, Defaults::relative_tolerance)
 }
 
 KRATOS_TEST_CASE_IN_SUITE(LineInterfaceElement_RightHandSideEqualsMinusInternalForceVector_Rotated,

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_elements/test_interface_element.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_elements/test_interface_element.cpp
@@ -557,11 +557,25 @@ KRATOS_TEST_CASE_IN_SUITE(LineInterfaceElement_RightHandSideEqualsMinusInternalF
     // Act
     Vector actual_right_hand_side;
     element.CalculateRightHandSide(actual_right_hand_side, ProcessInfo{});
-
     // Assert
     auto expected_right_hand_side = Vector{8};
     expected_right_hand_side <<= 1.0, 5.0, 1.0, 5.0, -1.0, -5.0, -1.0, -5.0;
     KRATOS_EXPECT_VECTOR_RELATIVE_NEAR(actual_right_hand_side, expected_right_hand_side, Defaults::relative_tolerance)
+
+    // Act
+    Vector actual_external_forces_vector;
+    element.Calculate(EXTERNAL_FORCES_VECTOR, actual_external_forces_vector, ProcessInfo{});
+    // Assert
+    auto expected_external_forces_vector = Vector{8,0.0};
+    KRATOS_EXPECT_VECTOR_RELATIVE_NEAR(actual_external_forces_vector, expected_external_forces_vector, Defaults::relative_tolerance)
+
+    // Act
+    Vector actual_internal_forces_vector;
+    element.Calculate(INTERNAL_FORCES_VECTOR, actual_internal_forces_vector, ProcessInfo{});
+    // Assert
+    auto expected_internal_forces_vector = Vector{- expected_right_hand_side};
+    KRATOS_EXPECT_VECTOR_RELATIVE_NEAR(actual_internal_forces_vector, expected_internal_forces_vector, Defaults::relative_tolerance)
+
 }
 
 KRATOS_TEST_CASE_IN_SUITE(LineInterfaceElement_RightHandSideEqualsMinusInternalForceVector_Rotated,

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_elements/test_interface_element.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_elements/test_interface_element.cpp
@@ -574,7 +574,7 @@ KRATOS_TEST_CASE_IN_SUITE(LineInterfaceElement_RightHandSideEqualsMinusInternalF
     Vector actual_internal_forces_vector;
     element.Calculate(INTERNAL_FORCES_VECTOR, actual_internal_forces_vector, ProcessInfo{});
     // Assert
-    auto expected_internal_forces_vector = Vector{(-1.0) * expected_right_hand_side};
+    const auto expected_internal_forces_vector = Vector{(-1.0) * expected_right_hand_side};
     KRATOS_EXPECT_VECTOR_RELATIVE_NEAR(actual_internal_forces_vector,
                                        expected_internal_forces_vector, Defaults::relative_tolerance)
 }


### PR DESCRIPTION
**📝 Description**
For the incremental load stepping in GeoMechanicsApplication, separation of internal and external forces is needed. This separation is provided by the Calculate.

**🆕 Changelog**
- Added Calculate to the interface element in GeoMechanicsApplication
- Added test coverage by extending a unit test.
