### PR TITLE
[GeoMechanicsApplication] Add a class that represents a (p, q) stress invariant

### DIFF
--- a/applications/GeoMechanicsApplication/custom_constitutive/p_q.cpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/p_q.cpp
@@ -18,14 +18,14 @@ namespace Kratos::Geo
 
 PQ::PQ(const std::initializer_list<double>& rValues) : PQ{rValues.begin(), rValues.end()} {}
 
-const PQ::InternalVectorType& PQ::Values() const { return mValues; }
+const PQ::InternalVectorType& PQ::Values() const noexcept { return mValues; }
 
-double PQ::P() const { return mValues[0]; }
+double PQ::P() const noexcept { return mValues[0]; }
 
-double& PQ::P() { return mValues[0]; }
+double& PQ::P() noexcept { return mValues[0]; }
 
-double PQ::Q() const { return mValues[1]; }
+double PQ::Q() const noexcept { return mValues[1]; }
 
-double& PQ::Q() { return mValues[1]; }
+double& PQ::Q() noexcept { return mValues[1]; }
 
 } // namespace Kratos::Geo

--- a/applications/GeoMechanicsApplication/custom_constitutive/p_q.cpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/p_q.cpp
@@ -18,7 +18,7 @@ namespace Kratos::Geo
 
 PQ::PQ(const std::initializer_list<double>& rValues) : PQ{rValues.begin(), rValues.end()} {}
 
-const PQ::InternalVectorType& PQ::Values() const { return mValues; }
+const PQ::InternalArrayType& PQ::Values() const { return mValues; }
 
 double PQ::P() const { return mValues[0]; }
 

--- a/applications/GeoMechanicsApplication/custom_constitutive/p_q.cpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/p_q.cpp
@@ -18,7 +18,7 @@ namespace Kratos::Geo
 
 PQ::PQ(const std::initializer_list<double>& rValues) : PQ{rValues.begin(), rValues.end()} {}
 
-const PQ::InternalArrayType& PQ::Values() const { return mValues; }
+const PQ::InternalVectorType& PQ::Values() const { return mValues; }
 
 double PQ::P() const { return mValues[0]; }
 

--- a/applications/GeoMechanicsApplication/custom_constitutive/p_q.cpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/p_q.cpp
@@ -16,7 +16,11 @@
 namespace Kratos::Geo
 {
 
-PQ::PQ(const std::initializer_list<double>& rValues) : PQ{rValues.begin(), rValues.end()} {}
+PQ::PQ(double P, double Q)
+{
+    mValues[0] = P;
+    mValues[1] = Q;
+}
 
 const PQ::InternalVectorType& PQ::Values() const noexcept { return mValues; }
 

--- a/applications/GeoMechanicsApplication/custom_constitutive/p_q.cpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/p_q.cpp
@@ -1,0 +1,31 @@
+// KRATOS___
+//     //   ) )
+//    //         ___      ___
+//   //  ____  //___) ) //   ) )
+//  //    / / //       //   / /
+// ((____/ / ((____   ((___/ /  MECHANICS
+//
+//  License:         geo_mechanics_application/license.txt
+//
+//
+//  Main authors:    Anne van de Graaf
+//
+
+#include "custom_constitutive/p_q.hpp"
+
+namespace Kratos::Geo
+{
+
+PQ::PQ(const std::initializer_list<double>& rValues) : PQ{rValues.begin(), rValues.end()} {}
+
+const PQ::InternalVectorType& PQ::Values() const { return mValues; }
+
+double PQ::P() const { return mValues[0]; }
+
+double& PQ::P() { return mValues[0]; }
+
+double PQ::Q() const { return mValues[1]; }
+
+double& PQ::Q() { return mValues[1]; }
+
+} // namespace Kratos::Geo

--- a/applications/GeoMechanicsApplication/custom_constitutive/p_q.hpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/p_q.hpp
@@ -13,11 +13,10 @@
 
 #pragma once
 
-#include "includes/exception.h"
 #include "includes/kratos_export_api.h"
+#include "includes/ublas_interface.h"
 
 #include <algorithm>
-#include <array>
 #include <initializer_list>
 #include <iterator>
 
@@ -27,8 +26,8 @@ namespace Kratos::Geo
 class KRATOS_API(GEO_MECHANICS_APPLICATION) PQ
 {
 public:
-    static constexpr std::size_t msArraySize = 2;
-    using InternalArrayType                  = std::array<double, msArraySize>;
+    static constexpr std::size_t msVectorSize = 2;
+    using InternalVectorType                  = BoundedVector<double, msVectorSize>;
 
     PQ() = default;
 
@@ -39,16 +38,16 @@ public:
 
     explicit PQ(const std::initializer_list<double>& rValues);
 
-    [[nodiscard]] const InternalArrayType& Values() const;
-    [[nodiscard]] double                   P() const;
-    double&                                P();
-    [[nodiscard]] double                   Q() const;
-    double&                                Q();
+    [[nodiscard]] const InternalVectorType& Values() const;
+    [[nodiscard]] double                    P() const;
+    double&                                 P();
+    [[nodiscard]] double                    Q() const;
+    double&                                 Q();
 
     template <typename VectorType>
     VectorType CopyTo() const
     {
-        auto result = VectorType(msArraySize);
+        auto result = VectorType(msVectorSize);
         std::ranges::copy(mValues, result.begin());
         return result;
     }
@@ -57,14 +56,14 @@ private:
     template <std::forward_iterator Iter>
     PQ(Iter First, Iter Last)
     {
-        KRATOS_DEBUG_ERROR_IF(std::distance(First, Last) != msArraySize)
-            << "Cannot construct a PQ instance: expected " << msArraySize << " values, but got "
+        KRATOS_DEBUG_ERROR_IF(std::distance(First, Last) != msVectorSize)
+            << "Cannot construct a PQ instance: expected " << msVectorSize << " values, but got "
             << std::distance(First, Last) << " value(s)\n";
 
         std::copy(First, Last, mValues.begin());
     }
 
-    InternalArrayType mValues = {0.0, 0.0};
+    InternalVectorType mValues = ZeroVector{msVectorSize};
 };
 
 } // namespace Kratos::Geo

