### PR TITLE
[Core] Fix uninitialized `BoundedMatrix` warning in `ParallelDistanceCalculationProcess`

### DIFF
--- a/kratos/processes/parallel_distance_calculation_process.cpp
+++ b/kratos/processes/parallel_distance_calculation_process.cpp
@@ -19,7 +19,6 @@
 
 // Project includes
 #include "containers/model.h"
-#include "includes/model_part.h"
 #include "utilities/geometry_utilities.h"
 #include "utilities/parallel_utilities.h"
 #include "processes/parallel_distance_calculation_process.h"
@@ -88,20 +87,16 @@ double ParallelDistanceCalculationProcess<TDim>::FindMaximumEdgeSize()
 
     double h_max = 0.0;
 
-    for(ModelPart::ElementsContainerType::iterator it=mrModelPart.ElementsBegin(); it!=mrModelPart.ElementsEnd(); it++)
-    {
+    for(ModelPart::ElementsContainerType::iterator it=mrModelPart.ElementsBegin(); it!=mrModelPart.ElementsEnd(); it++) {
         Geometry<NodeType >&geom = it->GetGeometry();
 
         double h = 0.0;
 
-        for(unsigned int i=0; i<TDim+1; i++)
-        {
-
+        for(unsigned int i=0; i<TDim+1; i++) {
             double xc = geom[i].X();
             double yc = geom[i].Y();
             double zc = geom[i].Z();
-            for(unsigned int j=i+1; j<TDim+1; j++)
-            {
+            for(unsigned int j=i+1; j<TDim+1; j++) {
                 double x = geom[j].X();
                 double y = geom[j].Y();
                 double z = geom[j].Z();
@@ -414,7 +409,7 @@ void ParallelDistanceCalculationProcess<TDim>::ExtendDistancesByLayer()
 
     // Set the TLS container
     array_1d<double,TDim+1> visited, N;
-    BoundedMatrix <double, TDim+1,TDim> DN_DX;
+    BoundedMatrix <double, TDim+1,TDim> DN_DX = ZeroMatrix(TDim+1, TDim);
     typedef std::tuple<array_1d<double,TDim+1>, array_1d<double,TDim+1>, BoundedMatrix<double, TDim+1, TDim>> TLSType;
     TLSType tls_container = std::make_tuple(visited, N, DN_DX);
 


### PR DESCRIPTION
**📝 Description**

This PR addresses a compilation error encountered when using **GCC 13** (and other recent toolsets) in the `ParallelDistanceCalculationProcess`.

The compiler flags an `-Werror=uninitialized` error during the construction of a `std::tuple` in `ExtendDistancesByLayer()`. This occurs because `DN_DX` (a `BoundedMatrix`) is declared but not initialized before being passed into `std::make_tuple`. While the logic might eventually populate these values, GCC 13’s aggressive static analysis detects that the **copy constructor** is invoked on uninitialized memory.

```cpp
// Before
BoundedMatrix <double, TDim+1, TDim> DN_DX;

// After
BoundedMatrix <double, TDim+1, TDim> DN_DX = ZeroMatrix(TDim + 1, TDim);
```
**🆕 Changelog**

- [Fix uninitialized `BoundedMatrix` warning in `ParallelDistanceCalculationProcess`](https://github.com/KratosMultiphysics/Kratos/commit/14bab56db13dd044e4889195b1ae75697ebc5969)
