### PR TITLE
[MappingApplication] Add IGA–FEM mortar surface mapping modeler (Brep surface ↔ FEM triangles)

### DIFF
--- a/applications/MappingApplication/custom_modelers/iga_fem_mapping_geometries_modeler.cpp
+++ b/applications/MappingApplication/custom_modelers/iga_fem_mapping_geometries_modeler.cpp
@@ -107,18 +107,18 @@ namespace Kratos
 
         if (!is_surface_mapping)
         {
-            IgaMappingIntersectionUtilities::CreateIgaFEMCouplingGeometries(
+            IgaMappingIntersectionUtilities::CreateIgaFEMCouplingGeometriesOnCurve(
                 coupling_interface_origin,
                 coupling_interface_destination,
                 is_origin_iga,
                 coupling_model_part, 1e-6);
-            IgaMappingIntersectionUtilities::CreateIgaFEMQuadraturePointsCouplingInterface(
+            IgaMappingIntersectionUtilities::CreateIgaFEMQuadraturePointsOnCurve(
                 coupling_model_part, 1e-6);
         } else {
             IgaMappingIntersectionUtilities::PatchCacheMap patch_cache;
 
             // Create coupling geometries connecting each finite element with the IGA surface 
-            IgaMappingIntersectionUtilities::CreateIgaFEMSurfaceCouplingGeometries(
+            IgaMappingIntersectionUtilities::CreateIgaFEMCouplingGeometriesOnSurface(
                 coupling_interface_origin,
                 coupling_interface_destination,
                 coupling_model_part, 
@@ -127,7 +127,7 @@ namespace Kratos
                 patch_cache);
             
              // Create quadrature point geometries in the origin and destination domain
-            IgaMappingIntersectionUtilities::CreateIgaFEMQuadraturePointsCoupling2DGeometries3D(
+            IgaMappingIntersectionUtilities::CreateIgaFEMQuadraturePointsOnSurface(
                 coupling_model_part, 
                 is_origin_iga,
                 patch_cache,

--- a/applications/MappingApplication/custom_modelers/iga_fem_mapping_geometries_modeler.cpp
+++ b/applications/MappingApplication/custom_modelers/iga_fem_mapping_geometries_modeler.cpp
@@ -44,8 +44,10 @@ namespace Kratos
             << "Surface mapping with this modeler requires the origin ModelPart to be IGA.\n"
             << "Got is_origin_iga = false." << std::endl;
 
-        KRATOS_ERROR_IF_NOT(mParameters.Has("search_radius")) << "'search_radius' was not specified in the CoSim parameters file\n";
-        const double search_radius = mParameters["search_radius"].GetDouble();
+        if (is_surface_mapping){
+            KRATOS_ERROR_IF_NOT(mParameters.Has("search_radius")) << "'search_radius' was not specified in the CoSim parameters file\n";
+            const double search_radius = mParameters["search_radius"].GetDouble();
+        }
        
         if (is_origin_iga && !is_surface_mapping)
         {

--- a/applications/MappingApplication/custom_modelers/iga_fem_mapping_geometries_modeler.cpp
+++ b/applications/MappingApplication/custom_modelers/iga_fem_mapping_geometries_modeler.cpp
@@ -44,9 +44,10 @@ namespace Kratos
             << "Surface mapping with this modeler requires the origin ModelPart to be IGA.\n"
             << "Got is_origin_iga = false." << std::endl;
 
+        double search_radius = 0.0;
         if (is_surface_mapping){
             KRATOS_ERROR_IF_NOT(mParameters.Has("search_radius")) << "'search_radius' was not specified in the CoSim parameters file\n";
-            const double search_radius = mParameters["search_radius"].GetDouble();
+            search_radius = mParameters["search_radius"].GetDouble();
         }
        
         if (is_origin_iga && !is_surface_mapping)

--- a/applications/MappingApplication/custom_modelers/iga_fem_mapping_geometries_modeler.cpp
+++ b/applications/MappingApplication/custom_modelers/iga_fem_mapping_geometries_modeler.cpp
@@ -87,7 +87,8 @@ namespace Kratos
             {
                 const auto& r_geom = r_cond.GetGeometry();
 
-                KRATOS_ERROR_IF(r_geom.PointsNumber() != 3)
+                KRATOS_ERROR_IF_NOT(r_geom.GetGeometryType() == GeometryData::KratosGeometryType::Kratos_Triangle3D3 || 
+                                r_geom.GetGeometryType() == GeometryData::KratosGeometryType::Kratos_Triangle2D3)
                     << "Surface mapping currently supports only TRIANGULAR interface conditions.\n"
                     << "Condition Id: " << r_cond.Id() << "\n"
                     << "Geometry: " << r_geom.Info() << "\n"

--- a/applications/MappingApplication/custom_modelers/iga_fem_mapping_geometries_modeler.cpp
+++ b/applications/MappingApplication/custom_modelers/iga_fem_mapping_geometries_modeler.cpp
@@ -77,7 +77,19 @@ namespace Kratos
             CopySubModelPartIgaInterface(coupling_interface_destination,
                 mpModels[1]->GetModelPart(destination_interface_sub_model_part_name));
         } else if (is_origin_iga && is_surface_mapping){
-            KRATOS_ERROR_IF(mpModels[1]->GetModelPart(destination_interface_sub_model_part_name).NumberOfConditions() == 0) << "the destination model part has no conditions for the mapping. Please change the elements to conditions";
+            KRATOS_ERROR_IF(mpModels[1]->GetModelPart(destination_interface_sub_model_part_name).NumberOfConditions() == 0) 
+                << "the destination model part has no conditions for the mapping. Please change the elements to conditions";
+            
+            for (const auto& r_cond : mpModels[1]->GetModelPart(destination_interface_sub_model_part_name).Conditions())
+            {
+                const auto& r_geom = r_cond.GetGeometry();
+
+                KRATOS_ERROR_IF(r_geom.PointsNumber() != 3)
+                    << "Surface mapping currently supports only TRIANGULAR interface conditions.\n"
+                    << "Condition Id: " << r_cond.Id() << "\n"
+                    << "Geometry: " << r_geom.Info() << "\n"
+                    << "PointsNumber(): " << r_geom.PointsNumber() << "\n";
+            }
 
             CopySubModelPartSurfaceInterface(coupling_interface_origin,
                 mpModels[0]->GetModelPart(origin_interface_sub_model_part_name), true);

--- a/applications/MappingApplication/custom_modelers/iga_fem_mapping_geometries_modeler.h
+++ b/applications/MappingApplication/custom_modelers/iga_fem_mapping_geometries_modeler.h
@@ -148,6 +148,25 @@ private:
         rDestinationMP.SetConditions(coupling_conditions.pConditions());
     }
 
+    void CopySubModelPartSurfaceInterface(ModelPart& rDestinationMP, ModelPart& rReferenceMP, bool is_model_part_iga)
+    {
+        rDestinationMP.SetNodes(rReferenceMP.pNodes());
+        rDestinationMP.SetNodalSolutionStepVariablesList(rReferenceMP.pGetNodalSolutionStepVariablesList());
+        rDestinationMP.SetConditions(rReferenceMP.pConditions());
+        rDestinationMP.SetElements(rReferenceMP.pElements());
+        rDestinationMP.SetProperties(rReferenceMP.pProperties());
+        
+        if (is_model_part_iga){
+            for (const auto& r_cond : rReferenceMP.Conditions())
+            {
+                const auto& r_geom = r_cond.GetGeometry();
+                const auto& r_parent = r_geom.GetGeometryParent(0);
+                const IndexType parent_id = r_parent.Id();
+                rDestinationMP.AddGeometry(rReferenceMP.GetRootModelPart().pGetGeometry(parent_id));
+            }
+        }
+    }
+
     void CreateIgaInterfaceBrepCurveOnSurfaceConditions(ModelPart& rInterfaceModelPart);
 
     void CreateFEMInterfaceNurbsCurveConditions(ModelPart& rInterfaceModelPart);
@@ -159,6 +178,7 @@ private:
         return Parameters( R"({
             "is_origin_iga"                : true,
             "is_surface_mapping"          : false,
+            "search_radius"              : 1.0e+10,
             "use_initial_configuration"    : true,
             "echo_level"                   : 0,
         })");

--- a/applications/MappingApplication/custom_utilities/iga_mapping_intersection_utilities.cpp
+++ b/applications/MappingApplication/custom_utilities/iga_mapping_intersection_utilities.cpp
@@ -294,7 +294,6 @@ void IgaMappingIntersectionUtilities::CreateIgaFEMQuadraturePointsCoupling2DGeom
 
         auto geom_master = geometry_itr->pGetGeometryPart(0); // IGA Surface
         auto geom_slave = geometry_itr->pGetGeometryPart(1);  // Finite element
-        auto& r_geom_master = *geom_master;
         auto& r_geom_slave = *geom_slave;
 
         // Get the Brep surface representing the IGA patch (NURBS surface + boundary loops)

--- a/applications/MappingApplication/custom_utilities/iga_mapping_intersection_utilities.cpp
+++ b/applications/MappingApplication/custom_utilities/iga_mapping_intersection_utilities.cpp
@@ -549,10 +549,6 @@ void IgaMappingIntersectionUtilities::CreateIgaFEMQuadraturePointsOnSurface(
             double clip_area = 0.0;
             if (solution.size() > 0){
                 clip_area = std::abs(Clipper2Lib::Area(solution[0]));
-                // for (IndexType k = 1; k < solution.size(); ++k) {
-                //         clip_area -= std::abs(Clipper2Lib::Area(solution_outer[k]));
-                //     }
-                // }
             }
 
             std::vector<Matrix> triangles;
@@ -608,10 +604,6 @@ void IgaMappingIntersectionUtilities::CreateIgaFEMQuadraturePointsOnSurface(
         for (IndexType tri_id = 0; tri_id < triangles_param_space.size(); ++tri_id)
         {
             obtained_triangles_after_intersection_with_knot_lines.clear();
-
-            // If enabled, triangulation fills obtained_triangles
-            // IgaMappingIntersectionUtilities::Triangulation(
-            //     triangle_coordinates_parameter_space[tri_id], geom_master, obtained_triangles);
 
             // Fallback: no triangulation => process original triangle
             if (obtained_triangles_after_intersection_with_knot_lines.empty()) {

--- a/applications/MappingApplication/custom_utilities/iga_mapping_intersection_utilities.cpp
+++ b/applications/MappingApplication/custom_utilities/iga_mapping_intersection_utilities.cpp
@@ -340,7 +340,6 @@ void IgaMappingIntersectionUtilities::CreateIgaFEMQuadraturePointsOnSurface(
             const bool projection_ok = geom_master->ProjectionPointGlobalToLocalSpace(
                 node_coordinate_xyz, local_parameter, 1e-5) == 1;
             
-
             if (projection_ok)
             {
                 successful_nodes_xyz.push_back(node_coordinate_xyz);
@@ -480,6 +479,8 @@ void IgaMappingIntersectionUtilities::CreateIgaFEMQuadraturePointsOnSurface(
 
             // Get the trimming curves outer loop
             auto outer_loop_array = geom_master_cast->GetOuterLoops();
+
+            KRATOS_ERROR_IF(geom_master_cast->GetInnerLoops().size() > 0) << "The current patch has inner loops and this is not yet supported for the IGA-FEM Surface Mortar Mapper" << std::endl;
 
             Clipper2Lib::Paths64 all_loops(1), triangle(1), solution;
             const double factor = 1e-10;

--- a/applications/MappingApplication/custom_utilities/iga_mapping_intersection_utilities.cpp
+++ b/applications/MappingApplication/custom_utilities/iga_mapping_intersection_utilities.cpp
@@ -17,6 +17,10 @@
 // Project includes
 #include "iga_mapping_intersection_utilities.h"
 
+// Data structures for doing spatial search 
+#include "utilities/function_parser_utility.h"
+#include "spatial_containers/bins_dynamic.h"
+
 namespace Kratos
 {
 
@@ -101,5 +105,754 @@ void IgaMappingIntersectionUtilities::CreateIgaFEMQuadraturePointsCouplingInterf
         }
     }
 }
+
+void IgaMappingIntersectionUtilities::CreateIgaFEMSurfaceCouplingGeometries(
+        ModelPart &rModelPartDomainA,
+        ModelPart &rModelPartDomainB,
+        ModelPart &rModelPartResult,
+        bool is_origin_iga,
+        const double search_radius,
+        PatchCacheMap& rPatchCache)
+{
+    // Get a pointer to the brep surface starting from the underlying element or condition (quadrature point)
+    std::vector<IndexType> patches_id;
+
+    if (is_origin_iga == true){
+        std::unordered_set<IndexType> patch_ids;
+
+        // Looping over the elements to get the patch ids 
+        for (const auto& r_elem : rModelPartDomainA.Elements())
+        {
+            const auto& r_geom = r_elem.GetGeometry();
+            const auto& r_parent = r_geom.GetGeometryParent(0);
+            patch_ids.insert(r_parent.Id());
+        }
+        
+        // Looping over the conditions to get the patch ids
+        for (const auto& r_cond : rModelPartDomainA.Conditions())
+        {
+            const auto& r_geom = r_cond.GetGeometry();
+            const auto& r_parent = r_geom.GetGeometryParent(0);
+            patch_ids.insert(r_parent.Id());
+        }
+
+        patches_id.assign(patch_ids.begin(), patch_ids.end());
+    }
+
+    const IndexType patch_divisions = 100;
+    rPatchCache = IgaMappingIntersectionUtilities::BuildPatchCaches(
+        patches_id, rModelPartDomainA, patch_divisions);
+
+    /* - Iterate over the elements
+        - For each element, we should decide which patches are the ones that the element has a projection on 
+        - Create a new list called patchs_id_projection depending on the element considered */
+    for (auto condition_b_itr = rModelPartDomainB.ConditionsBegin(); condition_b_itr != rModelPartDomainB.ConditionsEnd(); ++condition_b_itr){
+        CoordinatesArrayType element_center = condition_b_itr->GetGeometry().Center();
+
+        std::vector<IndexType> patches_with_probable_projection_id = IgaMappingIntersectionUtilities::GetPatchesWithProbableProjection(patches_id, rPatchCache, element_center, search_radius);
+
+        for (IndexType i = 0; i < patches_with_probable_projection_id.size(); i++){
+            // Get a pointer to the brep surface geometry
+            auto p_brep_surface = rModelPartDomainA.GetRootModelPart().pGetGeometry(patches_with_probable_projection_id[i]);
+
+            // Cast the nurbs surface pointer and brep surface to the derived class
+            auto brep_surface_cast = dynamic_pointer_cast<BrepSurface<PointerVector<NodeType>, false, PointerVector<Point>>>(p_brep_surface);
+
+            // Creating one coupling geometry for each combination of load condition and patch surface
+            rModelPartResult.AddGeometry(Kratos::make_shared<CouplingGeometry<NodeType>>(
+                    p_brep_surface, condition_b_itr->pGetGeometry()));
+        }       
+    }
+}
+
+IgaMappingIntersectionUtilities::PatchCacheMap IgaMappingIntersectionUtilities::BuildPatchCaches(
+    const std::vector<IndexType>& patches_id,
+    const ModelPart& rModelPartIga,
+    const IndexType n_div)
+{
+    PatchCacheMap cache;
+    cache.reserve(patches_id.size());
+
+    for (const IndexType patch_id : patches_id) {
+        PatchSearchCache pc;
+
+        // Get BrepSurface
+        auto p_geom = rModelPartIga.pGetGeometry(patch_id);
+
+        auto p_brep = dynamic_pointer_cast<
+            BrepSurface<PointerVector<NodeType>, false, PointerVector<Point>>
+        >(p_geom);
+
+        KRATOS_ERROR_IF_NOT(p_brep)
+            << "Geometry with id " << patch_id << " is not a BrepSurface\n";
+
+        auto p_background =
+            p_brep->pGetGeometryPart(GeometryType::BACKGROUND_GEOMETRY_INDEX);
+
+        std::vector<double> knot_u, knot_v;
+        p_background->SpansLocalSpace(knot_u, 0);
+        p_background->SpansLocalSpace(knot_v, 1);
+
+        KRATOS_ERROR_IF(knot_u.empty() || knot_v.empty())
+            << "Empty knot vectors for patch " << patch_id << "\n";
+
+        const double u_0  = knot_u.front();
+        const double u_1  = knot_u.back();
+        const double v_0 = knot_v.front();
+        const double v_1 = knot_v.back();
+
+        const IndexType number_pts = n_div + 1;
+
+        pc.number_pts = number_pts;
+        pc.u_0 = u_0;
+        pc.v_0 = v_0;
+        pc.delta_u  = (u_1  - u_0)  / static_cast<double>(n_div);
+        pc.delta_v = (v_1 - v_0) / static_cast<double>(n_div);
+
+        pc.points.reserve(number_pts * number_pts);
+
+        CoordinatesArrayType local = ZeroVector(3);
+        CoordinatesArrayType phys  = ZeroVector(3);
+
+        IndexType id = 0;
+        for (IndexType i = 0; i < number_pts; ++i) {
+            local[0] = pc.u_0 + pc.delta_u * static_cast<double>(i);
+            for (IndexType j = 0; j < number_pts; ++j) {
+                local[1] = pc.v_0 + pc.delta_v * static_cast<double>(j);
+
+                p_brep->GlobalCoordinates(phys, local);
+
+                // IMPORTANT: use intrusive pointer type
+                pc.points.push_back(PointTypePointer(new PointType(
+                    id++, phys[0], phys[1], phys[2]
+                )));
+                // If available in your Kratos:
+                // pc.points.push_back(Kratos::make_intrusive<PointType>(id++, phys[0], phys[1], phys[2]));
+            }
+        }
+
+        pc.p_bins = std::make_unique<DynamicBins>(pc.points.begin(), pc.points.end());
+
+        cache.emplace(patch_id, std::move(pc));
+    }
+
+    return cache;
+}
+
+std::vector<IndexType> IgaMappingIntersectionUtilities::GetPatchesWithProbableProjection(
+    const std::vector<IndexType>& patches_id,
+    const PatchCacheMap& rCache,
+    const CoordinatesArrayType& element_center,
+    const double search_radius)
+{
+    std::vector<IndexType> out;
+    out.reserve(patches_id.size());
+
+    PointType search_point(0, element_center[0], element_center[1], element_center[2]);
+
+    constexpr int number_of_results = 1;
+    std::vector<PointTypePointer> results(number_of_results);
+    std::vector<double> distances(number_of_results);
+
+    for (const IndexType patch_id : patches_id) {
+        auto it = rCache.find(patch_id);
+        KRATOS_ERROR_IF(it == rCache.end())
+            << "Patch id " << patch_id << " not found in patch cache.\n";
+
+        const auto& pc = it->second;
+        KRATOS_ERROR_IF_NOT(pc.p_bins)
+            << "Bins not built for patch id " << patch_id << "\n";
+
+        const int obtained = pc.p_bins->SearchInRadius(
+            search_point,
+            search_radius,
+            results.begin(),
+            distances.begin(),
+            number_of_results);
+
+        if (obtained > 0) out.push_back(patch_id);
+    }
+
+    return out.empty() ? patches_id : out;
+}
+
+
+void IgaMappingIntersectionUtilities::CreateIgaFEMQuadraturePointsCoupling2DGeometries3D(
+    ModelPart& rModelPartCoupling,
+    bool origin_is_iga,
+    const PatchCacheMap& rPatchCache,
+    const double search_radius)
+{
+    const ModelPart& rParentModelPart = rModelPartCoupling.GetParentModelPart();
+
+    // Iterate over the coupling geometries and create the quadrature points
+    for (auto geometry_itr = rModelPartCoupling.GeometriesBegin();
+        geometry_itr != rModelPartCoupling.GeometriesEnd();
+        ++geometry_itr)
+    {
+        if (geometry_itr->NumberOfGeometryParts() < 2){ continue;}
+
+        auto geom_master = geometry_itr->pGetGeometryPart(0); // IGA Surface
+        auto geom_slave = geometry_itr->pGetGeometryPart(1);  // Finite element
+        auto& r_geom_master = *geom_master;
+        auto& r_geom_slave = *geom_slave;
+
+        // Get the Brep surface representing the IGA patch (NURBS surface + boundary loops)
+        auto geom_master_cast = dynamic_pointer_cast<BrepSurface<PointerVector<NodeType>, false, PointerVector<Point>>>(geom_master);
+
+        // Get the NURBS Surface defining the Brep surface 
+        GeometryPointerType master_nurbs_surface = geom_master_cast->pGetGeometryPart(GeometryType::BACKGROUND_GEOMETRY_INDEX);
+        auto master_nurbs_surface_cast = dynamic_pointer_cast<NurbsSurfaceGeometry<3, PointerVector<Node>>>(master_nurbs_surface);
+
+        // This vector stores all the triangles resulting from the projection of a triangle to the surface patch (projection + subdivision)
+        std::vector<std::vector<CoordinatesArrayType>> triangles_param_space;
+
+        CoordinatesArrayType local_parameter = ZeroVector(3);
+        CoordinatesArrayType node_coordinate_xyz;
+
+        const IndexType n_nodes = r_geom_slave.size();
+
+        // These nodes refer to the FEM nodes which are being projected to the IGA patch
+        std::vector<CoordinatesArrayType> successful_nodes_xyz;
+        std::vector<CoordinatesArrayType> failed_nodes_xyz;
+        std::vector<CoordinatesArrayType> points_to_triangulate;
+
+        // Reserve (worst case: all nodes succeed or fail)
+        successful_nodes_xyz.reserve(n_nodes);
+        failed_nodes_xyz.reserve(n_nodes);
+        points_to_triangulate.reserve(n_nodes);
+
+        for (IndexType i = 0; i < n_nodes; ++i){
+            const auto p_point = r_geom_slave.pGetPoint(i);
+            node_coordinate_xyz = p_point->GetInitialPosition();
+
+            // Provide a good initial guess (reuses local_parameter)
+            const bool have_initial_guess =
+            IgaMappingIntersectionUtilities::FindInitialGuessNewtonRaphsonProjection(
+                node_coordinate_xyz,        // slave XYZ
+                geom_master,                // Brep surface geometry
+                rPatchCache,                // PatchCacheMap (built once)
+                local_parameter,            // output (u,v)
+                search_radius               // bins search radius
+            );
+
+            if (!have_initial_guess) {
+            // Fallback if bins find nothing
+                local_parameter = ZeroVector(3);
+            }
+
+            const bool projection_ok = geom_master->ProjectionPointGlobalToLocalSpace(
+                node_coordinate_xyz, local_parameter, 1e-5) == 1;
+            
+
+            if (projection_ok)
+            {
+                successful_nodes_xyz.push_back(node_coordinate_xyz);
+                points_to_triangulate.push_back(local_parameter);
+            }
+            else
+            {
+                failed_nodes_xyz.push_back(node_coordinate_xyz);
+            }
+        }
+
+        const IndexType projection_is_successful_count =
+            static_cast<IndexType>(successful_nodes_xyz.size());
+        
+        // If no node is projected inside the patch, continue to the next iteration. Otherwise, find the intersection between the triangle sides and the surface
+        if (projection_is_successful_count == 0){
+            continue;
+        }
+        else if (projection_is_successful_count == 1){  // If just one node is projected inside the surface, create one triangle  
+            
+            KRATOS_ERROR_IF(points_to_triangulate.size() != 1)
+                << "Expected points_to_triangulate.size()==1, got "
+                << points_to_triangulate.size() << "\n";
+
+            KRATOS_ERROR_IF(failed_nodes_xyz.size() < 2)
+                << "Expected at least 2 failed nodes, got "
+                << failed_nodes_xyz.size() << "\n";
+
+            // Check if the projection is on the boundary of the parameter space and, if so, continue to the next element
+            if (AreProjectionsOnParameterSpaceBoundary(points_to_triangulate, *master_nurbs_surface_cast) == true) continue;
+
+            // Vector for storing the intersection of the triangle side with the boundaries of the patch
+            std::vector<CoordinatesArrayType> triangle_segment_intersection_with_surface_patch_local_parameter;
+            triangle_segment_intersection_with_surface_patch_local_parameter.reserve(2);
+
+            points_to_triangulate.reserve(3); // 1 existing + 2 intersections
+
+            bool all_found = true;
+            for (IndexType i = 0; i < 2; ++i)
+            {
+                CoordinatesArrayType intersection_point_local_space = ZeroVector(3);
+
+                const bool found =
+                    FindTriangleSegmentSurfaceIntersectionWithBisection(
+                        geom_master,
+                        successful_nodes_xyz[0],
+                        failed_nodes_xyz[i],
+                        points_to_triangulate[0],
+                        intersection_point_local_space);
+
+                if (!found) {
+                    all_found = false;
+                    break;
+                }
+
+                triangle_segment_intersection_with_surface_patch_local_parameter.push_back(intersection_point_local_space);
+                points_to_triangulate.push_back(intersection_point_local_space);
+            }
+
+            if (!all_found) {continue;}
+
+            // If the intersection between the triangle and the patch surface is at just one point, ignore the element and go to the next triangle
+            if (norm_2(triangle_segment_intersection_with_surface_patch_local_parameter[0] - triangle_segment_intersection_with_surface_patch_local_parameter[1]) < 1e-4)
+            {
+                continue;
+            }
+
+            KRATOS_ERROR_IF(points_to_triangulate.size() != 3)
+                << "Expected 3 points to form a triangle, got "
+                << points_to_triangulate.size() << "\n";
+
+            // Sort the vertices counter-clockwise before doing triangulation
+            SortVerticesCounterClockwise(points_to_triangulate);
+
+            // Form one triangle with the one point projected inside the patch and the two intersections
+            triangles_param_space.push_back(points_to_triangulate);
+        } else if (projection_is_successful_count == 2){  // If just one node is projected inside the surface, create 2 triangles
+
+            // Skip if projections lie on parameter-space boundary
+            if (AreProjectionsOnParameterSpaceBoundary(points_to_triangulate, *master_nurbs_surface_cast) == true) continue;
+
+            KRATOS_ERROR_IF(points_to_triangulate.size() != 2)
+                << "Expected 2 param points in points_to_triangulate, got "
+                << points_to_triangulate.size() << "\n";
+
+            KRATOS_ERROR_IF(failed_nodes_xyz.size() < 1)
+                << "Expected at least 1 non-successful node.\n";
+
+            // We will add up to 2 intersection points
+            points_to_triangulate.reserve(4);
+
+            constexpr double tol_dup = 1e-4;
+
+            auto IsDuplicateParamPoint = [&](const CoordinatesArrayType& p) {
+                for (const auto& q : points_to_triangulate) {
+                    if (norm_2(p - q) < tol_dup) return true;
+                }
+                return false;
+            };
+
+            for (IndexType i = 0; i < 2; ++i)
+            {
+                CoordinatesArrayType intersection_point_local_space = ZeroVector(3);
+
+                // Use your current intersection routine (void). If you have the new bool routine, use it instead.
+                IgaMappingIntersectionUtilities::FindTriangleSegmentSurfaceIntersectionWithBisection(
+                    geom_master,
+                    successful_nodes_xyz[i],              // inside the patch
+                    failed_nodes_xyz[0],          // outside the patch
+                    points_to_triangulate[i],                                       // better initial guess: the corresponding inside param
+                    intersection_point_local_space);
+
+                if (!IsDuplicateParamPoint(intersection_point_local_space)) {
+                    points_to_triangulate.push_back(intersection_point_local_space);
+                }
+            }
+
+            SortVerticesCounterClockwise(points_to_triangulate);
+
+            if (points_to_triangulate.size() == 3)
+            {
+                // Create one triangle
+                triangles_param_space.push_back(points_to_triangulate);
+            }
+            else if (points_to_triangulate.size() == 4)
+            {
+                // Create two triangles: (0,1,2) and (0,2,3)
+                triangles_param_space.push_back(
+                    {points_to_triangulate[0], points_to_triangulate[1], points_to_triangulate[2]}
+                );
+                triangles_param_space.push_back(
+                    {points_to_triangulate[0], points_to_triangulate[2], points_to_triangulate[3]}
+                );
+            }
+        } else if (projection_is_successful_count == 3)
+        { // If the 3 nodes are projected inside the untrimmed surface, check if the triangles intersect the trimming curves and , if so, create new triangles
+
+            // Get the trimming curves outer loop
+            auto outer_loop_array = geom_master_cast->GetOuterLoops();
+
+            Clipper2Lib::Paths64 all_loops(1), triangle(1), solution;
+            const double factor = 1e-10;
+
+            Clipper2Lib::Point64 int_point;
+            int_point.x = static_cast<cInt>(std::numeric_limits<int>::min());
+            int_point.y = static_cast<cInt>(std::numeric_limits<int>::min());
+
+            // Reuse tessellation object 
+            CurveTessellation<PointerVector<Node>> curve_tessellation;
+
+            // Reserve some space for the curve tessellation
+            all_loops[0].reserve(all_loops[0].size() + 1000);
+
+            for (IndexType j = 0; j < outer_loop_array[0].size(); ++j)
+            {
+                const auto& geometry_outer = *(outer_loop_array[0][j]);
+
+                curve_tessellation.Tessellate(
+                    geometry_outer, 0.001, 1, true);
+
+                // Avoid copy
+                const auto& tessellation = curve_tessellation.GetTessellation();
+
+                for (IndexType u = 0; u < tessellation.size(); ++u)
+                {
+                    // Bind once
+                    const auto& uv = std::get<1>(tessellation[u]);
+
+                    auto new_int_point = BrepTrimmingUtilities<false>::ToIntPoint(
+                        uv[0], uv[1], factor);
+
+                    // Shift tolerance
+                    new_int_point.x += 100000.0;
+                    new_int_point.y += 100000.0;
+
+                    // Fast duplicate rejection
+                    if (new_int_point.x != int_point.x ||
+                        new_int_point.y != int_point.y)
+                    {
+                        all_loops[0].push_back(new_int_point);
+                        int_point = new_int_point;
+                    }
+                }
+            }
+
+            triangle[0].reserve(triangle[0].size() + 3);
+
+            for (IndexType u = 0; u < 3; ++u){
+                const auto new_int_point =
+                    BrepTrimmingUtilities<false>::ToIntPoint(
+                            points_to_triangulate[u][0],
+                            points_to_triangulate[u][1],
+                            factor);
+
+                if (new_int_point.x != int_point.x ||
+                    new_int_point.y != int_point.y)
+                {
+                    triangle[0].push_back(new_int_point);
+                    int_point = new_int_point;
+                }
+            }
+
+            // Intersect the triangle with the polygon resulting from the tessellation of the outer loop
+            solution = Clipper2Lib::Intersect(all_loops, triangle, Clipper2Lib::FillRule::NonZero);
+
+            double clip_area = 0.0;
+            if (solution.size() > 0){
+                clip_area = std::abs(Clipper2Lib::Area(solution[0]));
+                // for (IndexType k = 1; k < solution.size(); ++k) {
+                //         clip_area -= std::abs(Clipper2Lib::Area(solution_outer[k]));
+                //     }
+                // }
+            }
+
+            std::vector<Matrix> triangles;
+            std::vector<CoordinatesArrayType> sorted_points_to_triangulate;
+            sorted_points_to_triangulate.resize(3);
+
+            if (!solution.empty()){
+                triangles.clear();
+
+                BrepTrimmingUtilities<false>::Triangulate_OPT(solution[0], triangles, factor, clip_area);
+
+                triangles_param_space.reserve(
+                    triangles_param_space.size() + triangles.size());
+
+                for (IndexType u = 0; u < triangles.size(); ++u){
+                    // Fill local triangle points
+                    for (IndexType v = 0; v < 3; ++v){
+                        points_to_triangulate[v][0] = triangles[u](v, 0);
+                        points_to_triangulate[v][1] = triangles[u](v, 1);
+                        points_to_triangulate[v][2] = 0.0;
+                    }
+
+                    // Reuse preallocated output container
+                    SortVerticesCounterClockwise(points_to_triangulate);
+
+                    // Avoid copy if possible
+                    triangles_param_space.push_back(points_to_triangulate);
+                }
+                } else {    
+                    KRATOS_WARNING("The intersection resulted in an empty polygon, skipping the triangle.");
+                }
+
+        } else {
+            KRATOS_WARNING("IgaMappingIntersectionUtilities")
+                << "The FEM-IGA projection resulted in a failure";
+            continue;
+        }
+
+        std::vector<std::vector<CoordinatesArrayType>> obtained_triangles_after_intersection_with_knot_lines;
+
+        // Reuse quadrature containers outside loops
+        IntegrationPointsArrayType integration_points_master(3);
+        GeometriesArrayType quadrature_point_geometries_master(3);
+
+        IntegrationPointsArrayType integration_points_slave(3);
+        GeometriesArrayType quadrature_point_geometries_slave(3);
+
+        CoordinatesArrayType master_quadrature_point_xyz = ZeroVector(3);
+        CoordinatesArrayType slave_quadrature_point_local_space = ZeroVector(3);
+
+        IntegrationInfo master_integration_info = geom_master->GetDefaultIntegrationInfo();
+
+        for (IndexType tri_id = 0; tri_id < triangles_param_space.size(); ++tri_id)
+        {
+            obtained_triangles_after_intersection_with_knot_lines.clear();
+
+            // If enabled, triangulation fills obtained_triangles
+            // IgaMappingIntersectionUtilities::Triangulation(
+            //     triangle_coordinates_parameter_space[tri_id], geom_master, obtained_triangles);
+
+            // Fallback: no triangulation => process original triangle
+            if (obtained_triangles_after_intersection_with_knot_lines.empty()) {
+                obtained_triangles_after_intersection_with_knot_lines.push_back(triangles_param_space[tri_id]);
+            }
+
+            for (IndexType j = 0; j < obtained_triangles_after_intersection_with_knot_lines.size(); ++j)
+            {
+                const auto& r_triangle = obtained_triangles_after_intersection_with_knot_lines[j];
+
+                const double xi_0  = r_triangle[0][0];
+                const double xi_1  = r_triangle[1][0];
+                const double xi_2  = r_triangle[2][0];
+                const double eta_0 = r_triangle[0][1];
+                const double eta_1 = r_triangle[1][1];
+                const double eta_2 = r_triangle[2][1];
+
+                auto master_it = integration_points_master.begin();
+                IntegrationPointUtilities::IntegrationPointsTriangle2D(
+                    master_it, 1, xi_0, xi_1, xi_2, eta_0, eta_1, eta_2);
+
+                geom_master->CreateQuadraturePointGeometries(
+                    quadrature_point_geometries_master, 3, integration_points_master, master_integration_info);
+
+                integration_points_slave = integration_points_master;
+
+                for (IndexType qp = 0; qp < quadrature_point_geometries_master.size(); ++qp)
+                {
+                    master_quadrature_point_xyz = quadrature_point_geometries_master[qp].Center();
+
+                    geom_slave->PointLocalCoordinates(
+                        slave_quadrature_point_local_space, master_quadrature_point_xyz);
+
+                    integration_points_slave[qp].X() = slave_quadrature_point_local_space[0];
+                    integration_points_slave[qp].Y() = slave_quadrature_point_local_space[1];
+                }
+
+                CreateQuadraturePointsUtility<NodeType>::Create(
+                    r_geom_slave, quadrature_point_geometries_slave, integration_points_slave, 1);
+
+                IndexType base_id =
+                    (rParentModelPart.NumberOfConditions() == 0)
+                        ? 1
+                        : (rParentModelPart.ConditionsEnd() - 1)->Id() + 1;
+
+                if (origin_is_iga)
+                {
+                    for (IndexType qp = 0; qp < quadrature_point_geometries_master.size(); ++qp)
+                    {
+                        rModelPartCoupling.AddCondition(Kratos::make_intrusive<Condition>(
+                            base_id + qp,
+                            Kratos::make_shared<CouplingGeometry<Node>>(
+                                quadrature_point_geometries_master(qp),
+                                quadrature_point_geometries_slave(qp))));
+                    }
+                }
+                else
+                {
+                    for (IndexType qp = 0; qp < quadrature_point_geometries_master.size(); ++qp)
+                    {
+                        rModelPartCoupling.AddCondition(Kratos::make_intrusive<Condition>(
+                            base_id + qp,
+                            Kratos::make_shared<CouplingGeometry<Node>>(
+                                quadrature_point_geometries_slave(qp),
+                                quadrature_point_geometries_master(qp))));
+                    }
+                }
+            }
+        }
+    }
+
+}
+
+bool IgaMappingIntersectionUtilities::FindInitialGuessNewtonRaphsonProjection(
+    const CoordinatesArrayType& slave_xyz,
+    const GeometryPointerType master_geometry,
+    const PatchCacheMap& rPatchCache,
+    CoordinatesArrayType& initial_guess,
+    const double search_radius)
+{
+    const IndexType patch_id = master_geometry->Id();
+
+    auto it = rPatchCache.find(patch_id);
+    KRATOS_ERROR_IF(it == rPatchCache.end())
+        << "Patch id " << patch_id << " not found in patch cache.\n";
+
+    const PatchSearchCache& pc = it->second;
+    KRATOS_ERROR_IF_NOT(pc.p_bins)
+        << "Bins not built for patch id " << patch_id << "\n";
+
+    PointType search_point(0, slave_xyz[0], slave_xyz[1], slave_xyz[2]);
+
+    constexpr int number_of_results = 1;
+    std::vector<PointTypePointer> results(number_of_results);
+    std::vector<double> distances(number_of_results);
+
+    const int obtained = pc.p_bins->SearchInRadius(
+        search_point,
+        search_radius,
+        results.begin(),
+        distances.begin(),
+        number_of_results);
+
+    if (obtained <= 0 || !results[0]) return false;
+
+    const IndexType id = results[0]->Id();
+
+    // Map id -> (i,j)
+    const IndexType i = id / pc.number_pts;
+    const IndexType j = id % pc.number_pts;
+
+    initial_guess = ZeroVector(3);
+    initial_guess[0] = pc.u_0  + pc.delta_u  * static_cast<double>(i);
+    initial_guess[1] = pc.v_0 + pc.delta_v * static_cast<double>(j);
+
+    return true;
+}
+
+bool IgaMappingIntersectionUtilities::AreProjectionsOnParameterSpaceBoundary(
+    const std::vector<CoordinatesArrayType>& r_points_to_triangulate,
+    const NurbsSurfaceGeometry<3, PointerVector<Node>>& r_nurbs_surface)
+{
+    if (r_points_to_triangulate.empty()) {
+        return false;
+    }
+
+    const NurbsInterval interval_u = r_nurbs_surface.DomainIntervalU();
+    const NurbsInterval interval_v = r_nurbs_surface.DomainIntervalV(); 
+
+    const double u_min = interval_u.MinParameter();
+    const double u_max = interval_u.MaxParameter();
+    const double v_min = interval_v.MinParameter();
+    const double v_max = interval_v.MaxParameter();
+
+    constexpr double eps = 1.0e-2;
+
+    auto near = [](double a, double b) noexcept {
+        return std::abs(a - b) < eps;
+    };
+
+    const auto& p0 = r_points_to_triangulate[0];
+
+    // One point: on any boundary
+    if (r_points_to_triangulate.size() == 1) {
+        return near(p0[0], u_min) || near(p0[0], u_max) ||
+               near(p0[1], v_min) || near(p0[1], v_max);
+    }
+
+    // Two or more points: check first two points on same boundary edge
+    const auto& p1 = r_points_to_triangulate[1];
+
+    const bool on_u_min = near(p0[0], u_min) && near(p1[0], u_min);
+    const bool on_u_max = near(p0[0], u_max) && near(p1[0], u_max);
+    const bool on_v_min = near(p0[1], v_min) && near(p1[1], v_min);
+    const bool on_v_max = near(p0[1], v_max) && near(p1[1], v_max);
+
+    return on_u_min || on_u_max || on_v_min || on_v_max;
+}
+
+bool IgaMappingIntersectionUtilities::FindTriangleSegmentSurfaceIntersectionWithBisection(
+    GeometryPointerType p_geom_master,
+    const CoordinatesArrayType& r_point_inside,
+    const CoordinatesArrayType& r_point_outside,
+    const CoordinatesArrayType& r_initial_guess,
+    CoordinatesArrayType& r_intersection_point)
+{
+    CoordinatesArrayType a = r_point_inside;
+    CoordinatesArrayType b = r_point_outside;
+
+    // This will be updated by ProjectionPointGlobalToLocalSpace
+    CoordinatesArrayType local_param = r_initial_guess;
+
+    constexpr IndexType max_iters = 1000;
+    constexpr double    x_tol     = 1e-8;  // tolerance in physical space (segment length)
+    constexpr double    proj_tol  = 1e-6;  // projection tolerance (your original)
+
+    CoordinatesArrayType mid = ZeroVector(3);
+
+    for (IndexType it = 0; it < max_iters; ++it)
+    {
+        mid = 0.5 * (a + b);
+
+        // Stop when segment is small enough (more meaningful than consecutive-mid distance)
+        const double seg_len = norm_2(b - a);
+        if (seg_len < x_tol) {
+            r_intersection_point = local_param;
+            return true;
+        }
+
+        // "Inside test" via projection success
+        const IndexType projection_ok = p_geom_master->ProjectionPointGlobalToLocalSpace(
+            mid, local_param, proj_tol);
+
+        if (projection_ok == 0) {
+            // midpoint behaves as outside -> move outside endpoint inward
+            b = mid;
+        } else {
+            // midpoint behaves as inside -> move inside endpoint outward
+            a = mid;
+        }
+    }
+
+    // Best effort output after max iters
+    r_intersection_point = local_param;
+    return true; // or false if you want to signal "hit max iters"
+}
+
+void IgaMappingIntersectionUtilities::SortVerticesCounterClockwise(
+    std::vector<CoordinatesArrayType>& r_vertices)
+{
+    KRATOS_ERROR_IF(r_vertices.size() < 3)
+        << "SortVerticesCounterClockwise expects at least 3 vertices, got "
+        << r_vertices.size() << "\n";
+
+    // --- centroid in parametric space ---
+    double cx = 0.0;
+    double cy = 0.0;
+
+    for (const auto& v : r_vertices) {
+        cx += v[0];
+        cy += v[1];
+    }
+    cx /= static_cast<double>(r_vertices.size());
+    cy /= static_cast<double>(r_vertices.size());
+
+    // --- sort by angle around centroid ---
+    std::sort(
+        r_vertices.begin(),
+        r_vertices.end(),
+        [cx, cy](const CoordinatesArrayType& a, const CoordinatesArrayType& b)
+        {
+            const double ang_a = std::atan2(a[1] - cy, a[0] - cx);
+            const double ang_b = std::atan2(b[1] - cy, b[0] - cx);
+            return ang_a < ang_b;
+        }
+    );
+}
+
 
 } // namespace Kratos.

--- a/applications/MappingApplication/custom_utilities/iga_mapping_intersection_utilities.cpp
+++ b/applications/MappingApplication/custom_utilities/iga_mapping_intersection_utilities.cpp
@@ -326,7 +326,7 @@ void IgaMappingIntersectionUtilities::CreateIgaFEMQuadraturePointsOnSurface(
             const bool have_initial_guess =
             IgaMappingIntersectionUtilities::FindInitialGuessNewtonRaphsonProjection(
                 node_coordinate_xyz,        // slave XYZ
-                geom_master,                // Brep surface geometry
+                geometry_itr->GetGeometryPart(0),                // Brep surface geometry
                 rPatchCache,                // PatchCacheMap (built once)
                 local_parameter,            // output (u,v)
                 search_radius               // bins search radius
@@ -385,7 +385,7 @@ void IgaMappingIntersectionUtilities::CreateIgaFEMQuadraturePointsOnSurface(
 
                 const bool found =
                     FindTriangleSegmentSurfaceIntersectionWithBisection(
-                        geom_master,
+                        geometry_itr->GetGeometryPart(0),
                         successful_nodes_xyz[0],
                         failed_nodes_xyz[i],
                         points_to_triangulate[0],
@@ -447,7 +447,7 @@ void IgaMappingIntersectionUtilities::CreateIgaFEMQuadraturePointsOnSurface(
 
                 // Use your current intersection routine (void). If you have the new bool routine, use it instead.
                 IgaMappingIntersectionUtilities::FindTriangleSegmentSurfaceIntersectionWithBisection(
-                    geom_master,
+                    geometry_itr->GetGeometryPart(0),
                     successful_nodes_xyz[i],              // inside the patch
                     failed_nodes_xyz[0],          // outside the patch
                     points_to_triangulate[i],                                       // better initial guess: the corresponding inside param
@@ -679,12 +679,12 @@ void IgaMappingIntersectionUtilities::CreateIgaFEMQuadraturePointsOnSurface(
 
 bool IgaMappingIntersectionUtilities::FindInitialGuessNewtonRaphsonProjection(
     const CoordinatesArrayType& slave_xyz,
-    const GeometryPointerType master_geometry,
+    const GeometryType& r_master_geometry,
     const PatchCacheMap& rPatchCache,
     CoordinatesArrayType& initial_guess,
     const double search_radius)
 {
-    const IndexType patch_id = master_geometry->Id();
+    const IndexType patch_id = r_master_geometry.Id();
 
     auto it = rPatchCache.find(patch_id);
     KRATOS_ERROR_IF(it == rPatchCache.end())
@@ -764,7 +764,7 @@ bool IgaMappingIntersectionUtilities::AreProjectionsOnParameterSpaceBoundary(
 }
 
 bool IgaMappingIntersectionUtilities::FindTriangleSegmentSurfaceIntersectionWithBisection(
-    GeometryPointerType p_geom_master,
+    const GeometryType& r_geom_master,
     const CoordinatesArrayType& r_point_inside,
     const CoordinatesArrayType& r_point_outside,
     const CoordinatesArrayType& r_initial_guess,
@@ -794,7 +794,7 @@ bool IgaMappingIntersectionUtilities::FindTriangleSegmentSurfaceIntersectionWith
         }
 
         // "Inside test" via projection success
-        const IndexType projection_ok = p_geom_master->ProjectionPointGlobalToLocalSpace(
+        const IndexType projection_ok = r_geom_master.ProjectionPointGlobalToLocalSpace(
             mid, local_param, proj_tol);
 
         if (projection_ok == 0) {

--- a/applications/MappingApplication/custom_utilities/iga_mapping_intersection_utilities.cpp
+++ b/applications/MappingApplication/custom_utilities/iga_mapping_intersection_utilities.cpp
@@ -222,12 +222,9 @@ IgaMappingIntersectionUtilities::PatchCacheMap IgaMappingIntersectionUtilities::
 
                 p_brep->GlobalCoordinates(phys, local);
 
-                // IMPORTANT: use intrusive pointer type
                 pc.points.push_back(PointTypePointer(new PointType(
                     id++, phys[0], phys[1], phys[2]
                 )));
-                // If available in your Kratos:
-                // pc.points.push_back(Kratos::make_intrusive<PointType>(id++, phys[0], phys[1], phys[2]));
             }
         }
 

--- a/applications/MappingApplication/custom_utilities/iga_mapping_intersection_utilities.cpp
+++ b/applications/MappingApplication/custom_utilities/iga_mapping_intersection_utilities.cpp
@@ -512,7 +512,7 @@ void IgaMappingIntersectionUtilities::CreateIgaFEMQuadraturePointsOnSurface(
                     auto new_int_point = BrepTrimmingUtilities<false>::ToIntPoint(
                         uv[0], uv[1], factor);
 
-                    // Shift tolerance
+                    // We need to define this tolerance for the clipping process
                     new_int_point.x += 100000.0;
                     new_int_point.y += 100000.0;
 

--- a/applications/MappingApplication/custom_utilities/iga_mapping_intersection_utilities.cpp
+++ b/applications/MappingApplication/custom_utilities/iga_mapping_intersection_utilities.cpp
@@ -24,7 +24,7 @@
 namespace Kratos
 {
 
-void IgaMappingIntersectionUtilities::CreateIgaFEMCouplingGeometries(
+void IgaMappingIntersectionUtilities::CreateIgaFEMCouplingGeometriesOnCurve(
     ModelPart& rModelPartDomainA,
     ModelPart& rModelPartDomainB,
     const bool& rIsOriginIga,
@@ -70,7 +70,7 @@ void IgaMappingIntersectionUtilities::CreateIgaFEMCouplingGeometries(
     }
 }
 
-void IgaMappingIntersectionUtilities::CreateIgaFEMQuadraturePointsCouplingInterface(
+void IgaMappingIntersectionUtilities::CreateIgaFEMQuadraturePointsOnCurve(
     ModelPart& rModelPartCoupling,
     double Tolerance)
 {
@@ -106,7 +106,7 @@ void IgaMappingIntersectionUtilities::CreateIgaFEMQuadraturePointsCouplingInterf
     }
 }
 
-void IgaMappingIntersectionUtilities::CreateIgaFEMSurfaceCouplingGeometries(
+void IgaMappingIntersectionUtilities::CreateIgaFEMCouplingGeometriesOnSurface(
         ModelPart &rModelPartDomainA,
         ModelPart &rModelPartDomainB,
         ModelPart &rModelPartResult,
@@ -274,7 +274,7 @@ std::vector<IndexType> IgaMappingIntersectionUtilities::GetPatchesWithProbablePr
 }
 
 
-void IgaMappingIntersectionUtilities::CreateIgaFEMQuadraturePointsCoupling2DGeometries3D(
+void IgaMappingIntersectionUtilities::CreateIgaFEMQuadraturePointsOnSurface(
     ModelPart& rModelPartCoupling,
     bool origin_is_iga,
     const PatchCacheMap& rPatchCache,

--- a/applications/MappingApplication/custom_utilities/iga_mapping_intersection_utilities.h
+++ b/applications/MappingApplication/custom_utilities/iga_mapping_intersection_utilities.h
@@ -20,6 +20,8 @@
 #include "includes/model_part.h"
 
 #include "geometries/coupling_geometry.h"
+#include "geometries/brep_surface.h"
+#include "spatial_containers/bins_dynamic.h"
 
 #include "integration/integration_point_utilities.h"
 #include "utilities/quadrature_points_utility.h"
@@ -33,24 +35,260 @@ namespace IgaMappingIntersectionUtilities
 
     using NodeType = Node;
     using GeometryType = Geometry<NodeType>;
+    using GeometryPointerType = GeometryType::Pointer;
 
     using GeometriesArrayType = typename GeometryType::GeometriesArrayType;
     using CoordinatesArrayType = typename GeometryType::CoordinatesArrayType;
     using IntegrationPointsArrayType = typename GeometryType::IntegrationPointsArrayType;
 
-    // This function creates coupling geometries between the IGA and FEM interface. This coupling geometry is composed of a brep_curve_on_surface (IGA side) and 
-    // a nurbs curve (FEM side)
+    using PointType = Node;
+    using PointTypePointer = Node::Pointer;
+    using PointVector = std::vector<PointType::Pointer>;
+    using PointIterator = std::vector<PointType::Pointer>::iterator;
+
+    using DistanceVector = std::vector<double>;
+    using DistanceIterator = std::vector<double>::iterator;
+
+    using DynamicBins = BinsDynamic<3, PointType, PointVector, PointTypePointer, PointIterator, DistanceIterator>;
+    using PointerType = DynamicBins::PointerType;
+    struct PatchSearchCache
+    {
+        std::vector<PointTypePointer> points;
+        std::unique_ptr<DynamicBins> p_bins;
+
+        // Regular sampling info (needed to reconstruct xi/eta from Point Id)
+        IndexType number_pts = 0;   // = n_div+1
+        double u_0 = 0.0, v_0 = 0.0;
+        double delta_u = 0.0, delta_v = 0.0;
+    };
+
+    using PatchCacheMap = std::unordered_map<IndexType, PatchSearchCache>;
+    using cInt = int64_t;
+
+        /**
+     * @brief Builds a spatial cache (sampling + search bins) for a set of IGA BRep patches.
+     *
+     * This function samples each IGA patch surface in physical space using a structured grid in its
+     * parametric space (u,v). The sampled points are stored together with a spatial search structure
+     * (DynamicBins), enabling fast radius queries.
+     *
+     * The cache is typically used to:
+     *  - quickly determine which patches are near a given FEM point/element/condition
+     *  - provide good initial guesses for Newton-Raphson surface projections
+     *
+     * @param patches_id      List of patch geometry IDs (must exist in @p rModelPartIga as geometries)
+     * @param rModelPartIga   ModelPart containing the IGA patch geometries (BrepSurface)
+     * @param n_div           Number of divisions per parametric direction (sampling resolution = (n_div+1)^2)
+     * @return PatchCacheMap  Map patch_id -> PatchSearchCache (sampled points + bins + metadata)
+     */
+    PatchCacheMap KRATOS_API(MAPPING_APPLICATION) BuildPatchCaches(
+        const std::vector<IndexType>& patches_id,
+        const ModelPart& rModelPartIga,
+        const IndexType n_div);
+
+
+    /**
+     * @brief Creates line coupling geometries between an IGA trimming curve and a FEM curve interface.
+     *
+     * This utility creates a set of @ref CouplingGeometry objects for line-to-line coupling.
+     * Each coupling geometry is composed of:
+     *  - an IGA curve on surface (BrepCurveOnSurface) representing the IGA interface
+     *  - a FEM NurbsCurveGeometry representing the FEM interface
+     *
+     * The output coupling geometries are stored inside @p rModelPartResult and can later be used
+     * to generate quadrature points (integration entities) along the shared interface.
+     *
+     * Typical use-case: line coupling between an IGA boundary curve and a FEM curve for mortar-style mapping.
+     *
+     * @param rModelPartDomainA   ModelPart containing the origin interface
+     * @param rModelPartDomainB   ModelPart containing the destination interface
+     * @param rIsOriginIga        If true: DomainA is treated as IGA and DomainB as FEM, otherwise swapped
+     * @param rModelPartResult    ModelPart where the generated coupling geometries will be stored
+     * @param Tolerance           Geometric tolerance used for intersection/projection decisions
+     */
     void KRATOS_API(MAPPING_APPLICATION) CreateIgaFEMCouplingGeometries(
         ModelPart& rModelPartDomainA,
         ModelPart& rModelPartDomainB,
         const bool& rIsOriginIga,
-        ModelPart& rModelPartResult, 
+        ModelPart& rModelPartResult,
         double Tolerance = 1.0e-6);
-    
-    // This function creates quadrature points along the coupling interface (intersection of both domains)
+
+
+    /**
+     * @brief Creates quadrature-point coupling geometries along the IGA-FEM coupling interface curve.
+     *
+     * This utility takes a ModelPart containing coupling geometries (line coupling) and generates
+     * quadrature point entities along the intersection/interface curve. These quadrature points are
+     * intended for integration-based coupling (e.g. mortar coupling, consistent force transfer).
+     *
+     * The procedure typically:
+     *  1. Computes integration points along the coupling curve(s)
+     *  2. Creates quadrature point geometries on both sides (IGA + FEM)
+     *  3. Stores the new quadrature coupling entities (usually as conditions) into the same ModelPart
+     *
+     * @param rModelPartCoupling   ModelPart containing the previously created line coupling geometries
+     * @param Tolerance            Geometric tolerance used during evaluation/projection
+     */
     void KRATOS_API(MAPPING_APPLICATION) CreateIgaFEMQuadraturePointsCouplingInterface(
         ModelPart& rModelPartCoupling,
         double Tolerance);
+
+    
+        /**
+     * @brief Creates surface-to-surface coupling geometries between an IGA interface and a FEM interface.
+     *
+     * This utility builds a set of @ref CouplingGeometry objects, where each coupling geometry contains:
+     *  - The IGA patch surface (represented by a @ref BrepSurface / NURBS surface)
+     *  - A FEM interface condition geometry
+     *
+     * For efficiency, each FEM condition is only paired with a subset of candidate IGA patches, determined
+     * through a spatial pre-filtering (radius-based search on a cached patch sampling).
+     *
+     * @param rModelPartDomainA       ModelPart containing the origin interface (IGA side if @p is_origin_iga = true)
+     * @param rModelPartDomainB       ModelPart containing the destination interface (FEM side if @p is_origin_iga = true)
+     * @param rModelPartResult        ModelPart where the generated coupling geometries will be stored
+     * @param is_origin_iga           If true, DomainA is treated as IGA and DomainB as FEM. Otherwise the opposite.
+     * @param search_radius           Radius used for spatial pre-filtering of candidate IGA patches
+     * @param rPatchCache             Patch cache (sampling + bins). It is rebuilt internally for the involved patches.
+     */
+    void KRATOS_API(MAPPING_APPLICATION) CreateIgaFEMSurfaceCouplingGeometries(
+        ModelPart& rModelPartDomainA,
+        ModelPart& rModelPartDomainB,
+        ModelPart& rModelPartResult,
+        bool is_origin_iga,
+        const double search_radius,
+        PatchCacheMap& rPatchCache);
+
+
+    /**
+     * @brief Creates quadrature-point coupling geometries from previously generated surface coupling geometries.
+     *
+     * This method takes a ModelPart containing coupling geometries (IGA surface + FEM geometry) and builds
+     * quadrature point geometries for integration-based coupling (mortar-like approach).
+     *
+     * For each coupling geometry:
+     *  1. FEM nodes are projected onto the IGA patch in parametric space (u,v)
+     *  2. The projected FEM triangle (or clipped triangles, in case of trimming) is triangulated in parameter space
+     *  3. Integration points are generated for each parametric triangle
+     *  4. The integration points are mapped to the FEM side by projecting the master quadrature-point coordinates
+     *     into the FEM local space
+     *  5. Quadrature-point geometries are created on both sides and stored as new coupling conditions
+     *
+     * @param rModelPartCoupling      ModelPart containing the surface coupling geometries (IGA patch + FEM condition)
+     * @param origin_is_iga           If true, master = IGA patch and slave = FEM geometry. Otherwise swapped.
+     * @param rPatchCache             Patch cache used for fast initial guess generation for surface projections
+     * @param search_radius           Radius used in the cached spatial bins search for initial guess estimation
+     */
+    void KRATOS_API(MAPPING_APPLICATION) CreateIgaFEMQuadraturePointsCoupling2DGeometries3D(
+        ModelPart& rModelPartCoupling,
+        bool origin_is_iga,
+        const PatchCacheMap& rPatchCache,
+        const double search_radius);
+
+
+    /**
+     * @brief Filters the set of candidate IGA patches for a given FEM entity location.
+     *
+     * Given a list of patch IDs and a query point (typically the FEM element/condition center), this function
+     * performs a radius-based search on each patch sampling cache and returns only the patches for which at least
+     * one sampled point lies within @p search_radius of the query point.
+     *
+     * If no patch is found within the radius, the function falls back to returning the full input list.
+     * (This avoids accidentally discarding valid patches due to too small radius.)
+     *
+     * @param patches_id              List of patch IDs to check
+     * @param rCache                  Cache containing sampled points and spatial bins per patch
+     * @param element_center          Query point in physical space (x,y,z)
+     * @param search_radius           Search radius in physical space
+     * @return std::vector<IndexType> List of patch IDs likely containing a valid projection
+     */
+    std::vector<IndexType> KRATOS_API(MAPPING_APPLICATION) GetPatchesWithProbableProjection(
+        const std::vector<IndexType>& patches_id,
+        const PatchCacheMap& rCache,
+        const CoordinatesArrayType& element_center,
+        const double search_radius);
+
+
+    /**
+     * @brief Provides an initial guess for a Newton-Raphson projection of a FEM point onto an IGA patch.
+     *
+     * This method finds the closest cached sample point (within a radius) on the patch bins structure and converts
+     * it back to the corresponding parametric coordinates (u,v). The guess is returned in @p rInitialGuess and can
+     * be passed to ProjectionPointGlobalToLocalSpace / Newton projection.
+     *
+     * @param rSlaveElementNode       Point in physical space to be projected (x,y,z)
+     * @param pMasterGeometry         IGA patch geometry (must have a corresponding entry in @p rPatchCache)
+     * @param rPatchCache             Patch cache containing sampled points and mapping to parametric indices
+     * @param rInitialGuess           Output initial guess in parametric coordinates (u,v,0)
+     * @param SearchRadius            Radius used in the spatial bins query
+     * @return true                   If a valid guess was found
+     * @return false                  If no cached point was found within the search radius
+     */
+    bool KRATOS_API(MAPPING_APPLICATION) FindInitialGuessNewtonRaphsonProjection(
+        const CoordinatesArrayType& rSlaveElementNode,
+        GeometryPointerType pMasterGeometry,
+        const PatchCacheMap& rPatchCache,
+        CoordinatesArrayType& rInitialGuess,
+        const double SearchRadius);
+
+
+    /**
+     * @brief Checks whether the projected points lie on the boundary of the NURBS patch parameter domain.
+     *
+     * This is typically used as a safeguard to avoid degenerate/unstable triangulations when the projected points
+     * lie directly on patch boundaries (u = u_min/u_max or v = v_min/v_max).
+     *
+     * If one point is provided: returns true if it lies on any boundary line.
+     * If two or more points are provided: returns true if the first two points lie on the same boundary line.
+     *
+     * @param points_to_triangulate   Projected points in parameter space (u,v,0)
+     * @param nurbs_surface           The NURBS surface defining the parametric domain limits
+     * @return true                   If boundary conditions are detected
+     * @return false                  Otherwise
+     */
+    bool KRATOS_API(MAPPING_APPLICATION) AreProjectionsOnParameterSpaceBoundary(
+        const std::vector<CoordinatesArrayType>& points_to_triangulate,
+        const NurbsSurfaceGeometry<3, PointerVector<Node>>& nurbs_surface);
+
+
+    /**
+     * @brief Computes the intersection between a line segment and the IGA patch using bisection.
+     *
+     * Given two physical-space points defining a segment:
+     *  - r_point_inside  : point known to be projectable onto the patch
+     *  - r_point_outside : point known to fail projection onto the patch
+     *
+     * The method repeatedly bisects the segment and tests the midpoint by attempting a projection onto the patch.
+     * The boundary intersection point is approximated once the segment becomes sufficiently small.
+     *
+     * @param p_geom_master           Patch geometry onto which the projection is attempted
+     * @param r_point_inside          Segment endpoint known to be inside (projectable)
+     * @param r_point_outside         Segment endpoint known to be outside (not projectable)
+     * @param r_initial_guess         Initial guess for local coordinates (u,v), typically from the inside node
+     * @param r_intersection_point    Output intersection point in local patch coordinates (u,v,0)
+     * @return true                   Always true (current implementation). Can be extended to signal failure.
+     */
+    bool KRATOS_API(MAPPING_APPLICATION) FindTriangleSegmentSurfaceIntersectionWithBisection(
+        GeometryPointerType p_geom_master,
+        const CoordinatesArrayType& r_point_inside,
+        const CoordinatesArrayType& r_point_outside,
+        const CoordinatesArrayType& r_initial_guess,
+        CoordinatesArrayType& r_intersection_point);
+
+
+    /**
+     * @brief Sorts polygon vertices counter-clockwise in (u,v) parametric space.
+     *
+     * This utility ensures a consistent vertex ordering for downstream operations such as triangulation
+     * and signed-area computations.
+     *
+     * The vertices are sorted by their polar angle around the centroid of the polygon.
+     *
+     * @param r_triangle_vertices     Vertices in parameter space (u,v,0), modified in-place
+     */
+    void KRATOS_API(MAPPING_APPLICATION) SortVerticesCounterClockwise(
+        std::vector<CoordinatesArrayType>& r_triangle_vertices);
+
 
 }  // namespace IgaMappingIntersectionUtilities.
 

--- a/applications/MappingApplication/custom_utilities/iga_mapping_intersection_utilities.h
+++ b/applications/MappingApplication/custom_utilities/iga_mapping_intersection_utilities.h
@@ -106,7 +106,7 @@ namespace IgaMappingIntersectionUtilities
      * @param rModelPartResult    ModelPart where the generated coupling geometries will be stored
      * @param Tolerance           Geometric tolerance used for intersection/projection decisions
      */
-    void KRATOS_API(MAPPING_APPLICATION) CreateIgaFEMCouplingGeometries(
+    void KRATOS_API(MAPPING_APPLICATION) CreateIgaFEMCouplingGeometriesOnCurve(
         ModelPart& rModelPartDomainA,
         ModelPart& rModelPartDomainB,
         const bool& rIsOriginIga,
@@ -129,7 +129,7 @@ namespace IgaMappingIntersectionUtilities
      * @param rModelPartCoupling   ModelPart containing the previously created line coupling geometries
      * @param Tolerance            Geometric tolerance used during evaluation/projection
      */
-    void KRATOS_API(MAPPING_APPLICATION) CreateIgaFEMQuadraturePointsCouplingInterface(
+    void KRATOS_API(MAPPING_APPLICATION) CreateIgaFEMQuadraturePointsOnCurve(
         ModelPart& rModelPartCoupling,
         double Tolerance);
 
@@ -151,7 +151,7 @@ namespace IgaMappingIntersectionUtilities
      * @param search_radius           Radius used for spatial pre-filtering of candidate IGA patches
      * @param rPatchCache             Patch cache (sampling + bins). It is rebuilt internally for the involved patches.
      */
-    void KRATOS_API(MAPPING_APPLICATION) CreateIgaFEMSurfaceCouplingGeometries(
+    void KRATOS_API(MAPPING_APPLICATION) CreateIgaFEMCouplingGeometriesOnSurface(
         ModelPart& rModelPartDomainA,
         ModelPart& rModelPartDomainB,
         ModelPart& rModelPartResult,
@@ -179,7 +179,7 @@ namespace IgaMappingIntersectionUtilities
      * @param rPatchCache             Patch cache used for fast initial guess generation for surface projections
      * @param search_radius           Radius used in the cached spatial bins search for initial guess estimation
      */
-    void KRATOS_API(MAPPING_APPLICATION) CreateIgaFEMQuadraturePointsCoupling2DGeometries3D(
+    void KRATOS_API(MAPPING_APPLICATION) CreateIgaFEMQuadraturePointsOnSurface(
         ModelPart& rModelPartCoupling,
         bool origin_is_iga,
         const PatchCacheMap& rPatchCache,

--- a/applications/MappingApplication/custom_utilities/iga_mapping_intersection_utilities.h
+++ b/applications/MappingApplication/custom_utilities/iga_mapping_intersection_utilities.h
@@ -226,7 +226,7 @@ namespace IgaMappingIntersectionUtilities
      */
     bool KRATOS_API(MAPPING_APPLICATION) FindInitialGuessNewtonRaphsonProjection(
         const CoordinatesArrayType& rSlaveElementNode,
-        GeometryPointerType pMasterGeometry,
+        const GeometryType& rMasterGeometry,
         const PatchCacheMap& rPatchCache,
         CoordinatesArrayType& rInitialGuess,
         const double SearchRadius);
@@ -269,7 +269,7 @@ namespace IgaMappingIntersectionUtilities
      * @return true                   Always true (current implementation). Can be extended to signal failure.
      */
     bool KRATOS_API(MAPPING_APPLICATION) FindTriangleSegmentSurfaceIntersectionWithBisection(
-        GeometryPointerType p_geom_master,
+        const GeometryType& p_geom_master,
         const CoordinatesArrayType& r_point_inside,
         const CoordinatesArrayType& r_point_outside,
         const CoordinatesArrayType& r_initial_guess,

--- a/applications/MappingApplication/tests/cpp_tests/test_iga_mapping_intersection_utilities.cpp
+++ b/applications/MappingApplication/tests/cpp_tests/test_iga_mapping_intersection_utilities.cpp
@@ -156,7 +156,7 @@ KRATOS_TEST_CASE_IN_SUITE(IgaMappingIntersection_BuildPatchCaches_Basic, KratosM
     // BuildPatchCaches needs patch ids
     std::vector<IndexType> patches_id{patch_id};
 
-    const IndexType n_div = 10; // keep test fast
+    const IndexType n_div = 10; 
     auto cache = BuildPatchCaches(patches_id, r_mp, n_div);
 
     KRATOS_EXPECT_EQ(cache.size(), 1u);
@@ -198,7 +198,7 @@ KRATOS_TEST_CASE_IN_SUITE(
 
     std::vector<IndexType> patches_id = {patch_id_1, patch_id_2};
 
-    const IndexType n_div = 20; // a bit finer helps at the shared boundary
+    const IndexType n_div = 20; 
     auto patch_cache = BuildPatchCaches(patches_id, r_model_part, n_div);
 
     KRATOS_WATCH(patch_cache.size())
@@ -294,7 +294,7 @@ KRATOS_TEST_CASE_IN_SUITE(IgaMappingIntersection_FindInitialGuessNewtonRaphsonPr
     std::vector<IndexType> patches_id{patch_id};
 
     // --- Build cache ---
-    const IndexType n_div = 10; // small but enough
+    const IndexType n_div = 10;
     auto patch_cache = BuildPatchCaches(patches_id, r_mp, n_div);
 
     KRATOS_EXPECT_EQ(patch_cache.size(), 1u);
@@ -311,7 +311,7 @@ KRATOS_TEST_CASE_IN_SUITE(IgaMappingIntersection_FindInitialGuessNewtonRaphsonPr
 
     const bool found = FindInitialGuessNewtonRaphsonProjection(
         slave_xyz,
-        r_master_geom,          // GeometryPointerType
+        r_master_geom,          
         patch_cache,
         initial_guess,
         search_radius);
@@ -412,7 +412,7 @@ KRATOS_TEST_CASE_IN_SUITE(IgaMappingIntersection_AreProjectionsOnParameterSpaceB
     {
         std::vector<CoordinatesArrayType> points(1);
         points[0] = ZeroVector(3);
-        points[0][0] = u_min;                      // boundary
+        points[0][0] = u_min;                      
         points[0][1] = 0.5 * (v_min + v_max);
 
         const bool is_boundary = AreProjectionsOnParameterSpaceBoundary(points, r_nurbs);
@@ -470,10 +470,10 @@ KRATOS_TEST_CASE_IN_SUITE(IgaMappingIntersection_AreProjectionsOnParameterSpaceB
 
         // p0 on u = u_min
         points[0][0] = u_min;
-        points[0][1] = 0.75 * (v_min + 1.0*v_max); // not on v boundary
+        points[0][1] = 0.75 * (v_min + 1.0*v_max); 
 
         // p1 on v = v_min
-        points[1][0] = 0.75 * (u_min + 1.0*u_max); // not on u boundary
+        points[1][0] = 0.75 * (u_min + 1.0*u_max); 
         points[1][1] = v_min;
 
         const bool is_boundary = AreProjectionsOnParameterSpaceBoundary(points, r_nurbs);
@@ -531,7 +531,7 @@ KRATOS_TEST_CASE_IN_SUITE(
 
     // --- Define outside point by moving in +X direction (outside patch domain) ---
     CoordinatesArrayType point_outside_xyz = point_inside_xyz;
-    point_outside_xyz[0] += 2.0; // move far outside in x
+    point_outside_xyz[0] += 2.0; 
 
     // --- Provide an initial guess in local space ---
     CoordinatesArrayType initial_guess = ZeroVector(3);

--- a/applications/MappingApplication/tests/cpp_tests/test_iga_mapping_intersection_utilities.cpp
+++ b/applications/MappingApplication/tests/cpp_tests/test_iga_mapping_intersection_utilities.cpp
@@ -187,9 +187,6 @@ KRATOS_TEST_CASE_IN_SUITE(
     const IndexType patch_id_1 = 1;
     const IndexType patch_id_2 = 2;
 
-    // No gap: patch2 starts at x = 1.0
-    const double patch2_offset_x = 1.0;
-
     IndexType next_node_id = 1;
 
     auto p_patch_1 = CreateTestBrepSurface_NoTrim(

--- a/applications/MappingApplication/tests/cpp_tests/test_iga_mapping_intersection_utilities.cpp
+++ b/applications/MappingApplication/tests/cpp_tests/test_iga_mapping_intersection_utilities.cpp
@@ -1,0 +1,571 @@
+#include "testing/testing.h"
+#include "custom_utilities/iga_mapping_intersection_utilities.h"
+#include "geometries/nurbs_surface_geometry.h"
+
+#include <vector>
+#include <cmath>
+
+namespace Kratos::Testing {
+
+namespace Utils = Kratos::IgaMappingIntersectionUtilities;
+using CoordinatesArrayType = Utils::CoordinatesArrayType;
+
+namespace {
+
+static BrepSurface<PointerVector<Node>, false, PointerVector<Point>>::Pointer
+CreateTestBrepSurface_NoTrim(
+    ModelPart& rModelPart,
+    const IndexType patch_id,
+    const double x0,
+    const double y0,
+    const double z0,
+    const double L,
+    const IndexType node_id_offset)   // <<< NEW
+{
+    using NodeType = Node;
+    using BrepSurfaceType = BrepSurface<PointerVector<NodeType>, false, PointerVector<Point>>;
+
+    // ------------------------------------------------------------------
+    // Create a very simple 2D degree-2 NURBS surface (3x3 control points)
+    // ------------------------------------------------------------------
+    Geometry<NodeType>::PointsArrayType ctrl_pts;
+
+    IndexType id = node_id_offset;
+
+    // 3x3 grid (u-direction, v-direction)
+    // coordinates span [x0, x0+L] x [y0, y0+L]
+    for (IndexType j = 0; j < 3; ++j) {
+        for (IndexType i = 0; i < 3; ++i) {
+            const double x = x0 + L * (static_cast<double>(i) / 2.0);
+            const double y = y0 + L * (static_cast<double>(j) / 2.0);
+            const double z = z0;
+
+            ctrl_pts.push_back(rModelPart.CreateNewNode(id++, x, y, z));
+        }
+    }
+
+    // Degree
+    const int p = 2;
+    const int q = 2;
+
+    // Open uniform knot vectors for degree 2 with 3 control points:
+    // [0 0 0 1 1 1]
+    Vector knot_u(6);
+    knot_u[0]=0.0; knot_u[1]=0.0; knot_u[2]=0.0; knot_u[3]=1.0; knot_u[4]=1.0; knot_u[5]=1.0;
+
+    Vector knot_v(6);
+    knot_v[0]=0.0; knot_v[1]=0.0; knot_v[2]=0.0; knot_v[3]=1.0; knot_v[4]=1.0; knot_v[5]=1.0;
+
+    // Non-rational
+    Vector weights(9);
+    for (IndexType k = 0; k < 9; ++k) weights[k] = 1.0;
+
+    auto p_surface = Kratos::make_shared<NurbsSurfaceGeometry<3, PointerVector<NodeType>>>(
+        ctrl_pts, p, q, knot_u, knot_v, weights);
+
+    // No trimming loops
+    typename BrepSurfaceType::BrepCurveOnSurfaceLoopArrayType outer_loops(0);
+    typename BrepSurfaceType::BrepCurveOnSurfaceLoopArrayType inner_loops(0);
+
+    auto p_brep = Kratos::make_shared<BrepSurfaceType>(p_surface, outer_loops, inner_loops);
+
+    // IMPORTANT: geometry id must be patch_id so BuildPatchCaches can find it
+    p_brep->SetId(patch_id);
+
+    // Register inside modelpart geometries
+    rModelPart.AddGeometry(p_brep);
+
+    return p_brep;
+}
+
+double SignedArea2D(const std::vector<CoordinatesArrayType>& r_vertices)
+{
+    const std::size_t n = r_vertices.size();
+    double A = 0.0;
+
+    for (std::size_t i = 0; i < n; ++i) {
+        const std::size_t j = (i + 1) % n;
+        A += r_vertices[i][0] * r_vertices[j][1]
+           - r_vertices[j][0] * r_vertices[i][1];
+    }
+    return 0.5 * A;
+}
+
+void CheckCCW(std::vector<CoordinatesArrayType>& r_vertices)
+{
+    Utils::SortVerticesCounterClockwise(r_vertices);
+    KRATOS_EXPECT_GT(SignedArea2D(r_vertices), 0.0);
+}
+
+} // unnamed namespace
+
+KRATOS_TEST_CASE_IN_SUITE(IgaMappingIntersection_SortVerticesCounterClockwise_Triangle, KratosMappingApplicationSerialTestSuite)
+{
+    std::vector<CoordinatesArrayType> tri(3);
+    for (auto& v : tri) v = ZeroVector(3);
+
+    tri[0][0] = 1.0; tri[0][1] = 0.0;
+    tri[1][0] = 0.0; tri[1][1] = 0.0;
+    tri[2][0] = 0.0; tri[2][1] = 1.0;
+
+    CheckCCW(tri);
+}
+
+KRATOS_TEST_CASE_IN_SUITE(IgaMappingIntersection_SortVerticesCounterClockwise_Quad, KratosMappingApplicationSerialTestSuite)
+{
+    std::vector<CoordinatesArrayType> quad(4);
+    for (auto& v : quad) v = ZeroVector(3);
+
+    // square shuffled
+    quad[0][0] = 1.0; quad[0][1] = 0.0;
+    quad[1][0] = 0.0; quad[1][1] = 1.0;
+    quad[2][0] = 0.0; quad[2][1] = 0.0;
+    quad[3][0] = 1.0; quad[3][1] = 1.0;
+
+    CheckCCW(quad);
+}
+
+KRATOS_TEST_CASE_IN_SUITE(IgaMappingIntersection_BuildPatchCaches_Basic, KratosMappingApplicationSerialTestSuite)
+{
+    using namespace Kratos;
+    using namespace Kratos::IgaMappingIntersectionUtilities;
+
+    Model model;
+    ModelPart& r_mp = model.CreateModelPart("iga_domain");
+    r_mp.CreateNewProperties(0);
+
+    // --- Create one BrepSurface patch inside the modelpart ---
+    const IndexType patch_id = 1;
+
+    // surface origin + size
+    const double x0 = 0.0;
+    const double y0 = 0.0;
+    const double z0 = 0.0;
+    const double L  = 1.0;
+
+    // unique node id range for this patch
+    const IndexType node_id_offset = 1;
+
+    auto p_brep = CreateTestBrepSurface_NoTrim(
+        r_mp,
+        patch_id,
+        x0, y0, z0,
+        L,
+        node_id_offset);
+
+    // BuildPatchCaches needs patch ids
+    std::vector<IndexType> patches_id{patch_id};
+
+    const IndexType n_div = 10; // keep test fast
+    auto cache = BuildPatchCaches(patches_id, r_mp, n_div);
+
+    KRATOS_EXPECT_EQ(cache.size(), 1u);
+
+    auto it = cache.find(patch_id);
+    KRATOS_EXPECT_TRUE(it != cache.end());
+
+    const auto& pc = it->second;
+
+    KRATOS_EXPECT_TRUE(pc.p_bins != nullptr);
+    KRATOS_EXPECT_EQ(pc.number_pts, n_div + 1);
+
+    // (n_div+1)^2 points
+    KRATOS_EXPECT_EQ(pc.points.size(), (n_div + 1) * (n_div + 1));
+}
+
+KRATOS_TEST_CASE_IN_SUITE(
+    IgaMappingIntersection_GetPatchesWithProbableProjection_Basic,
+    KratosMappingApplicationSerialTestSuite)
+{
+    using namespace Kratos;
+    using namespace Kratos::IgaMappingIntersectionUtilities;
+
+    Model model;
+    ModelPart& r_model_part = model.CreateModelPart("iga_model_part");
+    r_model_part.CreateNewProperties(0);
+
+    const IndexType patch_id_1 = 1;
+    const IndexType patch_id_2 = 2;
+
+    // No gap: patch2 starts at x = 1.0
+    const double patch2_offset_x = 1.0;
+
+    IndexType next_node_id = 1;
+
+    auto p_patch_1 = CreateTestBrepSurface_NoTrim(
+        r_model_part, patch_id_1, 0.0, 0.0, 0.0, 1.0, next_node_id);
+    next_node_id += 9;
+
+    auto p_patch_2 = CreateTestBrepSurface_NoTrim(
+        r_model_part, patch_id_2, 1.0, 0.0, 0.0, 1.0, next_node_id);
+
+    std::vector<IndexType> patches_id = {patch_id_1, patch_id_2};
+
+    const IndexType n_div = 20; // a bit finer helps at the shared boundary
+    auto patch_cache = BuildPatchCaches(patches_id, r_model_part, n_div);
+
+    KRATOS_WATCH(patch_cache.size())
+
+    KRATOS_EXPECT_EQ(patch_cache.size(), 2);
+
+    // ------------------------------------------------------------
+    // Query 1: clearly inside patch 1
+    CoordinatesArrayType element_center_1 = ZeroVector(3);
+    element_center_1[0] = 0.25;
+    element_center_1[1] = 0.50;
+    element_center_1[2] = 0.0;
+
+    const double search_radius_close = 0.20;
+
+    auto out_1 = GetPatchesWithProbableProjection(
+        patches_id, patch_cache, element_center_1, search_radius_close);
+
+    KRATOS_EXPECT_EQ(out_1.size(), 1);
+    KRATOS_EXPECT_EQ(out_1[0], patch_id_1);
+
+    // ------------------------------------------------------------
+    // Query 2: clearly inside patch 2
+    CoordinatesArrayType element_center_2 = ZeroVector(3);
+    element_center_2[0] = 1.75;
+    element_center_2[1] = 0.50;
+    element_center_2[2] = 0.0;
+
+    auto out_2 = GetPatchesWithProbableProjection(
+        patches_id, patch_cache, element_center_2, search_radius_close);
+
+    KRATOS_EXPECT_EQ(out_2.size(), 1);
+    KRATOS_EXPECT_EQ(out_2[0], patch_id_2);
+
+    // ------------------------------------------------------------
+    // Query 3: exactly on the shared boundary -> should hit BOTH
+    CoordinatesArrayType element_center_mid = ZeroVector(3);
+    element_center_mid[0] = 1.0;
+    element_center_mid[1] = 0.50;
+    element_center_mid[2] = 0.0;
+
+    const double search_radius_mid = 0.05;
+
+    auto out_mid = GetPatchesWithProbableProjection(
+        patches_id, patch_cache, element_center_mid, search_radius_mid);
+
+    KRATOS_EXPECT_EQ(out_mid.size(), 2);
+    KRATOS_EXPECT_EQ(out_mid[0], patch_id_1);
+    KRATOS_EXPECT_EQ(out_mid[1], patch_id_2);
+
+    // ------------------------------------------------------------
+    // Query 4: far from both -> fallback to full list
+    CoordinatesArrayType element_center_far = ZeroVector(3);
+    element_center_far[0] = 100.0;
+    element_center_far[1] = 100.0;
+    element_center_far[2] = 0.0;
+
+    auto out_far = GetPatchesWithProbableProjection(
+        patches_id, patch_cache, element_center_far, search_radius_close);
+
+    KRATOS_EXPECT_EQ(out_far.size(), patches_id.size());
+    KRATOS_EXPECT_EQ(out_far[0], patches_id[0]);
+    KRATOS_EXPECT_EQ(out_far[1], patches_id[1]);
+}
+
+KRATOS_TEST_CASE_IN_SUITE(IgaMappingIntersection_FindInitialGuessNewtonRaphsonProjection_Basic, KratosMappingApplicationSerialTestSuite)
+{
+    using namespace Kratos;
+    using namespace Kratos::IgaMappingIntersectionUtilities;
+
+    Model model;
+    ModelPart& r_mp = model.CreateModelPart("iga_domain");
+    r_mp.CreateNewProperties(0);
+
+    // --- Create BrepSurface patch ---
+    const IndexType patch_id = 1;
+
+    const double x0 = 0.0;
+    const double y0 = 0.0;
+    const double z0 = 0.0;
+    const double L  = 1.0;
+
+    const IndexType node_id_offset = 1;
+
+    auto p_brep = CreateTestBrepSurface_NoTrim(
+        r_mp,
+        patch_id,
+        x0, y0, z0,
+        L,
+        node_id_offset);
+
+    std::vector<IndexType> patches_id{patch_id};
+
+    // --- Build cache ---
+    const IndexType n_div = 10; // small but enough
+    auto patch_cache = BuildPatchCaches(patches_id, r_mp, n_div);
+
+    KRATOS_EXPECT_EQ(patch_cache.size(), 1u);
+
+    // --- CASE 1: point close to the patch -> should return true ---
+    CoordinatesArrayType slave_xyz = ZeroVector(3);
+    slave_xyz[0] = 0.5;
+    slave_xyz[1] = 0.5;
+    slave_xyz[2] = 0.0;
+
+    CoordinatesArrayType initial_guess = ZeroVector(3);
+
+    const double search_radius = 0.25;
+
+    const bool found = FindInitialGuessNewtonRaphsonProjection(
+        slave_xyz,
+        p_brep,          // GeometryPointerType
+        patch_cache,
+        initial_guess,
+        search_radius);
+
+    KRATOS_EXPECT_TRUE(found);
+
+    // Check that initial guess is "reasonable"
+    KRATOS_EXPECT_GE(initial_guess[0], 0.0);
+    KRATOS_EXPECT_LE(initial_guess[0], 1.0);
+    KRATOS_EXPECT_GE(initial_guess[1], 0.0);
+    KRATOS_EXPECT_LE(initial_guess[1], 1.0);
+
+    // --- CASE 2: far point -> should return false ---
+    CoordinatesArrayType slave_xyz_far = ZeroVector(3);
+    slave_xyz_far[0] = 100.0;
+    slave_xyz_far[1] = 100.0;
+    slave_xyz_far[2] = 0.0;
+
+    CoordinatesArrayType initial_guess_far = ZeroVector(3);
+
+    const bool found_far = FindInitialGuessNewtonRaphsonProjection(
+        slave_xyz_far,
+        p_brep,
+        patch_cache,
+        initial_guess_far,
+        search_radius);
+
+    KRATOS_EXPECT_FALSE(found_far);
+}
+
+KRATOS_TEST_CASE_IN_SUITE(IgaMappingIntersection_AreProjectionsOnParameterSpaceBoundary_Basic, KratosMappingApplicationSerialTestSuite)
+{
+    using namespace Kratos;
+    using namespace Kratos::IgaMappingIntersectionUtilities;
+
+    Model model;
+    ModelPart& r_mp = model.CreateModelPart("iga_domain");
+    r_mp.CreateNewProperties(0);
+
+    // --- Create BrepSurface patch ---
+    const IndexType patch_id = 1;
+
+    const double x0 = 0.0;
+    const double y0 = 0.0;
+    const double z0 = 0.0;
+    const double L  = 1.0;
+
+    const IndexType node_id_offset = 1;
+
+    auto p_brep = CreateTestBrepSurface_NoTrim(
+        r_mp,
+        patch_id,
+        x0, y0, z0,
+        L,
+        node_id_offset);
+
+    // Get BACKGROUND nurbs surface from BrepSurface
+    auto p_background = p_brep->pGetGeometryPart(GeometryType::BACKGROUND_GEOMETRY_INDEX);
+
+    auto p_nurbs = dynamic_pointer_cast<NurbsSurfaceGeometry<3, PointerVector<Node>>>(
+        p_background);
+
+    KRATOS_EXPECT_TRUE(p_nurbs != nullptr);
+
+    const auto& r_nurbs = *p_nurbs;
+
+    // Read intervals to construct boundary points robustly
+    const double u_min = r_nurbs.DomainIntervalU().MinParameter();
+    const double u_max = r_nurbs.DomainIntervalU().MaxParameter();
+    const double v_min = r_nurbs.DomainIntervalV().MinParameter();
+    const double v_max = r_nurbs.DomainIntervalV().MaxParameter();
+
+    // ============================================================
+    // CASE 0: empty -> false
+    // ============================================================
+    {
+        std::vector<CoordinatesArrayType> points;
+        const bool is_boundary = AreProjectionsOnParameterSpaceBoundary(points, r_nurbs);
+        KRATOS_EXPECT_FALSE(is_boundary);
+    }
+
+    // ============================================================
+    // CASE 1: one point strictly inside -> false
+    // ============================================================
+    {
+        std::vector<CoordinatesArrayType> points(1);
+        points[0] = ZeroVector(3);
+        points[0][0] = 0.5 * (u_min + u_max);
+        points[0][1] = 0.5 * (v_min + v_max);
+
+        const bool is_boundary = AreProjectionsOnParameterSpaceBoundary(points, r_nurbs);
+        KRATOS_EXPECT_FALSE(is_boundary);
+    }
+
+    // ============================================================
+    // CASE 2: one point on boundary (u=u_min) -> true
+    // ============================================================
+    {
+        std::vector<CoordinatesArrayType> points(1);
+        points[0] = ZeroVector(3);
+        points[0][0] = u_min;                      // boundary
+        points[0][1] = 0.5 * (v_min + v_max);
+
+        const bool is_boundary = AreProjectionsOnParameterSpaceBoundary(points, r_nurbs);
+        KRATOS_EXPECT_TRUE(is_boundary);
+    }
+
+    // ============================================================
+    // CASE 3: two points on same boundary edge -> true
+    // (both on v=v_max)
+    // ============================================================
+    {
+        std::vector<CoordinatesArrayType> points(2);
+
+        points[0] = ZeroVector(3);
+        points[1] = ZeroVector(3);
+
+        points[0][0] = 0.25 * (u_min + 3.0*u_max);
+        points[1][0] = 0.75 * (u_min + 1.0*u_max);
+
+        points[0][1] = v_max;
+        points[1][1] = v_max;
+
+        const bool is_boundary = AreProjectionsOnParameterSpaceBoundary(points, r_nurbs);
+        KRATOS_EXPECT_TRUE(is_boundary);
+    }
+
+    // ============================================================
+    // CASE 4: two points on different boundaries -> false
+    // (one on u_min, one on u_max) => not "same edge"
+    // ============================================================
+    {
+        std::vector<CoordinatesArrayType> points(2);
+
+        points[0] = ZeroVector(3);
+        points[1] = ZeroVector(3);
+
+        points[0][0] = u_min;
+        points[0][1] = 0.25 * (v_min + 3.0*v_max);
+
+        points[1][0] = u_max;
+        points[1][1] = 0.75 * (v_min + 1.0*v_max);
+
+        const bool is_boundary = AreProjectionsOnParameterSpaceBoundary(points, r_nurbs);
+        KRATOS_EXPECT_FALSE(is_boundary);
+    }
+
+    // ============================================================
+    // CASE: p0 on u_min, p1 on v_min -> false (different edges)
+    // ============================================================
+    {
+        std::vector<CoordinatesArrayType> points(2);
+
+        points[0] = ZeroVector(3);
+        points[1] = ZeroVector(3);
+
+        // p0 on u = u_min
+        points[0][0] = u_min;
+        points[0][1] = 0.75 * (v_min + 1.0*v_max); // not on v boundary
+
+        // p1 on v = v_min
+        points[1][0] = 0.75 * (u_min + 1.0*u_max); // not on u boundary
+        points[1][1] = v_min;
+
+        const bool is_boundary = AreProjectionsOnParameterSpaceBoundary(points, r_nurbs);
+        KRATOS_EXPECT_FALSE(is_boundary);
+    }
+
+}
+
+KRATOS_TEST_CASE_IN_SUITE(
+    IgaMappingIntersection_FindTriangleSegmentSurfaceIntersectionWithBisection_Basic,
+    KratosMappingApplicationSerialTestSuite)
+{
+    using namespace Kratos;
+    using namespace Kratos::IgaMappingIntersectionUtilities;
+
+    Model model;
+    ModelPart& r_mp = model.CreateModelPart("iga_domain");
+    r_mp.CreateNewProperties(0);
+
+    // --- Create one BrepSurface patch and register it ---
+    const IndexType patch_id = 1;
+
+    // IMPORTANT: use the same helper you already have
+    auto p_brep = CreateTestBrepSurface_NoTrim(r_mp, patch_id, 0.0, 0.0, 0.0, 1.0, 1);
+    r_mp.AddGeometry(p_brep);
+
+    GeometryPointerType p_geom_master = p_brep;
+
+    // --- Get parametric bounds (u_min,u_max,v_min,v_max) ---
+    auto p_background = p_brep->pGetGeometryPart(GeometryType::BACKGROUND_GEOMETRY_INDEX);
+
+    std::vector<double> knot_u, knot_v;
+    p_background->SpansLocalSpace(knot_u, 0);
+    p_background->SpansLocalSpace(knot_v, 1);
+
+    KRATOS_ERROR_IF(knot_u.empty() || knot_v.empty())
+        << "Empty knot vectors in test surface.\n";
+
+    const double u_min = knot_u.front();
+    const double u_max = knot_u.back();
+    const double v_min = knot_v.front();
+    const double v_max = knot_v.back();
+
+    const double u_mid = 0.5 * (u_min + u_max);
+    const double v_mid = 0.5 * (v_min + v_max);
+
+    // --- Define inside point using GlobalCoordinates at (u_mid, v_mid) ---
+    CoordinatesArrayType local_inside = ZeroVector(3);
+    local_inside[0] = u_mid;
+    local_inside[1] = v_mid;
+
+    CoordinatesArrayType point_inside_xyz = ZeroVector(3);
+    p_brep->GlobalCoordinates(point_inside_xyz, local_inside);
+
+    // --- Define outside point by moving in +X direction (outside patch domain) ---
+    CoordinatesArrayType point_outside_xyz = point_inside_xyz;
+    point_outside_xyz[0] += 2.0; // move far outside in x
+
+    // --- Provide an initial guess in local space ---
+    CoordinatesArrayType initial_guess = ZeroVector(3);
+    initial_guess[0] = u_mid;
+    initial_guess[1] = v_mid;
+
+    // --- Output of function ---
+    CoordinatesArrayType intersection_local = ZeroVector(3);
+
+    const bool found =
+        FindTriangleSegmentSurfaceIntersectionWithBisection(
+            p_geom_master,
+            point_inside_xyz,
+            point_outside_xyz,
+            initial_guess,
+            intersection_local);
+
+    KRATOS_EXPECT_TRUE(found);
+
+    // Expect intersection to be close to u_max boundary
+    KRATOS_EXPECT_NEAR(intersection_local[0], u_max, 1e-4);
+
+    // and keep v close to v_mid (since we moved only in X direction)
+    KRATOS_EXPECT_NEAR(intersection_local[1], v_mid, 1e-3);
+
+    // Extra verification: physical intersection is on the boundary 
+    CoordinatesArrayType intersection_xyz = ZeroVector(3);
+    p_brep->GlobalCoordinates(intersection_xyz, intersection_local);
+
+    // The boundary physical point should have x ≈ max x on surface
+    // (since u=u_max means right edge for your flat surface)
+    // We also check it's near z-plane of the surface.
+    KRATOS_EXPECT_NEAR(intersection_xyz[2], point_inside_xyz[2], 1e-8);
+}
+
+} // namespace Kratos::Testing

--- a/applications/MappingApplication/tests/cpp_tests/test_iga_mapping_intersection_utilities.cpp
+++ b/applications/MappingApplication/tests/cpp_tests/test_iga_mapping_intersection_utilities.cpp
@@ -289,6 +289,7 @@ KRATOS_TEST_CASE_IN_SUITE(IgaMappingIntersection_FindInitialGuessNewtonRaphsonPr
         x0, y0, z0,
         L,
         node_id_offset);
+    const GeometryType& r_master_geom = *p_brep;
 
     std::vector<IndexType> patches_id{patch_id};
 
@@ -310,7 +311,7 @@ KRATOS_TEST_CASE_IN_SUITE(IgaMappingIntersection_FindInitialGuessNewtonRaphsonPr
 
     const bool found = FindInitialGuessNewtonRaphsonProjection(
         slave_xyz,
-        p_brep,          // GeometryPointerType
+        r_master_geom,          // GeometryPointerType
         patch_cache,
         initial_guess,
         search_radius);
@@ -333,7 +334,7 @@ KRATOS_TEST_CASE_IN_SUITE(IgaMappingIntersection_FindInitialGuessNewtonRaphsonPr
 
     const bool found_far = FindInitialGuessNewtonRaphsonProjection(
         slave_xyz_far,
-        p_brep,
+        r_master_geom,
         patch_cache,
         initial_guess_far,
         search_radius);
@@ -497,6 +498,7 @@ KRATOS_TEST_CASE_IN_SUITE(
 
     // IMPORTANT: use the same helper you already have
     auto p_brep = CreateTestBrepSurface_NoTrim(r_mp, patch_id, 0.0, 0.0, 0.0, 1.0, 1);
+    const GeometryType& r_master_geom = *p_brep;
     r_mp.AddGeometry(p_brep);
 
     GeometryPointerType p_geom_master = p_brep;
@@ -541,7 +543,7 @@ KRATOS_TEST_CASE_IN_SUITE(
 
     const bool found =
         FindTriangleSegmentSurfaceIntersectionWithBisection(
-            p_geom_master,
+            r_master_geom,
             point_inside_xyz,
             point_outside_xyz,
             initial_guess,


### PR DESCRIPTION
**Summary**

This PR introduces a new IGA–FEM surface mapping modeler for mortar-based coupling, enabling surface-to-surface mapping between an IGA patch represented by a `BrepSurface` and a FEM interface represented by triangular conditions.
The modeler creates the required coupling geometries and quadrature point geometries to support mortar surface mapping workflows in the `MappingApplication`.

**Motivation**

Until now, the IGA–FEM mapping workflow in the `MappingApplication` mainly supported curve/line-based coupling (`BrepCurveOnSurface` ↔ FEM NurbsCurve).
For 3D coupling problems (e.g. shell/solid surface coupling, load transfer, or partitioned FSI), a surface mapping capability is needed. This PR adds a modeler that builds the required coupling interface geometry structure automatically.

**Reference** 
[An isogeometric b-rep mortar-based mapping method for non-matching grids in FSI.pdf](https://github.com/user-attachments/files/24620021/An.isogeometric.b-rep.mortar-based.mapping.method.for.non-matching.grids.in.FSI.pdf)

FYI @rickyaristio @philbucher 
