### PR TITLE
[Core] Hotfix for `geometries_tensor_adaptor`

### DIFF
--- a/kratos/tensor_adaptors/geometries_tensor_adaptor.cpp
+++ b/kratos/tensor_adaptors/geometries_tensor_adaptor.cpp
@@ -170,25 +170,14 @@ void GeometriesTensorAdaptor::CollectShapeFunctionsDerivatives(
     IndexPartition<std::size_t>(n_elem).for_each([&](std::size_t i) {
         const auto& r_geometry = GetGeometry(*(rContainer.begin() + i));
 
-        Geometry<Node>::ShapeFunctionsGradientsType DN_De;
-        r_geometry.ShapeFunctionsIntegrationPointsGradients(DN_De, Method);
-
-        Geometry<Node>::JacobiansType J;
-        r_geometry.Jacobian(J, Method);
+        Geometry<Node>::ShapeFunctionsGradientsType DN_Dx;
+        r_geometry.ShapeFunctionsIntegrationPointsGradients(DN_Dx, Method);
 
         for (std::size_t g = 0; g < n_gauss; ++g) {
-            Matrix InvJ;
-            double DetJ;
-            const Matrix& J_g = J[g];
-            MathUtils<double>::GeneralizedInvertMatrix(J_g, InvJ, DetJ);
-
-            const Matrix& DN_De_g = DN_De[g];
-            Matrix DN_DX_g = prod(DN_De_g, InvJ);
-
             for (std::size_t n = 0; n < n_node; ++n) {
                 for (std::size_t k = 0; k < dim; ++k) {
                     pData[i * n_gauss * n_node * dim + g * n_node * dim +
-                          n * dim + k] = DN_DX_g(n, k);
+                          n * dim + k] = DN_Dx[g](n, k);
                 }
             }
         }
@@ -330,3 +319,4 @@ std::string GeometriesTensorAdaptor::Info() const
 }
 
 } // namespace Kratos
+


### PR DESCRIPTION
#  **📝 Description**

The manual calculation of Cartesian shape function derivatives (computing local gradients, calculating the Jacobian, inverting it, and performing matrix multiplication) has been replaced by a direct call to the geometry's gradient method. This removes significant boilerplate and leverages the internal optimizations of the `Geometry` class.

## Key Changes

* **Removed Manual Jacobian Inversion:** Eliminated the manual loop that calculated , , and the subsequent product .
* **Direct Gradient Retrieval:** Updated `CollectShapeFunctionsDerivatives` to fetch the required gradients (presumably Cartesian, depending on the `Method` passed) directly into the `DN_Dx` container.
* **Code Cleanup:** Reduced the nesting level and complexity of the Gauss-point loop, making the data mapping to `pData` more direct and readable.

## Impact

* **Readability:** Significant reduction in lines of code within the core integration loop.
* **Performance:** Potential minor speedup by avoiding redundant manual matrix operations and utilizing optimized geometry methods.
* **Maintainability:** Reduces the surface area for bugs related to manual linear algebra implementations.

# **🆕 Changelog**

- [Hotfix for `geometries_tensor_adaptor`](https://github.com/KratosMultiphysics/Kratos/pull/14182/commits/94cfcaffe6b7b2c728af495e036a55402a65996c)