### PR TITLE
[GeoMechanicsApplication] Defined addition operators for class `SigmaTau`

### DIFF
--- a/applications/GeoMechanicsApplication/custom_constitutive/coulomb_with_tension_cut_off_impl.cpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/coulomb_with_tension_cut_off_impl.cpp
@@ -184,7 +184,7 @@ Geo::SigmaTau CoulombWithTensionCutOffImpl::ReturnStressAtTensionCutoffReturnZon
     const auto derivative_of_flow_function = mTensionCutOff.DerivativeOfFlowFunction(rTraction);
     const auto lambda_tc = (mTensionCutOff.GetTensileStrength() - rTraction.Sigma() - rTraction.Tau()) /
                            (derivative_of_flow_function[0] + derivative_of_flow_function[1]);
-    return Geo::SigmaTau{rTraction.Values() + lambda_tc * derivative_of_flow_function};
+    return rTraction + lambda_tc * derivative_of_flow_function;
 }
 
 Geo::PrincipalStresses CoulombWithTensionCutOffImpl::ReturnStressAtTensionCutoffReturnZone(
@@ -202,7 +202,7 @@ Geo::SigmaTau CoulombWithTensionCutOffImpl::ReturnStressAtRegularFailureZone(
     const auto derivative_of_flow_function =
         mCoulombYieldSurface.DerivativeOfFlowFunction(rTraction, AveragingType);
     const auto lambda = mCoulombYieldSurface.CalculatePlasticMultiplier(rTraction, derivative_of_flow_function);
-    return Geo::SigmaTau{rTraction.Values() + lambda * derivative_of_flow_function};
+    return rTraction + lambda * derivative_of_flow_function;
 }
 
 Geo::PrincipalStresses CoulombWithTensionCutOffImpl::ReturnStressAtRegularFailureZone(

--- a/applications/GeoMechanicsApplication/custom_constitutive/coulomb_with_tension_cut_off_impl.cpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/coulomb_with_tension_cut_off_impl.cpp
@@ -184,7 +184,7 @@ Geo::SigmaTau CoulombWithTensionCutOffImpl::ReturnStressAtTensionCutoffReturnZon
     const auto derivative_of_flow_function = mTensionCutOff.DerivativeOfFlowFunction(rTraction);
     const auto lambda_tc = (mTensionCutOff.GetTensileStrength() - rTraction.Sigma() - rTraction.Tau()) /
                            (derivative_of_flow_function[0] + derivative_of_flow_function[1]);
-    return rTraction + lambda_tc * derivative_of_flow_function;
+    return rTraction + Geo::SigmaTau{lambda_tc * derivative_of_flow_function};
 }
 
 Geo::PrincipalStresses CoulombWithTensionCutOffImpl::ReturnStressAtTensionCutoffReturnZone(
@@ -202,7 +202,7 @@ Geo::SigmaTau CoulombWithTensionCutOffImpl::ReturnStressAtRegularFailureZone(
     const auto derivative_of_flow_function =
         mCoulombYieldSurface.DerivativeOfFlowFunction(rTraction, AveragingType);
     const auto lambda = mCoulombYieldSurface.CalculatePlasticMultiplier(rTraction, derivative_of_flow_function);
-    return rTraction + lambda * derivative_of_flow_function;
+    return rTraction + Geo::SigmaTau{lambda * derivative_of_flow_function};
 }
 
 Geo::PrincipalStresses CoulombWithTensionCutOffImpl::ReturnStressAtRegularFailureZone(

--- a/applications/GeoMechanicsApplication/custom_constitutive/principal_stresses.hpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/principal_stresses.hpp
@@ -12,6 +12,7 @@
 
 #pragma once
 
+#include "includes/exception.h"
 #include "includes/kratos_export_api.h"
 #include "includes/ublas_interface.h"
 

--- a/applications/GeoMechanicsApplication/custom_constitutive/sigma_tau.cpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/sigma_tau.cpp
@@ -21,7 +21,7 @@ SigmaTau::SigmaTau(const std::initializer_list<double>& rValues)
 {
 }
 
-const SigmaTau::InternalArrayType& SigmaTau::Values() const { return mValues; }
+const SigmaTau::InternalVectorType& SigmaTau::Values() const { return mValues; }
 
 double SigmaTau::Sigma() const { return mValues[0]; }
 

--- a/applications/GeoMechanicsApplication/custom_constitutive/sigma_tau.cpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/sigma_tau.cpp
@@ -31,4 +31,12 @@ double SigmaTau::Tau() const { return mValues[1]; }
 
 double& SigmaTau::Tau() { return mValues[1]; }
 
+SigmaTau operator+(const SigmaTau& rFirstTraction, const SigmaTau& rSecondTraction)
+{
+    return SigmaTau{rFirstTraction.mValues[0] + rSecondTraction.mValues[0],
+                    rFirstTraction.mValues[1] + rSecondTraction.mValues[1]};
+    // SigmaTau r_first_traction(rFirstTraction);
+    // return r_first_traction += rSecondTraction;
+}
+
 } // namespace Kratos::Geo

--- a/applications/GeoMechanicsApplication/custom_constitutive/sigma_tau.cpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/sigma_tau.cpp
@@ -31,6 +31,12 @@ double SigmaTau::Tau() const { return mValues[1]; }
 
 double& SigmaTau::Tau() { return mValues[1]; }
 
+SigmaTau& SigmaTau::operator+=(const SigmaTau& rRhsTraction)
+{
+    std::ranges::transform(mValues, rRhsTraction.mValues, mValues.begin(), std::plus{});
+    return *this;
+}
+
 SigmaTau operator+(const SigmaTau& rFirstTraction, const SigmaTau& rSecondTraction)
 {
     return SigmaTau{rFirstTraction.mValues[0] + rSecondTraction.mValues[0],

--- a/applications/GeoMechanicsApplication/custom_constitutive/sigma_tau.cpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/sigma_tau.cpp
@@ -37,12 +37,10 @@ SigmaTau& SigmaTau::operator+=(const SigmaTau& rRhsTraction)
     return *this;
 }
 
-SigmaTau operator+(const SigmaTau& rFirstTraction, const SigmaTau& rSecondTraction)
+SigmaTau operator+(SigmaTau LhsTraction, const SigmaTau& rRhsTraction)
 {
-    return SigmaTau{rFirstTraction.mValues[0] + rSecondTraction.mValues[0],
-                    rFirstTraction.mValues[1] + rSecondTraction.mValues[1]};
-    // SigmaTau r_first_traction(rFirstTraction);
-    // return r_first_traction += rSecondTraction;
+    LhsTraction += rRhsTraction;
+    return LhsTraction;
 }
 
 } // namespace Kratos::Geo

--- a/applications/GeoMechanicsApplication/custom_constitutive/sigma_tau.cpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/sigma_tau.cpp
@@ -21,7 +21,7 @@ SigmaTau::SigmaTau(const std::initializer_list<double>& rValues)
 {
 }
 
-const SigmaTau::InternalVectorType& SigmaTau::Values() const { return mValues; }
+const SigmaTau::InternalArrayType& SigmaTau::Values() const { return mValues; }
 
 double SigmaTau::Sigma() const { return mValues[0]; }
 

--- a/applications/GeoMechanicsApplication/custom_constitutive/sigma_tau.hpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/sigma_tau.hpp
@@ -53,7 +53,6 @@ public:
         return result;
     }
 
-    // See Section "Binary arithmetic operators" at https://en.cppreference.com/w/cpp/language/operators.html
     SigmaTau& operator+=(const SigmaTau& rRhsTraction);
     KRATOS_API(GEO_MECHANICS_APPLICATION)
     friend SigmaTau operator+(SigmaTau LhsTraction, /* passing this one by value helps optimize chained a+b+c */

--- a/applications/GeoMechanicsApplication/custom_constitutive/sigma_tau.hpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/sigma_tau.hpp
@@ -53,8 +53,10 @@ public:
         return result;
     }
 
+    // See Section "Binary arithmetic operators" at https://en.cppreference.com/w/cpp/language/operators.html
     SigmaTau& operator+=(const SigmaTau& rRhsTraction);
-    friend KRATOS_API(GEO_MECHANICS_APPLICATION) SigmaTau operator+(const SigmaTau&, const SigmaTau&);
+    friend KRATOS_API(GEO_MECHANICS_APPLICATION) inline SigmaTau operator+(SigmaTau LhsTraction, /* passing this one by value helps optimize chained a+b+c */
+                                                                           const SigmaTau& rRhsTraction);
 
 private:
     template <std::forward_iterator Iter>

--- a/applications/GeoMechanicsApplication/custom_constitutive/sigma_tau.hpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/sigma_tau.hpp
@@ -13,11 +13,10 @@
 
 #pragma once
 
-#include "includes/exception.h"
 #include "includes/kratos_export_api.h"
+#include "includes/ublas_interface.h"
 
 #include <algorithm>
-#include <array>
 #include <initializer_list>
 #include <iterator>
 
@@ -27,8 +26,8 @@ namespace Kratos::Geo
 class KRATOS_API(GEO_MECHANICS_APPLICATION) SigmaTau
 {
 public:
-    static constexpr std::size_t msArraySize = 2;
-    using InternalArrayType                  = std::array<double, msArraySize>;
+    static constexpr std::size_t msVectorSize = 2;
+    using InternalVectorType                  = BoundedVector<double, msVectorSize>;
 
     SigmaTau() = default;
 
@@ -39,37 +38,36 @@ public:
 
     explicit SigmaTau(const std::initializer_list<double>& rValues);
 
-    [[nodiscard]] const InternalArrayType& Values() const;
-    [[nodiscard]] double                   Sigma() const;
-    double&                                Sigma();
-    [[nodiscard]] double                   Tau() const;
-    double&                                Tau();
+    [[nodiscard]] const InternalVectorType& Values() const;
+    [[nodiscard]] double                    Sigma() const;
+    double&                                 Sigma();
+    [[nodiscard]] double                    Tau() const;
+    double&                                 Tau();
 
     template <typename VectorType>
     VectorType CopyTo() const
     {
-        auto result = VectorType(msArraySize);
+        auto result = VectorType(msVectorSize);
         std::ranges::copy(mValues, result.begin());
         return result;
     }
 
     SigmaTau& operator+=(const SigmaTau& rRhsTraction);
     KRATOS_API(GEO_MECHANICS_APPLICATION)
-    friend SigmaTau operator+(SigmaTau LhsTraction, /* passing this one by value helps optimize chained a+b+c */
-                              const SigmaTau& rRhsTraction);
+    friend SigmaTau operator+(SigmaTau LhsTraction, const SigmaTau& rRhsTraction);
 
 private:
     template <std::forward_iterator Iter>
     SigmaTau(Iter First, Iter Last)
     {
-        KRATOS_DEBUG_ERROR_IF(std::distance(First, Last) != msArraySize)
-            << "Cannot construct a SigmaTau instance: expected " << msArraySize
+        KRATOS_DEBUG_ERROR_IF(std::distance(First, Last) != msVectorSize)
+            << "Cannot construct a SigmaTau instance: expected " << msVectorSize
             << " values, but got " << std::distance(First, Last) << " value(s)\n";
 
         std::copy(First, Last, mValues.begin());
     }
 
-    InternalArrayType mValues = {0.0, 0.0};
+    InternalVectorType mValues = ZeroVector{msVectorSize};
 };
 
 } // namespace Kratos::Geo

