### PR TITLE
[GeoMechanicsApplication] Added two missing inclusion guards

### DIFF
--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_constitutive/mock_constitutive_law.hpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_constitutive/mock_constitutive_law.hpp
@@ -11,6 +11,8 @@
 //                   Gennady Markelov
 //
 
+#pragma once
+
 #include "geo_mechanics_application_variables.h"
 #include "includes/constitutive_law.h"
 #include <gmock/gmock.h>

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/flow_stubs.h
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/flow_stubs.h
@@ -10,6 +10,8 @@
 //  Main authors:    Carlos Lubbers
 //
 
+#pragma once
+
 namespace flow_stubs
 {
 void emptyProgress(double progress);


### PR DESCRIPTION
**📝 Description**
Two header files in the C++ unit tests of the GeoMechanicsApplication lacked an inclusion guard. As a result, Unity builds may start to fail unexpectedly when the way files are joined changes. (This has happened, for instance, [on this branch](https://github.com/KratosMultiphysics/Kratos/tree/geo/14195-add-a-pq-class).) By adding `#pragma once` directives, we overcome this kind of problem.
