### PR TITLE
[Scripts][Docker] Update GCC in Rocky Docker image to version 13

### DIFF
--- a/scripts/docker_files/docker_file_ci_rockylinux8/DockerFile
+++ b/scripts/docker_files/docker_file_ci_rockylinux8/DockerFile
@@ -4,8 +4,8 @@ USER root
 
 ENV HOME /root
 
-# Install devtools 11
-RUN dnf -y install gcc-toolset-11
+# Install devtools 13
+RUN dnf -y install gcc-toolset-13
 
 # Enable devtools 11 every time a shell is started
 # TODO: /etc/bashrc is never executed so this line does not fulfill its purpose => fix it.


### PR DESCRIPTION
**📝 Description**

Let's update GCC to 13 to fully support C++20. For the moment we will create a draft PR to see what fails in the CI. In my machine it fails this: https://github.com/KratosMultiphysics/Kratos/issues/14125

**🆕 Changelog**

- [Update GCC in Rocky Docker image to version 13](https://github.com/KratosMultiphysics/Kratos/commit/a326cfc74d2cb124edd143fd2c74f152e5d44b2c)