--- a/applications/GeoMechanicsApplication/custom_constitutive/sigma_tau.hpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/sigma_tau.hpp
@@ -53,6 +53,7 @@ public:
         return result;
     }
 
+    SigmaTau& operator+=(const SigmaTau& rRhsTraction);
     friend KRATOS_API(GEO_MECHANICS_APPLICATION) SigmaTau operator+(const SigmaTau&, const SigmaTau&);
 
 private:

--- a/applications/GeoMechanicsApplication/custom_constitutive/sigma_tau.hpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/sigma_tau.hpp
@@ -13,10 +13,11 @@
 
 #pragma once
 
+#include "includes/exception.h"
 #include "includes/kratos_export_api.h"
-#include "includes/ublas_interface.h"
 
 #include <algorithm>
+#include <array>
 #include <initializer_list>
 #include <iterator>
 
@@ -26,8 +27,8 @@ namespace Kratos::Geo
 class KRATOS_API(GEO_MECHANICS_APPLICATION) SigmaTau
 {
 public:
-    static constexpr std::size_t msVectorSize = 2;
-    using InternalVectorType                  = BoundedVector<double, msVectorSize>;
+    static constexpr std::size_t msArraySize = 2;
+    using InternalArrayType                  = std::array<double, msArraySize>;
 
     SigmaTau() = default;
 
@@ -38,16 +39,16 @@ public:
 
     explicit SigmaTau(const std::initializer_list<double>& rValues);
 
-    [[nodiscard]] const InternalVectorType& Values() const;
-    [[nodiscard]] double                    Sigma() const;
-    double&                                 Sigma();
-    [[nodiscard]] double                    Tau() const;
-    double&                                 Tau();
+    [[nodiscard]] const InternalArrayType& Values() const;
+    [[nodiscard]] double                   Sigma() const;
+    double&                                Sigma();
+    [[nodiscard]] double                   Tau() const;
+    double&                                Tau();
 
     template <typename VectorType>
     VectorType CopyTo() const
     {
-        auto result = VectorType(msVectorSize);
+        auto result = VectorType(msArraySize);
         std::ranges::copy(mValues, result.begin());
         return result;
     }
@@ -56,14 +57,20 @@ private:
     template <std::forward_iterator Iter>
     SigmaTau(Iter First, Iter Last)
     {
-        KRATOS_DEBUG_ERROR_IF(std::distance(First, Last) != msVectorSize)
-            << "Cannot construct a SigmaTau instance: expected " << msVectorSize
+        KRATOS_DEBUG_ERROR_IF(std::distance(First, Last) != msArraySize)
+            << "Cannot construct a SigmaTau instance: expected " << msArraySize
             << " values, but got " << std::distance(First, Last) << " value(s)\n";
 
         std::copy(First, Last, mValues.begin());
     }
 
-    InternalVectorType mValues = ZeroVector{msVectorSize};
+    InternalArrayType mValues = {0.0, 0.0};
 };
