### PR TITLE
Geo/let elements provide material permeability to calculators

### DIFF
--- a/applications/GeoMechanicsApplication/custom_elements/Pw_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/Pw_element.cpp
@@ -459,8 +459,9 @@ template <unsigned int TDim, unsigned int TNumNodes>
 typename PermeabilityCalculator<TNumNodes>::InputProvider PwElement<TDim, TNumNodes>::CreatePermeabilityInputProvider()
 {
     return typename PermeabilityCalculator<TNumNodes>::InputProvider(
-        MakePropertiesGetter(), MakeRetentionLawsGetter(), GetIntegrationCoefficients(),
-        MakeNodalVariableGetter(), MakeShapeFunctionLocalGradientsGetter(), GetFluidPressures());
+        MakePropertiesGetter(), MakeRetentionLawsGetter(), MakeMaterialPermeabilityGetter(),
+        GetIntegrationCoefficients(), MakeNodalVariableGetter(),
+        MakeShapeFunctionLocalGradientsGetter(), GetFluidPressures());
 }
 
 template <unsigned int TDim, unsigned int TNumNodes>

--- a/applications/GeoMechanicsApplication/custom_elements/Pw_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/Pw_element.cpp
@@ -480,10 +480,10 @@ Matrix PwElement<TDim, TNumNodes>::CalculateNContainer()
 }
 
 template <unsigned int TDim, unsigned int TNumNodes>
-Vector PwElement<TDim, TNumNodes>::CalculateIntegrationCoefficients()
+std::vector<double> PwElement<TDim, TNumNodes>::CalculateIntegrationCoefficients()
 {
     GetGeometry().DeterminantOfJacobian(mDetJCcontainer, this->GetIntegrationMethod());
-    return mIntegrationCoefficientsCalculator.Run<Vector>(
+    return mIntegrationCoefficientsCalculator.Run<>(
         GetGeometry().IntegrationPoints(GetIntegrationMethod()), mDetJCcontainer, this);
 }
 

--- a/applications/GeoMechanicsApplication/custom_elements/Pw_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/Pw_element.cpp
@@ -470,7 +470,7 @@ typename FluidBodyFlowCalculator<TNumNodes>::InputProvider PwElement<TDim, TNumN
     return typename FluidBodyFlowCalculator<TNumNodes>::InputProvider(
         MakePropertiesGetter(), MakeRetentionLawsGetter(), MakeMaterialPermeabilityGetter(),
         GetIntegrationCoefficients(), MakeProjectedGravityForIntegrationPointsGetter(),
-        MakeShapeFunctionLocalGradientsGetter(), MakeLocalSpaceDimensionGetter(), GetFluidPressures());
+        MakeShapeFunctionLocalGradientsGetter(), GetFluidPressures());
 }
 
 template <unsigned int TDim, unsigned int TNumNodes>

--- a/applications/GeoMechanicsApplication/custom_elements/Pw_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/Pw_element.cpp
@@ -468,9 +468,9 @@ template <unsigned int TDim, unsigned int TNumNodes>
 typename FluidBodyFlowCalculator<TNumNodes>::InputProvider PwElement<TDim, TNumNodes>::CreateFluidBodyFlowInputProvider()
 {
     return typename FluidBodyFlowCalculator<TNumNodes>::InputProvider(
-        MakePropertiesGetter(), MakeRetentionLawsGetter(), GetIntegrationCoefficients(),
-        MakeProjectedGravityForIntegrationPointsGetter(), MakeShapeFunctionLocalGradientsGetter(),
-        MakeLocalSpaceDimensionGetter(), GetFluidPressures());
+        MakePropertiesGetter(), MakeRetentionLawsGetter(), MakeMaterialPermeabilityGetter(),
+        GetIntegrationCoefficients(), MakeProjectedGravityForIntegrationPointsGetter(),
+        MakeShapeFunctionLocalGradientsGetter(), MakeLocalSpaceDimensionGetter(), GetFluidPressures());
 }
 
 template <unsigned int TDim, unsigned int TNumNodes>

--- a/applications/GeoMechanicsApplication/custom_elements/Pw_element.hpp
+++ b/applications/GeoMechanicsApplication/custom_elements/Pw_element.hpp
@@ -202,11 +202,6 @@ private:
         };
     }
 
-    auto MakeLocalSpaceDimensionGetter() const
-    {
-        return [this]() -> std::size_t { return this->GetGeometry().LocalSpaceDimension(); };
-    }
-
     [[nodiscard]] DofsVectorType GetDofs() const;
 
     friend class Serializer;

--- a/applications/GeoMechanicsApplication/custom_elements/Pw_element.hpp
+++ b/applications/GeoMechanicsApplication/custom_elements/Pw_element.hpp
@@ -141,7 +141,7 @@ private:
     {
         return [this]() -> Matrix {
             return GeoElementUtilities::FillPermeabilityMatrix(
-                GetProperties(), this->GetGeometry().LocalSpaceDimension());
+                this->GetProperties(), this->GetGeometry().LocalSpaceDimension());
         };
     }
 

--- a/applications/GeoMechanicsApplication/custom_elements/Pw_element.hpp
+++ b/applications/GeoMechanicsApplication/custom_elements/Pw_element.hpp
@@ -101,7 +101,7 @@ private:
     std::vector<CalculationContribution> mContributions;
     IntegrationCoefficientsCalculator    mIntegrationCoefficientsCalculator;
     std::vector<RetentionLaw::Pointer>   mRetentionLawVector;