--- a/applications/GeoMechanicsApplication/custom_constitutive/p_q.hpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/p_q.hpp
@@ -31,13 +31,12 @@ public:
     using InternalVectorType                  = BoundedVector<double, msVectorSize>;
 
     PQ() = default;
+    PQ(double P, double Q);
 
     template <typename VectorType>
     explicit PQ(const VectorType& rValues) : PQ{std::begin(rValues), std::end(rValues)}
     {
     }
-
-    explicit PQ(const std::initializer_list<double>& rValues);
 
     [[nodiscard]] const InternalVectorType& Values() const noexcept;
     [[nodiscard]] double                    P() const noexcept;

--- a/applications/GeoMechanicsApplication/custom_constitutive/p_q.hpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/p_q.hpp
@@ -18,8 +18,6 @@
 #include "includes/ublas_interface.h"
 
 #include <algorithm>
-#include <initializer_list>
-#include <iterator>
 
 namespace Kratos::Geo
 {
@@ -34,8 +32,13 @@ public:
     PQ(double P, double Q);
 
     template <typename VectorType>
-    explicit PQ(const VectorType& rValues) : PQ{std::begin(rValues), std::end(rValues)}
+    explicit PQ(const VectorType& rValues)
     {
+        KRATOS_DEBUG_ERROR_IF(std::ranges::distance(rValues) != msVectorSize)
+            << "Cannot construct a PQ instance: expected " << msVectorSize << " values, but got "
+            << std::ranges::distance(rValues) << " value(s)\n";
+
+        std::ranges::copy(rValues, mValues.begin());
     }
 
     [[nodiscard]] const InternalVectorType& Values() const noexcept;
@@ -53,16 +56,6 @@ public:
     }
 
 private:
-    template <std::forward_iterator Iter>
-    PQ(Iter First, Iter Last)
-    {
-        KRATOS_DEBUG_ERROR_IF(std::distance(First, Last) != msVectorSize)
-            << "Cannot construct a PQ instance: expected " << msVectorSize << " values, but got "
-            << std::distance(First, Last) << " value(s)\n";
-
-        std::copy(First, Last, mValues.begin());
-    }
-
     InternalVectorType mValues = ZeroVector{msVectorSize};
 };
 