+
+template <typename VectorType>
+SigmaTau operator+(const SigmaTau& rTraction, const VectorType& rVector)
+{
+    return SigmaTau{rTraction.Sigma() + rVector[0], rTraction.Tau() + rVector[1]};
+}
 
 } // namespace Kratos::Geo

--- a/applications/GeoMechanicsApplication/custom_constitutive/sigma_tau.hpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/sigma_tau.hpp
@@ -53,6 +53,8 @@ public:
         return result;
     }
 
+    friend KRATOS_API(GEO_MECHANICS_APPLICATION) SigmaTau operator+(const SigmaTau&, const SigmaTau&);
+
 private:
     template <std::forward_iterator Iter>
     SigmaTau(Iter First, Iter Last)
@@ -66,11 +68,5 @@ private:
 
     InternalArrayType mValues = {0.0, 0.0};
 };
-
-template <typename VectorType>
-SigmaTau operator+(const SigmaTau& rTraction, const VectorType& rVector)
-{
-    return SigmaTau{rTraction.Sigma() + rVector[0], rTraction.Tau() + rVector[1]};
-}
 
 } // namespace Kratos::Geo

--- a/applications/GeoMechanicsApplication/custom_constitutive/sigma_tau.hpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/sigma_tau.hpp
@@ -13,6 +13,7 @@
 
 #pragma once
 
