### PR TITLE
[Core][Future] Add linear algebra defines

### DIFF
--- a/kratos/future/containers/define_linear_algebra_mpi.h
+++ b/kratos/future/containers/define_linear_algebra_mpi.h
@@ -1,0 +1,49 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
+//
+//  Main authors:    Ruben Zorrilla
+//
+
+#pragma once
+
+// System includes
+
+// External includes
+
+// Project includes
+#include "containers/distributed_csr_matrix.h"
+#include "containers/distributed_sparse_graph.h"
+#include "containers/distributed_system_vector.h"
+
+namespace Kratos::Future
+{
+
+///@addtogroup KratosCore
+///@{
+
+///@name Kratos Classes
+///@{
+
+struct DistributedLinearAlgebra
+{
+    using DataType = double;
+
+    using IndexType = std::size_t;
+
+    using MatrixType = DistributedCsrMatrix<DataType, IndexType>;
+
+    using VectorType = DistributedSystemVector<DataType, IndexType>;
+
+    using SparseGraphType = DistributedSparseGraph<IndexType>;
+};
+
+///@}
+///@} addtogroup block
+
+} // namespace Kratos::Future

--- a/kratos/future/containers/define_linear_algebra_mpi.h
+++ b/kratos/future/containers/define_linear_algebra_mpi.h
@@ -30,7 +30,7 @@ namespace Kratos::Future
 ///@name Kratos Classes
 ///@{
 
-struct DistributedLinearAlgebra
+struct DistributedLinearAlgebraTraits
 {
     using DataType = double;
 

--- a/kratos/future/containers/define_linear_algebra_serial.h
+++ b/kratos/future/containers/define_linear_algebra_serial.h
@@ -40,6 +40,8 @@ struct SerialLinearAlgebraTraits
 
     using VectorType = SystemVector<DataType, IndexType>;
 
+    using DenseMatrixType = DenseMatrix<DataType>; //TODO: think about this one
+
     using SparseGraphType = SparseContiguousRowGraph<IndexType>;
 };
 

--- a/kratos/future/containers/define_linear_algebra_serial.h
+++ b/kratos/future/containers/define_linear_algebra_serial.h
@@ -1,0 +1,49 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
+//
+//  Main authors:    Ruben Zorrilla
+//
+
+#pragma once
+
+// System includes
+
+// External includes
+
+// Project includes
+#include "containers/csr_matrix.h"
+#include "containers/sparse_contiguous_row_graph.h"
+#include "containers/system_vector.h"
+
+namespace Kratos::Future
+{
+
+///@addtogroup KratosCore
+///@{
+
+///@name Kratos Classes
+///@{
+
+struct SerialLinearAlgebra
+{
+    using DataType = double;
+
+    using IndexType = std::size_t;
+
+    using MatrixType = CsrMatrix<DataType, IndexType>;
+
+    using VectorType = SystemVector<DataType, IndexType>;
+
+    using SparseGraphType = SparseContiguousRowGraph<IndexType>;
+};
+
+///@}
+///@} addtogroup block
+
+} // namespace Kratos::Future

--- a/kratos/future/containers/define_linear_algebra_serial.h
+++ b/kratos/future/containers/define_linear_algebra_serial.h
@@ -30,7 +30,7 @@ namespace Kratos::Future
 ///@name Kratos Classes
 ///@{
 
-struct SerialLinearAlgebra
+struct SerialLinearAlgebraTraits
 {
     using DataType = double;
 


### PR DESCRIPTION
**📝 Description**
This PR adds two headers to define the serial and MPI linear algebra types. The idea of these is two use the `struct`s inside as unique template arguments for all the new strategies environment.

Besides simplifying quite a lot the implementation and reducing the template specialization complexity, these ensure that the linear algebra pairs (i.e., matrix and vector) are compatible.  Also note that these also simplify the extension to other data types (e.g., `float` vs `double`) or even to other array types.

A subsequent PR will incorporate these (and other features) into the future strategies, schemes, builders and linear solvers.

EDIT: I placed them into `containers` folder without being sure if this is the best place. Feel free to suggest any other folder.