### PR TITLE
[GeoMechanicsApplication] Renamed three local helper functions `CreateProperties`

### DIFF
--- a/applications/GeoMechanicsApplication/benchmarks/upw_diff_order_element_benchmark.cpp
+++ b/applications/GeoMechanicsApplication/benchmarks/upw_diff_order_element_benchmark.cpp
@@ -23,7 +23,7 @@ namespace
 
 using namespace Kratos;
 
-std::shared_ptr<Properties> CreateProperties()
+std::shared_ptr<Properties> CreatePropertiesForUPwDiffOrderElementBenchmark()
 {
     const auto p_properties = std::make_shared<Properties>();
     p_properties->SetValue(CONSTITUTIVE_LAW, std::make_shared<GeoIncrementalLinearElasticLaw>(
@@ -97,7 +97,7 @@ namespace Kratos
 
 void benchmarkUPwDiffOrderLocalSystemCalculation(benchmark::State& rState)
 {
-    const auto p_properties = CreateProperties();
+    const auto p_properties = CreatePropertiesForUPwDiffOrderElementBenchmark();
     auto       p_element    = CreateSmallStrainUPwDiffOrderElementWithUPwDofs(p_properties);
 
     SetSolutionStepValuesForGeneralCheck(p_element);
@@ -114,7 +114,7 @@ void benchmarkUPwDiffOrderLocalSystemCalculation(benchmark::State& rState)
 
 void benchmarkUPwDiffOrderRHSCalculation(benchmark::State& rState)
 {
-    const auto p_properties = CreateProperties();
+    const auto p_properties = CreatePropertiesForUPwDiffOrderElementBenchmark();
     auto       p_element    = CreateSmallStrainUPwDiffOrderElementWithUPwDofs(p_properties);
 
     SetSolutionStepValuesForGeneralCheck(p_element);
@@ -130,7 +130,7 @@ void benchmarkUPwDiffOrderRHSCalculation(benchmark::State& rState)
 
 void benchmarkUPwDiffOrderLHSCalculation(benchmark::State& rState)
 {
-    const auto p_properties = CreateProperties();
+    const auto p_properties = CreatePropertiesForUPwDiffOrderElementBenchmark();
     auto       p_element    = CreateSmallStrainUPwDiffOrderElementWithUPwDofs(p_properties);
 
     SetSolutionStepValuesForGeneralCheck(p_element);

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_elements/test_small_strain_u_pw_diff_order_element.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_elements/test_small_strain_u_pw_diff_order_element.cpp
@@ -32,7 +32,7 @@ namespace
 using namespace Kratos;
 using namespace std::string_literals;
 
-std::shared_ptr<Properties> CreateProperties()
+std::shared_ptr<Properties> CreatePropertiesForUPwDiffOrderElementTest()
 {
     const auto p_properties = std::make_shared<Properties>();
     p_properties->SetValue(CONSTITUTIVE_LAW, std::make_shared<GeoIncrementalLinearElasticLaw>(
@@ -182,7 +182,8 @@ KRATOS_TEST_CASE_IN_SUITE(SmallStrainUPwDiffOrderElement_CalculateShearCapacity,
 KRATOS_TEST_CASE_IN_SUITE(SmallStrainUPwDiffOrderElement_CalculateLHS, KratosGeoMechanicsFastSuiteWithoutKernel)
 {
     // Arrange
-    auto p_element = CreateSmallStrainUPwDiffOrderElementWithUPwDofs(CreateProperties());
+    auto p_element =
+        CreateSmallStrainUPwDiffOrderElementWithUPwDofs(CreatePropertiesForUPwDiffOrderElementTest());
 
     SetSolutionStepValuesForGeneralCheck(p_element);
 
@@ -203,7 +204,8 @@ KRATOS_TEST_CASE_IN_SUITE(SmallStrainUPwDiffOrderElement_CalculateLHS_WithSaveAn
         std::make_pair("PlaneStrainStressState"s, PlaneStrainStressState{}));
 
     // Arrange
-    auto p_element = CreateSmallStrainUPwDiffOrderElementWithUPwDofs(CreateProperties());
+    auto p_element =
+        CreateSmallStrainUPwDiffOrderElementWithUPwDofs(CreatePropertiesForUPwDiffOrderElementTest());
 
     SetSolutionStepValuesForGeneralCheck(p_element);
 
@@ -224,7 +226,7 @@ KRATOS_TEST_CASE_IN_SUITE(SmallStrainUPwDiffOrderElement_CalculateLHS_WithSaveAn
 KRATOS_TEST_CASE_IN_SUITE(SmallStrainUPwDiffOrderElement_CalculateRHS, KratosGeoMechanicsFastSuiteWithoutKernel)
 {
     // Arrange
-    auto p_properties = CreateProperties();
+    auto p_properties = CreatePropertiesForUPwDiffOrderElementTest();
     p_properties->SetValue(BIOT_COEFFICIENT, 1.0); // to get RHS contributions of coupling
     auto p_element = CreateSmallStrainUPwDiffOrderElementWithUPwDofs(p_properties);
 
@@ -250,7 +252,7 @@ KRATOS_TEST_CASE_IN_SUITE(SmallStrainUPwDiffOrderElement_CalculateRHS, KratosGeo
 KRATOS_TEST_CASE_IN_SUITE(SmallStrainUPwDiffOrderElement_RHSEqualsUnbalanceVector, KratosGeoMechanicsFastSuiteWithoutKernel)
 {
     // Arrange
-    auto p_properties = CreateProperties();
+    auto p_properties = CreatePropertiesForUPwDiffOrderElementTest();
     p_properties->SetValue(BIOT_COEFFICIENT, 1.0); // to get RHS contributions of coupling
     auto p_element = CreateSmallStrainUPwDiffOrderElementWithUPwDofs(p_properties);
 
@@ -282,7 +284,7 @@ KRATOS_TEST_CASE_IN_SUITE(SmallStrainUPwDiffOrderElement_RHSEqualsUnbalanceVecto
 KRATOS_TEST_CASE_IN_SUITE(SmallStrainUPwDiffOrderElement_CalculateThrowsDebugErrorForUnknownVectorVariable,
                           KratosGeoMechanicsFastSuiteWithoutKernel)
 {
-    auto p_properties = CreateProperties();
+    auto p_properties = CreatePropertiesForUPwDiffOrderElementTest();
     p_properties->SetValue(BIOT_COEFFICIENT, 1.0); // to get RHS contributions of coupling
     auto p_element = CreateSmallStrainUPwDiffOrderElementWithUPwDofs(p_properties);
 

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_elements/test_u_pw_small_strain_element.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_elements/test_u_pw_small_strain_element.cpp
@@ -49,7 +49,7 @@ ModelPart& CreateModelPartWithUPwSolutionStepVariables(Model& rModel)
     return r_result;
 }
 
-std::shared_ptr<Properties> CreateProperties()
+std::shared_ptr<Properties> CreatePropertiesForUPwSmallStrainElementTest()
 {
     const auto p_properties = std::make_shared<Properties>();
     p_properties->SetValue(CONSTITUTIVE_LAW, std::make_shared<GeoIncrementalLinearElasticLaw>(
@@ -218,7 +218,8 @@ KRATOS_TEST_CASE_IN_SUITE(UPwSmallStrainElement_CheckDoesNotThrowOnCorrectInput,
 {
     // Arrange
     Model model;
-    auto  p_element = CreateUPwSmallStrainElementWithUPwDofs(model, CreateProperties());
+    auto  p_element =
+        CreateUPwSmallStrainElementWithUPwDofs(model, CreatePropertiesForUPwSmallStrainElementTest());
     SetSolutionStepValuesForGeneralCheck(p_element);
     const auto dummy_process_info = ProcessInfo{};
     p_element->Initialize(dummy_process_info);
@@ -230,7 +231,8 @@ KRATOS_TEST_CASE_IN_SUITE(UPwSmallStrainElement_CalculatesSteadyStateRightHandSi
 {
     // Arrange
     Model model;
-    auto  p_element = CreateUPwSmallStrainElementWithUPwDofs(model, CreateProperties());
+    auto  p_element =
+        CreateUPwSmallStrainElementWithUPwDofs(model, CreatePropertiesForUPwSmallStrainElementTest());
     SetSolutionStepValuesForFluidFluxCheck(p_element);
     const auto process_info = ProcessInfo{};
 
@@ -257,7 +259,8 @@ KRATOS_TEST_CASE_IN_SUITE(UPwSmallStrainElement_CalculatesSteadyStateLeftHandSid
 {
     // Arrange
     Model model;
-    auto  p_element = CreateUPwSmallStrainElementWithUPwDofs(model, CreateProperties());
+    auto  p_element =
+        CreateUPwSmallStrainElementWithUPwDofs(model, CreatePropertiesForUPwSmallStrainElementTest());
     SetSolutionStepValuesForGeneralCheck(p_element);
     const auto process_info = ProcessInfo{};
 
@@ -278,7 +281,8 @@ KRATOS_TEST_CASE_IN_SUITE(UPwSmallStrainElement_CalculatesCorrectLHSAfterSaveAnd
         std::make_pair("PlaneStrainStressState"s, PlaneStrainStressState{}));
 
     Model model;
-    auto  p_element = CreateUPwSmallStrainElementWithUPwDofs(model, CreateProperties());
+    auto  p_element =
+        CreateUPwSmallStrainElementWithUPwDofs(model, CreatePropertiesForUPwSmallStrainElementTest());
     SetSolutionStepValuesForGeneralCheck(p_element);
     const auto process_info = ProcessInfo{};
     p_element->Initialize(process_info);
@@ -305,7 +309,8 @@ KRATOS_TEST_CASE_IN_SUITE(UPwSmallStrainElement_CalculatesCorrectRHSAfterSaveAnd
         std::make_pair("PlaneStrainStressState"s, PlaneStrainStressState{}));
 
     Model model;
-    auto  p_element = CreateUPwSmallStrainElementWithUPwDofs(model, CreateProperties());
+    auto  p_element =
+        CreateUPwSmallStrainElementWithUPwDofs(model, CreatePropertiesForUPwSmallStrainElementTest());
     SetSolutionStepValuesForFluidFluxCheck(p_element);
     const auto process_info = ProcessInfo{};
 
@@ -338,7 +343,8 @@ KRATOS_TEST_CASE_IN_SUITE(UPwSmallStrainElement_InitializeSolutionStep, KratosGe
 {
     // Arrange
     Model model;
-    auto  p_element = CreateUPwSmallStrainElementWithUPwDofs(model, CreateProperties());
+    auto  p_element =
+        CreateUPwSmallStrainElementWithUPwDofs(model, CreatePropertiesForUPwSmallStrainElementTest());
     SetSolutionStepValuesForGeneralCheck(p_element);
     const auto process_info = ProcessInfo{};
     p_element->Initialize(process_info);
@@ -410,7 +416,8 @@ KRATOS_TEST_CASE_IN_SUITE(UPwSmallStrainElement_InitializeNonLinearIterationAndC
 {
     // Arrange
     Model model;
-    auto  p_element = CreateUPwSmallStrainElementWithUPwDofs(model, CreateProperties());
+    auto  p_element =
+        CreateUPwSmallStrainElementWithUPwDofs(model, CreatePropertiesForUPwSmallStrainElementTest());
     p_element->GetProperties().SetValue(BIOT_COEFFICIENT, 1.000000e+00);
     SetSolutionStepValuesForGeneralCheck(p_element);
     const auto process_info = ProcessInfo{};
@@ -432,7 +439,8 @@ KRATOS_TEST_CASE_IN_SUITE(UPwSmallStrainElement_InitializeNonLinearIterationAndC
 
     // Arrange
     Model model;
-    auto  p_element = CreateUPwSmallStrainElementWithUPwDofs(model, CreateProperties());
+    auto  p_element =
+        CreateUPwSmallStrainElementWithUPwDofs(model, CreatePropertiesForUPwSmallStrainElementTest());
     p_element->GetProperties().SetValue(BIOT_COEFFICIENT, 1.000000e+00);
     SetSolutionStepValuesForGeneralCheck(p_element);
     const auto process_info = ProcessInfo{};
@@ -455,7 +463,8 @@ KRATOS_TEST_CASE_IN_SUITE(UPwSmallStrainElement_CalculateOnIntegrationPointsVari
 {
     // Arrange
     Model model;
-    auto  p_element = CreateUPwSmallStrainElementWithUPwDofs(model, CreateProperties());
+    auto  p_element =
+        CreateUPwSmallStrainElementWithUPwDofs(model, CreatePropertiesForUPwSmallStrainElementTest());
     p_element->GetProperties().SetValue(BIOT_COEFFICIENT, 1.000000e+00);
     SetSolutionStepValuesForGeneralCheck(p_element);
     const auto process_info = ProcessInfo{};
@@ -547,7 +556,8 @@ KRATOS_TEST_CASE_IN_SUITE(UPwSmallStrainElement_FinalizeSolutionStep, KratosGeoM
 {
     // Arrange
     Model model;
-    auto  p_element = CreateUPwSmallStrainElementWithUPwDofs(model, CreateProperties());
+    auto  p_element =
+        CreateUPwSmallStrainElementWithUPwDofs(model, CreatePropertiesForUPwSmallStrainElementTest());
     p_element->GetProperties().SetValue(BIOT_COEFFICIENT, 1.000000e+00);
     SetSolutionStepValuesForFluidFluxCheck(p_element);
     const auto process_info = ProcessInfo{};
@@ -567,7 +577,8 @@ KRATOS_TEST_CASE_IN_SUITE(UPwSmallStrainElement_SetValuesOnIntegrationPointsMatr
 {
     // Arrange
     Model model;
-    auto  p_element = CreateUPwSmallStrainElementWithUPwDofs(model, CreateProperties());
+    auto  p_element =
+        CreateUPwSmallStrainElementWithUPwDofs(model, CreatePropertiesForUPwSmallStrainElementTest());
     p_element->GetProperties().SetValue(BIOT_COEFFICIENT, 1.000000e+00);
     SetSolutionStepValuesForGeneralCheck(p_element);
     const auto process_info = ProcessInfo{};


### PR DESCRIPTION
**📝 Description**
Three test/benchmark files had a local helper named `CreateProperties` in their anonymous namespaces. This PR resolves the multiple definition problem that may occur in case of a Unity build.