--- a/applications/GeoMechanicsApplication/custom_constitutive/p_q.hpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/p_q.hpp
@@ -1,0 +1,69 @@
+// KRATOS___
+//     //   ) )
+//    //         ___      ___
+//   //  ____  //___) ) //   ) )
+//  //    / / //       //   / /
+// ((____/ / ((____   ((___/ /  MECHANICS
+//
+//  License:         geo_mechanics_application/license.txt
+//
+//
+//  Main authors:    Anne van de Graaf
+//
+
+#pragma once
+
+#include "includes/kratos_export_api.h"
+#include "includes/ublas_interface.h"
+
+#include <algorithm>
+#include <initializer_list>
+#include <iterator>
+
+namespace Kratos::Geo
+{
+
+class KRATOS_API(GEO_MECHANICS_APPLICATION) PQ
+{
+public:
+    static constexpr std::size_t msVectorSize = 2;
+    using InternalVectorType                  = BoundedVector<double, msVectorSize>;
+
+    PQ() = default;
+
+    template <typename VectorType>
+    explicit PQ(const VectorType& rValues) : PQ{std::begin(rValues), std::end(rValues)}
+    {
+    }
+
+    explicit PQ(const std::initializer_list<double>& rValues);
+
+    [[nodiscard]] const InternalVectorType& Values() const;
+    [[nodiscard]] double                    P() const;
+    double&                                 P();
+    [[nodiscard]] double                    Q() const;
+    double&                                 Q();
+
+    template <typename VectorType>
+    VectorType CopyTo() const
+    {
+        auto result = VectorType(msVectorSize);
+        std::ranges::copy(mValues, result.begin());
+        return result;
+    }
+
+private:
+    template <std::forward_iterator Iter>
+    PQ(Iter First, Iter Last)
+    {
+        KRATOS_DEBUG_ERROR_IF(std::distance(First, Last) != msVectorSize)
+            << "Cannot construct a PQ instance: expected " << msVectorSize << " values, but got "
+            << std::distance(First, Last) << " value(s)\n";
+
+        std::copy(First, Last, mValues.begin());
+    }
+
+    InternalVectorType mValues = ZeroVector{msVectorSize};
+};
+
+} // namespace Kratos::Geo

--- a/applications/GeoMechanicsApplication/custom_constitutive/p_q.hpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/p_q.hpp
@@ -39,11 +39,11 @@ public:
 
     explicit PQ(const std::initializer_list<double>& rValues);
 
-    [[nodiscard]] const InternalVectorType& Values() const;
-    [[nodiscard]] double                    P() const;
-    double&                                 P();
-    [[nodiscard]] double                    Q() const;
-    double&                                 Q();
+    [[nodiscard]] const InternalVectorType& Values() const noexcept;
+    [[nodiscard]] double                    P() const noexcept;
+    double&                                 P() noexcept;
+    [[nodiscard]] double                    Q() const noexcept;
+    double&                                 Q() noexcept;
 
     template <typename VectorType>
     VectorType CopyTo() const

--- a/applications/GeoMechanicsApplication/custom_constitutive/p_q.hpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/p_q.hpp
@@ -13,10 +13,11 @@
 
 #pragma once
 
+#include "includes/exception.h"
 #include "includes/kratos_export_api.h"
-#include "includes/ublas_interface.h"
 
 #include <algorithm>
+#include <array>
 #include <initializer_list>
 #include <iterator>
 
@@ -26,8 +27,8 @@ namespace Kratos::Geo
 class KRATOS_API(GEO_MECHANICS_APPLICATION) PQ
 {
 public:
-    static constexpr std::size_t msVectorSize = 2;
-    using InternalVectorType                  = BoundedVector<double, msVectorSize>;
+    static constexpr std::size_t msArraySize = 2;
+    using InternalArrayType                  = std::array<double, msArraySize>;
 
     PQ() = default;
 
@@ -38,16 +39,16 @@ public:
 
     explicit PQ(const std::initializer_list<double>& rValues);
 
-    [[nodiscard]] const InternalVectorType& Values() const;
-    [[nodiscard]] double                    P() const;
-    double&                                 P();
-    [[nodiscard]] double                    Q() const;
-    double&                                 Q();
+    [[nodiscard]] const InternalArrayType& Values() const;
+    [[nodiscard]] double                   P() const;
+    double&                                P();
+    [[nodiscard]] double                   Q() const;
+    double&                                Q();
 
     template <typename VectorType>
     VectorType CopyTo() const
     {
-        auto result = VectorType(msVectorSize);
+        auto result = VectorType(msArraySize);
         std::ranges::copy(mValues, result.begin());
         return result;
     }
@@ -56,14 +57,14 @@ private:
     template <std::forward_iterator Iter>
     PQ(Iter First, Iter Last)
     {
-        KRATOS_DEBUG_ERROR_IF(std::distance(First, Last) != msVectorSize)
-            << "Cannot construct a PQ instance: expected " << msVectorSize << " values, but got "
+        KRATOS_DEBUG_ERROR_IF(std::distance(First, Last) != msArraySize)
+            << "Cannot construct a PQ instance: expected " << msArraySize << " values, but got "
             << std::distance(First, Last) << " value(s)\n";
 
         std::copy(First, Last, mValues.begin());
     }
 
-    InternalVectorType mValues = ZeroVector{msVectorSize};
+    InternalArrayType mValues = {0.0, 0.0};
 };
 
 } // namespace Kratos::Geo

