### PR TITLE
[Hotfix][Core] Proper initialize in matrix map CSR constructor

### DIFF
--- a/kratos/containers/csr_matrix.h
+++ b/kratos/containers/csr_matrix.h
@@ -133,6 +133,7 @@ public:
         mNrows = size1();
         ComputeColSize();
         ResizeValueData(mColIndices.size());
+        SetValue(0.0);
 
         // Assemble data from matrix map
         this->BeginAssemble();


### PR DESCRIPTION
**📝 Description**
Initialize the values to zero before assembling the matrix map data. Note that this constructor uses the `AseembleEntry`, which inside calls an `AtomicAdd` that adds the entry to what is already in memory (potentially crap if the set to zero is not done).