### PR TITLE
[Core] Fix Parallel Future

### DIFF
--- a/kratos/future/solving_strategies/builders/builder.h
+++ b/kratos/future/solving_strategies/builders/builder.h
@@ -170,7 +170,7 @@ public:
             });
             IndexPartition<IndexType>(mpModelPart->NumberOfConditions()).for_each([&](IndexType Index) {
                 Condition::EquationIdVectorType eq_ids; //TODO: we don't use TLS for this (decide what to do once we finish the parallelism discussion)
-                auto it_cond = mpModelPart->ElementsBegin() + Index;
+                auto it_cond = mpModelPart->ConditionsBegin() + Index;
                 it_cond->EquationIdVector(eq_ids, mpModelPart->GetProcessInfo());
                 rSparseGraph.AddEntries(eq_ids);
             });

--- a/kratos/future/solving_strategies/schemes/implicit_scheme.h
+++ b/kratos/future/solving_strategies/schemes/implicit_scheme.h
@@ -388,7 +388,7 @@ public:
             }
 
             // Assemble conditions
-            # pragma omp for schedule(guided, 512) nowait
+            # pragma omp for schedule(guided, 512)
             for (int k = 0; k < n_conds; ++k) {
                 // Calculate local LHS and RHS contributions
                 auto it_cond = conds_begin + k;

--- a/kratos/future/solving_strategies/schemes/implicit_scheme.h
+++ b/kratos/future/solving_strategies/schemes/implicit_scheme.h
@@ -374,7 +374,7 @@ public:
             TLSType aux_tls;
 
             // Assemble elements
-            # pragma omp for
+            # pragma omp for schedule(guided, 512) nowait
             for (int k = 0; k < n_elems; ++k) {
                 // Calculate local LHS and RHS contributions
                 auto it_elem = elems_begin + k;
@@ -388,7 +388,7 @@ public:
             }
 
             // Assemble conditions
-            # pragma omp for
+            # pragma omp for schedule(guided, 512) nowait
             for (int k = 0; k < n_conds; ++k) {
                 // Calculate local LHS and RHS contributions
                 auto it_cond = conds_begin + k;
@@ -923,7 +923,7 @@ public:
             #pragma omp parallel
             {
                 TLSType aux_tls;
-                
+
                 // Auxiliary set to store the inactive constraints slave DOFs (required by the block build)
                 std::unordered_set<IndexType> auxiliar_inactive_slave_dofs;
 

--- a/kratos/future/solving_strategies/schemes/implicit_scheme.h
+++ b/kratos/future/solving_strategies/schemes/implicit_scheme.h
@@ -369,11 +369,12 @@ public:
         rLHS.BeginAssemble();
 
         // Assemble entities
-        TLSType aux_tls;
         #pragma omp parallel
         {
+            TLSType aux_tls;
+
             // Assemble elements
-            # pragma omp for schedule(guided, 512) nowait
+            # pragma omp for
             for (int k = 0; k < n_elems; ++k) {
                 // Calculate local LHS and RHS contributions
                 auto it_elem = elems_begin + k;
@@ -387,7 +388,7 @@ public:
             }
 
             // Assemble conditions
-            # pragma omp for schedule(guided, 512)
+            # pragma omp for
             for (int k = 0; k < n_conds; ++k) {
                 // Calculate local LHS and RHS contributions
                 auto it_cond = conds_begin + k;
@@ -435,9 +436,10 @@ public:
         rLHS.BeginAssemble();
 
         // Assemble entities
-        TLSType aux_tls;
         #pragma omp parallel
         {
+            TLSType aux_tls;
+
             // Assemble elements
             # pragma omp for schedule(guided, 512) nowait
             for (int k = 0; k < n_elems; ++k) {
@@ -665,9 +667,10 @@ public:
         rRHS.BeginAssemble();
 
         // Assemble entities
-        TLSType aux_tls;
         #pragma omp parallel
         {
+            TLSType aux_tls;
+
             // Assemble elements
             # pragma omp for schedule(guided, 512) nowait
             for (int k = 0; k < n_elems; ++k) {
@@ -725,9 +728,10 @@ public:
         rLHS.BeginAssemble();
 
         // Assemble entities
-        TLSType aux_tls;
         #pragma omp parallel
         {
+            TLSType aux_tls;
+
             // Assemble elements
             # pragma omp for schedule(guided, 512) nowait
             for (int k = 0; k < n_elems; ++k) {
@@ -785,9 +789,10 @@ public:
         rMassMatrix.BeginAssemble();
 
         // Assemble entities
-        TLSType aux_tls;
         #pragma omp parallel
         {
+            TLSType aux_tls;
+
             // Assemble elements
             # pragma omp for schedule(guided, 512) nowait
             for (int k = 0; k < n_elems; ++k) {
@@ -845,9 +850,10 @@ public:
         rDampingMatrix.BeginAssemble();
 
         // Assemble entities
-        TLSType aux_tls;
         #pragma omp parallel
         {
+            TLSType aux_tls;
+            
             // Assemble elements
             # pragma omp for schedule(guided, 512) nowait
             for (int k = 0; k < n_elems; ++k) {
@@ -913,10 +919,11 @@ public:
             r_constraints_T.BeginAssemble();
             r_constraints_q.BeginAssemble();
 
-            TLSType aux_tls;
             auto& r_eff_dof_set = *(rLinearSystemContainer.pEffectiveDofSet);
             #pragma omp parallel
             {
+                TLSType aux_tls;
+                
                 // Auxiliary set to store the inactive constraints slave DOFs (required by the block build)
                 std::unordered_set<IndexType> auxiliar_inactive_slave_dofs;
 

--- a/kratos/future/tests/cpp_tests/test_schemes.cpp
+++ b/kratos/future/tests/cpp_tests/test_schemes.cpp
@@ -57,6 +57,7 @@ KRATOS_TEST_CASE_IN_SUITE(StaticSchemeBuild1D, KratosCoreFastSuite)
     Future::LinearSystemContainer<CsrMatrix<>, SystemVector<>> linear_system_container;
 
     // Call the initialize solution step (note that this sets all the arrays above)
+    p_scheme->Initialize(linear_system_container);
     p_scheme->InitializeSolutionStep(linear_system_container);
 
     // Call the build
@@ -116,6 +117,7 @@ KRATOS_TEST_CASE_IN_SUITE(StaticSchemeBuild2D, KratosCoreFastSuite)
     Future::LinearSystemContainer<CsrMatrix<>, SystemVector<>> linear_system_container;
 
     // Call the initialize solution step (note that this sets all the arrays above)
+    p_scheme->Initialize(linear_system_container);
     p_scheme->InitializeSolutionStep(linear_system_container);
 
     // Call the build

--- a/kratos/tests/cpp_tests/utilities/test_atomic_utilities.cpp
+++ b/kratos/tests/cpp_tests/utilities/test_atomic_utilities.cpp
@@ -11,9 +11,11 @@
 //
 
 // System includes
-#include <ranges>
-#include <execution>
-#include <algorithm>
+#ifdef KRATOS_USE_TBB
+    #include <ranges>
+    #include <execution>
+    #include <algorithm>
+#endif
 
 // External includes
 

--- a/kratos/tests/cpp_tests/utilities/test_atomic_utilities.cpp
+++ b/kratos/tests/cpp_tests/utilities/test_atomic_utilities.cpp
@@ -11,6 +11,9 @@
 //
 
 // System includes
+#include <ranges>
+#include <execution>
+#include <algorithm>
 
 // External includes
 
@@ -56,11 +59,18 @@ KRATOS_TEST_CASE(AtomicMult)
     const double exp = 1.001;
     double sum = 5;
 
+#ifdef KRATOS_USE_TBB
+    auto range = std::ranges::views::iota(0uz, size);
+    std::for_each(std::execution::par_unseq, range.begin(), range.end(), [&sum, exp](int x) {
+        AtomicMult(sum, exp);
+    });
+#else
     IndexPartition(size).for_each(
-        [&sum, exp](auto i){
+        [&sum, exp](auto i) {
             AtomicMult(sum, exp);
-            }
-        );
+        }
+    );
+#endif
 
     KRATOS_EXPECT_NEAR(5 * std::pow(exp, size), sum, 1e-3);
 }

--- a/kratos/utilities/atomic_utilities.h
+++ b/kratos/utilities/atomic_utilities.h
@@ -169,21 +169,21 @@ inline void AtomicSubMatrix(TMatrixType1& target, const TMatrixType2& value)
  * @param factor vector value being multiplied
  */
 template<class T>
-T atomic_mul(std::atomic_ref<T>& ref, T factor)
+inline T atomic_mul(std::atomic_ref<T>& ref, T factor)
 {
     T old = ref.load(std::memory_order_relaxed);
     T result;
     do {
         result = old * result;
-    } while (!ref.compare_exchange_weak(
-                 old, desired,
-                 std::memory_order_acq_rel,
-                 std::memory_order_relaxed));
-    return result; // or return old, depending on semantics you want
+    } while (!ref.compare_exchange_weak(old, desired, std::memory_order_acq_rel, std::memory_order_relaxed));
+
+    return result;
 }
 
 /** @param target vector variable being atomically updated by doing target *= value
  * @param value vector value being multiplied
+ * Note that "=*" compound operator is --> **NOT** <-- defined for multiplication in boost::atomic//std::atomic,
+ * so we need to implement it ourselves
  */
 template<class TDataType>
 inline void AtomicMult(TDataType& target, const TDataType& value)

--- a/kratos/utilities/atomic_utilities.h
+++ b/kratos/utilities/atomic_utilities.h
@@ -188,7 +188,7 @@ inline T atomic_mul(std::atomic_ref<T>& ref, T factor)
 template<class TDataType>
 inline void AtomicMult(TDataType& target, const TDataType& value)
 {
-#ifdef defined(KRATOS_SMP_CXX11) || defined(KRATOS_COMPILED_IN_OS)
+#if defined(KRATOS_SMP_CXX11) || defined(KRATOS_COMPILED_IN_OS)
     AtomicRef<TDataType> at_ref{target};
     atomic_mul(at_ref, value);
 #elif defined(KRATOS_SMP_OPENMP)

--- a/kratos/utilities/atomic_utilities.h
+++ b/kratos/utilities/atomic_utilities.h
@@ -54,7 +54,7 @@ namespace Kratos {
 template<class TDataType>
 inline void AtomicAdd(TDataType& target, const TDataType& value)
 {
-#if defined(KRATOS_SMP_CXX11) || (KRATOS_COMPILED_IN_OS)
+#if defined(KRATOS_SMP_CXX11) || defined(KRATOS_COMPILED_IN_OS)
     AtomicRef<TDataType>{target} += value;
 #elif defined(KRATOS_SMP_CXX11)
     #pragma omp atomic
@@ -188,7 +188,7 @@ inline T atomic_mul(std::atomic_ref<T>& ref, T factor)
 template<class TDataType>
 inline void AtomicMult(TDataType& target, const TDataType& value)
 {
-#ifdef defined(KRATOS_SMP_CXX11) || (KRATOS_COMPILED_IN_OS)
+#ifdef defined(KRATOS_SMP_CXX11) || defined(KRATOS_COMPILED_IN_OS)
     AtomicRef<TDataType> at_ref{target};
     atomic_mul(at_ref, value);
 #elif defined(KRATOS_SMP_OPENMP)

--- a/kratos/utilities/atomic_utilities.h
+++ b/kratos/utilities/atomic_utilities.h
@@ -56,7 +56,7 @@ inline void AtomicAdd(TDataType& target, const TDataType& value)
 {
 #if defined(KRATOS_SMP_CXX11) || defined(KRATOS_COMPILED_IN_OS)
     AtomicRef<TDataType>{target} += value;
-#elif defined(KRATOS_SMP_CXX11)
+#elif defined(KRATOS_SMP_OPENMP)
     #pragma omp atomic
     target += value;
 #else

--- a/kratos/utilities/atomic_utilities.h
+++ b/kratos/utilities/atomic_utilities.h
@@ -54,11 +54,11 @@ namespace Kratos {
 template<class TDataType>
 inline void AtomicAdd(TDataType& target, const TDataType& value)
 {
-#ifdef KRATOS_SMP_OPENMP
+#if defined(KRATOS_SMP_CXX11) || (KRATOS_COMPILED_IN_OS)
+    AtomicRef<TDataType>{target} += value;
+#elif defined(KRATOS_SMP_CXX11)
     #pragma omp atomic
     target += value;
-#elif defined(KRATOS_SMP_CXX11)
-    AtomicRef<TDataType>{target} += value;
 #else
     target += value;
 #endif
@@ -117,11 +117,11 @@ inline void AtomicAddMatrix(TMatrixType1& target, const TMatrixType2& value)
 template<class TDataType>
 inline void AtomicSub(TDataType& target, const TDataType& value)
 {
-#ifdef KRATOS_SMP_OPENMP
+#if defined(KRATOS_SMP_CXX11) || (KRATOS_COMPILED_IN_OS)
+    AtomicRef<TDataType>{target} -= value;
+#elif defined(KRATOS_SMP_OPENMP)
     #pragma omp atomic
     target -= value;
-#elif defined(KRATOS_SMP_CXX11)
-    AtomicRef<TDataType>{target} -= value;
 #else
     target -= value;
 #endif
@@ -178,12 +178,12 @@ inline void AtomicSubMatrix(TMatrixType1& target, const TMatrixType2& value)
 template<class TDataType>
 inline void AtomicMult(TDataType& target, const TDataType& value)
 {
-#ifdef KRATOS_SMP_OPENMP
+#ifdef defined(KRATOS_SMP_CXX11) || (KRATOS_COMPILED_IN_OS)
+    AtomicRef<TDataType> at_ref{target};
+    at_ref = atref*value;
+#elif defined(KRATOS_SMP_OPENMP)
     #pragma omp atomic
     target *= value;
-#elif defined(KRATOS_SMP_CXX11)
-    AtomicRef<TDataType> at_ref{target};
-    at_ref = at_ref*value;
 #else
     target *= value;
 #endif

--- a/kratos/utilities/atomic_utilities.h
+++ b/kratos/utilities/atomic_utilities.h
@@ -32,7 +32,7 @@
 
 namespace Kratos {
 
-#if defined(KRATOS_SMP_CXX11)
+#if defined(KRATOS_SMP_CXX11) || defined(KRATOS_COMPILED_IN_OS)
     #if defined(__cpp_lib_atomic_ref) // C++20
         template <class T>
         using AtomicRef = std::atomic_ref<T>;

--- a/kratos/utilities/atomic_utilities.h
+++ b/kratos/utilities/atomic_utilities.h
@@ -117,14 +117,7 @@ inline void AtomicAddMatrix(TMatrixType1& target, const TMatrixType2& value)
 template<class TDataType>
 inline void AtomicSub(TDataType& target, const TDataType& value)
 {
-#if defined(KRATOS_SMP_CXX11) || (KRATOS_COMPILED_IN_OS)
-    AtomicRef<TDataType>{target} -= value;
-#elif defined(KRATOS_SMP_OPENMP)
-    #pragma omp atomic
-    target -= value;
-#else
-    target -= value;
-#endif
+    AtomicAdd(target, -value);
 }
 
 /**

--- a/kratos/utilities/atomic_utilities.h
+++ b/kratos/utilities/atomic_utilities.h
@@ -174,7 +174,7 @@ inline T atomic_mul(std::atomic_ref<T>& ref, T factor)
     T old = ref.load(std::memory_order_relaxed);
     T result;
     do {
-        result = old * result;
+        result = old * factor;
     } while (!ref.compare_exchange_weak(old, result, std::memory_order_acq_rel, std::memory_order_relaxed));
 
     return result;

--- a/kratos/utilities/atomic_utilities.h
+++ b/kratos/utilities/atomic_utilities.h
@@ -175,7 +175,7 @@ inline T atomic_mul(std::atomic_ref<T>& ref, T factor)
     T result;
     do {
         result = old * result;
-    } while (!ref.compare_exchange_weak(old, desired, std::memory_order_acq_rel, std::memory_order_relaxed));
+    } while (!ref.compare_exchange_weak(old, result, std::memory_order_acq_rel, std::memory_order_relaxed));
 
     return result;
 }


### PR DESCRIPTION
**📝 Description**
Yes guys, I fixed the future :tada:

Jokes aside, this has several fixes
- It makes macOS to use `std::atomic_ref` if possible, as `#pragma atomic` causes races while running on M4 with efficient and performant cores enabled (don't ask)
- Changes the implementation of `AtomicMult`. @philbucher if you are still among us and can you check this :pray: , I moved to this implementation because apparently `=*` does not exists and defaults to:
```c++
var.load()
var *= xxx
var.store()
```
So multiple threads can issue a store at the same time which causes a race.
- Fixed future builder to iterate over conditions
- Fixed future implicit scheme TLS
