### PR TITLE
[GeoMechanicsApplication] Make interface contributions controllable through the constructor

### DIFF
--- a/applications/GeoMechanicsApplication/custom_elements/U_Pw_interface_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/U_Pw_interface_element.cpp
@@ -157,9 +157,7 @@ void UPwInterfaceElement::CalculateLeftHandSide(MatrixType& rLeftHandSideMatrix,
 
     // Currently, the left-hand side matrix only includes the stiffness matrix. In the future, it
     // will also include water pressure contributions and coupling terms.
-    const std::vector contributions = {CalculationContribution::Stiffness};
-
-    for (auto contribution : contributions) {
+    for (auto contribution : mContributions) {
         switch (contribution) {
         case CalculationContribution::Stiffness:
             CalculateAndAssignStifnessMatrix(rLeftHandSideMatrix, rProcessInfo);
@@ -204,9 +202,7 @@ void UPwInterfaceElement::CalculateRightHandSide(Element::VectorType& rRightHand
 
     // Currently, the right-hand side only includes the internal force vector. In the future, it
     // will also include water pressure contributions and coupling terms.
-    const std::vector contributions = {CalculationContribution::Stiffness};
-
-    for (auto contribution : contributions) {
+    for (auto contribution : mContributions) {
         switch (contribution) {
         case CalculationContribution::Stiffness:
             CalculateAndAssignStifnessForceVector(rRightHandSideVector, rProcessInfo);

--- a/applications/GeoMechanicsApplication/custom_elements/U_Pw_interface_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/U_Pw_interface_element.cpp
@@ -96,8 +96,11 @@ UPwInterfaceElement::UPwInterfaceElement(IndexType                          NewI
                                          const GeometryType::Pointer&       rpGeometry,
                                          const Properties::Pointer&         rpProperties,
                                          std::unique_ptr<StressStatePolicy> pStressStatePolicy,
-                                         IsDiffOrderElement                 IsDiffOrder)
-    : Element(NewId, rpGeometry, rpProperties), mpStressStatePolicy(std::move(pStressStatePolicy))
+                                         IsDiffOrderElement                 IsDiffOrder,
+                                         const std::vector<CalculationContribution>& rContributions)
+    : Element(NewId, rpGeometry, rpProperties),
+      mpStressStatePolicy(std::move(pStressStatePolicy)),
+      mContributions(rContributions)
 {
     MakeIntegrationSchemeAndAssignFunction();
     mpOptionalPressureGeometry = MakeOptionalWaterPressureGeometry(GetDisplacementGeometry(), IsDiffOrder);
@@ -106,8 +109,10 @@ UPwInterfaceElement::UPwInterfaceElement(IndexType                          NewI
 UPwInterfaceElement::UPwInterfaceElement(IndexType                          NewId,
                                          const GeometryType::Pointer&       rpGeometry,
                                          std::unique_ptr<StressStatePolicy> pStressStatePolicy,
-                                         IsDiffOrderElement                 IsDiffOrder)
-    : UPwInterfaceElement(NewId, rpGeometry, nullptr /* no properties */, std::move(pStressStatePolicy), IsDiffOrder)
+                                         IsDiffOrderElement                 IsDiffOrder,
+                                         const std::vector<CalculationContribution>& rContributions)
+    : UPwInterfaceElement(
+          NewId, rpGeometry, nullptr /* no properties */, std::move(pStressStatePolicy), IsDiffOrder, rContributions)
 {
 }
 
@@ -136,8 +141,8 @@ Element::Pointer UPwInterfaceElement::Create(IndexType               NewId,
                                              PropertiesType::Pointer pProperties) const
 {
     const auto is_diff_order = mpOptionalPressureGeometry ? IsDiffOrderElement::Yes : IsDiffOrderElement::No;
-    return make_intrusive<UPwInterfaceElement>(NewId, pGeometry, pProperties,
-                                               mpStressStatePolicy->Clone(), is_diff_order);
+    return make_intrusive<UPwInterfaceElement>(
+        NewId, pGeometry, pProperties, mpStressStatePolicy->Clone(), is_diff_order, mContributions);
 }
 
 void UPwInterfaceElement::EquationIdVector(EquationIdVectorType& rResult, const ProcessInfo&) const

--- a/applications/GeoMechanicsApplication/custom_elements/U_Pw_interface_element.h
+++ b/applications/GeoMechanicsApplication/custom_elements/U_Pw_interface_element.h
@@ -13,6 +13,7 @@
 
 #pragma once
 
+#include "contribution_calculators/calculation_contribution.h"
 #include "contribution_calculators/stiffness_calculator.hpp"
 #include "geo_aliases.h"
 #include "includes/element.h"
@@ -43,16 +44,18 @@ public:
     UPwInterfaceElement(UPwInterfaceElement&&) noexcept            = default;
     UPwInterfaceElement& operator=(UPwInterfaceElement&&) noexcept = default;
 
-    UPwInterfaceElement(IndexType                          NewId,
-                        const GeometryType::Pointer&       rpGeometry,
-                        const PropertiesType::Pointer&     rpProperties,
-                        std::unique_ptr<StressStatePolicy> pStressStatePolicy,
-                        IsDiffOrderElement                 IsDiffOrder);
+    UPwInterfaceElement(IndexType                                   NewId,
+                        const GeometryType::Pointer&                rpGeometry,
+                        const PropertiesType::Pointer&              rpProperties,
+                        std::unique_ptr<StressStatePolicy>          pStressStatePolicy,
+                        IsDiffOrderElement                          IsDiffOrder,
+                        const std::vector<CalculationContribution>& rContributions);
 
-    UPwInterfaceElement(IndexType                          NewId,
-                        const GeometryType::Pointer&       rpGeometry,
-                        std::unique_ptr<StressStatePolicy> pStressStatePolicy,
-                        IsDiffOrderElement                 IsDiffOrder);
+    UPwInterfaceElement(IndexType                                   NewId,
+                        const GeometryType::Pointer&                rpGeometry,
+                        std::unique_ptr<StressStatePolicy>          pStressStatePolicy,
+                        IsDiffOrderElement                          IsDiffOrder,
+                        const std::vector<CalculationContribution>& rContributions);
     Element::Pointer Create(IndexType NewId, const NodesArrayType& rNodes, PropertiesType::Pointer pProperties) const override;
     Element::Pointer Create(IndexType NewId, GeometryType::Pointer pGeom, PropertiesType::Pointer pProperties) const override;
 
@@ -131,6 +134,7 @@ private:
     std::vector<ConstitutiveLaw::Pointer> mConstitutiveLaws;
     IntegrationCoefficientsCalculator     mIntegrationCoefficientsCalculator;
     Geo::GeometryUniquePtr                mpOptionalPressureGeometry;
+    std::vector<CalculationContribution>  mContributions;
 
     friend class Serializer;
 };

--- a/applications/GeoMechanicsApplication/geo_mechanics_application.h
+++ b/applications/GeoMechanicsApplication/geo_mechanics_application.h
@@ -517,23 +517,42 @@ private:
         std::make_unique<ThreeDimensionalStressState>()};
 
     const UPwInterfaceElement mUPwLineInterfacePlaneStrainElement2Plus2N{
-        0, Kratos::make_shared<InterfaceGeometry<Line2D2<NodeType>>>(Element::GeometryType::PointsArrayType(4)),
-        std::make_unique<Line2DInterfaceStressState>(), IsDiffOrderElement::No};
+        0,
+        Kratos::make_shared<InterfaceGeometry<Line2D2<NodeType>>>(Element::GeometryType::PointsArrayType(4)),
+        std::make_unique<Line2DInterfaceStressState>(),
+        IsDiffOrderElement::No,
+        {CalculationContribution::Stiffness}};
     const UPwInterfaceElement mUPwLineInterfacePlaneStrainElement3Plus3N{
-        0, Kratos::make_shared<InterfaceGeometry<Line2D3<NodeType>>>(Element::GeometryType::PointsArrayType(6)),
-        std::make_unique<Line2DInterfaceStressState>(), IsDiffOrderElement::No};
+        0,
+        Kratos::make_shared<InterfaceGeometry<Line2D3<NodeType>>>(Element::GeometryType::PointsArrayType(6)),
+        std::make_unique<Line2DInterfaceStressState>(),
+        IsDiffOrderElement::No,
+        {CalculationContribution::Stiffness}};
     const UPwInterfaceElement mUPwSurfaceInterfaceElement3Plus3N{
-        0, Kratos::make_shared<InterfaceGeometry<Triangle3D3<NodeType>>>(Element::GeometryType::PointsArrayType(6)),
-        std::make_unique<SurfaceInterfaceStressState>(), IsDiffOrderElement::No};
+        0,
+        Kratos::make_shared<InterfaceGeometry<Triangle3D3<NodeType>>>(Element::GeometryType::PointsArrayType(6)),
+        std::make_unique<SurfaceInterfaceStressState>(),
+        IsDiffOrderElement::No,
+        {CalculationContribution::Stiffness}};
     const UPwInterfaceElement mUPwSurfaceInterfaceElement4Plus4N{
-        0, Kratos::make_shared<InterfaceGeometry<Quadrilateral3D4<NodeType>>>(Element::GeometryType::PointsArrayType(8)),
-        std::make_unique<SurfaceInterfaceStressState>(), IsDiffOrderElement::No};
+        0,
+        Kratos::make_shared<InterfaceGeometry<Quadrilateral3D4<NodeType>>>(Element::GeometryType::PointsArrayType(8)),
+        std::make_unique<SurfaceInterfaceStressState>(),
+        IsDiffOrderElement::No,
+        {CalculationContribution::Stiffness}};
     const UPwInterfaceElement mUPwSurfaceInterfaceElement6Plus6N{
-        0, Kratos::make_shared<InterfaceGeometry<Triangle3D6<NodeType>>>(Element::GeometryType::PointsArrayType(12)),
-        std::make_unique<SurfaceInterfaceStressState>(), IsDiffOrderElement::No};
+        0,
+        Kratos::make_shared<InterfaceGeometry<Triangle3D6<NodeType>>>(Element::GeometryType::PointsArrayType(12)),
+        std::make_unique<SurfaceInterfaceStressState>(),
+        IsDiffOrderElement::No,
+        {CalculationContribution::Stiffness}};
     const UPwInterfaceElement mUPwSurfaceInterfaceElement8Plus8N{
-        0, Kratos::make_shared<InterfaceGeometry<Quadrilateral3D8<NodeType>>>(Element::GeometryType::PointsArrayType(16)),
-        std::make_unique<SurfaceInterfaceStressState>(), IsDiffOrderElement::No};
+        0,
+        Kratos::make_shared<InterfaceGeometry<Quadrilateral3D8<NodeType>>>(
+            Element::GeometryType::PointsArrayType(16)),
+        std::make_unique<SurfaceInterfaceStressState>(),
+        IsDiffOrderElement::No,
+        {CalculationContribution::Stiffness}};
 
     // Updated-Lagrangian elements:
     const UPwUpdatedLagrangianElement<2, 3> mUPwUpdatedLagrangianElement2D3N{

--- a/applications/GeoMechanicsApplication/test_setup_utilities/element_setup_utilities.cpp
+++ b/applications/GeoMechanicsApplication/test_setup_utilities/element_setup_utilities.cpp
@@ -279,44 +279,49 @@ Element::Pointer ElementSetupUtilities::Create2D15NElement()
 }
 
 Element::Pointer ElementSetupUtilities::Create2D4NInterfaceElement(const PointerVector<Node>& rNodes,
-                                                                   const Properties::Pointer& rProperties)
+                                                                   const Properties::Pointer& rProperties,
+                                                                   const std::vector<CalculationContribution>& rContributions)
 {
     return make_intrusive<UPwInterfaceElement>(
         1, std::make_shared<InterfaceGeometry<Line2D2<Node>>>(rNodes), rProperties,
-        std::make_unique<Line2DInterfaceStressState>(), IsDiffOrderElement::No);
+        std::make_unique<Line2DInterfaceStressState>(), IsDiffOrderElement::No, rContributions);
 }
 
 Element::Pointer ElementSetupUtilities::Create2D6NInterfaceElement(const PointerVector<Node>& rNodes,
-                                                                   const Properties::Pointer& rProperties)
+                                                                   const Properties::Pointer& rProperties,
+                                                                   const std::vector<CalculationContribution>& rContributions)
 {
     return make_intrusive<UPwInterfaceElement>(
         1, std::make_shared<InterfaceGeometry<Line2D3<Node>>>(rNodes), rProperties,
-        std::make_unique<Line2DInterfaceStressState>(), IsDiffOrderElement::No);
+        std::make_unique<Line2DInterfaceStressState>(), IsDiffOrderElement::No, rContributions);
 }
 
 Element::Pointer ElementSetupUtilities::Create3D6NInterfaceElement(const PointerVector<Node>& rNodes,
-                                                                   const Properties::Pointer& rProperties)
+                                                                   const Properties::Pointer& rProperties,
+                                                                   const std::vector<CalculationContribution>& rContributions)
 {
     return make_intrusive<UPwInterfaceElement>(
         1, std::make_shared<InterfaceGeometry<Triangle3D3<Node>>>(rNodes), rProperties,
-        std::make_unique<SurfaceInterfaceStressState>(), IsDiffOrderElement::No);
+        std::make_unique<SurfaceInterfaceStressState>(), IsDiffOrderElement::No, rContributions);
 }
 
 Element::Pointer ElementSetupUtilities::Create3D12NInterfaceElement(const PointerVector<Node>& rNodes,
-                                                                    const Properties::Pointer& rProperties)
+                                                                    const Properties::Pointer& rProperties,
+                                                                    const std::vector<CalculationContribution>& rContributions)
 {
     return make_intrusive<UPwInterfaceElement>(
         1, std::make_shared<InterfaceGeometry<Triangle3D6<Node>>>(rNodes), rProperties,
-        std::make_unique<SurfaceInterfaceStressState>(), IsDiffOrderElement::No);
+        std::make_unique<SurfaceInterfaceStressState>(), IsDiffOrderElement::No, rContributions);
 }
 
 Element::Pointer ElementSetupUtilities::Create3D8NInterfaceElement(const PointerVector<Node>& rNodes,
                                                                    const Properties::Pointer& rProperties,
-                                                                   std::size_t Id)
+                                                                   std::size_t Id,
+                                                                   const std::vector<CalculationContribution>& rContributions)
 {
     return make_intrusive<UPwInterfaceElement>(
         Id, std::make_shared<InterfaceGeometry<Quadrilateral3D4<Node>>>(rNodes), rProperties,
-        std::make_unique<SurfaceInterfaceStressState>(), IsDiffOrderElement::No);
+        std::make_unique<SurfaceInterfaceStressState>(), IsDiffOrderElement::No, rContributions);
 }
 
 Element::Pointer ElementSetupUtilities::Create3D4NElement(const PointerVector<Node>& rNodes,

--- a/applications/GeoMechanicsApplication/test_setup_utilities/element_setup_utilities.hpp
+++ b/applications/GeoMechanicsApplication/test_setup_utilities/element_setup_utilities.hpp
@@ -12,6 +12,7 @@
 
 #pragma once
 
+#include "custom_elements/contribution_calculators/calculation_contribution.h"
 #include "geo_aliases.h"
 #include "geometries/point.h"
 #include "includes/condition.h"
@@ -82,17 +83,27 @@ public:
     static Element::Pointer Create2D15NElement();
 
     static Element::Pointer Create2D4NInterfaceElement(const PointerVector<Node>& rNodes,
-                                                       const Properties::Pointer& rProperties);
+                                                       const Properties::Pointer& rProperties,
+                                                       const std::vector<CalculationContribution>& rContributions = {
+                                                           CalculationContribution::Stiffness});
     static Element::Pointer Create2D6NInterfaceElement(const PointerVector<Node>& rNodes,
-                                                       const Properties::Pointer& rProperties);
+                                                       const Properties::Pointer& rProperties,
+                                                       const std::vector<CalculationContribution>& rContributions = {
+                                                           CalculationContribution::Stiffness});
     static Element::Pointer Create3D6NInterfaceElement(const PointerVector<Node>& rNodes,
-                                                       const Properties::Pointer& rProperties);
+                                                       const Properties::Pointer& rProperties,
+                                                       const std::vector<CalculationContribution>& rContributions = {
+                                                           CalculationContribution::Stiffness});
     static Element::Pointer Create3D12NInterfaceElement(const PointerVector<Node>& rNodes,
-                                                        const Properties::Pointer& rProperties);
+                                                        const Properties::Pointer& rProperties,
+                                                        const std::vector<CalculationContribution>& rContributions = {
+                                                            CalculationContribution::Stiffness});
 
     static Element::Pointer Create3D8NInterfaceElement(const PointerVector<Node>& rNodes,
                                                        const Properties::Pointer& rProperties,
-                                                       std::size_t Id = std::size_t{0});
+                                                       std::size_t Id = std::size_t{0},
+                                                       const std::vector<CalculationContribution>& rContributions = {
+                                                           CalculationContribution::Stiffness});
 
     static Element::Pointer Create3D4NElement(const PointerVector<Node>& rNodes,
                                               const Properties::Pointer& rProperties);

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_elements/test_U_Pw_interface_element.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_elements/test_U_Pw_interface_element.cpp
@@ -93,8 +93,8 @@ UPwInterfaceElement CreateInterfaceElementWithUPwDofs(const Properties::Pointer&
                                                       const Geometry<Node>::Pointer& rpGeometry,
                                                       IsDiffOrderElement             IsDiffOrder)
 {
-    auto       result = UPwInterfaceElement{1, rpGeometry, rpProperties,
-                                      std::make_unique<TInterfaceDimension>(), IsDiffOrder};
+    auto result = UPwInterfaceElement{
+        1, rpGeometry, rpProperties, std::make_unique<TInterfaceDimension>(), IsDiffOrder, {CalculationContribution::Stiffness}};
     const auto solution_step_variables =
         Geo::ConstVariableDataRefs{std::cref(WATER_PRESSURE), std::cref(DISPLACEMENT)};
     const auto degrees_of_freedom =
@@ -404,7 +404,8 @@ KRATOS_TEST_CASE_IN_SUITE(UPwInterfaceElement_IsAnElement, KratosGeoMechanicsFas
 {
     const UPwInterfaceElement element(
         0, std::make_shared<LineInterfaceGeometry2D2Plus2Noded>(CreateNodesFor2Plus2LineInterfaceGeometry()),
-        std::make_unique<Line2DInterfaceStressState>(), IsDiffOrderElement::No);
+        std::make_unique<Line2DInterfaceStressState>(), IsDiffOrderElement::No,
+        {CalculationContribution::Stiffness});
     auto p_casted_element = dynamic_cast<const Element*>(&element);
     EXPECT_NE(p_casted_element, nullptr);
 }
@@ -414,7 +415,8 @@ KRATOS_TEST_CASE_IN_SUITE(UPwLineInterfaceElement_CreatesInstanceWithGeometryInp
     // Arrange
     const UPwInterfaceElement element(
         0, std::make_shared<LineInterfaceGeometry2D2Plus2Noded>(CreateNodesFor2Plus2LineInterfaceGeometry()),
-        std::make_unique<Line2DInterfaceStressState>(), IsDiffOrderElement::No);
+        std::make_unique<Line2DInterfaceStressState>(), IsDiffOrderElement::No,
+        {CalculationContribution::Stiffness});
     const auto p_geometry =
         std::make_shared<LineInterfaceGeometry2D2Plus2Noded>(CreateNodesFor2Plus2LineInterfaceGeometry());
     const auto p_properties = std::make_shared<Properties>();
@@ -438,8 +440,9 @@ KRATOS_TEST_CASE_IN_SUITE(UPwLineInterfaceElement_CreatesInstanceWithNodeInput, 
     // The source element needs to have a geometry, otherwise the version of the
     // Create method with a node input will fail.
     const auto p_geometry = std::make_shared<LineInterfaceGeometry2D2Plus2Noded>(nodes);
-    const UPwInterfaceElement element(
-        0, p_geometry, p_properties, std::make_unique<Line2DInterfaceStressState>(), IsDiffOrderElement::No);
+    const UPwInterfaceElement element(0, p_geometry, p_properties,
+                                      std::make_unique<Line2DInterfaceStressState>(),
+                                      IsDiffOrderElement::No, {CalculationContribution::Stiffness});
 
     // Act
     const auto p_created_element = element.Create(1, nodes, p_properties);
@@ -866,7 +869,8 @@ KRATOS_TEST_CASE_IN_SUITE(UPwTriangleInterfaceElement_CreatesInstanceWithGeometr
     // Arrange
     const UPwInterfaceElement element(
         0, std::make_shared<TriangleInterfaceGeometry3D3Plus3Noded>(CreateNodesFor3Plus3SurfaceInterfaceGeometry()),
-        std::make_unique<SurfaceInterfaceStressState>(), IsDiffOrderElement::No);
+        std::make_unique<SurfaceInterfaceStressState>(), IsDiffOrderElement::No,
+        {CalculationContribution::Stiffness});
     const auto p_geometry = std::make_shared<TriangleInterfaceGeometry3D3Plus3Noded>(
         CreateNodesFor3Plus3SurfaceInterfaceGeometry());
     const auto p_properties = std::make_shared<Properties>();
@@ -890,8 +894,9 @@ KRATOS_TEST_CASE_IN_SUITE(UPwTriangleInterfaceElement_CreatesInstanceWithNodeInp
     // The source element needs to have a geometry, otherwise the version of the
     // Create method with a node input will fail.
     const auto p_geometry = std::make_shared<TriangleInterfaceGeometry3D3Plus3Noded>(nodes);
-    const UPwInterfaceElement element(
-        0, p_geometry, p_properties, std::make_unique<SurfaceInterfaceStressState>(), IsDiffOrderElement::No);
+    const UPwInterfaceElement element(0, p_geometry, p_properties,
+                                      std::make_unique<SurfaceInterfaceStressState>(),
+                                      IsDiffOrderElement::No, {CalculationContribution::Stiffness});
 
     // Act
     const auto p_created_element = element.Create(1, nodes, p_properties);


### PR DESCRIPTION
The LHS and RHS contributions are now done based on the list provided in the constructor