+#include "includes/exception.h"
 #include "includes/kratos_export_api.h"
 #include "includes/ublas_interface.h"
 

--- a/applications/GeoMechanicsApplication/custom_constitutive/sigma_tau.hpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/sigma_tau.hpp
@@ -55,8 +55,9 @@ public:
 
     // See Section "Binary arithmetic operators" at https://en.cppreference.com/w/cpp/language/operators.html
     SigmaTau& operator+=(const SigmaTau& rRhsTraction);
-    friend KRATOS_API(GEO_MECHANICS_APPLICATION) inline SigmaTau operator+(SigmaTau LhsTraction, /* passing this one by value helps optimize chained a+b+c */
-                                                                           const SigmaTau& rRhsTraction);
+    KRATOS_API(GEO_MECHANICS_APPLICATION)
+    friend SigmaTau operator+(SigmaTau LhsTraction, /* passing this one by value helps optimize chained a+b+c */
+                              const SigmaTau& rRhsTraction);
 
 private:
     template <std::forward_iterator Iter>

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_constitutive/test_sigma_tau.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_constitutive/test_sigma_tau.cpp
@@ -116,11 +116,20 @@ TYPED_TEST(TestSigmaTauFixture, SigmaTau_CanBeCopiedToAnyVectorTypeWithSizeOf2)
 
 TEST_F(KratosGeoMechanicsFastSuiteWithoutKernel, SigmaTau_CanBeAddedToAnotherSigmaTau)
 {
+    // Arrange
+    auto traction = Geo::SigmaTau{1.0, 2.0};
+
     // Act
-    const auto total_traction = Geo::SigmaTau{1.0, 2.0} + Geo::SigmaTau{3.0, 4.0};
+    traction += Geo::SigmaTau{3.0, 4.0};
 
     // Assert
-    KRATOS_EXPECT_VECTOR_NEAR(total_traction.Values(), (std::array{4.0, 6.0}), Defaults::absolute_tolerance);
+    KRATOS_EXPECT_VECTOR_NEAR(traction.Values(), (std::array{4.0, 6.0}), Defaults::absolute_tolerance);
+
+    // Arrange & Act
+    traction = Geo::SigmaTau{2.0, 1.0} + Geo::SigmaTau{3.0, 4.0};
+
+    // Assert
+    KRATOS_EXPECT_VECTOR_NEAR(traction.Values(), (std::array{5.0, 5.0}), Defaults::absolute_tolerance);
 }
 
 } // namespace Kratos::Testing

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_constitutive/test_sigma_tau.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_constitutive/test_sigma_tau.cpp
@@ -114,13 +114,13 @@ TYPED_TEST(TestSigmaTauFixture, SigmaTau_CanBeCopiedToAnyVectorTypeWithSizeOf2)
     KRATOS_EXPECT_VECTOR_NEAR(sigma_tau.CopyTo<TypeParam>(), (std::array{1.0, 2.0}), Defaults::absolute_tolerance);
 }
 