--- a/applications/GeoMechanicsApplication/custom_constitutive/p_q.hpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/p_q.hpp
@@ -13,6 +13,7 @@
 
 #pragma once
 
+#include "includes/exception.h"
 #include "includes/kratos_export_api.h"
 #include "includes/ublas_interface.h"
 

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_constitutive/test_p_q.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_constitutive/test_p_q.cpp
@@ -1,0 +1,114 @@
+// KRATOS___
+//     //   ) )
+//    //         ___      ___
+//   //  ____  //___) ) //   ) )
+//  //    / / //       //   / /
+// ((____/ / ((____   ((___/ /  MECHANICS
+//
+//  License:         geo_mechanics_application/license.txt
+//
+//
+//  Main authors:    Anne van de Graaf
+//
+
+#include "custom_constitutive/p_q.hpp"
+#include "custom_utilities/ublas_utilities.h"
+#include "includes/expect.h"
+#include "tests/cpp_tests/geo_mechanics_fast_suite_without_kernel.h"
+#include "tests/cpp_tests/test_utilities.h"
+
+namespace Kratos::Testing
+{
+
+TEST_F(KratosGeoMechanicsFastSuiteWithoutKernel, PQ_HasZeroesAsValuesWhenDefaultConstructed)
+{
+    KRATOS_EXPECT_VECTOR_NEAR(Geo::PQ().Values(), Vector(2, 0.0), Defaults::absolute_tolerance);
+    EXPECT_NEAR(Geo::PQ{}.P(), 0.0, Defaults::absolute_tolerance);
+    EXPECT_NEAR(Geo::PQ{}.Q(), 0.0, Defaults::absolute_tolerance);
+}
+
+template <typename T>
+class TestPQFixture : public ::testing::Test
+{
+};
+
+using TestVectorTypes = ::testing::Types<Vector, BoundedVector<double, 2>, std::vector<double>>;
+TYPED_TEST_SUITE(TestPQFixture, TestVectorTypes);
+
+TYPED_TEST(TestPQFixture, PQ_CanBeConstructedFromAnyVectorWithSizeOf2)
+{
+    // Arrange
+    auto initialization_vector = TypeParam(2);
+    initialization_vector[0]   = 1.0;
+    initialization_vector[1]   = 2.0;
+
+    // Act
+    const auto stress_invariant = Geo::PQ{initialization_vector};
+
+    // Assert
+    KRATOS_EXPECT_VECTOR_NEAR(stress_invariant.Values(), initialization_vector, Defaults::absolute_tolerance);
+    EXPECT_NEAR(stress_invariant.P(), initialization_vector[0], Defaults::absolute_tolerance);
+    EXPECT_NEAR(stress_invariant.Q(), initialization_vector[1], Defaults::absolute_tolerance);
+}
+
+TEST_F(KratosGeoMechanicsFastSuiteWithoutKernel, PQ_RaisesADebugErrorWhenAttemptingToConstructFromAVectorWithSizeUnequalTo2)
+{
+#ifndef KRATOS_DEBUG
+    GTEST_SKIP() << "This test requires a debug build";
+#endif
+
+    // Arrange
+    const auto too_short = UblasUtilities::CreateVector({1.0});
+    const auto too_long  = UblasUtilities::CreateVector({2.0, 3.0, 4.0});
+
+    // Act & Assert
+    EXPECT_THROW(Geo::PQ{too_short}, Exception);
+    EXPECT_THROW(Geo::PQ{too_long}, Exception);
+}
+
+TEST_F(KratosGeoMechanicsFastSuiteWithoutKernel, PQ_CanBeConstructedFromAStdInitializerListWithSize2)
+{
+    EXPECT_NEAR((Geo::PQ{1.0, 2.0}.P()), 1.0, Defaults::absolute_tolerance);
+    EXPECT_NEAR((Geo::PQ{1.0, 2.0}.Q()), 2.0, Defaults::absolute_tolerance);
+}
+
+TEST_F(KratosGeoMechanicsFastSuiteWithoutKernel,
+       PQ_RaisesADebugErrorWhenAttemptingToConstructFromAnStdInitializerListWithSizeUnequalTo2)
+{
+#ifndef KRATOS_DEBUG
+    GTEST_SKIP() << "This test requires a debug build";
+#endif
+
+    EXPECT_THROW(Geo::PQ{1.0}, Exception);
+    EXPECT_THROW((Geo::PQ{2.0, 3.0, 4.0}), Exception);
+}
+
+TEST_F(KratosGeoMechanicsFastSuiteWithoutKernel, PQ_ComponentsCanBeModifiedDirectly)
+{
+    // Arrange
+    auto stress_invariant = Geo::PQ{1.0, 2.0};
+
+    // Act
+    stress_invariant.P() = 3.0;
+
+    // Assert
+    KRATOS_EXPECT_VECTOR_NEAR(stress_invariant.Values(), (std::vector{3.0, 2.0}), Defaults::absolute_tolerance);
+
+    // Act
+    stress_invariant.Q() = 4.0;
+
+    // Assert
+    KRATOS_EXPECT_VECTOR_NEAR(stress_invariant.Values(), (std::vector{3.0, 4.0}), Defaults::absolute_tolerance);
+}
+
+TYPED_TEST(TestPQFixture, PQ_CanBeCopiedToAnyVectorTypeWithSizeOf2)
+{
+    // Arrange
+    const auto stress_invariant = Geo::PQ{1.0, 2.0};
+
+    // Act & Assert
+    KRATOS_EXPECT_VECTOR_NEAR(stress_invariant.CopyTo<TypeParam>(), (std::vector{1.0, 2.0}),
+                              Defaults::absolute_tolerance);
+}
+
+} // namespace Kratos::Testing

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_constitutive/test_p_q.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_constitutive/test_p_q.cpp
@@ -17,12 +17,15 @@
 #include "tests/cpp_tests/geo_mechanics_fast_suite_without_kernel.h"
 #include "tests/cpp_tests/test_utilities.h"
 
