### PR TITLE
[Core] Add Clone method to TensorAdaptor

### DIFF
--- a/kratos/python/add_tensor_adaptors_to_python.cpp
+++ b/kratos/python/add_tensor_adaptors_to_python.cpp
@@ -45,298 +45,259 @@ namespace Kratos::Python {
 namespace Detail {
 
 template <class TDataType>
-void AddBaseTensorAdaptor(pybind11::module &rModule, const std::string &rName) {
-  // add the base tensor adaptor
-  using tensor_adaptor = TensorAdaptor<TDataType>;
-  pybind11::class_<tensor_adaptor, typename tensor_adaptor::Pointer>(
-      rModule, (rName + "Adaptor").c_str())
-      .def(pybind11::init<typename tensor_adaptor::ContainerPointerType,
-                          typename NDData<TDataType>::Pointer, const bool>(),
-           pybind11::arg("container"), pybind11::arg("nd_data"),
-           pybind11::arg("copy") = true)
-      .def(pybind11::init<const tensor_adaptor &, const bool>(),
-           pybind11::arg("tensor_adaptor"), pybind11::arg("copy") = true)
-      .def("Check", &tensor_adaptor::Check)
-      .def("CollectData", &tensor_adaptor::CollectData)
-      .def("StoreData", &tensor_adaptor::StoreData)
-      .def("GetContainer", &tensor_adaptor::GetContainer)
-      .def("HasContainer", &tensor_adaptor::HasContainer)
-      .def("Shape", &tensor_adaptor::Shape)
-      .def("DataShape", &tensor_adaptor::DataShape)
-      .def("Size", &tensor_adaptor::Size)
-      .def("__str__", PrintObject<tensor_adaptor>)
-      .def("ViewData",
-           [](tensor_adaptor &rSelf) {
-             return GetPybindArray<TDataType>(*rSelf.pGetStorage());
-           })
-      .def(
-          "SetData",
-          [](tensor_adaptor &rSelf, const pybind11::array &rArray) {
-            SetPybindArray<TDataType>(*rSelf.pGetStorage(), rArray);
-          },
-          pybind11::arg("array").noconvert())
-      .def_property(
-          "data",
-          [](tensor_adaptor &rSelf) {
-            return GetPybindArray<TDataType>(*rSelf.pGetStorage());
-          },
-          pybind11::cpp_function(
-              [](tensor_adaptor &rSelf, const pybind11::array &rArray) {
-                SetPybindArray<TDataType>(*rSelf.pGetStorage(), rArray);
-              },
-              pybind11::arg("self"),
-              // no convert makes sure that the numpy arrays are
-              // not converted, hence nothing will be copied. numpy
-              // array will be passed as it is to the SetPybindArray
-              // method.
-              pybind11::arg("array").noconvert()));
+void AddBaseTensorAdaptor(
+     pybind11::module& rModule,
+     const std::string& rName)
+{
+     // add the base tensor adaptor
+     using tensor_adaptor = TensorAdaptor<TDataType>;
+     pybind11::class_<tensor_adaptor, typename tensor_adaptor::Pointer>(rModule, (rName + "Adaptor").c_str())
+          .def(pybind11::init<typename tensor_adaptor::ContainerPointerType, typename NDData<TDataType>::Pointer, const bool>(),
+               pybind11::arg("container"),
+               pybind11::arg("nd_data"),
+               pybind11::arg("copy") = true)
+          .def(pybind11::init<const tensor_adaptor&, const bool>(),
+               pybind11::arg("tensor_adaptor"),
+               pybind11::arg("copy") = true)
+          .def("Clone", &tensor_adaptor::Clone)
+          .def("Check", &tensor_adaptor::Check)
+          .def("CollectData", &tensor_adaptor::CollectData)
+          .def("StoreData", &tensor_adaptor::StoreData)
+          .def("GetContainer", &tensor_adaptor::GetContainer)
+          .def("HasContainer", &tensor_adaptor::HasContainer)
+          .def("Shape", &tensor_adaptor::Shape)
+          .def("DataShape", &tensor_adaptor::DataShape)
+          .def("Size", &tensor_adaptor::Size)
+          .def("__str__", PrintObject<tensor_adaptor>)
+          .def("ViewData", [](tensor_adaptor& rSelf) { return GetPybindArray<TDataType>(*rSelf.pGetStorage()); })
+          .def("SetData", [](tensor_adaptor& rSelf, const pybind11::array& rArray) { SetPybindArray<TDataType>(*rSelf.pGetStorage(), rArray); },
+               pybind11::arg("array").noconvert())
+          .def_property("data",
+               [](tensor_adaptor& rSelf) {
+                    return GetPybindArray<TDataType>(*rSelf.pGetStorage());
+               },
+               pybind11::cpp_function(
+                    [](tensor_adaptor& rSelf, const pybind11::array& rArray) {
+                    SetPybindArray<TDataType>(*rSelf.pGetStorage(), rArray);
+                    },
+                    pybind11::arg("self"),
+                    // no convert makes sure that the numpy arrays are
+                    // not converted, hence nothing will be copied. numpy
+                    // array will be passed as it is to the SetPybindArray
+                    // method.
+                    pybind11::arg("array").noconvert()));
 }
 
 template <class TDataType>
-void AddCombinedTensorAdaptor(pybind11::module &rModule,
-                              const std::string &rName) {
-  using combined_ta_type = CombinedTensorAdaptor<TDataType>;
-  pybind11::class_<combined_ta_type, typename combined_ta_type::Pointer,
-                   typename combined_ta_type::BaseType>(rModule, rName.c_str())
-      .def(pybind11::init<
-               const typename combined_ta_type::TensorAdaptorVectorType &,
-               const bool, const bool>(),
-           pybind11::arg("list_of_tensor_adaptors"),
-           pybind11::arg("perform_collect_data_recursively") = true,
-           pybind11::arg("perform_store_data_recursively") =
-               true) // reveling ctor
-      .def(pybind11::init<
-               const typename combined_ta_type::TensorAdaptorVectorType &,
-               const unsigned int, const bool, const bool>(),
-           pybind11::arg("list_of_tensor_adaptors"), pybind11::arg("axis"),
-           pybind11::arg("perform_collect_data_recursively") = true,
-           pybind11::arg("perform_store_data_recursively") =
-               true) // axis based ctor
-      .def(pybind11::init<const combined_ta_type &, const bool, const bool,
-                          const bool>(),
-           pybind11::arg("list_of_tensor_adaptors"),
-           pybind11::arg("perform_collect_data_recursively") = true,
-           pybind11::arg("perform_store_data_recursively") = true,
-           pybind11::arg("copy") = true)
-      .def("GetTensorAdaptors", &combined_ta_type::GetTensorAdaptors);
+void AddCombinedTensorAdaptor(
+     pybind11::module &rModule,
+     const std::string &rName)
+{
+     using combined_ta_type = CombinedTensorAdaptor<TDataType>;
+     pybind11::class_<combined_ta_type, typename combined_ta_type::Pointer, typename combined_ta_type::BaseType>(rModule, rName.c_str())
+          .def(pybind11::init<const typename combined_ta_type::TensorAdaptorVectorType &, const bool, const bool, const bool>(),
+               pybind11::arg("list_of_tensor_adaptors"),
+               pybind11::arg("perform_collect_data_recursively") = true,
+               pybind11::arg("perform_store_data_recursively") = true,
+               pybind11::arg("copy") = true) // reveling ctor
+          .def(pybind11::init<const typename combined_ta_type::TensorAdaptorVectorType &, const unsigned int, const bool, const bool, const bool>(),
+               pybind11::arg("list_of_tensor_adaptors"), pybind11::arg("axis"),
+               pybind11::arg("perform_collect_data_recursively") = true,
+               pybind11::arg("perform_store_data_recursively") = true,
+               pybind11::arg("copy") = true) // axis based ctor
+          .def(pybind11::init<const combined_ta_type &, const bool, const bool, const bool>(),
+               pybind11::arg("combined_tensor_adaptor"),
+               pybind11::arg("perform_collect_data_recursively") = true,
+               pybind11::arg("perform_store_data_recursively") = true,
+               pybind11::arg("copy") = true)
+          .def("GetTensorAdaptors", &combined_ta_type::GetTensorAdaptors);
 }
 
 } // namespace Detail
 
-void AddTensorAdaptorsToPython(pybind11::module &m) {
-  namespace py = pybind11;
+void AddTensorAdaptorsToPython(pybind11::module& m)
+{
+     namespace py = pybind11;
 
-  auto tensor_adaptor_sub_module = m.def_submodule("TensorAdaptors");
-  Detail::AddBaseTensorAdaptor<bool>(tensor_adaptor_sub_module, "BoolTensor");
-  Detail::AddBaseTensorAdaptor<int>(tensor_adaptor_sub_module, "IntTensor");
-  Detail::AddBaseTensorAdaptor<double>(tensor_adaptor_sub_module,
-                                       "DoubleTensor");
+     auto tensor_adaptor_sub_module = m.def_submodule("TensorAdaptors");
+     Detail::AddBaseTensorAdaptor<bool>(tensor_adaptor_sub_module, "BoolTensor");
+     Detail::AddBaseTensorAdaptor<int>(tensor_adaptor_sub_module, "IntTensor");
+     Detail::AddBaseTensorAdaptor<double>(tensor_adaptor_sub_module, "DoubleTensor");
 
-  Detail::AddCombinedTensorAdaptor<bool>(tensor_adaptor_sub_module,
-                                         "BoolCombinedTensorAdaptor");
-  Detail::AddCombinedTensorAdaptor<int>(tensor_adaptor_sub_module,
-                                        "IntCombinedTensorAdaptor");
-  Detail::AddCombinedTensorAdaptor<double>(tensor_adaptor_sub_module,
-                                           "DoubleCombinedTensorAdaptor");
+     Detail::AddCombinedTensorAdaptor<bool>(tensor_adaptor_sub_module, "BoolCombinedTensorAdaptor");
+     Detail::AddCombinedTensorAdaptor<int>(tensor_adaptor_sub_module, "IntCombinedTensorAdaptor");
+     Detail::AddCombinedTensorAdaptor<double>(tensor_adaptor_sub_module, "DoubleCombinedTensorAdaptor");
 
-  py::class_<HistoricalVariableTensorAdaptor,
-             HistoricalVariableTensorAdaptor::Pointer,
-             HistoricalVariableTensorAdaptor::BaseType>(
-      tensor_adaptor_sub_module, "HistoricalVariableTensorAdaptor")
-      .def(py::init<ModelPart::NodesContainerType::Pointer,
-                    HistoricalVariableTensorAdaptor::VariablePointerType,
-                    const int>(),
-           py::arg("container"), py::arg("variable"), py::arg("step_index") = 0)
-      .def(py::init<ModelPart::NodesContainerType::Pointer,
-                    TensorAdaptorUtils::VariablePointerType,
-                    const std::vector<unsigned int> &, const int>(),
-           py::arg("container"), py::arg("variable"), py::arg("data_shape"),
-           py::arg("step_index") = 0)
-      .def(py::init<const HistoricalVariableTensorAdaptor::BaseType &,
-                    HistoricalVariableTensorAdaptor::VariablePointerType,
-                    const int, const bool>(),
-           py::arg("tensor_adaptor"), py::arg("variable"),
-           py::arg("step_index") = 0, py::arg("copy") = true);
+     py::class_<HistoricalVariableTensorAdaptor, HistoricalVariableTensorAdaptor::Pointer, HistoricalVariableTensorAdaptor::BaseType>(tensor_adaptor_sub_module, "HistoricalVariableTensorAdaptor")
+          .def(py::init<ModelPart::NodesContainerType::Pointer, HistoricalVariableTensorAdaptor::VariablePointerType, const int>(),
+               py::arg("container"),
+               py::arg("variable"),
+               py::arg("step_index") = 0)
+          .def(py::init<ModelPart::NodesContainerType::Pointer, TensorAdaptorUtils::VariablePointerType, const std::vector<unsigned int>&, const int>(),
+               py::arg("container"),
+               py::arg("variable"),
+               py::arg("data_shape"),
+               py::arg("step_index") = 0)
+          .def(py::init<const HistoricalVariableTensorAdaptor::BaseType&, HistoricalVariableTensorAdaptor::VariablePointerType, const int, const bool>(),
+               py::arg("tensor_adaptor"),
+               py::arg("variable"),
+               py::arg("step_index") = 0,
+               py::arg("copy") = true);
 
-  py::class_<VariableTensorAdaptor, VariableTensorAdaptor::Pointer,
-             VariableTensorAdaptor::BaseType>(tensor_adaptor_sub_module,
-                                              "VariableTensorAdaptor")
-      .def(py::init<ModelPart::NodesContainerType::Pointer,
-                    VariableTensorAdaptor::VariablePointerType>(),
-           py::arg("container"), py::arg("variable"))
-      .def(py::init<ModelPart::NodesContainerType::Pointer,
-                    VariableTensorAdaptor::VariablePointerType,
-                    const std::vector<unsigned int> &>(),
-           py::arg("container"), py::arg("variable"), py::arg("data_shape"))
-      .def(py::init<ModelPart::ConditionsContainerType::Pointer,
-                    VariableTensorAdaptor::VariablePointerType>(),
-           py::arg("container"), py::arg("variable"))
-      .def(py::init<ModelPart::ConditionsContainerType::Pointer,
-                    VariableTensorAdaptor::VariablePointerType,
-                    const std::vector<unsigned int> &>(),
-           py::arg("container"), py::arg("variable"), py::arg("data_shape"))
-      .def(py::init<ModelPart::ElementsContainerType::Pointer,
-                    VariableTensorAdaptor::VariablePointerType>(),
-           py::arg("container"), py::arg("variable"))
-      .def(py::init<ModelPart::ElementsContainerType::Pointer,
-                    VariableTensorAdaptor::VariablePointerType,
-                    const std::vector<unsigned int> &>(),
-           py::arg("container"), py::arg("variable"), py::arg("data_shape"))
-      .def(py::init<ModelPart::PropertiesContainerType::Pointer,
-                    VariableTensorAdaptor::VariablePointerType>(),
-           py::arg("container"), py::arg("variable"))
-      .def(py::init<ModelPart::PropertiesContainerType::Pointer,
-                    VariableTensorAdaptor::VariablePointerType,
-                    const std::vector<unsigned int> &>(),
-           py::arg("container"), py::arg("variable"), py::arg("data_shape"))
-      .def(py::init<ModelPart::GeometryContainerType::Pointer,
-                    VariableTensorAdaptor::VariablePointerType>(),
-           py::arg("container"), py::arg("variable"))
-      .def(py::init<ModelPart::GeometryContainerType::Pointer,
-                    VariableTensorAdaptor::VariablePointerType,
-                    const std::vector<unsigned int> &>(),
-           py::arg("container"), py::arg("variable"), py::arg("data_shape"))
-      .def(py::init<ModelPart::MasterSlaveConstraintContainerType::Pointer,
-                    VariableTensorAdaptor::VariablePointerType>(),
-           py::arg("container"), py::arg("variable"))
-      .def(py::init<ModelPart::MasterSlaveConstraintContainerType::Pointer,
-                    VariableTensorAdaptor::VariablePointerType,
-                    const std::vector<unsigned int> &>(),
-           py::arg("container"), py::arg("variable"), py::arg("data_shape"))
-      .def(py::init<const VariableTensorAdaptor::BaseType &,
-                    VariableTensorAdaptor::VariablePointerType, const bool>(),
-           py::arg("tensor_adaptor"), py::arg("variable"),
-           py::arg("copy") = true);
+     py::class_<VariableTensorAdaptor, VariableTensorAdaptor::Pointer, VariableTensorAdaptor::BaseType>(tensor_adaptor_sub_module, "VariableTensorAdaptor")
+          .def(py::init<ModelPart::NodesContainerType::Pointer, VariableTensorAdaptor::VariablePointerType>(),
+               py::arg("container"),
+               py::arg("variable"))
+          .def(py::init<ModelPart::NodesContainerType::Pointer, VariableTensorAdaptor::VariablePointerType, const std::vector<unsigned int>&>(),
+               py::arg("container"),
+               py::arg("variable"),
+               py::arg("data_shape"))
+          .def(py::init<ModelPart::ConditionsContainerType::Pointer, VariableTensorAdaptor::VariablePointerType>(),
+               py::arg("container"),
+               py::arg("variable"))
+          .def(py::init<ModelPart::ConditionsContainerType::Pointer, VariableTensorAdaptor::VariablePointerType, const std::vector<unsigned int>&>(),
+               py::arg("container"),
+               py::arg("variable"),
+               py::arg("data_shape"))
+          .def(py::init<ModelPart::ElementsContainerType::Pointer, VariableTensorAdaptor::VariablePointerType>(),
+               py::arg("container"),
+               py::arg("variable"))
+          .def(py::init<ModelPart::ElementsContainerType::Pointer, VariableTensorAdaptor::VariablePointerType, const std::vector<unsigned int>&>(),
+               py::arg("container"),
+               py::arg("variable"),
+               py::arg("data_shape"))
+          .def(py::init<ModelPart::PropertiesContainerType::Pointer, VariableTensorAdaptor::VariablePointerType>(),
+               py::arg("container"),
+               py::arg("variable"))
+          .def(py::init<ModelPart::PropertiesContainerType::Pointer, VariableTensorAdaptor::VariablePointerType, const std::vector<unsigned int>&>(),
+               py::arg("container"),
+               py::arg("variable"),
+               py::arg("data_shape"))
+          .def(py::init<ModelPart::GeometryContainerType::Pointer, VariableTensorAdaptor::VariablePointerType>(),
+               py::arg("container"),
+               py::arg("variable"))
+          .def(py::init<ModelPart::GeometryContainerType::Pointer, VariableTensorAdaptor::VariablePointerType, const std::vector<unsigned int>&>(),
+               py::arg("container"),
+               py::arg("variable"),
+               py::arg("data_shape"))
+          .def(py::init<ModelPart::MasterSlaveConstraintContainerType::Pointer, VariableTensorAdaptor::VariablePointerType>(),
+               py::arg("container"),
+               py::arg("variable"))
+          .def(py::init<ModelPart::MasterSlaveConstraintContainerType::Pointer, VariableTensorAdaptor::VariablePointerType, const std::vector<unsigned int>&>(),
+               py::arg("container"),
+               py::arg("variable"),
+               py::arg("data_shape"))
+          .def(py::init<const VariableTensorAdaptor::BaseType&, VariableTensorAdaptor::VariablePointerType, const bool>(),
+               py::arg("tensor_adaptor"),
+               py::arg("variable"),
+               py::arg("copy") = true);
 
-  py::class_<GaussPointVariableTensorAdaptor,
-             GaussPointVariableTensorAdaptor::Pointer,
-             GaussPointVariableTensorAdaptor::BaseType>(
-      tensor_adaptor_sub_module, "GaussPointVariableTensorAdaptor")
-      .def(py::init<ModelPart::ConditionsContainerType::Pointer,
-                    GaussPointVariableTensorAdaptor::VariablePointerType,
-                    ProcessInfo::Pointer>(),
-           py::arg("container"), py::arg("variable"), py::arg("process_info"))
-      .def(py::init<ModelPart::ElementsContainerType::Pointer,
-                    GaussPointVariableTensorAdaptor::VariablePointerType,
-                    ProcessInfo::Pointer>(),
-           py::arg("container"), py::arg("variable"), py::arg("process_info"))
-      .def(py::init<const GaussPointVariableTensorAdaptor::BaseType &,
-                    GaussPointVariableTensorAdaptor::VariablePointerType,
-                    ProcessInfo::Pointer, const bool>(),
-           py::arg("tensor_adaptor"), py::arg("variable"),
-           py::arg("process_info"), py::arg("copy") = true);
+     py::class_<GaussPointVariableTensorAdaptor, GaussPointVariableTensorAdaptor::Pointer, GaussPointVariableTensorAdaptor::BaseType>(tensor_adaptor_sub_module, "GaussPointVariableTensorAdaptor")
+          .def(py::init<ModelPart::ConditionsContainerType::Pointer, GaussPointVariableTensorAdaptor::VariablePointerType, ProcessInfo::Pointer>(),
+               py::arg("container"),
+               py::arg("variable"),
+               py::arg("process_info"))
+          .def(py::init<ModelPart::ElementsContainerType::Pointer, GaussPointVariableTensorAdaptor::VariablePointerType, ProcessInfo::Pointer>(),
+               py::arg("container"),
+               py::arg("variable"),
+               py::arg("process_info"))
+          .def(py::init<const GaussPointVariableTensorAdaptor::BaseType&, GaussPointVariableTensorAdaptor::VariablePointerType, ProcessInfo::Pointer, const bool>(),
+               py::arg("tensor_adaptor"),
+               py::arg("variable"),
+               py::arg("process_info"),
+               py::arg("copy") = true);
 
-  py::class_<EquationIdsTensorAdaptor, EquationIdsTensorAdaptor::Pointer,
-             EquationIdsTensorAdaptor::BaseType>(tensor_adaptor_sub_module,
-                                                 "EquationIdsTensorAdaptor")
-      .def(py::init<ModelPart::ConditionsContainerType::Pointer,
-                    ProcessInfo::Pointer>(),
-           py::arg("container"), py::arg("process_info"))
-      .def(py::init<ModelPart::ElementsContainerType::Pointer,
-                    ProcessInfo::Pointer>(),
-           py::arg("container"), py::arg("process_info"))
-      .def(py::init<const EquationIdsTensorAdaptor::BaseType &,
-                    ProcessInfo::Pointer, const bool>(),
-           py::arg("tensor_adaptor"), py::arg("process_info"),
-           py::arg("copy") = true);
+     py::class_<EquationIdsTensorAdaptor, EquationIdsTensorAdaptor::Pointer, EquationIdsTensorAdaptor::BaseType>(tensor_adaptor_sub_module, "EquationIdsTensorAdaptor")
+          .def(py::init<ModelPart::ConditionsContainerType::Pointer, ProcessInfo::Pointer>(),
+               py::arg("container"),
+               py::arg("process_info"))
+          .def(py::init<ModelPart::ElementsContainerType::Pointer, ProcessInfo::Pointer>(),
+               py::arg("container"),
+               py::arg("process_info"))
+          .def(py::init<const EquationIdsTensorAdaptor::BaseType&, ProcessInfo::Pointer, const bool>(),
+               py::arg("tensor_adaptor"),
+               py::arg("process_info"),
+               py::arg("copy") = true);
 
-  py::class_<FlagsTensorAdaptor, FlagsTensorAdaptor::Pointer,
-             FlagsTensorAdaptor::BaseType>(tensor_adaptor_sub_module,
-                                           "FlagsTensorAdaptor")
-      .def(py::init<ModelPart::NodesContainerType::Pointer, const Flags &>(),
-           py::arg("container"), py::arg("flag"))
-      .def(py::init<ModelPart::ConditionsContainerType::Pointer,
-                    const Flags &>(),
-           py::arg("container"), py::arg("flag"))
-      .def(py::init<ModelPart::ElementsContainerType::Pointer, const Flags &>(),
-           py::arg("container"), py::arg("flag"))
-      .def(py::init<const FlagsTensorAdaptor::BaseType &, const Flags &,
-                    const bool>(),
-           py::arg("tensor_adaptor"), py::arg("flag"), py::arg("copy") = true);
+     py::class_<FlagsTensorAdaptor, FlagsTensorAdaptor::Pointer, FlagsTensorAdaptor::BaseType>(tensor_adaptor_sub_module, "FlagsTensorAdaptor")
+          .def(py::init<ModelPart::NodesContainerType::Pointer, const Flags&>(),
+               py::arg("container"),
+               py::arg("flag"))
+          .def(py::init<ModelPart::ConditionsContainerType::Pointer, const Flags&>(),
+               py::arg("container"),
+               py::arg("flag"))
+          .def(py::init<ModelPart::ElementsContainerType::Pointer, const Flags&>(),
+               py::arg("container"),
+               py::arg("flag"))
+          .def(py::init<const FlagsTensorAdaptor::BaseType&, const Flags&, const bool>(),
+               py::arg("tensor_adaptor"),
+               py::arg("flag"), py::arg("copy") = true);
 
-  py::class_<NodePositionTensorAdaptor, NodePositionTensorAdaptor::Pointer,
-             NodePositionTensorAdaptor::BaseType>(tensor_adaptor_sub_module,
-                                                  "NodePositionTensorAdaptor")
-      .def(py::init<ModelPart::NodesContainerType::Pointer,
-                    Globals::Configuration>(),
-           py::arg("container"), py::arg("configuration"))
-      .def(
-          py::init<ModelPart::NodesContainerType::Pointer,
-                   Globals::Configuration, const std::vector<unsigned int> &>(),
-          py::arg("container"), py::arg("configuration"), py::arg("data_shape"))
-      .def(py::init<const NodePositionTensorAdaptor::BaseType &,
-                    Globals::Configuration, const bool>(),
-           py::arg("tensor_adaptor"), py::arg("configuration"),
-           py::arg("copy") = true);
+     py::class_<NodePositionTensorAdaptor, NodePositionTensorAdaptor::Pointer, NodePositionTensorAdaptor::BaseType>(tensor_adaptor_sub_module, "NodePositionTensorAdaptor")
+          .def(py::init<ModelPart::NodesContainerType::Pointer, Globals::Configuration>(),
+               py::arg("container"),
+               py::arg("configuration"))
+          .def(py::init<ModelPart::NodesContainerType::Pointer, Globals::Configuration, const std::vector<unsigned int>&>(),
+               py::arg("container"),
+               py::arg("configuration"),
+               py::arg("data_shape"))
+          .def(py::init<const NodePositionTensorAdaptor::BaseType&, Globals::Configuration, const bool>(),
+               py::arg("tensor_adaptor"),
+               py::arg("configuration"),
+               py::arg("copy") = true);
 
+     using GeometriesTensorAdaptorType = GeometriesTensorAdaptor;
+     py::class_<GeometriesTensorAdaptorType, GeometriesTensorAdaptorType::Pointer, GeometriesTensorAdaptorType::BaseType> geometries_tensor_adaptor(tensor_adaptor_sub_module, "GeometriesTensorAdaptor");
 
-    using GeometriesTensorAdaptorType = GeometriesTensorAdaptor;
-    py::class_<GeometriesTensorAdaptorType, GeometriesTensorAdaptorType::Pointer,
-    GeometriesTensorAdaptorType::BaseType>
-    geometries_tensor_adaptor(tensor_adaptor_sub_module,
-                              "GeometriesTensorAdaptor");
+     py::enum_<GeometriesTensorAdaptorType::DatumType>(geometries_tensor_adaptor,"DatumType")
+          .value("ShapeFunctions", GeometriesTensorAdaptorType::DatumType::ShapeFunctions)
+          .value("ShapeFunctionDerivatives", GeometriesTensorAdaptorType::DatumType::ShapeFunctionDerivatives)
+          .value("Jacobians", GeometriesTensorAdaptorType::DatumType::Jacobians)
+          .value("IntegrationWeights", GeometriesTensorAdaptorType::DatumType::IntegrationWeights)
+          .export_values();
 
-    py::enum_<GeometriesTensorAdaptorType::DatumType>(geometries_tensor_adaptor,
-            "DatumType")
-    .value("ShapeFunctions",
-           GeometriesTensorAdaptorType::DatumType::ShapeFunctions)
-    .value("ShapeFunctionDerivatives",
-           GeometriesTensorAdaptorType::DatumType::ShapeFunctionDerivatives)
-    .value("Jacobians", GeometriesTensorAdaptorType::DatumType::Jacobians)
-    .value("IntegrationWeights",
-           GeometriesTensorAdaptorType::DatumType::IntegrationWeights)
-    .export_values();
+     geometries_tensor_adaptor
+          .def(py::init<ModelPart::GeometryContainerType::Pointer, GeometriesTensorAdaptorType::DatumType,GeometryData::IntegrationMethod>(),
+               py::arg("container"),
+               py::arg("datum"),
+               py::arg("integration_method") = GeometryData::IntegrationMethod::NumberOfIntegrationMethods)
+          .def(py::init<ModelPart::ElementsContainerType::Pointer, GeometriesTensorAdaptorType::DatumType, GeometryData::IntegrationMethod>(),
+               py::arg("container"),
+               py::arg("datum"),
+               py::arg("integration_method") = GeometryData::IntegrationMethod::NumberOfIntegrationMethods)
+        .def(py::init<ModelPart::ConditionsContainerType::Pointer, GeometriesTensorAdaptorType::DatumType, GeometryData::IntegrationMethod>(),
+               py::arg("container"),
+               py::arg("datum"),
+               py::arg("integration_method") = GeometryData::IntegrationMethod::NumberOfIntegrationMethods)
+          .def(py::init<const GeometriesTensorAdaptorType::BaseType&, ModelPart::GeometryContainerType::Pointer, GeometriesTensorAdaptorType::DatumType, GeometryData::IntegrationMethod, const bool>(),
+               py::arg("tensor_adaptor"),
+               py::arg("container"),
+               py::arg("datum"),
+               py::arg("integration_method"),
+               py::arg("copy") = true)
+          .def(py::init<const GeometriesTensorAdaptorType::BaseType&, ModelPart::ElementsContainerType::Pointer, GeometriesTensorAdaptorType::DatumType, GeometryData::IntegrationMethod, const bool>(),
+               py::arg("tensor_adaptor"),
+               py::arg("container"),
+               py::arg("datum"),
+               py::arg("integration_method"),
+               py::arg("copy") = true)
+          .def(py::init<const GeometriesTensorAdaptorType::BaseType&, ModelPart::ConditionsContainerType::Pointer, GeometriesTensorAdaptorType::DatumType, GeometryData::IntegrationMethod, const bool>(),
+               py::arg("tensor_adaptor"),
+               py::arg("container"),
+               py::arg("datum"),
+               py::arg("integration_method"),
+               py::arg("copy") = true);
 
-    geometries_tensor_adaptor
-    .def(py::init<ModelPart::GeometryContainerType::Pointer,
-         GeometriesTensorAdaptorType::DatumType,
-         GeometryData::IntegrationMethod>(),
-         py::arg("container"), py::arg("datum"),
-         py::arg("integration_method") =
-             GeometryData::IntegrationMethod::NumberOfIntegrationMethods)
-    .def(py::init<ModelPart::ElementsContainerType::Pointer,
-         GeometriesTensorAdaptorType::DatumType,
-         GeometryData::IntegrationMethod>(),
-         py::arg("container"), py::arg("datum"),
-         py::arg("integration_method") =
-             GeometryData::IntegrationMethod::NumberOfIntegrationMethods)
-    .def(py::init<ModelPart::ConditionsContainerType::Pointer,
-         GeometriesTensorAdaptorType::DatumType,
-         GeometryData::IntegrationMethod>(),
-         py::arg("container"), py::arg("datum"),
-         py::arg("integration_method") =
-             GeometryData::IntegrationMethod::NumberOfIntegrationMethods)
-    .def(py::init<const GeometriesTensorAdaptorType::BaseType &,
-         ModelPart::GeometryContainerType::Pointer,
-         GeometriesTensorAdaptorType::DatumType,
-         GeometryData::IntegrationMethod, const bool>(),
-         py::arg("tensor_adaptor"), py::arg("container"), py::arg("datum"),
-         py::arg("integration_method"), py::arg("copy") = true)
-    .def(py::init<const GeometriesTensorAdaptorType::BaseType &,
-         ModelPart::ElementsContainerType::Pointer,
-         GeometriesTensorAdaptorType::DatumType,
-         GeometryData::IntegrationMethod, const bool>(),
-         py::arg("tensor_adaptor"), py::arg("container"), py::arg("datum"),
-         py::arg("integration_method"), py::arg("copy") = true)
-    .def(py::init<const GeometriesTensorAdaptorType::BaseType &,
-         ModelPart::ConditionsContainerType::Pointer,
-         GeometriesTensorAdaptorType::DatumType,
-         GeometryData::IntegrationMethod, const bool>(),
-         py::arg("tensor_adaptor"), py::arg("container"), py::arg("datum"),
-         py::arg("integration_method"), py::arg("copy") = true);
-  py::class_<ConnectivityIdsTensorAdaptor,
-             ConnectivityIdsTensorAdaptor::Pointer,
-             ConnectivityIdsTensorAdaptor::BaseType>(
-      tensor_adaptor_sub_module, "ConnectivityIdsTensorAdaptor")
-      .def(py::init<ModelPart::GeometryContainerType::Pointer>(),
-           py::arg("container"))
-      .def(py::init<ModelPart::ElementsContainerType::Pointer>(),
-           py::arg("container"))
-      .def(py::init<ModelPart::ConditionsContainerType::Pointer>(),
-           py::arg("container"))
-      .def(py::init<const ConnectivityIdsTensorAdaptor::BaseType &,
-                    const bool>(),
-           py::arg("tensor_adaptor"), py::arg("copy") = true);
+     py::class_<ConnectivityIdsTensorAdaptor, ConnectivityIdsTensorAdaptor::Pointer, ConnectivityIdsTensorAdaptor::BaseType>(tensor_adaptor_sub_module, "ConnectivityIdsTensorAdaptor")
+          .def(py::init<ModelPart::GeometryContainerType::Pointer>(),
+               py::arg("container"))
+          .def(py::init<ModelPart::ElementsContainerType::Pointer>(),
+               py::arg("container"))
+          .def(py::init<ModelPart::ConditionsContainerType::Pointer>(),
+               py::arg("container"))
+          .def(py::init<const ConnectivityIdsTensorAdaptor::BaseType&, const bool>(),
+               py::arg("tensor_adaptor"),
+               py::arg("copy") = true);
 }
 
 } // namespace Kratos::Python.

--- a/kratos/tensor_adaptors/combined_tensor_adaptor.cpp
+++ b/kratos/tensor_adaptors/combined_tensor_adaptor.cpp
@@ -42,13 +42,21 @@ CombinedTensorAdaptor<TDataType>::CombinedTensorAdaptor(
     const TensorAdaptorVectorType& rTensorAdaptorVector,
     const unsigned int Axis,
     const bool PerformCollectDataRecursively,
-    const bool PerformStoreDataRecursively)
+    const bool PerformStoreDataRecursively,
+    const bool Copy)
     : mPerformCollectDataRecursively(PerformCollectDataRecursively),
       mPerformStoreDataRecursively(PerformStoreDataRecursively),
-      mAxis(Axis),
-      mTensorAdaptors(rTensorAdaptorVector)
+      mAxis(Axis)
 {
     KRATOS_TRY
+
+    for (const auto& p_tensor_adaptor : rTensorAdaptorVector) {
+        if (Copy) {
+            mTensorAdaptors.push_back(p_tensor_adaptor->Clone());
+        } else {
+            mTensorAdaptors.push_back(p_tensor_adaptor);
+        }
+    }
 
     // It is not allowed to create combined tensor adaptors with empty list of tensor adaptors vector
     KRATOS_ERROR_IF(rTensorAdaptorVector.empty())
@@ -110,13 +118,21 @@ template<class TDataType>
 CombinedTensorAdaptor<TDataType>::CombinedTensorAdaptor(
     const TensorAdaptorVectorType& rTensorAdaptorVector,
     const bool PerformCollectDataRecursively,
-    const bool PerformStoreDataRecursively)
+    const bool PerformStoreDataRecursively,
+    const bool Copy)
     : mPerformCollectDataRecursively(PerformCollectDataRecursively),
       mPerformStoreDataRecursively(PerformStoreDataRecursively),
-      mAxis(-1), // represent that this combined tensor adaptor is used with ravel
-      mTensorAdaptors(rTensorAdaptorVector)
+      mAxis(-1) // represent that this combined tensor adaptor is used with ravel
 {
     KRATOS_TRY
+
+    for (const auto& p_tensor_adaptor : rTensorAdaptorVector) {
+        if (Copy) {
+            mTensorAdaptors.push_back(p_tensor_adaptor->Clone());
+        } else {
+            mTensorAdaptors.push_back(p_tensor_adaptor);
+        }
+    }
 
     // this combined tensor will have everything raveled. Therefore, it will only have one dimension.
     DenseVector<unsigned int> tensor_shape(1);
@@ -141,9 +157,25 @@ CombinedTensorAdaptor<TDataType>::CombinedTensorAdaptor(
     : BaseType(rOther, Copy),
       mPerformCollectDataRecursively(PerformCollectDataRecursively),
       mPerformStoreDataRecursively(PerformStoreDataRecursively),
-      mAxis(rOther.mAxis),
-      mTensorAdaptors(rOther.mTensorAdaptors)
+      mAxis(rOther.mAxis)
 {
+    KRATOS_TRY
+
+    for (const auto& p_tensor_adaptor : rOther.mTensorAdaptors) {
+        if (Copy) {
+            mTensorAdaptors.push_back(p_tensor_adaptor->Clone());
+        } else {
+            mTensorAdaptors.push_back(p_tensor_adaptor);
+        }
+    }
+
+    KRATOS_CATCH("");
+}
+
+template<class TDataType>
+TensorAdaptor<TDataType>::Pointer CombinedTensorAdaptor<TDataType>::Clone() const
+{
+    return Kratos::make_shared<CombinedTensorAdaptor<TDataType>>(*this, this->mPerformCollectDataRecursively, this->mPerformStoreDataRecursively);
 }
 
 template<class TDataType>

--- a/kratos/tensor_adaptors/combined_tensor_adaptor.cpp
+++ b/kratos/tensor_adaptors/combined_tensor_adaptor.cpp
@@ -173,7 +173,7 @@ CombinedTensorAdaptor<TDataType>::CombinedTensorAdaptor(
 }
 
 template<class TDataType>
-TensorAdaptor<TDataType>::Pointer CombinedTensorAdaptor<TDataType>::Clone() const
+typename TensorAdaptor<TDataType>::Pointer CombinedTensorAdaptor<TDataType>::Clone() const
 {
     return Kratos::make_shared<CombinedTensorAdaptor<TDataType>>(*this, this->mPerformCollectDataRecursively, this->mPerformStoreDataRecursively);
 }

--- a/kratos/tensor_adaptors/combined_tensor_adaptor.h
+++ b/kratos/tensor_adaptors/combined_tensor_adaptor.h
@@ -216,7 +216,7 @@ public:
     /**
      * @brief Clones the existing tensor adaptor.
      */
-    TensorAdaptor<TDataType>::Pointer Clone() const override;
+    typename TensorAdaptor<TDataType>::Pointer Clone() const override;
 
     /**
      * @brief Check if the necessary data is present in the underlying container.

--- a/kratos/tensor_adaptors/combined_tensor_adaptor.h
+++ b/kratos/tensor_adaptors/combined_tensor_adaptor.h
@@ -156,7 +156,8 @@ public:
     CombinedTensorAdaptor(
         const TensorAdaptorVectorType& rTensorAdaptorVector,
         const bool PerformCollectDataRecursively = true,
-        const bool PerformStoreDataRecursively = true);
+        const bool PerformStoreDataRecursively = true,
+        const bool Copy = true);
 
     /**
      * @brief Construct a new Combined Tensor Adaptor  given list of @ref TensorAdaptor instances along the specified @p Axis.
@@ -189,7 +190,8 @@ public:
         const TensorAdaptorVectorType& rTensorAdaptorVector,
         const unsigned int Axis,
         const bool PerformCollectDataRecursively = true,
-        const bool PerformStoreDataRecursively = true);
+        const bool PerformStoreDataRecursively = true,
+        const bool Copy = true);
 
     /**
      * @brief Construct a new Combined Tensor Adaptor based on an existing @p rOther.
@@ -210,6 +212,11 @@ public:
     ///@}
     ///@name Public operations
     ///@{
+
+    /**
+     * @brief Clones the existing tensor adaptor.
+     */
+    TensorAdaptor<TDataType>::Pointer Clone() const override;
 
     /**
      * @brief Check if the necessary data is present in the underlying container.

--- a/kratos/tensor_adaptors/connectivity_ids_tensor_adaptor.cpp
+++ b/kratos/tensor_adaptors/connectivity_ids_tensor_adaptor.cpp
@@ -114,6 +114,11 @@ void ConnectivityIdsTensorAdaptor::Check() const {
       *mpContainer);
 }
 
+TensorAdaptor<int>::Pointer ConnectivityIdsTensorAdaptor::Clone() const
+{
+    return Kratos::make_shared<ConnectivityIdsTensorAdaptor>(*this);
+}
+
 void ConnectivityIdsTensorAdaptor::CollectData() {
 
   const auto &shape = mpStorage->Shape();

--- a/kratos/tensor_adaptors/connectivity_ids_tensor_adaptor.h
+++ b/kratos/tensor_adaptors/connectivity_ids_tensor_adaptor.h
@@ -68,12 +68,20 @@ public:
 
   ConnectivityIdsTensorAdaptor(const BaseType &rOther, const bool Copy = true);
 
+  ConnectivityIdsTensorAdaptor(const ConnectivityIdsTensorAdaptor& rOther) = default;
+
   // Destructor
   ~ConnectivityIdsTensorAdaptor() override = default;
+
 
   ///@}
   ///@name Public operations
   ///@{
+
+  /**
+   * @brief Clones the existing tensor adaptor.
+   */
+  TensorAdaptor::Pointer Clone() const override;
 
   /**
    * @brief Check if the container is valid.

--- a/kratos/tensor_adaptors/equation_ids_tensor_adaptor.cpp
+++ b/kratos/tensor_adaptors/equation_ids_tensor_adaptor.cpp
@@ -99,6 +99,11 @@ EquationIdsTensorAdaptor::EquationIdsTensorAdaptor(
     KRATOS_CATCH("");
 }
 
+TensorAdaptor<int>::Pointer EquationIdsTensorAdaptor::Clone() const
+{
+    return Kratos::make_shared<EquationIdsTensorAdaptor>(*this);
+}
+
 void EquationIdsTensorAdaptor::CollectData()
 {
     KRATOS_TRY

--- a/kratos/tensor_adaptors/equation_ids_tensor_adaptor.h
+++ b/kratos/tensor_adaptors/equation_ids_tensor_adaptor.h
@@ -74,12 +74,19 @@ public:
         ProcessInfo::Pointer pProcessInfo,
         const bool Copy = true);
 
+    EquationIdsTensorAdaptor(const EquationIdsTensorAdaptor& rOther) = default;
+
     // Destructor
     ~EquationIdsTensorAdaptor() override = default;
 
     ///@}
     ///@name Public operations
     ///@{
+
+    /**
+     * @brief Clones the existing tensor adaptor.
+     */
+    TensorAdaptor::Pointer Clone() const override;
 
     /**
      * @brief Fill the internal data from Kratos data structures

--- a/kratos/tensor_adaptors/flags_tensor_adaptor.cpp
+++ b/kratos/tensor_adaptors/flags_tensor_adaptor.cpp
@@ -83,6 +83,11 @@ void FlagsTensorAdaptor::Check() const
     KRATOS_CATCH("");
 }
 
+TensorAdaptor<int>::Pointer FlagsTensorAdaptor::Clone() const
+{
+    return Kratos::make_shared<FlagsTensorAdaptor>(*this);
+}
+
 void FlagsTensorAdaptor::CollectData()
 {
     std::visit([this](auto pContainer) {

--- a/kratos/tensor_adaptors/flags_tensor_adaptor.h
+++ b/kratos/tensor_adaptors/flags_tensor_adaptor.h
@@ -82,12 +82,19 @@ public:
         const Flags& rFlags,
         const bool Copy = true);
 
+    FlagsTensorAdaptor(const FlagsTensorAdaptor& rOther) = default;
+
     // Destructor
     ~FlagsTensorAdaptor() override = default;
 
     ///@}
     ///@name Public operations
     ///@{
+
+    /**
+     * @brief Clones the existing tensor adaptor.
+     */
+    TensorAdaptor::Pointer Clone() const override;
 
     void Check() const override;
 

--- a/kratos/tensor_adaptors/gauss_point_variable_tensor_adaptor.cpp
+++ b/kratos/tensor_adaptors/gauss_point_variable_tensor_adaptor.cpp
@@ -80,6 +80,11 @@ GaussPointVariableTensorAdaptor::GaussPointVariableTensorAdaptor(
     KRATOS_CATCH("");
 }
 
+TensorAdaptor<double>::Pointer GaussPointVariableTensorAdaptor::Clone() const
+{
+    return Kratos::make_shared<GaussPointVariableTensorAdaptor>(*this);
+}
+
 void GaussPointVariableTensorAdaptor::CollectData()
 {
     std::visit([this](auto pContainer, auto pVariable) {

--- a/kratos/tensor_adaptors/gauss_point_variable_tensor_adaptor.h
+++ b/kratos/tensor_adaptors/gauss_point_variable_tensor_adaptor.h
@@ -79,12 +79,19 @@ public:
         ProcessInfo::Pointer pProcessInfo,
         const bool Copy = true);
 
+    GaussPointVariableTensorAdaptor(const GaussPointVariableTensorAdaptor& rOther) = default;
+
     // Destructor
     ~GaussPointVariableTensorAdaptor() override = default;
 
     ///@}
     ///@name Public operations
     ///@{
+
+    /**
+     * @brief Clones the existing tensor adaptor.
+     */
+    TensorAdaptor::Pointer Clone() const override;
 
     /**
      * @brief Fill the internal data from Kratos data structures

--- a/kratos/tensor_adaptors/geometries_tensor_adaptor.cpp
+++ b/kratos/tensor_adaptors/geometries_tensor_adaptor.cpp
@@ -297,6 +297,11 @@ GeometriesTensorAdaptor::GeometriesTensorAdaptor(
     *mpContainer);
 }
 
+TensorAdaptor<double>::Pointer GeometriesTensorAdaptor::Clone() const
+{
+    return Kratos::make_shared<GeometriesTensorAdaptor>(*this);
+}
+
 void GeometriesTensorAdaptor::Check() const {}
 
 void GeometriesTensorAdaptor::CollectData()

--- a/kratos/tensor_adaptors/geometries_tensor_adaptor.h
+++ b/kratos/tensor_adaptors/geometries_tensor_adaptor.h
@@ -74,14 +74,18 @@ public:
     ///@{
 
     GeometriesTensorAdaptor(
-        ContainerPointerType pContainer, DatumType Datum,
-        GeometryData::IntegrationMethod IntegrationMethod =
-            GeometryData::IntegrationMethod::NumberOfIntegrationMethods);
+        ContainerPointerType pContainer,
+        DatumType Datum,
+        GeometryData::IntegrationMethod IntegrationMethod = GeometryData::IntegrationMethod::NumberOfIntegrationMethods);
 
-    GeometriesTensorAdaptor(const TensorAdaptor &rOther,
-                            ContainerPointerType pContainer, DatumType Datum,
-                            GeometryData::IntegrationMethod IntegrationMethod,
-                            const bool Copy = true);
+    GeometriesTensorAdaptor(
+        const TensorAdaptor &rOther,
+        ContainerPointerType pContainer,
+        DatumType Datum,
+        GeometryData::IntegrationMethod IntegrationMethod,
+        const bool Copy = true);
+
+    GeometriesTensorAdaptor(const GeometriesTensorAdaptor& rOther) = default;
 
     // Destructor
     ~GeometriesTensorAdaptor() override = default;
@@ -89,6 +93,11 @@ public:
     ///@}
     ///@name Public operations
     ///@{
+
+    /**
+     * @brief Clones the existing tensor adaptor.
+     */
+    TensorAdaptor::Pointer Clone() const override;
 
     /**
      * @brief Check if the container is valid.
@@ -146,33 +155,39 @@ private:
 
     template <class TContainerType>
     static void CollectIntegrationWeights(
-        double* pData, const TContainerType& rContainer,
+        double* pData,
+        const TContainerType& rContainer,
         GeometryData::IntegrationMethod Method,
         const DenseVector<unsigned int>& Shape);
 
     template <class TContainerType>
-    static void CollectShapeFunctions(double* pData,
-                                      const TContainerType& rContainer,
-                                      GeometryData::IntegrationMethod Method,
-                                      const DenseVector<unsigned int>& Shape);
+    static void CollectShapeFunctions(
+        double* pData,
+        const TContainerType& rContainer,
+        GeometryData::IntegrationMethod Method,
+        const DenseVector<unsigned int>& Shape);
 
     template <class TContainerType>
     static void CollectShapeFunctionsDerivatives(
-        double* pData, const TContainerType& rContainer,
+        double* pData,
+        const TContainerType& rContainer,
         GeometryData::IntegrationMethod Method,
         const DenseVector<unsigned int>& Shape);
 
     template <class TContainerType>
-    static void CollectJacobians(double* pData,
-                                 const TContainerType& rContainer,
-                                 GeometryData::IntegrationMethod Method,
-                                 const DenseVector<unsigned int>& Shape);
+    static void CollectJacobians(
+        double* pData,
+        const TContainerType& rContainer,
+        GeometryData::IntegrationMethod Method,
+        const DenseVector<unsigned int>& Shape);
 
     template <class TContainerType>
-    static void FillData(double* pData, const TContainerType& rContainer,
-                         GeometriesTensorAdaptor::DatumType Datum,
-                         GeometryData::IntegrationMethod Method,
-                         const DenseVector<unsigned int>& Shape);
+    static void FillData(
+        double* pData,
+        const TContainerType& rContainer,
+        GeometriesTensorAdaptor::DatumType Datum,
+        GeometryData::IntegrationMethod Method,
+        const DenseVector<unsigned int>& Shape);
 
     DatumType mDatum;
     GeometryData::IntegrationMethod mIntegrationMethod;

--- a/kratos/tensor_adaptors/historical_variable_tensor_adaptor.cpp
+++ b/kratos/tensor_adaptors/historical_variable_tensor_adaptor.cpp
@@ -119,6 +119,11 @@ HistoricalVariableTensorAdaptor::HistoricalVariableTensorAdaptor(
     KRATOS_CATCH("");
 }
 
+TensorAdaptor<double>::Pointer HistoricalVariableTensorAdaptor::Clone() const
+{
+    return Kratos::make_shared<HistoricalVariableTensorAdaptor>(*this);
+}
+
 void HistoricalVariableTensorAdaptor::Check() const
 {
     KRATOS_TRY

--- a/kratos/tensor_adaptors/historical_variable_tensor_adaptor.h
+++ b/kratos/tensor_adaptors/historical_variable_tensor_adaptor.h
@@ -85,12 +85,19 @@ public:
         const int StepIndex = 0,
         const bool Copy = true);
 
+    HistoricalVariableTensorAdaptor(const HistoricalVariableTensorAdaptor& rOther) = default;
+
     // Destructor
     ~HistoricalVariableTensorAdaptor() override = default;
 
     ///@}
     ///@name Public operations
     ///@{
+
+    /**
+     * @brief Clones the existing tensor adaptor.
+     */
+    TensorAdaptor::Pointer Clone() const override;
 
     /**
      * @brief Checks if the given variable is available and the buffer size is enough in each node.

--- a/kratos/tensor_adaptors/node_position_tensor_adaptor.cpp
+++ b/kratos/tensor_adaptors/node_position_tensor_adaptor.cpp
@@ -80,6 +80,11 @@ NodePositionTensorAdaptor::NodePositionTensorAdaptor(
     KRATOS_CATCH("");
 }
 
+TensorAdaptor<double>::Pointer NodePositionTensorAdaptor::Clone() const
+{
+    return Kratos::make_shared<NodePositionTensorAdaptor>(*this);
+}
+
 void NodePositionTensorAdaptor::CollectData()
 {
     KRATOS_TRY

--- a/kratos/tensor_adaptors/node_position_tensor_adaptor.h
+++ b/kratos/tensor_adaptors/node_position_tensor_adaptor.h
@@ -80,12 +80,19 @@ public:
         Globals::Configuration Configuration,
         const bool Copy = true);
 
+    NodePositionTensorAdaptor(const NodePositionTensorAdaptor& rOther) = default;
+
     // Destructor
     ~NodePositionTensorAdaptor() override = default;
 
     ///@}
     ///@name Public operations
     ///@{
+
+    /**
+     * @brief Clones the existing tensor adaptor.
+     */
+    TensorAdaptor::Pointer Clone() const override;
 
     /**
      * @brief Fill the internal data from Kratos data structures

--- a/kratos/tensor_adaptors/tensor_adaptor.cpp
+++ b/kratos/tensor_adaptors/tensor_adaptor.cpp
@@ -58,7 +58,7 @@ TensorAdaptor<TDataType>::TensorAdaptor(
 }
 
 template<class TDataType>
-TensorAdaptor<TDataType>::Pointer TensorAdaptor<TDataType>::Clone() const
+typename TensorAdaptor<TDataType>::Pointer TensorAdaptor<TDataType>::Clone() const
 {
     return Kratos::make_shared<TensorAdaptor<TDataType>>(*this);
 }

--- a/kratos/tensor_adaptors/tensor_adaptor.cpp
+++ b/kratos/tensor_adaptors/tensor_adaptor.cpp
@@ -58,6 +58,12 @@ TensorAdaptor<TDataType>::TensorAdaptor(
 }
 
 template<class TDataType>
+TensorAdaptor<TDataType>::Pointer TensorAdaptor<TDataType>::Clone() const
+{
+    return Kratos::make_shared<TensorAdaptor<TDataType>>(*this);
+}
+
+template<class TDataType>
 void TensorAdaptor<TDataType>::Check() const
 {
     KRATOS_TRY

--- a/kratos/tensor_adaptors/tensor_adaptor.h
+++ b/kratos/tensor_adaptors/tensor_adaptor.h
@@ -156,6 +156,11 @@ public:
     ///@{
 
     /**
+     * @brief Clones the existing tensor adaptor.
+     */
+    virtual TensorAdaptor::Pointer Clone() const;
+
+    /**
      * @brief Check if the necessary data is present in the underlying container.
      * @details This method should not change anything in the underlying Kratos data structures. It should
      *          only make sure that @ref TensorAdaptor::CollectData "CollectData" and @ref TensorAdaptor::StoreData "StoreData"

--- a/kratos/tensor_adaptors/variable_tensor_adaptor.cpp
+++ b/kratos/tensor_adaptors/variable_tensor_adaptor.cpp
@@ -88,6 +88,11 @@ VariableTensorAdaptor::VariableTensorAdaptor(
     KRATOS_CATCH("");
 }
 
+TensorAdaptor<double>::Pointer VariableTensorAdaptor::Clone() const
+{
+    return Kratos::make_shared<VariableTensorAdaptor>(*this);
+}
+
 void VariableTensorAdaptor::Check() const
 {
     KRATOS_TRY

--- a/kratos/tensor_adaptors/variable_tensor_adaptor.h
+++ b/kratos/tensor_adaptors/variable_tensor_adaptor.h
@@ -88,12 +88,19 @@ public:
         VariablePointerType pVariable,
         const bool Copy = true);
 
+    VariableTensorAdaptor(const VariableTensorAdaptor& rOther) = default;
+
     // Destructor
     ~VariableTensorAdaptor() override = default;
 
     ///@}
     ///@name Public operations
     ///@{
+
+    /**
+     * @brief Clones the existing tensor adaptor.
+     */
+    TensorAdaptor::Pointer Clone() const override;
 
     /**
      * @brief Execution of this check is only required if this VariableTensorAdaptor

--- a/kratos/tests/test_tensor_adaptors.py
+++ b/kratos/tests/test_tensor_adaptors.py
@@ -714,60 +714,6 @@ class TestTensorAdaptors(KratosUnittest.TestCase):
         ref_combined_ta.data *= 3.0
         self.assertAlmostEqual(numpy.linalg.norm(ref_combined_ta.data - combined_ta.data), 0.0)
 
-    def test_NodalNeighboursTensorAdaptorCondition(self):
-        ta = Kratos.TensorAdaptors.NodalNeighbourCountTensorAdaptor(self.model_part.Nodes, self.model_part.Conditions)
-        ta.Check()
-        ta.CollectData()
-
-        for i, v in enumerate(ta.data):
-            if (i != 0 or i != ta.data.size - 1):
-                self.assertEqual(v, 2)
-            else:
-                self.assertEqual(v, 1)
-
-        with self.assertRaises(RuntimeError):
-            ta.StoreData()
-
-    def test_NodalNeighboursTensorAdaptorElement(self):
-        ta = Kratos.TensorAdaptors.NodalNeighbourCountTensorAdaptor(self.model_part.Nodes, self.model_part.Elements)
-        ta.Check()
-        ta.CollectData()
-
-        for i, v in enumerate(ta.data):
-            if (i != 0 or i != ta.data.size - 1):
-                self.assertEqual(v, 2)
-            else:
-                self.assertEqual(v, 1)
-
-        with self.assertRaises(RuntimeError):
-            ta.StoreData()
-
-    def testGeometryMetricsTensorAdaptorDomainSizeCondition(self):
-        ta = Kratos.TensorAdaptors.GeometryMetricsTensorAdaptor(self.model_part.Conditions, Kratos.TensorAdaptors.GeometryMetricsTensorAdaptor.DomainSize)
-        ta.CollectData()
-        for i, condition in enumerate(self.model_part.Conditions):
-            self.assertEqual(ta.data[i], condition.GetGeometry().DomainSize())
-
-    def testGeometryMetricsTensorAdaptorDomainSizeElement(self):
-        ta = Kratos.TensorAdaptors.GeometryMetricsTensorAdaptor(self.model_part.Elements, Kratos.TensorAdaptors.GeometryMetricsTensorAdaptor.DomainSize)
-        ta.CollectData()
-        for i, element in enumerate(self.model_part.Elements):
-            self.assertEqual(ta.data[i], element.GetGeometry().DomainSize())
-
-    def testGeometryMetricsTensorAdaptorDomainSizeCondition_Empty(self):
-        model = Kratos.Model()
-        model_part = model.CreateModelPart("test")
-        ta = Kratos.TensorAdaptors.GeometryMetricsTensorAdaptor(model_part.Conditions, Kratos.TensorAdaptors.GeometryMetricsTensorAdaptor.DomainSize)
-        ta.CollectData()
-        self.assertEqual(ta.data.shape, (0,))
-
-    def testGeometryMetricsTensorAdaptorDomainSizeElement_Empty(self):
-        model = Kratos.Model()
-        model_part = model.CreateModelPart("test")
-        ta = Kratos.TensorAdaptors.GeometryMetricsTensorAdaptor(model_part.Elements, Kratos.TensorAdaptors.GeometryMetricsTensorAdaptor.DomainSize)
-        ta.CollectData()
-        self.assertEqual(ta.data.shape, (0,))
-
     def __TestCopyTensorAdaptor(self, tensor_adaptor_type, value_getter):
         var_ta_orig = tensor_adaptor_type(self.model_part.Nodes, Kratos.VELOCITY, data_shape=[2])
         var_ta_orig.Check()


### PR DESCRIPTION
**📝 Description**
This PR adds virtual `TensorAdaptor::Clone` method and exposes it to python.  The requirement to have a clone method rises when one needs to copy a `CombinedTensorAdaptor`. The proper way to copy the given list of `TensorAdaptors` is to call the clone of each tensor adaptor at the construction of the `CombinedTensorAdaptor`, hence it is required to have in every `TensorAdaptor` a clone method defined.

https://github.com/KratosMultiphysics/Kratos/blob/0083963e267773b9fcff9c7e366338786bd1b509/kratos/tensor_adaptors/combined_tensor_adaptor.cpp#L151-L173

**🆕 Changelog**
- Adds virtual `TensorAdaptor::Clone`  method
- Adds all the derrived classes clone methods (default copy ctor is used in here)
- Updated the tests
