### PR TITLE
[CORE] [FastPR] Fix entity creation from geometries using correct 'Create' method

### DIFF
--- a/kratos/modeler/create_entities_from_geometries_modeler.cpp
+++ b/kratos/modeler/create_entities_from_geometries_modeler.cpp
@@ -55,10 +55,12 @@ void CreateEntitiesFromGeometries(
     // Loop geometries to create the corresponding entities from them
     // Note that we retrieve the corresponding prototype entity from the entities idenfifier
     // This makes possible to loop and create entities from different type geometries
-    for (auto& r_geom : rModelPart.Geometries()) {
-        if (rEntityIdentifier.HasPrototypeEntity(r_geom)) {
-            const auto& r_ref_entity = rEntityIdentifier.GetPrototypeEntity(r_geom);
-            auto p_entity = r_ref_entity.Create(++max_id, r_geom, nullptr);
+    for (auto it = rModelPart.GeometriesBegin();
+        it != rModelPart.GeometriesEnd(); ++it) {
+        auto p_geom = *(it.base());
+        if (rEntityIdentifier.HasPrototypeEntity(*p_geom)) {
+            const auto& r_ref_entity = rEntityIdentifier.GetPrototypeEntity(*p_geom);
+            auto p_entity = r_ref_entity.Create(++max_id, p_geom, nullptr);
             entities_to_add.push_back(p_entity);
         }
     }


### PR DESCRIPTION
**📝 Description**
This PR fixes the way entities are created in 'CreateEntitiesFromGeometriesModeler'.

Before this, entities were created using a Create call that did not correspond to the expected signature. The geometry was passed as a reference, while the standard Kratos interface expects a `Geometry::Pointer`.

As a consequence, when accessing the geometry through the created element or condition, the original geometry IDs were not preserved.

This update modifies the loop to retrieve the geometry pointer directly from the model part container and pass it to the correct `Create(IndexType, Geometry::Pointer, Properties::Pointer)` method.

- The correct Create overload is used now.
- No functional changes are expected apart from correcting the Create usage and preserving geometry IDs.