### PR TITLE
[LinearSolversApplication] Fix function hiding error in `MKLSmootherBase`

### DIFF
--- a/applications/LinearSolversApplication/custom_solvers/mkl_ilu.hpp
+++ b/applications/LinearSolversApplication/custom_solvers/mkl_ilu.hpp
@@ -34,6 +34,10 @@ class KRATOS_API(LINEARSOLVERS_APPLICATION) MKLILUSmootherBase
 private:
     using Base = MKLSmootherBase<TSparse,TDense>;
 
+    using BaseLinearSolver = LinearSolver<TSparse,TDense>;
+
+    using BaseLinearSolver::Solve;
+
 public:
     MKLILUSmootherBase();
 

--- a/applications/LinearSolversApplication/custom_solvers/mkl_smoother_base.hpp
+++ b/applications/LinearSolversApplication/custom_solvers/mkl_smoother_base.hpp
@@ -63,6 +63,8 @@ public:
 
     using Base = LinearSolver<TSparse,TDense>;
 
+    using Base::Solve;
+
     using SparseMatrix = typename TSparse::MatrixType;
 
     using Vector = typename TSparse::VectorType;


### PR DESCRIPTION
## **📝 Description**

This PR resolves a compilation error (`-Werror=overloaded-virtual`) occurring in `MKLSmootherBase` when compiling with GCC 13 and C++20.

The issue was caused by **C++ Name Hiding**: the derived class `MKLSmootherBase` introduced a new virtual `Solve` method with a signature involving `CSRView`. Because C++ name lookup stops at the first class scope where the name is found, all other `Solve` overloads from the parent class `LinearSolver` were hidden from the compiler's view.

### **Changes**

* Added `using Base::Solve;` to the public section of `MKLSmootherBase`.
* This explicitly brings all `LinearSolver<TSparse, TDense>::Solve` overloads into the derived class scope, allowing them to be correctly resolved during overload resolution.

### **Impact**

* Fixes build failures on GCC/Clang when `-Woverloaded-virtual` or `-Wall` is enabled.
* Ensures that users of `MKLSmootherBase` can still access the standard `LinearSolver` interfaces (e.g., the 4-argument `Solve` method) without casting to the base class.

##  **🆕 Changelog**

- [Fix function hiding error in `MKLSmootherBase`](https://github.com/KratosMultiphysics/Kratos/commit/91317de999e6a25669e94fdd21995846c34511d9)
- [Adding to `MKLILUSmootherBase` too](https://github.com/KratosMultiphysics/Kratos/pull/14118/commits/0486622e80269b6a5e7429f1ba20d314696b1892)