-    Vector                               mIntegrationCoefficients;
+    std::vector<double>                  mIntegrationCoefficients;
     Matrix                               mNContainer;
     Vector                               mDetJCcontainer;
     std::vector<double>                  mFluidPressures;
@@ -154,10 +154,10 @@ private:
 
     auto GetIntegrationCoefficients()
     {
-        return [this]() -> const Vector& { return mIntegrationCoefficients; };
+        return [this]() -> const std::vector<double>& { return mIntegrationCoefficients; };
     }
 
-    Vector CalculateIntegrationCoefficients();
+    std::vector<double> CalculateIntegrationCoefficients();
 
     auto GetFluidPressures()
     {

--- a/applications/GeoMechanicsApplication/custom_elements/Pw_element.hpp
+++ b/applications/GeoMechanicsApplication/custom_elements/Pw_element.hpp
@@ -137,6 +137,14 @@ private:
         return [this]() -> const std::vector<RetentionLaw::Pointer>& { return mRetentionLawVector; };
     }
 
+    auto MakeMaterialPermeabilityGetter()
+    {
+        return [this]() -> Matrix {
+            return GeoElementUtilities::FillPermeabilityMatrix(
+                GetProperties(), this->GetGeometry().LocalSpaceDimension());
+        };
+    }
+
     auto GetNContainer()
     {
         return [this]() -> const Matrix& { return mNContainer; };

--- a/applications/GeoMechanicsApplication/custom_elements/contribution_calculators/compressibility_calculator.hpp
+++ b/applications/GeoMechanicsApplication/custom_elements/contribution_calculators/compressibility_calculator.hpp
@@ -31,9 +31,9 @@ class CompressibilityCalculator : public ContributionCalculator<TNumNodes>
 {
 public:
     struct InputProvider {
-        InputProvider(Geo::PropertiesGetter GetElementProperties,
-                      std::function<const std::vector<RetentionLaw::Pointer>&()> GetRetentionLaws,
-                      std::function<const Matrix&()>                             GetNContainer,
+        InputProvider(Geo::PropertiesGetter                          GetElementProperties,
+                      Geo::RetentionLawsGetter                       GetRetentionLaws,
+                      std::function<const Matrix&()>                 GetNContainer,
                       Geo::IntegrationCoefficientsGetter             GetIntegrationCoefficients,
                       std::function<double()>                        GetMatrixScalarFactor,
                       std::function<Vector(const Variable<double>&)> GetNodalValuesOf,
@@ -48,13 +48,13 @@ public:
         {
         }
 
-        Geo::PropertiesGetter                                      GetElementProperties;
-        std::function<const std::vector<RetentionLaw::Pointer>&()> GetRetentionLaws;
-        std::function<const Matrix&()>                             GetNContainer;
-        Geo::IntegrationCoefficientsGetter                         GetIntegrationCoefficients;
-        std::function<double()>                                    GetMatrixScalarFactor;
-        std::function<Vector(const Variable<double>&)>             GetNodalValues;
-        std::function<std::vector<double>()>                       GetFluidPressures;
+        Geo::PropertiesGetter                          GetElementProperties;
+        Geo::RetentionLawsGetter                       GetRetentionLaws;
+        std::function<const Matrix&()>                 GetNContainer;
+        Geo::IntegrationCoefficientsGetter             GetIntegrationCoefficients;
+        std::function<double()>                        GetMatrixScalarFactor;
+        std::function<Vector(const Variable<double>&)> GetNodalValues;
+        std::function<std::vector<double>()>           GetFluidPressures;
     };
 
     explicit CompressibilityCalculator(InputProvider rInputProvider)

--- a/applications/GeoMechanicsApplication/custom_elements/contribution_calculators/compressibility_calculator.hpp
+++ b/applications/GeoMechanicsApplication/custom_elements/contribution_calculators/compressibility_calculator.hpp
@@ -15,6 +15,7 @@
 #include "contribution_calculator.h"
 #include "custom_retention/retention_law.h"
 #include "custom_utilities/transport_equation_utilities.hpp"
+#include "geo_aliases.h"
 #include "geo_mechanics_application_variables.h"
 #include "includes/properties.h"
 #include "includes/ublas_interface.h"
@@ -30,10 +31,10 @@ class CompressibilityCalculator : public ContributionCalculator<TNumNodes>
 {
 public:
     struct InputProvider {
-        InputProvider(std::function<const Properties&()> GetElementProperties,
+        InputProvider(Geo::PropertiesGetter GetElementProperties,
                       std::function<const std::vector<RetentionLaw::Pointer>&()> GetRetentionLaws,
                       std::function<const Matrix&()>                             GetNContainer,
-                      std::function<Vector()>                        GetIntegrationCoefficients,
+                      Geo::IntegrationCoefficientsGetter             GetIntegrationCoefficients,
                       std::function<double()>                        GetMatrixScalarFactor,
                       std::function<Vector(const Variable<double>&)> GetNodalValuesOf,
                       std::function<std::vector<double>()>           GetFluidPressures)
@@ -47,10 +48,10 @@ public:
         {
         }
 
-        std::function<const Properties&()>                         GetElementProperties;
+        Geo::PropertiesGetter                                      GetElementProperties;
         std::function<const std::vector<RetentionLaw::Pointer>&()> GetRetentionLaws;
         std::function<const Matrix&()>                             GetNContainer;
-        std::function<Vector()>                                    GetIntegrationCoefficients;
+        Geo::IntegrationCoefficientsGetter                         GetIntegrationCoefficients;
         std::function<double()>                                    GetMatrixScalarFactor;
         std::function<Vector(const Variable<double>&)>             GetNodalValues;
         std::function<std::vector<double>()>                       GetFluidPressures;

--- a/applications/GeoMechanicsApplication/custom_elements/contribution_calculators/filter_compressibility_calculator.hpp
+++ b/applications/GeoMechanicsApplication/custom_elements/contribution_calculators/filter_compressibility_calculator.hpp
@@ -14,6 +14,7 @@
 
 #include "contribution_calculator.h"
 #include "custom_utilities/transport_equation_utilities.hpp"
+#include "geo_aliases.h"
 #include "geo_mechanics_application_variables.h"
 #include "includes/properties.h"
 #include "includes/ublas_interface.h"
@@ -28,9 +29,9 @@ class FilterCompressibilityCalculator : public ContributionCalculator<TNumNodes>
 {
 public:
     struct InputProvider {
-        InputProvider(std::function<const Properties&()>   GetElementProperties,
+        InputProvider(Geo::PropertiesGetter                GetElementProperties,
                       std::function<const Matrix&()>       GetNContainer,
-                      std::function<Vector()>              GetIntegrationCoefficients,
+                      Geo::IntegrationCoefficientsGetter   GetIntegrationCoefficients,
                       std::function<std::vector<Vector>()> GetProjectedGravityAtIntegrationPoints,
                       std::function<double()>              GetMatrixScalarFactor,
                       std::function<Vector(const Variable<double>&)> GetNodalValuesOf)
@@ -43,9 +44,9 @@ public:
         {
         }
 
-        std::function<const Properties&()>             GetElementProperties;
+        Geo::PropertiesGetter                          GetElementProperties;
         std::function<const Matrix&()>                 GetNContainer;
-        std::function<Vector()>                        GetIntegrationCoefficients;
+        Geo::IntegrationCoefficientsGetter             GetIntegrationCoefficients;
         std::function<std::vector<Vector>()>           GetProjectedGravityAtIntegrationPoints;
         std::function<double()>                        GetMatrixScalarFactor;
         std::function<Vector(const Variable<double>&)> GetNodalValues;

--- a/applications/GeoMechanicsApplication/custom_elements/contribution_calculators/fluid_body_flow_calculator.hpp
+++ b/applications/GeoMechanicsApplication/custom_elements/contribution_calculators/fluid_body_flow_calculator.hpp
@@ -35,7 +35,6 @@ public:
                       std::function<Vector()>              GetIntegrationCoefficients,
                       std::function<std::vector<Vector>()> GetProjectedGravityAtIntegrationPoints,
                       std::function<Geometry<Node>::ShapeFunctionsGradientsType()> GetShapeFunctionGradients,
-                      std::function<std::size_t()>         GetLocalSpaceDimension,
                       std::function<std::vector<double>()> GetFluidPressures)
 
             : GetElementProperties(std::move(GetElementProperties)),
@@ -44,7 +43,6 @@ public:
               GetIntegrationCoefficients(std::move(GetIntegrationCoefficients)),
               GetProjectedGravityAtIntegrationPoints(std::move(GetProjectedGravityAtIntegrationPoints)),
               GetShapeFunctionGradients(std::move(GetShapeFunctionGradients)),
-              GetLocalSpaceDimension(std::move(GetLocalSpaceDimension)),
               GetFluidPressures(std::move(GetFluidPressures))
         {
         }
@@ -55,7 +53,6 @@ public:
         std::function<Vector()>                                    GetIntegrationCoefficients;
         std::function<std::vector<Vector>()> GetProjectedGravityAtIntegrationPoints;
         std::function<Geometry<Node>::ShapeFunctionsGradientsType()> GetShapeFunctionGradients;
-        std::function<std::size_t()>                                 GetLocalSpaceDimension;
         std::function<std::vector<double>()>                         GetFluidPressures;
     };
 

--- a/applications/GeoMechanicsApplication/custom_elements/contribution_calculators/fluid_body_flow_calculator.hpp
+++ b/applications/GeoMechanicsApplication/custom_elements/contribution_calculators/fluid_body_flow_calculator.hpp
@@ -33,7 +33,7 @@ public:
         InputProvider(Geo::PropertiesGetter                GetElementProperties,
                       Geo::RetentionLawsGetter             GetRetentionLaws,
                       std::function<Matrix()>              GetMaterialPermeability,
-                      std::function<Vector()>              GetIntegrationCoefficients,
+                      Geo::IntegrationCoefficientsGetter   GetIntegrationCoefficients,
                       std::function<std::vector<Vector>()> GetProjectedGravityAtIntegrationPoints,
                       std::function<Geometry<Node>::ShapeFunctionsGradientsType()> GetShapeFunctionGradients,
                       std::function<std::vector<double>()> GetFluidPressures)
@@ -51,7 +51,7 @@ public:
         Geo::PropertiesGetter                GetElementProperties;
         Geo::RetentionLawsGetter             GetRetentionLaws;
         std::function<Matrix()>              GetMaterialPermeability;
-        std::function<Vector()>              GetIntegrationCoefficients;
+        Geo::IntegrationCoefficientsGetter   GetIntegrationCoefficients;
         std::function<std::vector<Vector>()> GetProjectedGravityAtIntegrationPoints;
         std::function<Geometry<Node>::ShapeFunctionsGradientsType()> GetShapeFunctionGradients;
         std::function<std::vector<double>()>                         GetFluidPressures;

--- a/applications/GeoMechanicsApplication/custom_elements/contribution_calculators/fluid_body_flow_calculator.hpp
+++ b/applications/GeoMechanicsApplication/custom_elements/contribution_calculators/fluid_body_flow_calculator.hpp
@@ -30,11 +30,11 @@ class FluidBodyFlowCalculator : public ContributionCalculator<TNumNodes>
 {
 public:
     struct InputProvider {
-        InputProvider(Geo::PropertiesGetter                GetElementProperties,
-                      Geo::RetentionLawsGetter             GetRetentionLaws,
-                      std::function<Matrix()>              GetMaterialPermeability,
-                      Geo::IntegrationCoefficientsGetter   GetIntegrationCoefficients,
-                      std::function<std::vector<Vector>()> GetProjectedGravityAtIntegrationPoints,
+        InputProvider(Geo::PropertiesGetter                 GetElementProperties,
+                      Geo::RetentionLawsGetter              GetRetentionLaws,
+                      Geo::MaterialPermeabilityMatrixGetter GetMaterialPermeability,
+                      Geo::IntegrationCoefficientsGetter    GetIntegrationCoefficients,
+                      std::function<std::vector<Vector>()>  GetProjectedGravityAtIntegrationPoints,
                       std::function<Geometry<Node>::ShapeFunctionsGradientsType()> GetShapeFunctionGradients,
                       std::function<std::vector<double>()> GetFluidPressures)
 
@@ -48,11 +48,11 @@ public:
         {
         }
 
-        Geo::PropertiesGetter                GetElementProperties;
-        Geo::RetentionLawsGetter             GetRetentionLaws;
-        std::function<Matrix()>              GetMaterialPermeability;
-        Geo::IntegrationCoefficientsGetter   GetIntegrationCoefficients;
-        std::function<std::vector<Vector>()> GetProjectedGravityAtIntegrationPoints;
+        Geo::PropertiesGetter                 GetElementProperties;
+        Geo::RetentionLawsGetter              GetRetentionLaws;
+        Geo::MaterialPermeabilityMatrixGetter GetMaterialPermeability;
+        Geo::IntegrationCoefficientsGetter    GetIntegrationCoefficients;
+        std::function<std::vector<Vector>()>  GetProjectedGravityAtIntegrationPoints;
         std::function<Geometry<Node>::ShapeFunctionsGradientsType()> GetShapeFunctionGradients;
         std::function<std::vector<double>()>                         GetFluidPressures;
     };

--- a/applications/GeoMechanicsApplication/custom_elements/contribution_calculators/fluid_body_flow_calculator.hpp
+++ b/applications/GeoMechanicsApplication/custom_elements/contribution_calculators/fluid_body_flow_calculator.hpp
@@ -108,7 +108,7 @@ public:
 private:
     InputProvider mInputProvider;
 
-    std::vector<double> CalculateBishopCoefficients(const std::vector<double>& rFluidPressures) const
+    [[nodiscard]] std::vector<double> CalculateBishopCoefficients(const std::vector<double>& rFluidPressures) const
     {
         KRATOS_ERROR_IF_NOT(rFluidPressures.size() == mInputProvider.GetRetentionLaws().size());
 

--- a/applications/GeoMechanicsApplication/custom_elements/contribution_calculators/fluid_body_flow_calculator.hpp
+++ b/applications/GeoMechanicsApplication/custom_elements/contribution_calculators/fluid_body_flow_calculator.hpp
@@ -30,8 +30,8 @@ class FluidBodyFlowCalculator : public ContributionCalculator<TNumNodes>
 {
 public:
     struct InputProvider {
-        InputProvider(Geo::PropertiesGetter GetElementProperties,
-                      std::function<const std::vector<RetentionLaw::Pointer>&()> GetRetentionLaws,
+        InputProvider(Geo::PropertiesGetter                GetElementProperties,
+                      Geo::RetentionLawsGetter             GetRetentionLaws,
                       std::function<Matrix()>              GetMaterialPermeability,
                       std::function<Vector()>              GetIntegrationCoefficients,
                       std::function<std::vector<Vector>()> GetProjectedGravityAtIntegrationPoints,
@@ -48,10 +48,10 @@ public:
         {
         }
 
-        Geo::PropertiesGetter                                      GetElementProperties;
-        std::function<const std::vector<RetentionLaw::Pointer>&()> GetRetentionLaws;
-        std::function<Matrix()>                                    GetMaterialPermeability;
-        std::function<Vector()>                                    GetIntegrationCoefficients;
+        Geo::PropertiesGetter                GetElementProperties;
+        Geo::RetentionLawsGetter             GetRetentionLaws;
+        std::function<Matrix()>              GetMaterialPermeability;
+        std::function<Vector()>              GetIntegrationCoefficients;
         std::function<std::vector<Vector>()> GetProjectedGravityAtIntegrationPoints;
         std::function<Geometry<Node>::ShapeFunctionsGradientsType()> GetShapeFunctionGradients;
         std::function<std::vector<double>()>                         GetFluidPressures;

--- a/applications/GeoMechanicsApplication/custom_elements/contribution_calculators/fluid_body_flow_calculator.hpp
+++ b/applications/GeoMechanicsApplication/custom_elements/contribution_calculators/fluid_body_flow_calculator.hpp
@@ -39,10 +39,10 @@ public:
                       std::function<std::vector<double>()> GetFluidPressures)
 
             : GetElementProperties(std::move(GetElementProperties)),
-              GetProjectedGravityAtIntegrationPoints(std::move(GetProjectedGravityAtIntegrationPoints)),
               GetRetentionLaws(std::move(GetRetentionLaws)),
-              GetIntegrationCoefficients(std::move(GetIntegrationCoefficients)),
               GetMaterialPermeability(std::move(GetMaterialPermeability)),
+              GetIntegrationCoefficients(std::move(GetIntegrationCoefficients)),
+              GetProjectedGravityAtIntegrationPoints(std::move(GetProjectedGravityAtIntegrationPoints)),
               GetShapeFunctionGradients(std::move(GetShapeFunctionGradients)),
               GetLocalSpaceDimension(std::move(GetLocalSpaceDimension)),
               GetFluidPressures(std::move(GetFluidPressures))

--- a/applications/GeoMechanicsApplication/custom_elements/contribution_calculators/fluid_body_flow_calculator.hpp
+++ b/applications/GeoMechanicsApplication/custom_elements/contribution_calculators/fluid_body_flow_calculator.hpp
@@ -14,6 +14,7 @@
 
 #include "contribution_calculator.h"
 #include "custom_retention/retention_law.h"
+#include "geo_aliases.h"
 #include "includes/cfd_variables.h"
 #include "includes/properties.h"
 #include "includes/ublas_interface.h"
@@ -29,7 +30,7 @@ class FluidBodyFlowCalculator : public ContributionCalculator<TNumNodes>
 {
 public:
     struct InputProvider {
-        InputProvider(std::function<const Properties&()> GetElementProperties,
+        InputProvider(Geo::PropertiesGetter GetElementProperties,
                       std::function<const std::vector<RetentionLaw::Pointer>&()> GetRetentionLaws,
                       std::function<Matrix()>              GetMaterialPermeability,
                       std::function<Vector()>              GetIntegrationCoefficients,
@@ -47,7 +48,7 @@ public:
         {
         }
 
-        std::function<const Properties&()>                         GetElementProperties;
+        Geo::PropertiesGetter                                      GetElementProperties;
         std::function<const std::vector<RetentionLaw::Pointer>&()> GetRetentionLaws;
         std::function<Matrix()>                                    GetMaterialPermeability;
         std::function<Vector()>                                    GetIntegrationCoefficients;

--- a/applications/GeoMechanicsApplication/custom_elements/contribution_calculators/fluid_body_flow_calculator.hpp
+++ b/applications/GeoMechanicsApplication/custom_elements/contribution_calculators/fluid_body_flow_calculator.hpp
@@ -71,31 +71,31 @@ public:
 
     BoundedVector<double, TNumNodes> RHSContribution() override
     {
-        const auto& shape_function_gradients = mInputProvider.GetShapeFunctionGradients();
+        const auto& r_shape_function_gradients = mInputProvider.GetShapeFunctionGradients();
 
-        const auto& integration_coefficients = mInputProvider.GetIntegrationCoefficients();
+        const auto& r_integration_coefficients = mInputProvider.GetIntegrationCoefficients();
 
         const auto& r_properties          = mInputProvider.GetElementProperties();
         const auto  material_permeability = mInputProvider.GetMaterialPermeability();
 
         RetentionLaw::Parameters retention_law_parameters(r_properties);
-        const auto&              projected_gravity_on_integration_points =
+        const auto&              r_projected_gravity_on_integration_points =
             mInputProvider.GetProjectedGravityAtIntegrationPoints();
-        const auto&                      fluid_pressures = mInputProvider.GetFluidPressures();
-        BoundedVector<double, TNumNodes> result          = ZeroVector(TNumNodes);
-        const auto bishop_coefficients = CalculateBishopCoefficients(fluid_pressures);
+        const auto&                      r_fluid_pressures = mInputProvider.GetFluidPressures();
+        BoundedVector<double, TNumNodes> result            = ZeroVector(TNumNodes);
+        const auto bishop_coefficients = CalculateBishopCoefficients(r_fluid_pressures);
 
         for (unsigned int integration_point_index = 0;
-             integration_point_index < integration_coefficients.size(); ++integration_point_index) {
-            retention_law_parameters.SetFluidPressure(fluid_pressures[integration_point_index]);
+             integration_point_index < r_integration_coefficients.size(); ++integration_point_index) {
+            retention_law_parameters.SetFluidPressure(r_fluid_pressures[integration_point_index]);
             const auto relative_permeability =
                 mInputProvider.GetRetentionLaws()[integration_point_index]->CalculateRelativePermeability(
                     retention_law_parameters);
             noalias(result) +=
                 r_properties[DENSITY_WATER] * bishop_coefficients[integration_point_index] * relative_permeability *
-                prod(prod(shape_function_gradients[integration_point_index], material_permeability),
-                     projected_gravity_on_integration_points[integration_point_index]) *
-                integration_coefficients[integration_point_index] / r_properties[DYNAMIC_VISCOSITY];
+                prod(prod(r_shape_function_gradients[integration_point_index], material_permeability),
+                     r_projected_gravity_on_integration_points[integration_point_index]) *
+                r_integration_coefficients[integration_point_index] / r_properties[DYNAMIC_VISCOSITY];
         }
         return result;
     }

--- a/applications/GeoMechanicsApplication/custom_elements/contribution_calculators/permeability_calculator.hpp
+++ b/applications/GeoMechanicsApplication/custom_elements/contribution_calculators/permeability_calculator.hpp
@@ -26,8 +26,8 @@ class PermeabilityCalculator : public ContributionCalculator<TNumNodes> ///
 {
 public:
     struct InputProvider {
-        InputProvider(Geo::PropertiesGetter GetElementProperties,
-                      std::function<const std::vector<RetentionLaw::Pointer>&()> GetRetentionLaws,
+        InputProvider(Geo::PropertiesGetter                          GetElementProperties,
+                      Geo::RetentionLawsGetter                       GetRetentionLaws,
                       std::function<Matrix()>                        GetMaterialPermeability,
                       std::function<Vector()>                        GetIntegrationCoefficients,
                       std::function<Vector(const Variable<double>&)> GetNodalValuesOf,
@@ -44,7 +44,7 @@ public:
         }
 
         Geo::PropertiesGetter                                        GetElementProperties;
-        std::function<const std::vector<RetentionLaw::Pointer>&()>   GetRetentionLaws;
+        Geo::RetentionLawsGetter                                     GetRetentionLaws;
         std::function<Matrix()>                                      GetMaterialPermeability;
         std::function<Vector()>                                      GetIntegrationCoefficients;
         std::function<Vector(const Variable<double>&)>               GetNodalValues;

--- a/applications/GeoMechanicsApplication/custom_elements/contribution_calculators/permeability_calculator.hpp
+++ b/applications/GeoMechanicsApplication/custom_elements/contribution_calculators/permeability_calculator.hpp
@@ -15,6 +15,7 @@
 #include "contribution_calculator.h"
 #include "custom_retention/retention_law.h"
 #include "custom_utilities/transport_equation_utilities.hpp"
+#include "geo_aliases.h"
 #include "includes/cfd_variables.h"
 
 namespace Kratos
@@ -25,7 +26,7 @@ class PermeabilityCalculator : public ContributionCalculator<TNumNodes> ///
 {
 public:
     struct InputProvider {
-        InputProvider(std::function<const Properties&()> GetElementProperties,
+        InputProvider(Geo::PropertiesGetter GetElementProperties,
                       std::function<const std::vector<RetentionLaw::Pointer>&()> GetRetentionLaws,
                       std::function<Matrix()>                        GetMaterialPermeability,
                       std::function<Vector()>                        GetIntegrationCoefficients,
@@ -42,7 +43,7 @@ public:
         {
         }
 
-        std::function<const Properties&()>                           GetElementProperties;
+        Geo::PropertiesGetter                                        GetElementProperties;
         std::function<const std::vector<RetentionLaw::Pointer>&()>   GetRetentionLaws;
         std::function<Matrix()>                                      GetMaterialPermeability;
         std::function<Vector()>                                      GetIntegrationCoefficients;

--- a/applications/GeoMechanicsApplication/custom_elements/contribution_calculators/permeability_calculator.hpp
+++ b/applications/GeoMechanicsApplication/custom_elements/contribution_calculators/permeability_calculator.hpp
@@ -29,7 +29,7 @@ public:
         InputProvider(Geo::PropertiesGetter                          GetElementProperties,
                       Geo::RetentionLawsGetter                       GetRetentionLaws,
                       std::function<Matrix()>                        GetMaterialPermeability,
-                      std::function<Vector()>                        GetIntegrationCoefficients,
+                      Geo::IntegrationCoefficientsGetter             GetIntegrationCoefficients,
                       std::function<Vector(const Variable<double>&)> GetNodalValuesOf,
                       std::function<Geometry<Node>::ShapeFunctionsGradientsType()> GetShapeFunctionGradients,
                       std::function<std::vector<double>()> GetFluidPressures)
@@ -46,7 +46,7 @@ public:
         Geo::PropertiesGetter                                        GetElementProperties;
         Geo::RetentionLawsGetter                                     GetRetentionLaws;
         std::function<Matrix()>                                      GetMaterialPermeability;
-        std::function<Vector()>                                      GetIntegrationCoefficients;
+        Geo::IntegrationCoefficientsGetter                           GetIntegrationCoefficients;
         std::function<Vector(const Variable<double>&)>               GetNodalValues;
         std::function<Geometry<Node>::ShapeFunctionsGradientsType()> GetShapeFunctionGradients;
         std::function<std::vector<double>()>                         GetFluidPressures;

--- a/applications/GeoMechanicsApplication/custom_elements/contribution_calculators/permeability_calculator.hpp
+++ b/applications/GeoMechanicsApplication/custom_elements/contribution_calculators/permeability_calculator.hpp
@@ -79,26 +79,26 @@ private:
     [[nodiscard]] BoundedMatrix<double, TNumNodes, TNumNodes> CalculatePermeabilityMatrix() const
     {
         RetentionLaw::Parameters retention_parameters(mInputProvider.GetElementProperties());
-        const auto&              r_properties = mInputProvider.GetElementProperties();
-        const auto& integration_coefficients  = mInputProvider.GetIntegrationCoefficients();
-        const auto& shape_function_gradients  = mInputProvider.GetShapeFunctionGradients();
-        const auto  material_permeability     = mInputProvider.GetMaterialPermeability();
+        const auto&              r_properties  = mInputProvider.GetElementProperties();
+        const auto& r_integration_coefficients = mInputProvider.GetIntegrationCoefficients();
+        const auto& r_shape_function_gradients = mInputProvider.GetShapeFunctionGradients();
+        const auto  material_permeability      = mInputProvider.GetMaterialPermeability();
 
         BoundedMatrix<double, TNumNodes, TNumNodes> result = ZeroMatrix(TNumNodes, TNumNodes);
 
-        const double dynamic_viscosity_inverse = 1.0 / r_properties[DYNAMIC_VISCOSITY];
-        const auto&  fluid_pressures           = mInputProvider.GetFluidPressures();
+        const auto  dynamic_viscosity_inverse = 1.0 / r_properties[DYNAMIC_VISCOSITY];
+        const auto& r_fluid_pressures         = mInputProvider.GetFluidPressures();
 
         for (std::size_t integration_point_index = 0;
-             integration_point_index < integration_coefficients.size(); ++integration_point_index) {
-            retention_parameters.SetFluidPressure(fluid_pressures[integration_point_index]);
-            const double relative_permeability =
+             integration_point_index < r_integration_coefficients.size(); ++integration_point_index) {
+            retention_parameters.SetFluidPressure(r_fluid_pressures[integration_point_index]);
+            const auto relative_permeability =
                 mInputProvider.GetRetentionLaws()[integration_point_index]->CalculateRelativePermeability(
                     retention_parameters);
 
             noalias(result) += GeoTransportEquationUtilities::CalculatePermeabilityMatrix(
-                shape_function_gradients[integration_point_index], dynamic_viscosity_inverse, material_permeability,
-                relative_permeability, integration_coefficients[integration_point_index]);
+                r_shape_function_gradients[integration_point_index], dynamic_viscosity_inverse, material_permeability,
+                relative_permeability, r_integration_coefficients[integration_point_index]);
         }
         return result;
     }

--- a/applications/GeoMechanicsApplication/custom_elements/contribution_calculators/permeability_calculator.hpp
+++ b/applications/GeoMechanicsApplication/custom_elements/contribution_calculators/permeability_calculator.hpp
@@ -28,7 +28,7 @@ public:
     struct InputProvider {
         InputProvider(Geo::PropertiesGetter                          GetElementProperties,
                       Geo::RetentionLawsGetter                       GetRetentionLaws,
-                      std::function<Matrix()>                        GetMaterialPermeability,
+                      Geo::MaterialPermeabilityMatrixGetter          GetMaterialPermeability,
                       Geo::IntegrationCoefficientsGetter             GetIntegrationCoefficients,
                       std::function<Vector(const Variable<double>&)> GetNodalValuesOf,
                       std::function<Geometry<Node>::ShapeFunctionsGradientsType()> GetShapeFunctionGradients,
@@ -45,7 +45,7 @@ public:
 
         Geo::PropertiesGetter                                        GetElementProperties;
         Geo::RetentionLawsGetter                                     GetRetentionLaws;
-        std::function<Matrix()>                                      GetMaterialPermeability;
+        Geo::MaterialPermeabilityMatrixGetter                        GetMaterialPermeability;
         Geo::IntegrationCoefficientsGetter                           GetIntegrationCoefficients;
         std::function<Vector(const Variable<double>&)>               GetNodalValues;
         std::function<Geometry<Node>::ShapeFunctionsGradientsType()> GetShapeFunctionGradients;

--- a/applications/GeoMechanicsApplication/custom_elements/contribution_calculators/permeability_calculator.hpp
+++ b/applications/GeoMechanicsApplication/custom_elements/contribution_calculators/permeability_calculator.hpp
@@ -14,7 +14,6 @@
 
 #include "contribution_calculator.h"
 #include "custom_retention/retention_law.h"
-#include "custom_utilities/element_utilities.hpp"
 #include "custom_utilities/transport_equation_utilities.hpp"
 #include "includes/cfd_variables.h"
 

--- a/applications/GeoMechanicsApplication/custom_utilities/element_utilities.cpp
+++ b/applications/GeoMechanicsApplication/custom_utilities/element_utilities.cpp
@@ -33,62 +33,62 @@ void GeoElementUtilities::FillArray1dOutput(array_1d<double, 3>& rOutputValue, c
 }
 
 void GeoElementUtilities::FillPermeabilityMatrix(BoundedMatrix<double, 1, 1>&   rPermeabilityMatrix,
-                                                 const Element::PropertiesType& Prop)
+                                                 const Element::PropertiesType& rProperties)
 {
     // 1D
-    if (Prop[RETENTION_LAW] == "PressureFilterLaw") {
-        const auto equivalent_radius_square = Prop[CROSS_AREA] / Globals::Pi;
+    if (rProperties[RETENTION_LAW] == "PressureFilterLaw") {
+        const auto equivalent_radius_square = rProperties[CROSS_AREA] / Globals::Pi;
         rPermeabilityMatrix(0, 0)           = equivalent_radius_square * 0.125;
     } else {
-        rPermeabilityMatrix(0, 0) = Prop[PERMEABILITY_XX];
+        rPermeabilityMatrix(0, 0) = rProperties[PERMEABILITY_XX];
     }
 }
 
 void GeoElementUtilities::FillPermeabilityMatrix(BoundedMatrix<double, 2, 2>&   rPermeabilityMatrix,
-                                                 const Element::PropertiesType& Prop)
+                                                 const Element::PropertiesType& rProperties)
 {
     // 2D
-    rPermeabilityMatrix(0, 0) = Prop[PERMEABILITY_XX];
-    rPermeabilityMatrix(1, 1) = Prop[PERMEABILITY_YY];
+    rPermeabilityMatrix(0, 0) = rProperties[PERMEABILITY_XX];
+    rPermeabilityMatrix(1, 1) = rProperties[PERMEABILITY_YY];
 
-    rPermeabilityMatrix(0, 1) = Prop[PERMEABILITY_XY];
+    rPermeabilityMatrix(0, 1) = rProperties[PERMEABILITY_XY];
     rPermeabilityMatrix(1, 0) = rPermeabilityMatrix(0, 1);
 }
 
 void GeoElementUtilities::FillPermeabilityMatrix(BoundedMatrix<double, 3, 3>&   rPermeabilityMatrix,
-                                                 const Element::PropertiesType& Prop)
+                                                 const Element::PropertiesType& rProperties)
 {
     // 3D
-    rPermeabilityMatrix(0, 0) = Prop[PERMEABILITY_XX];
-    rPermeabilityMatrix(1, 1) = Prop[PERMEABILITY_YY];
-    rPermeabilityMatrix(2, 2) = Prop[PERMEABILITY_ZZ];
+    rPermeabilityMatrix(0, 0) = rProperties[PERMEABILITY_XX];
+    rPermeabilityMatrix(1, 1) = rProperties[PERMEABILITY_YY];
+    rPermeabilityMatrix(2, 2) = rProperties[PERMEABILITY_ZZ];
 
-    rPermeabilityMatrix(0, 1) = Prop[PERMEABILITY_XY];
+    rPermeabilityMatrix(0, 1) = rProperties[PERMEABILITY_XY];
     rPermeabilityMatrix(1, 0) = rPermeabilityMatrix(0, 1);
 
-    rPermeabilityMatrix(1, 2) = Prop[PERMEABILITY_YZ];
+    rPermeabilityMatrix(1, 2) = rProperties[PERMEABILITY_YZ];
     rPermeabilityMatrix(2, 1) = rPermeabilityMatrix(1, 2);
 
-    rPermeabilityMatrix(2, 0) = Prop[PERMEABILITY_ZX];
+    rPermeabilityMatrix(2, 0) = rProperties[PERMEABILITY_ZX];
     rPermeabilityMatrix(0, 2) = rPermeabilityMatrix(2, 0);
 }
 
-Matrix GeoElementUtilities::FillPermeabilityMatrix(const Element::PropertiesType& Prop, std::size_t Dimension)
+Matrix GeoElementUtilities::FillPermeabilityMatrix(const Element::PropertiesType& rProperties, std::size_t Dimension)
 {
     switch (Dimension) {
     case 1: {
         BoundedMatrix<double, 1, 1> result;
-        FillPermeabilityMatrix(result, Prop);
+        FillPermeabilityMatrix(result, rProperties);
         return result;
     }
     case 2: {
         BoundedMatrix<double, 2, 2> result;
-        FillPermeabilityMatrix(result, Prop);
+        FillPermeabilityMatrix(result, rProperties);
         return result;
     }
     case 3: {
         BoundedMatrix<double, 3, 3> result;
-        FillPermeabilityMatrix(result, Prop);
+        FillPermeabilityMatrix(result, rProperties);
         return result;
     }
     default:

--- a/applications/GeoMechanicsApplication/custom_utilities/element_utilities.hpp
+++ b/applications/GeoMechanicsApplication/custom_utilities/element_utilities.hpp
@@ -113,15 +113,15 @@ public:
     }
 
     static void FillPermeabilityMatrix(BoundedMatrix<double, 1, 1>&   rPermeabilityMatrix,
-                                       const Element::PropertiesType& Prop);
+                                       const Element::PropertiesType& rProperties);
 
     static void FillPermeabilityMatrix(BoundedMatrix<double, 2, 2>&   rPermeabilityMatrix,
-                                       const Element::PropertiesType& Prop);
+                                       const Element::PropertiesType& rProperties);
 
     static void FillPermeabilityMatrix(BoundedMatrix<double, 3, 3>&   rPermeabilityMatrix,
-                                       const Element::PropertiesType& Prop);
+                                       const Element::PropertiesType& rProperties);
 
-    static Matrix FillPermeabilityMatrix(const Element::PropertiesType& Prop, std::size_t Dimension);
+    static Matrix FillPermeabilityMatrix(const Element::PropertiesType& rProperties, std::size_t Dimension);
 
     template <typename MatrixType1, typename MatrixType2>
     static void AssembleUUBlockMatrix(MatrixType1& rLeftHandSideMatrix, const MatrixType2& rUUBlockMatrix)

--- a/applications/GeoMechanicsApplication/geo_aliases.h
+++ b/applications/GeoMechanicsApplication/geo_aliases.h
@@ -49,4 +49,5 @@ using PropertiesGetter              = std::function<const Properties&()>;
 using ProcessInfoGetter             = std::function<const ProcessInfo&()>;
 using ConstitutiveLawsGetter        = std::function<const std::vector<ConstitutiveLaw::Pointer>&()>;
 using RetentionLawsGetter           = std::function<const std::vector<RetentionLaw::Pointer>&()>;
+using MaterialPermeabilityMatrixGetter = std::function<Matrix()>;
 } // namespace Kratos::Geo

--- a/applications/GeoMechanicsApplication/geo_aliases.h
+++ b/applications/GeoMechanicsApplication/geo_aliases.h
@@ -17,6 +17,7 @@
 #include <vector>
 
 #include "containers/variable.h"
+#include "custom_retention/retention_law.h"
 #include "geometries/geometry.h"
 #include "includes/constitutive_law.h"
 #include "includes/node.h"
@@ -47,4 +48,5 @@ using IntegrationCoefficientsGetter = std::function<std::vector<double>()>;
 using PropertiesGetter              = std::function<const Properties&()>;
 using ProcessInfoGetter             = std::function<const ProcessInfo&()>;
 using ConstitutiveLawsGetter        = std::function<const std::vector<ConstitutiveLaw::Pointer>&()>;
+using RetentionLawsGetter           = std::function<const std::vector<RetentionLaw::Pointer>&()>;
 } // namespace Kratos::Geo


### PR DESCRIPTION
**📝 Description**
Added getter for material permeability matrix to calculators for element permeability matrix and fluid body flow.
Modified Pw element such that the necessary things are provided.