-TEST_F(KratosGeoMechanicsFastSuiteWithoutKernel, SigmaTau_AnyVectorWithSizeOf2CanBeAddedToIt)
+TEST_F(KratosGeoMechanicsFastSuiteWithoutKernel, SigmaTau_CanBeAddedToAnotherSigmaTau)
 {
     // Act
-    const auto total_traction = Geo::SigmaTau{1.0, 2.0} + Vector(2, 3.0);
+    const auto total_traction = Geo::SigmaTau{1.0, 2.0} + Geo::SigmaTau{3.0, 4.0};
 
     // Assert
-    KRATOS_EXPECT_VECTOR_NEAR(total_traction.Values(), (std::array{4.0, 5.0}), Defaults::absolute_tolerance);
+    KRATOS_EXPECT_VECTOR_NEAR(total_traction.Values(), (std::array{4.0, 6.0}), Defaults::absolute_tolerance);
 }
 
 } // namespace Kratos::Testing

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_constitutive/test_sigma_tau.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_constitutive/test_sigma_tau.cpp
@@ -46,12 +46,12 @@ TYPED_TEST(TestSigmaTauFixture, SigmaTau_CanBeConstructedFromAnyVectorWithSizeOf
     initialization_vector[1]   = 2.0;
 
     // Act
-    const auto sigma_tau = Geo::SigmaTau{initialization_vector};
+    const auto traction = Geo::SigmaTau{initialization_vector};
 
     // Assert
-    KRATOS_EXPECT_VECTOR_NEAR(sigma_tau.Values(), initialization_vector, Defaults::absolute_tolerance);
-    EXPECT_NEAR(sigma_tau.Sigma(), initialization_vector[0], Defaults::absolute_tolerance);
-    EXPECT_NEAR(sigma_tau.Tau(), initialization_vector[1], Defaults::absolute_tolerance);
+    KRATOS_EXPECT_VECTOR_NEAR(traction.Values(), initialization_vector, Defaults::absolute_tolerance);
+    EXPECT_NEAR(traction.Sigma(), initialization_vector[0], Defaults::absolute_tolerance);
+    EXPECT_NEAR(traction.Tau(), initialization_vector[1], Defaults::absolute_tolerance);
 }
 
 TEST_F(KratosGeoMechanicsFastSuiteWithoutKernel,
@@ -90,28 +90,28 @@ TEST_F(KratosGeoMechanicsFastSuiteWithoutKernel,
 TEST_F(KratosGeoMechanicsFastSuiteWithoutKernel, SigmaTau_ComponentsCanBeModifiedDirectly)
 {
     // Arrange
-    auto sigma_tau = Geo::SigmaTau{1.0, 2.0};
+    auto traction = Geo::SigmaTau{1.0, 2.0};
 
     // Act
-    sigma_tau.Sigma() = 3.0;
+    traction.Sigma() = 3.0;
 
     // Assert
-    KRATOS_EXPECT_VECTOR_NEAR(sigma_tau.Values(), (std::array{3.0, 2.0}), Defaults::absolute_tolerance);
+    KRATOS_EXPECT_VECTOR_NEAR(traction.Values(), (std::array{3.0, 2.0}), Defaults::absolute_tolerance);
 
     // Act
-    sigma_tau.Tau() = 4.0;
+    traction.Tau() = 4.0;
 
     // Assert
-    KRATOS_EXPECT_VECTOR_NEAR(sigma_tau.Values(), (std::array{3.0, 4.0}), Defaults::absolute_tolerance);
+    KRATOS_EXPECT_VECTOR_NEAR(traction.Values(), (std::array{3.0, 4.0}), Defaults::absolute_tolerance);
 }
 
 TYPED_TEST(TestSigmaTauFixture, SigmaTau_CanBeCopiedToAnyVectorTypeWithSizeOf2)
 {
     // Arrange
-    const auto sigma_tau = Geo::SigmaTau{1.0, 2.0};
+    const auto traction = Geo::SigmaTau{1.0, 2.0};
 
     // Act & Assert
-    KRATOS_EXPECT_VECTOR_NEAR(sigma_tau.CopyTo<TypeParam>(), (std::array{1.0, 2.0}), Defaults::absolute_tolerance);
+    KRATOS_EXPECT_VECTOR_NEAR(traction.CopyTo<TypeParam>(), (std::array{1.0, 2.0}), Defaults::absolute_tolerance);
 }
 
 TEST_F(KratosGeoMechanicsFastSuiteWithoutKernel, SigmaTau_CanBeAddedToAnotherSigmaTau)

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_constitutive/test_sigma_tau.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_constitutive/test_sigma_tau.cpp
@@ -17,7 +17,6 @@
 #include "tests/cpp_tests/geo_mechanics_fast_suite_without_kernel.h"
 #include "tests/cpp_tests/test_utilities.h"
 
-#include <array>
 #include <vector>
 
 namespace Kratos::Testing
@@ -25,7 +24,7 @@ namespace Kratos::Testing
 
 TEST_F(KratosGeoMechanicsFastSuiteWithoutKernel, SigmaTau_HasZeroesAsValuesWhenDefaultConstructed)
 {
-    KRATOS_EXPECT_VECTOR_NEAR(Geo::SigmaTau().Values(), (std::array{0.0, 0.0}), Defaults::absolute_tolerance);
+    KRATOS_EXPECT_VECTOR_NEAR(Geo::SigmaTau().Values(), Vector(2, 0.0), Defaults::absolute_tolerance);
     EXPECT_NEAR(Geo::SigmaTau{}.Sigma(), 0.0, Defaults::absolute_tolerance);
     EXPECT_NEAR(Geo::SigmaTau{}.Tau(), 0.0, Defaults::absolute_tolerance);
 }
@@ -96,13 +95,13 @@ TEST_F(KratosGeoMechanicsFastSuiteWithoutKernel, SigmaTau_ComponentsCanBeModifie
     traction.Sigma() = 3.0;
 
     // Assert
-    KRATOS_EXPECT_VECTOR_NEAR(traction.Values(), (std::array{3.0, 2.0}), Defaults::absolute_tolerance);
+    KRATOS_EXPECT_VECTOR_NEAR(traction.Values(), (std::vector{3.0, 2.0}), Defaults::absolute_tolerance);
 
     // Act
     traction.Tau() = 4.0;
 
     // Assert
-    KRATOS_EXPECT_VECTOR_NEAR(traction.Values(), (std::array{3.0, 4.0}), Defaults::absolute_tolerance);
+    KRATOS_EXPECT_VECTOR_NEAR(traction.Values(), (std::vector{3.0, 4.0}), Defaults::absolute_tolerance);
 }
 
 TYPED_TEST(TestSigmaTauFixture, SigmaTau_CanBeCopiedToAnyVectorTypeWithSizeOf2)
@@ -111,7 +110,7 @@ TYPED_TEST(TestSigmaTauFixture, SigmaTau_CanBeCopiedToAnyVectorTypeWithSizeOf2)
     const auto traction = Geo::SigmaTau{1.0, 2.0};
 
     // Act & Assert
-    KRATOS_EXPECT_VECTOR_NEAR(traction.CopyTo<TypeParam>(), (std::array{1.0, 2.0}), Defaults::absolute_tolerance);
+    KRATOS_EXPECT_VECTOR_NEAR(traction.CopyTo<TypeParam>(), (std::vector{1.0, 2.0}), Defaults::absolute_tolerance);
 }
 
 TEST_F(KratosGeoMechanicsFastSuiteWithoutKernel, SigmaTau_SupportsCompoundAssignment)
@@ -123,7 +122,7 @@ TEST_F(KratosGeoMechanicsFastSuiteWithoutKernel, SigmaTau_SupportsCompoundAssign
     traction += Geo::SigmaTau{3.0, 4.0};
 
     // Assert
-    KRATOS_EXPECT_VECTOR_NEAR(traction.Values(), (std::array{4.0, 6.0}), Defaults::absolute_tolerance);
+    KRATOS_EXPECT_VECTOR_NEAR(traction.Values(), (std::vector{4.0, 6.0}), Defaults::absolute_tolerance);
 }
 
 TEST_F(KratosGeoMechanicsFastSuiteWithoutKernel, SigmaTau_SupportsAdditionOfTwoInstances)
@@ -132,7 +131,7 @@ TEST_F(KratosGeoMechanicsFastSuiteWithoutKernel, SigmaTau_SupportsAdditionOfTwoI
     const auto summed_traction = Geo::SigmaTau{2.0, 1.0} + Geo::SigmaTau{3.0, 4.0};
 
     // Assert
-    KRATOS_EXPECT_VECTOR_NEAR(summed_traction.Values(), (std::array{5.0, 5.0}), Defaults::absolute_tolerance);
+    KRATOS_EXPECT_VECTOR_NEAR(summed_traction.Values(), (std::vector{5.0, 5.0}), Defaults::absolute_tolerance);
 }
 
 } // namespace Kratos::Testing

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_constitutive/test_sigma_tau.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_constitutive/test_sigma_tau.cpp
@@ -114,4 +114,13 @@ TYPED_TEST(TestSigmaTauFixture, SigmaTau_CanBeCopiedToAnyVectorTypeWithSizeOf2)
     KRATOS_EXPECT_VECTOR_NEAR(sigma_tau.CopyTo<TypeParam>(), (std::array{1.0, 2.0}), Defaults::absolute_tolerance);
 }
 