+#include <array>
+#include <vector>
+
 namespace Kratos::Testing
 {
 
 TEST_F(KratosGeoMechanicsFastSuiteWithoutKernel, PQ_HasZeroesAsValuesWhenDefaultConstructed)
 {
-    KRATOS_EXPECT_VECTOR_NEAR(Geo::PQ().Values(), Vector(2, 0.0), Defaults::absolute_tolerance);
+    KRATOS_EXPECT_VECTOR_NEAR(Geo::PQ().Values(), (std::array{0.0, 0.0}), Defaults::absolute_tolerance);
     EXPECT_NEAR(Geo::PQ{}.P(), 0.0, Defaults::absolute_tolerance);
     EXPECT_NEAR(Geo::PQ{}.Q(), 0.0, Defaults::absolute_tolerance);
 }
@@ -92,13 +95,13 @@ TEST_F(KratosGeoMechanicsFastSuiteWithoutKernel, PQ_ComponentsCanBeModifiedDirec
     stress_invariant.P() = 3.0;
 
     // Assert
-    KRATOS_EXPECT_VECTOR_NEAR(stress_invariant.Values(), (std::vector{3.0, 2.0}), Defaults::absolute_tolerance);
+    KRATOS_EXPECT_VECTOR_NEAR(stress_invariant.Values(), (std::array{3.0, 2.0}), Defaults::absolute_tolerance);
 
     // Act
     stress_invariant.Q() = 4.0;
 
     // Assert
-    KRATOS_EXPECT_VECTOR_NEAR(stress_invariant.Values(), (std::vector{3.0, 4.0}), Defaults::absolute_tolerance);
+    KRATOS_EXPECT_VECTOR_NEAR(stress_invariant.Values(), (std::array{3.0, 4.0}), Defaults::absolute_tolerance);
 }
 
 TYPED_TEST(TestPQFixture, PQ_CanBeCopiedToAnyVectorTypeWithSizeOf2)
@@ -107,7 +110,7 @@ TYPED_TEST(TestPQFixture, PQ_CanBeCopiedToAnyVectorTypeWithSizeOf2)
     const auto stress_invariant = Geo::PQ{1.0, 2.0};
 
     // Act & Assert
-    KRATOS_EXPECT_VECTOR_NEAR(stress_invariant.CopyTo<TypeParam>(), (std::vector{1.0, 2.0}),
+    KRATOS_EXPECT_VECTOR_NEAR(stress_invariant.CopyTo<TypeParam>(), (std::array{1.0, 2.0}),
                               Defaults::absolute_tolerance);
 }
 

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_constitutive/test_p_q.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_constitutive/test_p_q.cpp
@@ -46,12 +46,12 @@ TYPED_TEST(TestPQFixture, PQ_CanBeConstructedFromAnyVectorWithSizeOf2)
     initialization_vector[1]   = 2.0;
 
     // Act
-    const auto stress_invariant = Geo::PQ{initialization_vector};
+    const auto stress_state = Geo::PQ{initialization_vector};
 
     // Assert
-    KRATOS_EXPECT_VECTOR_NEAR(stress_invariant.Values(), initialization_vector, Defaults::absolute_tolerance);
-    EXPECT_NEAR(stress_invariant.P(), initialization_vector[0], Defaults::absolute_tolerance);
-    EXPECT_NEAR(stress_invariant.Q(), initialization_vector[1], Defaults::absolute_tolerance);
+    KRATOS_EXPECT_VECTOR_NEAR(stress_state.Values(), initialization_vector, Defaults::absolute_tolerance);
+    EXPECT_NEAR(stress_state.P(), initialization_vector[0], Defaults::absolute_tolerance);
+    EXPECT_NEAR(stress_state.Q(), initialization_vector[1], Defaults::absolute_tolerance);
 }
 
 TEST_F(KratosGeoMechanicsFastSuiteWithoutKernel, PQ_RaisesADebugErrorWhenAttemptingToConstructFromAVectorWithSizeUnequalTo2)
