### PR TITLE
[Core] Remove duplicated include in `matrix_market_interface`

### DIFF
--- a/kratos/includes/matrix_market_interface.h
+++ b/kratos/includes/matrix_market_interface.h
@@ -15,7 +15,6 @@
 // System includes
 #include <stdio.h>
 
-
 // External includes
 
 // To avoid linking problems

--- a/kratos/sources/matrix_market_interface.cpp
+++ b/kratos/sources/matrix_market_interface.cpp
@@ -1,9 +1,24 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ \.
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
+//
+//  Main authors:    Riccardo Rossi
+//
+
+// System includes
+
+// External includes
+
+// Project includes
 #include "includes/ublas_interface.h"
 #include "includes/ublas_complex_interface.h"
 #include "spaces/ublas_space.h"
-
 #include "includes/matrix_market_interface.h"
-#include "spaces/ublas_space.h"
 
 namespace Kratos {
 


### PR DESCRIPTION
**📝 Description**

 Remove duplicated include in `matrix_market_interface`.

**🆕 Changelog**

- [Remove duplicated include in `matrix_market_interface`](https://github.com/KratosMultiphysics/Kratos/commit/842ce32e67efb8ba097bff864082feb7bfe73458)