+TEST_F(KratosGeoMechanicsFastSuiteWithoutKernel, SigmaTau_AnyVectorWithSizeOf2CanBeAddedToIt)
+{
+    // Act
+    const auto total_traction = Geo::SigmaTau{1.0, 2.0} + Vector(2, 3.0);
+
+    // Assert
+    KRATOS_EXPECT_VECTOR_NEAR(total_traction.Values(), (std::array{4.0, 5.0}), Defaults::absolute_tolerance);
+}
+
 } // namespace Kratos::Testing

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_constitutive/test_sigma_tau.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_constitutive/test_sigma_tau.cpp
@@ -17,12 +17,15 @@
 #include "tests/cpp_tests/geo_mechanics_fast_suite_without_kernel.h"
 #include "tests/cpp_tests/test_utilities.h"
 
+#include <array>
+#include <vector>
+
 namespace Kratos::Testing
 {
 
 TEST_F(KratosGeoMechanicsFastSuiteWithoutKernel, SigmaTau_HasZeroesAsValuesWhenDefaultConstructed)
 {
-    KRATOS_EXPECT_VECTOR_NEAR(Geo::SigmaTau().Values(), Vector(2, 0.0), Defaults::absolute_tolerance);
+    KRATOS_EXPECT_VECTOR_NEAR(Geo::SigmaTau().Values(), (std::array{0.0, 0.0}), Defaults::absolute_tolerance);
     EXPECT_NEAR(Geo::SigmaTau{}.Sigma(), 0.0, Defaults::absolute_tolerance);
     EXPECT_NEAR(Geo::SigmaTau{}.Tau(), 0.0, Defaults::absolute_tolerance);
 }
@@ -93,13 +96,13 @@ TEST_F(KratosGeoMechanicsFastSuiteWithoutKernel, SigmaTau_ComponentsCanBeModifie
     sigma_tau.Sigma() = 3.0;
 
     // Assert
-    KRATOS_EXPECT_VECTOR_NEAR(sigma_tau.Values(), (std::vector{3.0, 2.0}), Defaults::absolute_tolerance);
+    KRATOS_EXPECT_VECTOR_NEAR(sigma_tau.Values(), (std::array{3.0, 2.0}), Defaults::absolute_tolerance);
 
     // Act
     sigma_tau.Tau() = 4.0;
 
     // Assert
-    KRATOS_EXPECT_VECTOR_NEAR(sigma_tau.Values(), (std::vector{3.0, 4.0}), Defaults::absolute_tolerance);
+    KRATOS_EXPECT_VECTOR_NEAR(sigma_tau.Values(), (std::array{3.0, 4.0}), Defaults::absolute_tolerance);
 }
 
 TYPED_TEST(TestSigmaTauFixture, SigmaTau_CanBeCopiedToAnyVectorTypeWithSizeOf2)
@@ -108,7 +111,7 @@ TYPED_TEST(TestSigmaTauFixture, SigmaTau_CanBeCopiedToAnyVectorTypeWithSizeOf2)
     const auto sigma_tau = Geo::SigmaTau{1.0, 2.0};
 
     // Act & Assert
-    KRATOS_EXPECT_VECTOR_NEAR(sigma_tau.CopyTo<TypeParam>(), (std::vector{1.0, 2.0}), Defaults::absolute_tolerance);
+    KRATOS_EXPECT_VECTOR_NEAR(sigma_tau.CopyTo<TypeParam>(), (std::array{1.0, 2.0}), Defaults::absolute_tolerance);
 }
 
 } // namespace Kratos::Testing

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_constitutive/test_sigma_tau.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_constitutive/test_sigma_tau.cpp
@@ -114,7 +114,7 @@ TYPED_TEST(TestSigmaTauFixture, SigmaTau_CanBeCopiedToAnyVectorTypeWithSizeOf2)
     KRATOS_EXPECT_VECTOR_NEAR(traction.CopyTo<TypeParam>(), (std::array{1.0, 2.0}), Defaults::absolute_tolerance);
 }
 