@@ -89,29 +89,28 @@ TEST_F(KratosGeoMechanicsFastSuiteWithoutKernel,
 TEST_F(KratosGeoMechanicsFastSuiteWithoutKernel, PQ_ComponentsCanBeModifiedDirectly)
 {
     // Arrange
-    auto stress_invariant = Geo::PQ{1.0, 2.0};
+    auto stress_state = Geo::PQ{1.0, 2.0};
 
     // Act
-    stress_invariant.P() = 3.0;
+    stress_state.P() = 3.0;
 
     // Assert
-    KRATOS_EXPECT_VECTOR_NEAR(stress_invariant.Values(), (std::array{3.0, 2.0}), Defaults::absolute_tolerance);
+    KRATOS_EXPECT_VECTOR_NEAR(stress_state.Values(), (std::array{3.0, 2.0}), Defaults::absolute_tolerance);
 
     // Act
-    stress_invariant.Q() = 4.0;
+    stress_state.Q() = 4.0;
 
     // Assert
-    KRATOS_EXPECT_VECTOR_NEAR(stress_invariant.Values(), (std::array{3.0, 4.0}), Defaults::absolute_tolerance);
+    KRATOS_EXPECT_VECTOR_NEAR(stress_state.Values(), (std::array{3.0, 4.0}), Defaults::absolute_tolerance);
 }
 
 TYPED_TEST(TestPQFixture, PQ_CanBeCopiedToAnyVectorTypeWithSizeOf2)
 {
     // Arrange
-    const auto stress_invariant = Geo::PQ{1.0, 2.0};
+    const auto stress_state = Geo::PQ{1.0, 2.0};
 
     // Act & Assert
-    KRATOS_EXPECT_VECTOR_NEAR(stress_invariant.CopyTo<TypeParam>(), (std::array{1.0, 2.0}),
-                              Defaults::absolute_tolerance);
+    KRATOS_EXPECT_VECTOR_NEAR(stress_state.CopyTo<TypeParam>(), (std::array{1.0, 2.0}), Defaults::absolute_tolerance);
 }
 
 } // namespace Kratos::Testing

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_constitutive/test_p_q.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_constitutive/test_p_q.cpp
@@ -68,21 +68,10 @@ TEST_F(KratosGeoMechanicsFastSuiteWithoutKernel, PQ_RaisesADebugErrorWhenAttempt
     EXPECT_THROW(Geo::PQ{too_long}, Exception);
 }
 
