### PR TITLE
[FastPR][Core] Adding FindValueIndex to CSR

### DIFF
--- a/kratos/containers/csr_matrix.h
+++ b/kratos/containers/csr_matrix.h
@@ -396,29 +396,30 @@ public:
             KRATOS_ERROR << " max column index : " << max_col << " exceeds mNcols :" << mNcols << std::endl;
     }
 
-    TDataType& operator()(IndexType I, IndexType J)
+    IndexType FindValueIndex(IndexType I, IndexType J) const
     {
         const IndexType row_begin = index1_data()[I];
         const IndexType row_end = index1_data()[I+1];
-        IndexType k = BinarySearch(index2_data(), row_begin, row_end, J);
+        return BinarySearch(index2_data(), row_begin, row_end, J);
+    }
+
+    TDataType& operator()(IndexType I, IndexType J)
+    {
+        const IndexType k = FindValueIndex(I,J);
         KRATOS_DEBUG_ERROR_IF(k==std::numeric_limits<IndexType>::max()) << "local indices I,J : " << I << " " << J << " not found in matrix" << std::endl;
         return value_data()[k];
     }
 
     const TDataType& operator()(IndexType I, IndexType J) const
     {
-        const IndexType row_begin = index1_data()[I];
-        const IndexType row_end = index1_data()[I+1];
-        IndexType k = BinarySearch(index2_data(), row_begin, row_end, J);
+        const IndexType k = FindValueIndex(I,J);
         KRATOS_DEBUG_ERROR_IF(k==std::numeric_limits<IndexType>::max()) << "local indices I,J : " << I << " " << J << " not found in matrix" << std::endl;
         return value_data()[k];
     }
 
     bool Has(IndexType I, IndexType J) const
     {
-        const IndexType row_begin = index1_data()[I];
-        const IndexType row_end = index1_data()[I+1];
-        IndexType k = BinarySearch(index2_data(), row_begin, row_end, J);
+        const IndexType k = FindValueIndex(I,J);
         return k != std::numeric_limits<IndexType>::max();
     }
 

--- a/kratos/tests/cpp_tests/containers/test_csr_matrix.cpp
+++ b/kratos/tests/cpp_tests/containers/test_csr_matrix.cpp
@@ -293,4 +293,31 @@ KRATOS_TEST_CASE_IN_SUITE(CSRMatrixDiagonalValues, KratosCoreFastSuite)
     KRATOS_CHECK_NEAR(A.NormDiagonal(), 22.135943621179, 1.0e-12);
 }
 
+KRATOS_TEST_CASE_IN_SUITE(CSRMatrixFindValueIndex, KratosCoreFastSuite)
+{
+    // matrix A
+    //[[1,0,0,7,2],
+    // [0,3,0,0,0],
+    // [0,0,0,7,7]]
+    SparseContiguousRowGraph<> Agraph(3);
+    Agraph.AddEntry(0,0); Agraph.AddEntry(0,3); Agraph.AddEntry(0,4);
+    Agraph.AddEntry(1,1);
+    Agraph.AddEntry(2,3); Agraph.AddEntry(2,4);
+    Agraph.Finalize();
+
+    CsrMatrix<double> A(Agraph);
+    A.BeginAssemble();
+    A.AssembleEntry(1.0,0,0); A.AssembleEntry(7.0,0,3); A.AssembleEntry(2.0,0,4);
+    A.AssembleEntry(3.0,1,1);
+    A.AssembleEntry(7.0,2,3); A.AssembleEntry(7.0,2,4);
+    A.FinalizeAssemble();
+
+    KRATOS_CHECK_EQUAL(A.FindValueIndex(0,0), 0);
+    KRATOS_CHECK_EQUAL(A.FindValueIndex(0,3), 1);
+    KRATOS_CHECK_EQUAL(A.FindValueIndex(0,4), 2);
+    KRATOS_CHECK_EQUAL(A.FindValueIndex(1,1), 3);
+    KRATOS_CHECK_EQUAL(A.FindValueIndex(2,3), 4);
+    KRATOS_CHECK_EQUAL(A.FindValueIndex(2,4), 5);
+}
+
 } // namespace Kratos::Testing


### PR DESCRIPTION
**📝 Description**
Add a tiny `FindValueIndex` function to the CSR matrix so we avoid copying and pasting the implementation as well as enabling the search from outside.