-TEST_F(KratosGeoMechanicsFastSuiteWithoutKernel, SigmaTau_CanBeAddedToAnotherSigmaTau)
+TEST_F(KratosGeoMechanicsFastSuiteWithoutKernel, SigmaTau_SupportsCompoundAssignment)
 {
     // Arrange
     auto traction = Geo::SigmaTau{1.0, 2.0};
@@ -124,12 +124,15 @@ TEST_F(KratosGeoMechanicsFastSuiteWithoutKernel, SigmaTau_CanBeAddedToAnotherSig
 
     // Assert
     KRATOS_EXPECT_VECTOR_NEAR(traction.Values(), (std::array{4.0, 6.0}), Defaults::absolute_tolerance);
+}
 
+TEST_F(KratosGeoMechanicsFastSuiteWithoutKernel, SigmaTau_SupportsAdditionOfTwoInstances)
+{
     // Arrange & Act
-    traction = Geo::SigmaTau{2.0, 1.0} + Geo::SigmaTau{3.0, 4.0};
+    const auto summed_traction = Geo::SigmaTau{2.0, 1.0} + Geo::SigmaTau{3.0, 4.0};
 
     // Assert
-    KRATOS_EXPECT_VECTOR_NEAR(traction.Values(), (std::array{5.0, 5.0}), Defaults::absolute_tolerance);
+    KRATOS_EXPECT_VECTOR_NEAR(summed_traction.Values(), (std::array{5.0, 5.0}), Defaults::absolute_tolerance);
 }
 
 } // namespace Kratos::Testing


### PR DESCRIPTION
**📝 Description**
Defined operators to support addition of `SigmaTau` objects.

**🆕 Changelog**
- Defined and unit-tested `operator+=` as well as `operator+` for objects of type `SigmaTau`. Code that adds two traction vectors has been updated accordingly.
- Renamed several local variables in the unit tests of class `SigmaTau`.