-TEST_F(KratosGeoMechanicsFastSuiteWithoutKernel, PQ_CanBeConstructedFromAStdInitializerListWithSize2)
+TEST_F(KratosGeoMechanicsFastSuiteWithoutKernel, PQ_CanBeConstructedFromFromTwoValues)
 {
     EXPECT_NEAR((Geo::PQ{1.0, 2.0}.P()), 1.0, Defaults::absolute_tolerance);
     EXPECT_NEAR((Geo::PQ{1.0, 2.0}.Q()), 2.0, Defaults::absolute_tolerance);
-}
-
-TEST_F(KratosGeoMechanicsFastSuiteWithoutKernel,
-       PQ_RaisesADebugErrorWhenAttemptingToConstructFromAnStdInitializerListWithSizeUnequalTo2)
-{
-#ifndef KRATOS_DEBUG
-    GTEST_SKIP() << "This test requires a debug build";
-#endif
-
-    EXPECT_THROW(Geo::PQ{1.0}, Exception);
-    EXPECT_THROW((Geo::PQ{2.0, 3.0, 4.0}), Exception);
 }
 
 TEST_F(KratosGeoMechanicsFastSuiteWithoutKernel, PQ_ComponentsCanBeModifiedDirectly)

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_constitutive/test_p_q.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_constitutive/test_p_q.cpp
@@ -17,7 +17,6 @@
 #include "tests/cpp_tests/geo_mechanics_fast_suite_without_kernel.h"
 #include "tests/cpp_tests/test_utilities.h"
 
-#include <array>
 #include <vector>
 
 namespace Kratos::Testing
@@ -25,7 +24,7 @@ namespace Kratos::Testing
 
 TEST_F(KratosGeoMechanicsFastSuiteWithoutKernel, PQ_HasZeroesAsValuesWhenDefaultConstructed)
 {
-    KRATOS_EXPECT_VECTOR_NEAR(Geo::PQ().Values(), (std::array{0.0, 0.0}), Defaults::absolute_tolerance);
+    KRATOS_EXPECT_VECTOR_NEAR(Geo::PQ().Values(), (std::vector{0.0, 0.0}), Defaults::absolute_tolerance);
     EXPECT_NEAR(Geo::PQ{}.P(), 0.0, Defaults::absolute_tolerance);
     EXPECT_NEAR(Geo::PQ{}.Q(), 0.0, Defaults::absolute_tolerance);
 }
@@ -95,13 +94,13 @@ TEST_F(KratosGeoMechanicsFastSuiteWithoutKernel, PQ_ComponentsCanBeModifiedDirec
     stress_state.P() = 3.0;
 
     // Assert
-    KRATOS_EXPECT_VECTOR_NEAR(stress_state.Values(), (std::array{3.0, 2.0}), Defaults::absolute_tolerance);
+    KRATOS_EXPECT_VECTOR_NEAR(stress_state.Values(), (std::vector{3.0, 2.0}), Defaults::absolute_tolerance);
 
     // Act
     stress_state.Q() = 4.0;
 
     // Assert
-    KRATOS_EXPECT_VECTOR_NEAR(stress_state.Values(), (std::array{3.0, 4.0}), Defaults::absolute_tolerance);
+    KRATOS_EXPECT_VECTOR_NEAR(stress_state.Values(), (std::vector{3.0, 4.0}), Defaults::absolute_tolerance);
 }
 
 TYPED_TEST(TestPQFixture, PQ_CanBeCopiedToAnyVectorTypeWithSizeOf2)
@@ -110,7 +109,7 @@ TYPED_TEST(TestPQFixture, PQ_CanBeCopiedToAnyVectorTypeWithSizeOf2)
     const auto stress_state = Geo::PQ{1.0, 2.0};
 
     // Act & Assert
-    KRATOS_EXPECT_VECTOR_NEAR(stress_state.CopyTo<TypeParam>(), (std::array{1.0, 2.0}), Defaults::absolute_tolerance);
+    KRATOS_EXPECT_VECTOR_NEAR(stress_state.CopyTo<TypeParam>(), (std::vector{1.0, 2.0}), Defaults::absolute_tolerance);
 }
 
 } // namespace Kratos::Testing


### PR DESCRIPTION
**📝 Description**
Added a new class `Geo::PQ` that represents a ($`p`$, $`q`$) stress state. It is very similar to the recently added class that represents a ($`\sigma`$, $`\tau`$) stress state. Needless to say, it comes with a set of unit tests that demonstrate and cover its key features.
