### PR TITLE
[CI] Attemting to fix rocky build

### DIFF
--- a/.github/workflows/rocky_configure.sh
+++ b/.github/workflows/rocky_configure.sh
@@ -62,7 +62,7 @@ ${KRATOS_CMAKE_OPTIONS_FLAGS}                                                   
 -DUSE_MPI=OFF                                                                   \
 -DPYBIND11_PYTHON_VERSION="3.8"                                                 \
 -DBOOST_ROOT="${BOOST_ROOT}"                                                    \
--DCMAKE_CXX_FLAGS="${KRATOS_CMAKE_CXX_FLAGS} -O0 -Wall -Woverloaded-virtual=1"  \
+-DCMAKE_CXX_FLAGS="${KRATOS_CMAKE_CXX_FLAGS} -O0 -Wall -Wno-overloaded-virtual" \
 -DCMAKE_UNITY_BUILD=ON                                                          \
 
 # Build

--- a/.github/workflows/rocky_configure.sh
+++ b/.github/workflows/rocky_configure.sh
@@ -57,13 +57,13 @@ rm -rf "${KRATOS_BUILD}/${KRATOS_BUILD_TYPE}/CMakeFiles"
 echo "Kratos build type is ${KRATOS_BUILD_TYPE}"
 
 # Configure
-cmake -H"${KRATOS_SOURCE}" -B"${KRATOS_BUILD}/${KRATOS_BUILD_TYPE}" \
-${KRATOS_CMAKE_OPTIONS_FLAGS}                                       \
--DUSE_MPI=OFF                                                       \
--DPYBIND11_PYTHON_VERSION="3.8"                                     \
--DBOOST_ROOT="${BOOST_ROOT}"                                        \
--DCMAKE_CXX_FLAGS="${KRATOS_CMAKE_CXX_FLAGS} -O0 -Wall"             \
--DCMAKE_UNITY_BUILD=ON                                              \
+cmake -H"${KRATOS_SOURCE}" -B"${KRATOS_BUILD}/${KRATOS_BUILD_TYPE}"             \
+${KRATOS_CMAKE_OPTIONS_FLAGS}                                                   \
+-DUSE_MPI=OFF                                                                   \
+-DPYBIND11_PYTHON_VERSION="3.8"                                                 \
+-DBOOST_ROOT="${BOOST_ROOT}"                                                    \
+-DCMAKE_CXX_FLAGS="${KRATOS_CMAKE_CXX_FLAGS} -O0 -Wall -Woverloaded-virtual=1"  \
+-DCMAKE_UNITY_BUILD=ON                                                          \
 
 # Build
 cmake --build "${KRATOS_BUILD}/${KRATOS_BUILD_TYPE}" --target install -- -j2


### PR DESCRIPTION
**📝 Description**
Attempts to fix Rocky build by setting the warning level for hidden overloads to 1 (default pretty much everywhere else).

Still not sure why this is active only in rocky

Edit: Its because Gcc13 is super picky with overloads...
