### PR TITLE
[Core][Minor] Fixing Expression test bug

### DIFF
--- a/kratos/tests/cpp_tests/expression/test_expression.cpp
+++ b/kratos/tests/cpp_tests/expression/test_expression.cpp
@@ -310,7 +310,8 @@ void ExecuteWriteTest(
     IndexType number_of_entities = rContainer.size();
     IndexType number_of_integration_points = 10;
 
-    std::vector<double> values(number_of_integration_points * number_of_entities * 12);
+    std::size_t values_size = number_of_integration_points * number_of_entities * 12;
+    std::vector<double> values(values_size ? values_size : 1);
     std::iota(values.begin(), values.end(), 1);
 
     ContainerExpression<TContainerType> double_exp(rModelPart);


### PR DESCRIPTION
**📝 Description**
Minimal bug while trying to calculate `&values[0]` of a size 0 vector.
