### PR TITLE
Geo/move generalized get nodal values to variables utilities

### DIFF
--- a/applications/GeoMechanicsApplication/custom_conditions/Pw_normal_flux_condition.cpp
+++ b/applications/GeoMechanicsApplication/custom_conditions/Pw_normal_flux_condition.cpp
@@ -67,8 +67,7 @@ void PwNormalFluxCondition<TDim, TNumNodes>::CalculateRHS(Vector&            rRi
     r_geometry.Jacobian(j_container, this->GetIntegrationMethod());
 
     // Condition variables
-    Vector normal_flux_vector(TNumNodes);
-    VariablesUtilities::GetNodalValues(r_geometry, NORMAL_FLUID_FLUX, normal_flux_vector.begin());
+    auto normal_flux_vector = VariablesUtilities::GetNodalValues(r_geometry, NORMAL_FLUID_FLUX);
 
     for (unsigned int integration_point = 0; integration_point < number_of_integration_points; ++integration_point) {
         // Interpolation of nodal normal flux to integration point normal flux.

--- a/applications/GeoMechanicsApplication/custom_conditions/Pw_normal_flux_condition.cpp
+++ b/applications/GeoMechanicsApplication/custom_conditions/Pw_normal_flux_condition.cpp
@@ -67,7 +67,7 @@ void PwNormalFluxCondition<TDim, TNumNodes>::CalculateRHS(Vector&            rRi
     r_geometry.Jacobian(j_container, this->GetIntegrationMethod());
 
     // Condition variables
-    auto normal_flux_vector = VariablesUtilities::GetNodalValues(r_geometry, NORMAL_FLUID_FLUX);
+    const auto normal_flux_vector = VariablesUtilities::GetNodalValues(r_geometry, NORMAL_FLUID_FLUX);
 
     for (unsigned int integration_point = 0; integration_point < number_of_integration_points; ++integration_point) {
         // Interpolation of nodal normal flux to integration point normal flux.

--- a/applications/GeoMechanicsApplication/custom_conditions/T_microclimate_flux_condition.cpp
+++ b/applications/GeoMechanicsApplication/custom_conditions/T_microclimate_flux_condition.cpp
@@ -100,9 +100,8 @@ void GeoTMicroClimateFluxCondition<TDim, TNumNodes>::CalculateLocalSystem(Matrix
     r_geom.Jacobian(jacobians, this->GetIntegrationMethod());
 
     const auto& r_N_container = this->GetGeometry().ShapeFunctionsValues(this->GetIntegrationMethod());
-
-    auto nodal_temperatures = array_1d<double, TNumNodes>{};
-    VariablesUtilities::GetNodalValues(this->GetGeometry(), TEMPERATURE, nodal_temperatures.begin());
+    const auto nodal_temperatures =
+        VariablesUtilities::GetNodalValues<TNumNodes>(this->GetGeometry(), TEMPERATURE);
 
     const auto time_step_size = rCurrentProcessInfo.GetValue(DELTA_TIME);
 

--- a/applications/GeoMechanicsApplication/custom_conditions/T_normal_flux_condition.cpp
+++ b/applications/GeoMechanicsApplication/custom_conditions/T_normal_flux_condition.cpp
@@ -68,8 +68,7 @@ void GeoTNormalFluxCondition<TDim, TNumNodes>::CalculateRHS(Vector&            r
     }
     r_geom.Jacobian(j_container, this->GetIntegrationMethod());
 
-    Vector normal_flux_vector(TNumNodes);
-    VariablesUtilities::GetNodalValues(r_geom, NORMAL_HEAT_FLUX, normal_flux_vector.begin());
+    auto normal_flux_vector = VariablesUtilities::GetNodalValues(r_geom, NORMAL_HEAT_FLUX);
 
     for (unsigned int integration_point = 0; integration_point < num_integration_points; ++integration_point) {
         const auto N = row(r_N_container, integration_point);

--- a/applications/GeoMechanicsApplication/custom_conditions/T_normal_flux_condition.cpp
+++ b/applications/GeoMechanicsApplication/custom_conditions/T_normal_flux_condition.cpp
@@ -68,7 +68,7 @@ void GeoTNormalFluxCondition<TDim, TNumNodes>::CalculateRHS(Vector&            r
     }
     r_geom.Jacobian(j_container, this->GetIntegrationMethod());
 
-    auto normal_flux_vector = VariablesUtilities::GetNodalValues(r_geom, NORMAL_HEAT_FLUX);
+    const auto normal_flux_vector = VariablesUtilities::GetNodalValues(r_geom, NORMAL_HEAT_FLUX);
 
     for (unsigned int integration_point = 0; integration_point < num_integration_points; ++integration_point) {
         const auto N = row(r_N_container, integration_point);

--- a/applications/GeoMechanicsApplication/custom_conditions/U_Pw_normal_face_load_condition.cpp
+++ b/applications/GeoMechanicsApplication/custom_conditions/U_Pw_normal_face_load_condition.cpp
@@ -93,11 +93,11 @@ template <unsigned int TDim, unsigned int TNumNodes>
 void UPwNormalFaceLoadCondition<TDim, TNumNodes>::InitializeConditionVariables(NormalFaceLoadVariables& rVariables,
                                                                                const GeometryType& rGeom)
 {
-    rVariables.NormalStressVector = VariablesUtilities::GetNodalValues<TNumNodes>(rGeom, NORMAL_CONTACT_STRESS);
+    VariablesUtilities::GetNodalValues(rGeom, NORMAL_CONTACT_STRESS, rVariables.NormalStressVector.begin());
 
     if constexpr (TDim == 2) {
-        rVariables.TangentialStressVector =
-            VariablesUtilities::GetNodalValues<TNumNodes>(rGeom, TANGENTIAL_CONTACT_STRESS);
+        VariablesUtilities::GetNodalValues(rGeom, TANGENTIAL_CONTACT_STRESS,
+                                           rVariables.TangentialStressVector.begin());
     }
 }
 

--- a/applications/GeoMechanicsApplication/custom_conditions/U_Pw_normal_face_load_condition.cpp
+++ b/applications/GeoMechanicsApplication/custom_conditions/U_Pw_normal_face_load_condition.cpp
@@ -93,11 +93,11 @@ template <unsigned int TDim, unsigned int TNumNodes>
 void UPwNormalFaceLoadCondition<TDim, TNumNodes>::InitializeConditionVariables(NormalFaceLoadVariables& rVariables,
                                                                                const GeometryType& rGeom)
 {
-    VariablesUtilities::GetNodalValues(rGeom, NORMAL_CONTACT_STRESS, rVariables.NormalStressVector.begin());
+    rVariables.NormalStressVector = VariablesUtilities::GetNodalValues<TNumNodes>(rGeom, NORMAL_CONTACT_STRESS);
 
     if constexpr (TDim == 2) {
-        VariablesUtilities::GetNodalValues(rGeom, TANGENTIAL_CONTACT_STRESS,
-                                           rVariables.TangentialStressVector.begin());
+        rVariables.TangentialStressVector =
+            VariablesUtilities::GetNodalValues<TNumNodes>(rGeom, TANGENTIAL_CONTACT_STRESS);
     }
 }
 

--- a/applications/GeoMechanicsApplication/custom_conditions/U_Pw_normal_flux_FIC_condition.cpp
+++ b/applications/GeoMechanicsApplication/custom_conditions/U_Pw_normal_flux_FIC_condition.cpp
@@ -88,7 +88,7 @@ void UPwNormalFluxFICCondition<TDim, TNumNodes>::CalculateAll(Matrix& rLeftHandS
     FICVariables.BiotModulusInverse =
         (BiotCoefficient - Porosity) / BulkModulusSolid + Porosity / r_prop[BULK_MODULUS_FLUID];
 
-    auto normal_flux_vector = VariablesUtilities::GetNodalValues<TNumNodes>(r_geom, NORMAL_FLUID_FLUX);
+    const auto normal_flux_vector = VariablesUtilities::GetNodalValues<TNumNodes>(r_geom, NORMAL_FLUID_FLUX);
     VariablesUtilities::GetNodalValues(r_geom, DT_WATER_PRESSURE, FICVariables.DtPressureVector.begin());
 
     // Loop over integration points

--- a/applications/GeoMechanicsApplication/custom_conditions/U_Pw_normal_flux_FIC_condition.cpp
+++ b/applications/GeoMechanicsApplication/custom_conditions/U_Pw_normal_flux_FIC_condition.cpp
@@ -89,8 +89,8 @@ void UPwNormalFluxFICCondition<TDim, TNumNodes>::CalculateAll(Matrix& rLeftHandS
     FICVariables.BiotModulusInverse =
         (BiotCoefficient - Porosity) / BulkModulusSolid + Porosity / r_prop[BULK_MODULUS_FLUID];
 
-    VariablesUtilities::GetNodalValues(r_geom, NORMAL_FLUID_FLUX, normal_flux_vector.begin());
-    VariablesUtilities::GetNodalValues(r_geom, DT_WATER_PRESSURE, FICVariables.DtPressureVector.begin());
+    normal_flux_vector = VariablesUtilities::GetNodalValues<TNumNodes>(r_geom, NORMAL_FLUID_FLUX);
+    FICVariables.DtPressureVector = VariablesUtilities::GetNodalValues<TNumNodes>(r_geom, DT_WATER_PRESSURE);
 
     // Loop over integration points
     for (unsigned int integration_point = 0; integration_point < number_of_integration_points;
@@ -133,9 +133,8 @@ void UPwNormalFluxFICCondition<TDim, TNumNodes>::CalculateRHS(Vector& rRightHand
     r_geom.Jacobian(j_container, this->GetIntegrationMethod());
 
     // Condition variables
-    array_1d<double, TNumNodes> normal_flux_vector;
-    NormalFluxVariables         Variables;
-    NormalFluxFICVariables      FICVariables;
+    NormalFluxVariables    Variables;
+    NormalFluxFICVariables FICVariables;
     FICVariables.DtPressureCoefficient = CurrentProcessInfo[DT_PRESSURE_COEFFICIENT];
     this->CalculateElementLength(FICVariables.ElementLength, r_geom);
     const double BulkModulusSolid = r_prop[BULK_MODULUS_SOLID];
@@ -144,8 +143,8 @@ void UPwNormalFluxFICCondition<TDim, TNumNodes>::CalculateRHS(Vector& rRightHand
     const double BiotCoefficient = 1.0 - BulkModulus / BulkModulusSolid;
     FICVariables.BiotModulusInverse =
         (BiotCoefficient - Porosity) / BulkModulusSolid + Porosity / r_prop[BULK_MODULUS_FLUID];
-    VariablesUtilities::GetNodalValues(r_geom, NORMAL_FLUID_FLUX, normal_flux_vector.begin());
-    VariablesUtilities::GetNodalValues(r_geom, DT_WATER_PRESSURE, FICVariables.DtPressureVector.begin());
+    const auto normal_flux_vector = VariablesUtilities::GetNodalValues<TNumNodes>(r_geom, NORMAL_FLUID_FLUX);
+    FICVariables.DtPressureVector = VariablesUtilities::GetNodalValues<TNumNodes>(r_geom, DT_WATER_PRESSURE);
 
     for (unsigned int integration_point = 0; integration_point < number_of_integration_points;
          integration_point++) {

--- a/applications/GeoMechanicsApplication/custom_conditions/U_Pw_normal_flux_FIC_condition.cpp
+++ b/applications/GeoMechanicsApplication/custom_conditions/U_Pw_normal_flux_FIC_condition.cpp
@@ -77,9 +77,8 @@ void UPwNormalFluxFICCondition<TDim, TNumNodes>::CalculateAll(Matrix& rLeftHandS
     r_geom.Jacobian(j_container, this->GetIntegrationMethod());
 
     // Condition variables
-    array_1d<double, TNumNodes> normal_flux_vector;
-    NormalFluxVariables         Variables;
-    NormalFluxFICVariables      FICVariables;
+    NormalFluxVariables    Variables;
+    NormalFluxFICVariables FICVariables;
     FICVariables.DtPressureCoefficient = CurrentProcessInfo[DT_PRESSURE_COEFFICIENT];
     this->CalculateElementLength(FICVariables.ElementLength, r_geom);
     const double BulkModulusSolid = r_prop[BULK_MODULUS_SOLID];
@@ -89,7 +88,7 @@ void UPwNormalFluxFICCondition<TDim, TNumNodes>::CalculateAll(Matrix& rLeftHandS
     FICVariables.BiotModulusInverse =
         (BiotCoefficient - Porosity) / BulkModulusSolid + Porosity / r_prop[BULK_MODULUS_FLUID];
 
-    normal_flux_vector = VariablesUtilities::GetNodalValues<TNumNodes>(r_geom, NORMAL_FLUID_FLUX);
+    auto normal_flux_vector = VariablesUtilities::GetNodalValues<TNumNodes>(r_geom, NORMAL_FLUID_FLUX);
     FICVariables.DtPressureVector = VariablesUtilities::GetNodalValues<TNumNodes>(r_geom, DT_WATER_PRESSURE);
 
     // Loop over integration points

--- a/applications/GeoMechanicsApplication/custom_conditions/U_Pw_normal_flux_FIC_condition.cpp
+++ b/applications/GeoMechanicsApplication/custom_conditions/U_Pw_normal_flux_FIC_condition.cpp
@@ -89,7 +89,7 @@ void UPwNormalFluxFICCondition<TDim, TNumNodes>::CalculateAll(Matrix& rLeftHandS
         (BiotCoefficient - Porosity) / BulkModulusSolid + Porosity / r_prop[BULK_MODULUS_FLUID];
 
     auto normal_flux_vector = VariablesUtilities::GetNodalValues<TNumNodes>(r_geom, NORMAL_FLUID_FLUX);
-    FICVariables.DtPressureVector = VariablesUtilities::GetNodalValues<TNumNodes>(r_geom, DT_WATER_PRESSURE);
+    VariablesUtilities::GetNodalValues(r_geom, DT_WATER_PRESSURE, FICVariables.DtPressureVector.begin());
 
     // Loop over integration points
     for (unsigned int integration_point = 0; integration_point < number_of_integration_points;
@@ -143,7 +143,7 @@ void UPwNormalFluxFICCondition<TDim, TNumNodes>::CalculateRHS(Vector& rRightHand
     FICVariables.BiotModulusInverse =
         (BiotCoefficient - Porosity) / BulkModulusSolid + Porosity / r_prop[BULK_MODULUS_FLUID];
     const auto normal_flux_vector = VariablesUtilities::GetNodalValues<TNumNodes>(r_geom, NORMAL_FLUID_FLUX);
-    FICVariables.DtPressureVector = VariablesUtilities::GetNodalValues<TNumNodes>(r_geom, DT_WATER_PRESSURE);
+    VariablesUtilities::GetNodalValues(r_geom, DT_WATER_PRESSURE, FICVariables.DtPressureVector.begin());
 
     for (unsigned int integration_point = 0; integration_point < number_of_integration_points;
          integration_point++) {

--- a/applications/GeoMechanicsApplication/custom_conditions/U_Pw_normal_flux_condition.cpp
+++ b/applications/GeoMechanicsApplication/custom_conditions/U_Pw_normal_flux_condition.cpp
@@ -65,7 +65,7 @@ void UPwNormalFluxCondition<TDim, TNumNodes>::CalculateRHS(Vector& rRightHandSid
     r_geometry.Jacobian(j_container, this->GetIntegrationMethod());
 
     // Condition variables
-    auto normal_flux_vector = VariablesUtilities::GetNodalValues(r_geometry, NORMAL_FLUID_FLUX);
+    const auto normal_flux_vector = VariablesUtilities::GetNodalValues(r_geometry, NORMAL_FLUID_FLUX);
 
     for (unsigned int integration_point = 0; integration_point < number_of_integration_points; ++integration_point) {
         const auto shape_function_values = row(r_n_container, integration_point);

--- a/applications/GeoMechanicsApplication/custom_conditions/U_Pw_normal_flux_condition.cpp
+++ b/applications/GeoMechanicsApplication/custom_conditions/U_Pw_normal_flux_condition.cpp
@@ -65,8 +65,7 @@ void UPwNormalFluxCondition<TDim, TNumNodes>::CalculateRHS(Vector& rRightHandSid
     r_geometry.Jacobian(j_container, this->GetIntegrationMethod());
 
     // Condition variables
-    Vector normal_flux_vector(TNumNodes);
-    VariablesUtilities::GetNodalValues(r_geometry, NORMAL_FLUID_FLUX, normal_flux_vector.begin());
+    auto normal_flux_vector = VariablesUtilities::GetNodalValues(r_geometry, NORMAL_FLUID_FLUX);
 
     for (unsigned int integration_point = 0; integration_point < number_of_integration_points; ++integration_point) {
         const auto shape_function_values = row(r_n_container, integration_point);

--- a/applications/GeoMechanicsApplication/custom_conditions/line_load_2D_diff_order_condition.cpp
+++ b/applications/GeoMechanicsApplication/custom_conditions/line_load_2D_diff_order_condition.cpp
@@ -15,6 +15,7 @@
 // Project includes
 #include "custom_conditions/line_load_2D_diff_order_condition.h"
 #include "custom_utilities/condition_utilities.hpp"
+#include "custom_utilities/variables_utilities.hpp"
 
 namespace Kratos
 {
@@ -52,12 +53,13 @@ void LineLoad2DDiffOrderCondition::CalculateConditionVector(ConditionVariables& 
     KRATOS_TRY
 
     const GeometryType& r_geometry = GetGeometry();
+    const auto line_load_vector    = VariablesUtilities::GetNodalValues(r_geometry, LINE_LOAD);
+
     rVariables.ConditionVector.resize(2, false);
     noalias(rVariables.ConditionVector) = ZeroVector(2);
     for (SizeType i = 0; i < r_geometry.PointsNumber(); ++i) {
-        auto line_load = r_geometry[i].FastGetSolutionStepValue(LINE_LOAD);
-        rVariables.ConditionVector[0] += rVariables.Nu[i] * line_load[0];
-        rVariables.ConditionVector[1] += rVariables.Nu[i] * line_load[1];
+        rVariables.ConditionVector[0] += rVariables.Nu[i] * line_load_vector[i][0];
+        rVariables.ConditionVector[1] += rVariables.Nu[i] * line_load_vector[i][1];
     }
 
     KRATOS_CATCH("")

--- a/applications/GeoMechanicsApplication/custom_conditions/line_load_2D_diff_order_condition.cpp
+++ b/applications/GeoMechanicsApplication/custom_conditions/line_load_2D_diff_order_condition.cpp
@@ -52,14 +52,13 @@ void LineLoad2DDiffOrderCondition::CalculateConditionVector(ConditionVariables& 
 {
     KRATOS_TRY
 
-    const GeometryType& r_geometry = GetGeometry();
-    const auto line_load_vector    = VariablesUtilities::GetNodalValues(r_geometry, LINE_LOAD);
+    const auto line_load_vectors = VariablesUtilities::GetNodalValues(GetGeometry(), LINE_LOAD);
 
     rVariables.ConditionVector.resize(2, false);
     noalias(rVariables.ConditionVector) = ZeroVector(2);
-    for (SizeType i = 0; i < r_geometry.PointsNumber(); ++i) {
-        rVariables.ConditionVector[0] += rVariables.Nu[i] * line_load_vector[i][0];
-        rVariables.ConditionVector[1] += rVariables.Nu[i] * line_load_vector[i][1];
+    for (SizeType i = 0; i < line_load_vectors.size(); ++i) {
+        rVariables.ConditionVector[0] += rVariables.Nu[i] * line_load_vectors[i][0];
+        rVariables.ConditionVector[1] += rVariables.Nu[i] * line_load_vectors[i][1];
     }
 
     KRATOS_CATCH("")

--- a/applications/GeoMechanicsApplication/custom_conditions/line_normal_fluid_flux_2D_diff_order_condition.cpp
+++ b/applications/GeoMechanicsApplication/custom_conditions/line_normal_fluid_flux_2D_diff_order_condition.cpp
@@ -56,7 +56,7 @@ void LineNormalFluidFlux2DDiffOrderCondition::CalculateConditionVector(Condition
                                                                        unsigned int PointNumber)
 {
     KRATOS_TRY
-    auto nodal_normal_fluid_flux_vector =
+    const auto nodal_normal_fluid_flux_vector =
         VariablesUtilities::GetNodalValues(*mpPressureGeometry, NORMAL_FLUID_FLUX);
     rVariables.ConditionVector =
         ScalarVector(1, std::inner_product(rVariables.Np.cbegin(), rVariables.Np.cend(),

--- a/applications/GeoMechanicsApplication/custom_conditions/line_normal_fluid_flux_2D_diff_order_condition.cpp
+++ b/applications/GeoMechanicsApplication/custom_conditions/line_normal_fluid_flux_2D_diff_order_condition.cpp
@@ -56,9 +56,8 @@ void LineNormalFluidFlux2DDiffOrderCondition::CalculateConditionVector(Condition
                                                                        unsigned int PointNumber)
 {
     KRATOS_TRY
-    Vector nodal_normal_fluid_flux_vector(mpPressureGeometry->PointsNumber());
-    VariablesUtilities::GetNodalValues(*mpPressureGeometry, NORMAL_FLUID_FLUX,
-                                       nodal_normal_fluid_flux_vector.begin());
+    auto nodal_normal_fluid_flux_vector =
+        VariablesUtilities::GetNodalValues(*mpPressureGeometry, NORMAL_FLUID_FLUX);
     rVariables.ConditionVector =
         ScalarVector(1, std::inner_product(rVariables.Np.cbegin(), rVariables.Np.cend(),
                                            nodal_normal_fluid_flux_vector.cbegin(), 0.0));

--- a/applications/GeoMechanicsApplication/custom_conditions/line_normal_load_2D_diff_order_condition.cpp
+++ b/applications/GeoMechanicsApplication/custom_conditions/line_normal_load_2D_diff_order_condition.cpp
@@ -63,8 +63,7 @@ void LineNormalLoad2DDiffOrderCondition::CalculateConditionVector(ConditionVaria
     Vector tangential_vector = ZeroVector(3);
     tangential_vector[0]     = column(rVariables.JContainer[PointNumber], 0)[0];
     tangential_vector[1]     = column(rVariables.JContainer[PointNumber], 0)[1];
-    Vector tangential_stresses(r_geometry.PointsNumber());
-    VariablesUtilities::GetNodalValues(r_geometry, TANGENTIAL_CONTACT_STRESS, tangential_stresses.begin());
+    auto tangential_stresses = VariablesUtilities::GetNodalValues(r_geometry, TANGENTIAL_CONTACT_STRESS);
     const auto tangential_stress = std::inner_product(rVariables.Nu.cbegin(), rVariables.Nu.cend(),
                                                       tangential_stresses.cbegin(), 0.0);
 
@@ -72,8 +71,7 @@ void LineNormalLoad2DDiffOrderCondition::CalculateConditionVector(ConditionVaria
     out_of_plane_vector[2]     = 1.0;
     Vector normal_vector       = ZeroVector(3);
     MathUtils<double>::CrossProduct(normal_vector, out_of_plane_vector, tangential_vector);
-    Vector normal_stresses(r_geometry.PointsNumber());
-    VariablesUtilities::GetNodalValues(r_geometry, NORMAL_CONTACT_STRESS, normal_stresses.begin());
+    auto normal_stresses = VariablesUtilities::GetNodalValues(r_geometry, NORMAL_CONTACT_STRESS);
     const auto normal_stress =
         std::inner_product(rVariables.Nu.cbegin(), rVariables.Nu.cend(), normal_stresses.cbegin(), 0.0);
 

--- a/applications/GeoMechanicsApplication/custom_conditions/line_normal_load_2D_diff_order_condition.cpp
+++ b/applications/GeoMechanicsApplication/custom_conditions/line_normal_load_2D_diff_order_condition.cpp
@@ -63,7 +63,7 @@ void LineNormalLoad2DDiffOrderCondition::CalculateConditionVector(ConditionVaria
     Vector tangential_vector = ZeroVector(3);
     tangential_vector[0]     = column(rVariables.JContainer[PointNumber], 0)[0];
     tangential_vector[1]     = column(rVariables.JContainer[PointNumber], 0)[1];
-    auto tangential_stresses = VariablesUtilities::GetNodalValues(r_geometry, TANGENTIAL_CONTACT_STRESS);
+    const auto tangential_stresses = VariablesUtilities::GetNodalValues(r_geometry, TANGENTIAL_CONTACT_STRESS);
     const auto tangential_stress = std::inner_product(rVariables.Nu.cbegin(), rVariables.Nu.cend(),
                                                       tangential_stresses.cbegin(), 0.0);
 
@@ -71,11 +71,11 @@ void LineNormalLoad2DDiffOrderCondition::CalculateConditionVector(ConditionVaria
     out_of_plane_vector[2]     = 1.0;
     Vector normal_vector       = ZeroVector(3);
     MathUtils<double>::CrossProduct(normal_vector, out_of_plane_vector, tangential_vector);
-    auto normal_stresses = VariablesUtilities::GetNodalValues(r_geometry, NORMAL_CONTACT_STRESS);
+    const auto normal_stresses = VariablesUtilities::GetNodalValues(r_geometry, NORMAL_CONTACT_STRESS);
     const auto normal_stress =
         std::inner_product(rVariables.Nu.cbegin(), rVariables.Nu.cend(), normal_stresses.cbegin(), 0.0);
 
-    auto traction_vector = tangential_stress * tangential_vector + normal_stress * normal_vector;
+    const auto traction_vector = tangential_stress * tangential_vector + normal_stress * normal_vector;
 
     rVariables.ConditionVector.resize(2, false);
     rVariables.ConditionVector[0] = traction_vector[0];

--- a/applications/GeoMechanicsApplication/custom_conditions/surface_normal_fluid_flux_3D_diff_order_condition.cpp
+++ b/applications/GeoMechanicsApplication/custom_conditions/surface_normal_fluid_flux_3D_diff_order_condition.cpp
@@ -56,9 +56,8 @@ void SurfaceNormalFluidFlux3DDiffOrderCondition::CalculateConditionVector(Condit
                                                                           unsigned int PointNumber)
 {
     KRATOS_TRY
-    Vector nodal_normal_fluid_flux_vector(mpPressureGeometry->PointsNumber());
-    VariablesUtilities::GetNodalValues(*mpPressureGeometry, NORMAL_FLUID_FLUX,
-                                       nodal_normal_fluid_flux_vector.begin());
+    auto nodal_normal_fluid_flux_vector =
+        VariablesUtilities::GetNodalValues(*mpPressureGeometry, NORMAL_FLUID_FLUX);
     rVariables.ConditionVector =
         ScalarVector{1, std::inner_product(rVariables.Np.cbegin(), rVariables.Np.cend(),
                                            nodal_normal_fluid_flux_vector.cbegin(), 0.0)};

--- a/applications/GeoMechanicsApplication/custom_conditions/surface_normal_fluid_flux_3D_diff_order_condition.cpp
+++ b/applications/GeoMechanicsApplication/custom_conditions/surface_normal_fluid_flux_3D_diff_order_condition.cpp
@@ -56,7 +56,7 @@ void SurfaceNormalFluidFlux3DDiffOrderCondition::CalculateConditionVector(Condit
                                                                           unsigned int PointNumber)
 {
     KRATOS_TRY
-    auto nodal_normal_fluid_flux_vector =
+    const auto nodal_normal_fluid_flux_vector =
         VariablesUtilities::GetNodalValues(*mpPressureGeometry, NORMAL_FLUID_FLUX);
     rVariables.ConditionVector =
         ScalarVector{1, std::inner_product(rVariables.Np.cbegin(), rVariables.Np.cend(),

--- a/applications/GeoMechanicsApplication/custom_conditions/surface_normal_load_3D_diff_order_condition.cpp
+++ b/applications/GeoMechanicsApplication/custom_conditions/surface_normal_load_3D_diff_order_condition.cpp
@@ -64,7 +64,7 @@ void SurfaceNormalLoad3DDiffOrderCondition::CalculateConditionVector(ConditionVa
     MathUtils<double>::CrossProduct(normal_vector, column(rVariables.JContainer[PointNumber], 0),
                                     column(rVariables.JContainer[PointNumber], 1));
 
-    auto normal_stresses = VariablesUtilities::GetNodalValues(GetGeometry(), NORMAL_CONTACT_STRESS);
+    const auto normal_stresses = VariablesUtilities::GetNodalValues(GetGeometry(), NORMAL_CONTACT_STRESS);
 
     // Since the normal vector is pointing outwards for the 3D conditions, the normal stress
     // should switch sign, such that positive normal contact stress is defined inwards.

--- a/applications/GeoMechanicsApplication/custom_conditions/surface_normal_load_3D_diff_order_condition.cpp
+++ b/applications/GeoMechanicsApplication/custom_conditions/surface_normal_load_3D_diff_order_condition.cpp
@@ -64,9 +64,7 @@ void SurfaceNormalLoad3DDiffOrderCondition::CalculateConditionVector(ConditionVa
     MathUtils<double>::CrossProduct(normal_vector, column(rVariables.JContainer[PointNumber], 0),
                                     column(rVariables.JContainer[PointNumber], 1));
 
-    const auto& r_geometry = GetGeometry();
-    Vector      normal_stresses(r_geometry.PointsNumber());
-    VariablesUtilities::GetNodalValues(r_geometry, NORMAL_CONTACT_STRESS, normal_stresses.begin());
+    auto normal_stresses = VariablesUtilities::GetNodalValues(GetGeometry(), NORMAL_CONTACT_STRESS);
 
     // Since the normal vector is pointing outwards for the 3D conditions, the normal stress
     // should switch sign, such that positive normal contact stress is defined inwards.

--- a/applications/GeoMechanicsApplication/custom_elements/Pw_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/Pw_element.cpp
@@ -491,7 +491,7 @@ template <unsigned int TDim, unsigned int TNumNodes>
 std::vector<double> PwElement<TDim, TNumNodes>::CalculateFluidPressure()
 {
     return GeoTransportEquationUtilities::CalculateFluidPressures(
-        mNContainer, VariablesUtilities::GetNodalValuesOf<TNumNodes>(WATER_PRESSURE, this->GetGeometry()));
+        mNContainer, VariablesUtilities::GetNodalValuesOf<TNumNodes>(this->GetGeometry(), WATER_PRESSURE));
 }
 
 template <unsigned int TDim, unsigned int TNumNodes>

--- a/applications/GeoMechanicsApplication/custom_elements/Pw_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/Pw_element.cpp
@@ -491,7 +491,7 @@ template <unsigned int TDim, unsigned int TNumNodes>
 std::vector<double> PwElement<TDim, TNumNodes>::CalculateFluidPressure()
 {
     return GeoTransportEquationUtilities::CalculateFluidPressures(
-        mNContainer, VariablesUtilities::GetNodalValuesOf<TNumNodes>(this->GetGeometry(), WATER_PRESSURE));
+        mNContainer, VariablesUtilities::GetNodalValues<TNumNodes>(this->GetGeometry(), WATER_PRESSURE));
 }
 
 template <unsigned int TDim, unsigned int TNumNodes>

--- a/applications/GeoMechanicsApplication/custom_elements/Pw_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/Pw_element.cpp
@@ -147,10 +147,9 @@ void PwElement<TDim, TNumNodes>::CalculateOnIntegrationPoints(const Variable<dou
         rVariable == DERIVATIVE_OF_SATURATION || rVariable == RELATIVE_PERMEABILITY) {
         Matrix N_container(number_of_integration_points, TNumNodes);
         N_container = r_geometry.ShapeFunctionsValues(this->GetIntegrationMethod());
-        RetentionLaw::Parameters    RetentionParameters(r_properties);
-        Vector                      Np(TNumNodes);
-        array_1d<double, TNumNodes> pressure_vector;
-        VariablesUtilities::GetNodalValues(r_geometry, WATER_PRESSURE, pressure_vector.begin());
+        RetentionLaw::Parameters RetentionParameters(r_properties);
+        Vector                   Np(TNumNodes);
+        const auto pressure_vector = VariablesUtilities::GetNodalValues<TNumNodes>(r_geometry, WATER_PRESSURE);
 
         for (unsigned int integration_point = 0; integration_point < number_of_integration_points;
              ++integration_point) {

--- a/applications/GeoMechanicsApplication/custom_elements/Pw_element.hpp
+++ b/applications/GeoMechanicsApplication/custom_elements/Pw_element.hpp
@@ -181,7 +181,7 @@ private:
     auto MakeNodalVariableGetter() const
     {
         return [this](const Variable<double>& rVariable) -> Vector {
-            return VariablesUtilities::GetNodalValuesOf<TNumNodes>(this->GetGeometry(), rVariable);
+            return VariablesUtilities::GetNodalValues<TNumNodes>(this->GetGeometry(), rVariable);
         };
     }
 

--- a/applications/GeoMechanicsApplication/custom_elements/Pw_element.hpp
+++ b/applications/GeoMechanicsApplication/custom_elements/Pw_element.hpp
@@ -181,7 +181,7 @@ private:
     auto MakeNodalVariableGetter() const
     {
         return [this](const Variable<double>& rVariable) -> Vector {
-            return VariablesUtilities::GetNodalValuesOf<TNumNodes>(rVariable, this->GetGeometry());
+            return VariablesUtilities::GetNodalValuesOf<TNumNodes>(this->GetGeometry(), rVariable);
         };
     }
 

--- a/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_element.cpp
@@ -1258,8 +1258,8 @@ void UPwSmallStrainElement<TDim, TNumNodes>::InitializeNodalPorePressureVariable
     KRATOS_TRY
 
     const auto& r_geometry = this->GetGeometry();
-    rVariables.PressureVector = VariablesUtilities::GetNodalValues<TNumNodes>(r_geometry, WATER_PRESSURE);
-    rVariables.DtPressureVector = VariablesUtilities::GetNodalValues<TNumNodes>(r_geometry, DT_WATER_PRESSURE);
+    VariablesUtilities::GetNodalValues(r_geometry, WATER_PRESSURE, rVariables.PressureVector.begin());
+    VariablesUtilities::GetNodalValues(r_geometry, DT_WATER_PRESSURE, rVariables.DtPressureVector.begin());
 
     KRATOS_CATCH("")
 }

--- a/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_element.cpp
@@ -1257,9 +1257,9 @@ void UPwSmallStrainElement<TDim, TNumNodes>::InitializeNodalPorePressureVariable
 {
     KRATOS_TRY
 
-    const GeometryType& r_geometry = this->GetGeometry();
-    VariablesUtilities::GetNodalValues(r_geometry, WATER_PRESSURE, rVariables.PressureVector.begin());
-    VariablesUtilities::GetNodalValues(r_geometry, DT_WATER_PRESSURE, rVariables.DtPressureVector.begin());
+    const auto& r_geometry = this->GetGeometry();
+    rVariables.PressureVector = VariablesUtilities::GetNodalValues<TNumNodes>(r_geometry, WATER_PRESSURE);
+    rVariables.DtPressureVector = VariablesUtilities::GetNodalValues<TNumNodes>(r_geometry, DT_WATER_PRESSURE);
 
     KRATOS_CATCH("")
 }
@@ -1269,7 +1269,7 @@ void UPwSmallStrainElement<TDim, TNumNodes>::InitializeNodalDisplacementVariable
 {
     KRATOS_TRY
 
-    const GeometryType& r_geometry = this->GetGeometry();
+    const auto& r_geometry = this->GetGeometry();
 
     // Nodal variables
     GeoElementUtilities::GetNodalVariableVector<TDim, TNumNodes>(rVariables.DisplacementVector,

--- a/applications/GeoMechanicsApplication/custom_elements/geo_steady_state_Pw_piping_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/geo_steady_state_Pw_piping_element.cpp
@@ -285,7 +285,7 @@ void GeoSteadyStatePwPipingElement<TDim, TNumNodes>::AddContributionsToRhsVector
     const array_1d<double, TNumNodes>&                 rFluidBodyVector) const
 {
     const auto permeability_vector = array_1d<double, TNumNodes>{-prod(
-        rPermeabilityMatrix, VariablesUtilities::GetNodalValuesOf<TNumNodes>(GetGeometry(), WATER_PRESSURE))};
+        rPermeabilityMatrix, VariablesUtilities::GetNodalValues<TNumNodes>(GetGeometry(), WATER_PRESSURE))};
     rRightHandSideVector           = permeability_vector + rFluidBodyVector;
 }
 

--- a/applications/GeoMechanicsApplication/custom_elements/geo_steady_state_Pw_piping_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/geo_steady_state_Pw_piping_element.cpp
@@ -285,7 +285,7 @@ void GeoSteadyStatePwPipingElement<TDim, TNumNodes>::AddContributionsToRhsVector
     const array_1d<double, TNumNodes>&                 rFluidBodyVector) const
 {
     const auto permeability_vector = array_1d<double, TNumNodes>{-prod(
-        rPermeabilityMatrix, VariablesUtilities::GetNodalValuesOf<TNumNodes>(WATER_PRESSURE, GetGeometry()))};
+        rPermeabilityMatrix, VariablesUtilities::GetNodalValuesOf<TNumNodes>(GetGeometry(), WATER_PRESSURE))};
     rRightHandSideVector           = permeability_vector + rFluidBodyVector;
 }
 

--- a/applications/GeoMechanicsApplication/custom_elements/transient_thermal_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/transient_thermal_element.cpp
@@ -194,10 +194,10 @@ void TransientThermalElement<TDim, TNumNodes>::AddContributionsToRhsVector(
     const BoundedMatrix<double, TNumNodes, TNumNodes>& rCapacityMatrix) const
 {
     const auto capacity_vector     = array_1d<double, TNumNodes>{-prod(
-        rCapacityMatrix, VariablesUtilities::GetNodalValuesOf<TNumNodes>(DT_TEMPERATURE, this->GetGeometry()))};
+        rCapacityMatrix, VariablesUtilities::GetNodalValuesOf<TNumNodes>(this->GetGeometry(), DT_TEMPERATURE))};
     rRightHandSideVector           = capacity_vector;
     const auto conductivity_vector = array_1d<double, TNumNodes>{-prod(
-        rConductivityMatrix, VariablesUtilities::GetNodalValuesOf<TNumNodes>(TEMPERATURE, this->GetGeometry()))};
+        rConductivityMatrix, VariablesUtilities::GetNodalValuesOf<TNumNodes>(this->GetGeometry(), TEMPERATURE))};
     rRightHandSideVector += conductivity_vector;
 }
 

--- a/applications/GeoMechanicsApplication/custom_elements/transient_thermal_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/transient_thermal_element.cpp
@@ -194,10 +194,10 @@ void TransientThermalElement<TDim, TNumNodes>::AddContributionsToRhsVector(
     const BoundedMatrix<double, TNumNodes, TNumNodes>& rCapacityMatrix) const
 {
     const auto capacity_vector     = array_1d<double, TNumNodes>{-prod(
-        rCapacityMatrix, VariablesUtilities::GetNodalValuesOf<TNumNodes>(this->GetGeometry(), DT_TEMPERATURE))};
+        rCapacityMatrix, VariablesUtilities::GetNodalValues<TNumNodes>(this->GetGeometry(), DT_TEMPERATURE))};
     rRightHandSideVector           = capacity_vector;
     const auto conductivity_vector = array_1d<double, TNumNodes>{-prod(
-        rConductivityMatrix, VariablesUtilities::GetNodalValuesOf<TNumNodes>(this->GetGeometry(), TEMPERATURE))};
+        rConductivityMatrix, VariablesUtilities::GetNodalValues<TNumNodes>(this->GetGeometry(), TEMPERATURE))};
     rRightHandSideVector += conductivity_vector;
 }
 

--- a/applications/GeoMechanicsApplication/custom_utilities/transport_equation_utilities.hpp
+++ b/applications/GeoMechanicsApplication/custom_utilities/transport_equation_utilities.hpp
@@ -55,8 +55,7 @@ public:
 
         std::vector<array_1d<double, TDim>> fluid_fluxes;
         fluid_fluxes.reserve(number_of_integration_points);
-        array_1d<double, TNumNodes> pressure_vector;
-        VariablesUtilities::GetNodalValues(rGeometry, WATER_PRESSURE, pressure_vector.begin());
+        const auto pressure_vector = VariablesUtilities::GetNodalValues<TNumNodes>(rGeometry, WATER_PRESSURE);
         Matrix N_container(number_of_integration_points, TNumNodes);
         N_container = rGeometry.ShapeFunctionsValues(IntegrationMethod);
         BoundedMatrix<double, TDim, TDim> permeability_matrix;

--- a/applications/GeoMechanicsApplication/custom_utilities/variables_utilities.hpp
+++ b/applications/GeoMechanicsApplication/custom_utilities/variables_utilities.hpp
@@ -25,11 +25,12 @@ namespace Kratos
 class KRATOS_API(GEO_MECHANICS_APPLICATION) VariablesUtilities
 {
 public:
-    template <typename OutputIt>
-    static OutputIt GetNodalValues(const Geometry<Node>& rGeometry, const Variable<double>& rNodalVariable, OutputIt FirstOut)
+    template <typename NodeContainerType, typename DataType, typename OutputIt>
+    static OutputIt GetNodalValues(const NodeContainerType& rNodes, const Variable<DataType>& rNodalVariable, OutputIt FirstOut)
     {
-        return std::transform(rGeometry.begin(), rGeometry.end(), FirstOut, [&rNodalVariable](const auto& node) {
-            return node.FastGetSolutionStepValue(rNodalVariable);
+        return std::transform(std::begin(rNodes), std::end(rNodes), FirstOut,
+                              [&rNodalVariable](const auto& rNode) {
+            return rNode.FastGetSolutionStepValue(rNodalVariable);
         });
     }
 
@@ -47,10 +48,7 @@ public:
     {
         auto result = std::vector<DataType>{};
         result.reserve(rNodes.size());
-        auto get_nodal_value = [&rVariable](const auto& rNode) {
-            return rNode.FastGetSolutionStepValue(rVariable);
-        };
-        std::ranges::transform(rNodes, std::back_inserter(result), get_nodal_value);
+        GetNodalValues(rNodes, rVariable, std::back_inserter(result));
         return result;
     }
 

--- a/applications/GeoMechanicsApplication/custom_utilities/variables_utilities.hpp
+++ b/applications/GeoMechanicsApplication/custom_utilities/variables_utilities.hpp
@@ -34,12 +34,12 @@ public:
         });
     }
 
-    template <unsigned int TNumNodes>
-    static array_1d<double, TNumNodes> GetNodalValuesOf(const Geometry<Node>&   rGeometry,
-                                                        const Variable<double>& rNodalVariable)
+    template <unsigned int TNumNodes, typename NodeContainerType>
+    static array_1d<double, TNumNodes> GetNodalValuesOf(const NodeContainerType& rNodes,
+                                                        const Variable<double>&  rNodalVariable)
     {
         auto result = array_1d<double, TNumNodes>{};
-        GetNodalValues(rGeometry, rNodalVariable, result.begin());
+        GetNodalValues(rNodes, rNodalVariable, result.begin());
         return result;
     }
 

--- a/applications/GeoMechanicsApplication/custom_utilities/variables_utilities.hpp
+++ b/applications/GeoMechanicsApplication/custom_utilities/variables_utilities.hpp
@@ -35,8 +35,8 @@ public:
     }
 
     template <unsigned int TNumNodes>
-    static array_1d<double, TNumNodes> GetNodalValuesOf(const Variable<double>& rNodalVariable,
-                                                        const Geometry<Node>&   rGeometry)
+    static array_1d<double, TNumNodes> GetNodalValuesOf(const Geometry<Node>&   rGeometry,
+                                                        const Variable<double>& rNodalVariable)
     {
         auto result = array_1d<double, TNumNodes>{};
         GetNodalValues(rGeometry, rNodalVariable, result.begin());

--- a/applications/GeoMechanicsApplication/custom_utilities/variables_utilities.hpp
+++ b/applications/GeoMechanicsApplication/custom_utilities/variables_utilities.hpp
@@ -35,8 +35,8 @@ public:
     }
 
     template <unsigned int TNumNodes, typename NodeContainerType>
-    static array_1d<double, TNumNodes> GetNodalValuesOf(const NodeContainerType& rNodes,
-                                                        const Variable<double>&  rNodalVariable)
+    static array_1d<double, TNumNodes> GetNodalValues(const NodeContainerType& rNodes,
+                                                      const Variable<double>&  rNodalVariable)
     {
         auto result = array_1d<double, TNumNodes>{};
         GetNodalValues(rNodes, rNodalVariable, result.begin());

--- a/applications/GeoMechanicsApplication/custom_utilities/variables_utilities.hpp
+++ b/applications/GeoMechanicsApplication/custom_utilities/variables_utilities.hpp
@@ -42,6 +42,18 @@ public:
         return result;
     }
 
+    template <typename NodeContainerType, typename DataType>
+    static std::vector<DataType> GetNodalValues(const NodeContainerType& rNodes, const Variable<DataType>& rVariable)
+    {
+        auto result = std::vector<DataType>{};
+        result.reserve(rNodes.size());
+        auto get_nodal_value = [&rVariable](const auto& rNode) {
+            return rNode.FastGetSolutionStepValue(rVariable);
+        };
+        std::ranges::transform(rNodes, std::back_inserter(result), get_nodal_value);
+        return result;
+    }
+
     static const Variable<double>& GetComponentFromVectorVariable(const std::string& rSourceVariableName,
                                                                   const std::string& rComponent);
 };

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_processes/test_geo_extrapolate_integration_point_values_to_nodes_process.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_processes/test_geo_extrapolate_integration_point_values_to_nodes_process.cpp
@@ -12,6 +12,7 @@
 
 #include "containers/model.h"
 #include "custom_processes/geo_extrapolate_integration_point_values_to_nodes_process.hpp"
+#include "custom_utilities/variables_utilities.hpp"
 #include "geo_mechanics_application_variables.h"
 #include "geometries/quadrilateral_2d_4.h"
 #include "test_setup_utilities/model_setup_utilities.h"
@@ -196,25 +197,13 @@ void CreateAndRunExtrapolationProcess(Model& rModel, const Parameters& rProcessS
     extrapolation_process.ExecuteFinalizeSolutionStep();
 }
 
-template <typename NodeContainerType, typename DataType>
-std::vector<DataType> GetNodalValues(const NodeContainerType& rNodes, const Variable<DataType>& rVariable)
-{
-    auto result = std::vector<DataType>{};
-    result.reserve(rNodes.size());
-    auto get_nodal_value = [&rVariable](const auto& rNode) {
-        return rNode.FastGetSolutionStepValue(rVariable);
-    };
-    std::ranges::transform(rNodes, std::back_inserter(result), get_nodal_value);
-    return result;
-}
-
 template <typename NodeContainerType>
 void AssertNodalValues(const NodeContainerType&   rNodes,
                        const Variable<double>&    rVariable,
                        const std::vector<double>& rExpectedNodalValues)
 {
-    KRATOS_EXPECT_VECTOR_NEAR(GetNodalValues(rNodes, rVariable), rExpectedNodalValues,
-                              Testing::Defaults::absolute_tolerance);
+    KRATOS_EXPECT_VECTOR_NEAR(VariablesUtilities::GetNodalValues(rNodes, rVariable),
+                              rExpectedNodalValues, Testing::Defaults::absolute_tolerance);
 }
 
 template <typename NodeContainerType, typename VectorType>
@@ -222,7 +211,7 @@ void AssertNodalVectorValues(const NodeContainerType&       rNodes,
                              const Variable<VectorType>&    rVectorVariable,
                              const std::vector<VectorType>& rExpectedNodalVectorValues)
 {
-    const auto actual_nodal_vector_values = GetNodalValues(rNodes, rVectorVariable);
+    const auto actual_nodal_vector_values = VariablesUtilities::GetNodalValues(rNodes, rVectorVariable);
 
     ASSERT_EQ(actual_nodal_vector_values.size(), rExpectedNodalVectorValues.size());
     for (auto i = std::size_t{0}; i < actual_nodal_vector_values.size(); ++i) {
@@ -252,7 +241,7 @@ void AssertNodalValues(const NodeContainerType&   rNodes,
                        const Variable<Matrix>&    rVariable,
                        const std::vector<Matrix>& rExpectedNodalValues)
 {
-    const auto actual_nodal_values = GetNodalValues(rNodes, rVariable);
+    const auto actual_nodal_values = VariablesUtilities::GetNodalValues(rNodes, rVariable);
 
     ASSERT_EQ(actual_nodal_values.size(), rExpectedNodalValues.size());
     for (auto i = std::size_t{0}; i < actual_nodal_values.size(); ++i) {

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_utilities/test_variables_utilities.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_utilities/test_variables_utilities.cpp
@@ -44,7 +44,7 @@ KRATOS_TEST_CASE_IN_SUITE(GeometryUtilities_ReturnsGetNodalValues, KratosGeoMech
     }
 
     // Act
-    const auto temperatures = VariablesUtilities::GetNodalValuesOf<2>(TEMPERATURE, geometry);
+    const auto temperatures = VariablesUtilities::GetNodalValuesOf<2>(geometry, TEMPERATURE);
 
     // Assert
     auto expected_temperatures = std::vector({4.5, 4.5});

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_utilities/test_variables_utilities.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_utilities/test_variables_utilities.cpp
@@ -44,7 +44,7 @@ KRATOS_TEST_CASE_IN_SUITE(GeometryUtilities_ReturnsGetNodalValues, KratosGeoMech
     }
 
     // Act
-    const auto temperatures = VariablesUtilities::GetNodalValuesOf<2>(geometry, TEMPERATURE);
+    const auto temperatures = VariablesUtilities::GetNodalValues<2>(geometry, TEMPERATURE);
 
     // Assert
     auto expected_temperatures = std::vector({4.5, 4.5});

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_utilities/test_variables_utilities.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_utilities/test_variables_utilities.cpp
@@ -51,7 +51,8 @@ KRATOS_TEST_CASE_IN_SUITE(GeometryUtilities_ReturnsGetNodalValues, KratosGeoMech
     KRATOS_EXPECT_VECTOR_EQ(temperatures, expected_temperatures);
 
     // Act
-    auto more_temperatures = VariablesUtilities::GetNodalValues(r_model_part.Nodes(), TEMPERATURE);
+    const auto more_temperatures = VariablesUtilities::GetNodalValues(r_model_part.Nodes(), TEMPERATURE);
+
     // Assert
     KRATOS_EXPECT_VECTOR_EQ(temperatures, expected_temperatures);
 }

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_utilities/test_variables_utilities.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_utilities/test_variables_utilities.cpp
@@ -28,7 +28,7 @@ KRATOS_TEST_CASE_IN_SUITE(TestVariablesUtilitiesThrowsWhenComponentDoesNotExist,
     VariablesUtilities::GetComponentFromVectorVariable(ACCELERATION.Name(), "?"),
     "Error: The component \"ACCELERATION_?\" is not registered!")}
 
-KRATOS_TEST_CASE_IN_SUITE(GeometryUtilities_ReturnsGetNodalValuesOf, KratosGeoMechanicsFastSuiteWithoutKernel)
+KRATOS_TEST_CASE_IN_SUITE(GeometryUtilities_ReturnsGetNodalValues, KratosGeoMechanicsFastSuiteWithoutKernel)
 {
     // Arrange
     Model model;
@@ -47,7 +47,13 @@ KRATOS_TEST_CASE_IN_SUITE(GeometryUtilities_ReturnsGetNodalValuesOf, KratosGeoMe
     const auto temperatures = VariablesUtilities::GetNodalValuesOf<2>(TEMPERATURE, geometry);
 
     // Assert
-    KRATOS_EXPECT_VECTOR_EQ(temperatures, std::vector({4.5, 4.5}));
+    auto expected_temperatures = std::vector({4.5, 4.5});
+    KRATOS_EXPECT_VECTOR_EQ(temperatures, expected_temperatures);
+
+    // Act
+    auto more_temperatures = VariablesUtilities::GetNodalValues(r_model_part.Nodes(), TEMPERATURE);
+    // Assert
+    KRATOS_EXPECT_VECTOR_EQ(temperatures, expected_temperatures);
 }
 
 } // namespace Kratos::Testing


### PR DESCRIPTION
**📝 Description**
Generalized functionality of GetNodalValues

**🆕 Changelog**
- One implementation with std::transform 
- All now use NodeContainerType ( not Geometry&)
- Argument order unified
- GetNodalValuesOf renamed to GetNodalValues
