### PR TITLE
[GeoMechanicsApplication] Sorted the stresses in the unit tests of the principal stress vectors

### DIFF
--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_constitutive/test_principal_stresses.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_constitutive/test_principal_stresses.cpp
@@ -11,7 +11,6 @@
 //
 
 #include "custom_constitutive/principal_stresses.hpp"
-#include "custom_utilities/ublas_utilities.h"
 #include "includes/expect.h"
 #include "tests/cpp_tests/geo_mechanics_fast_suite_without_kernel.h"
 #include "tests/cpp_tests/test_utilities.h"
@@ -35,9 +34,9 @@ TYPED_TEST_SUITE(TestPrincipalStressFixture, TestVectorTypesPrincipalStress);
 TYPED_TEST(TestPrincipalStressFixture, PrincipalStresses_CanBeConstructedFromAnyVectorWithSizeOf3)
 {
     TypeParam initialization_vector(3);
-    initialization_vector[0] = 1.0;
+    initialization_vector[0] = 3.0;
     initialization_vector[1] = 2.0;
-    initialization_vector[2] = 3.0;
+    initialization_vector[2] = 1.0;
 
     const auto principal_stresses = Geo::PrincipalStresses{initialization_vector};
 
@@ -50,16 +49,16 @@ TEST_F(KratosGeoMechanicsFastSuiteWithoutKernel, PrincipalStresses_ThrowsWhenSiz
     GTEST_SKIP() << "This test requires a debug build";
 #endif
 
-    const auto too_short = {1.0, 2.0};
-    const auto too_long  = {1.0, 2.0, 3.0, 4.0};
+    const auto too_short = {2.0, 1.0};
+    const auto too_long  = {4.0, 3.0, 2.0, 1.0};
     EXPECT_THROW(Geo::PrincipalStresses{too_long}, Exception);
     EXPECT_THROW(Geo::PrincipalStresses{too_short}, Exception);
 }
 
 TEST_F(KratosGeoMechanicsFastSuiteWithoutKernel, PrincipalStresses_CanBeConstructedFromAStdInitializerListWithSize3)
 {
-    KRATOS_EXPECT_VECTOR_NEAR((Geo::PrincipalStresses{1.0, 2.0, 3.0}.Values()),
-                              (std::vector{1.0, 2.0, 3.0}), Defaults::absolute_tolerance);
+    KRATOS_EXPECT_VECTOR_NEAR((Geo::PrincipalStresses{3.0, 2.0, 1.0}.Values()),
+                              (std::vector{3.0, 2.0, 1.0}), Defaults::absolute_tolerance);
 }
 
 TEST_F(KratosGeoMechanicsFastSuiteWithoutKernel,
@@ -69,13 +68,13 @@ TEST_F(KratosGeoMechanicsFastSuiteWithoutKernel,
     GTEST_SKIP() << "This test requires a debug build";
 #endif
 
-    EXPECT_THROW((Geo::PrincipalStresses{1.0, 2.0}), Exception);
-    EXPECT_THROW((Geo::PrincipalStresses{1.0, 2.0, 3.0, 4.0}), Exception);
+    EXPECT_THROW((Geo::PrincipalStresses{2.0, 1.0}), Exception);
+    EXPECT_THROW((Geo::PrincipalStresses{4.0, 3.0, 2.0, 1.0}), Exception);
 }
 
 TYPED_TEST(TestPrincipalStressFixture, PrincipalStressesCanBeCopiedToAnyVectorWithSize3)
 {
-    Geo::PrincipalStresses principal_stresses{std::vector{1.0, 2.0, 3.0}};
+    Geo::PrincipalStresses principal_stresses{std::vector{3.0, 2.0, 1.0}};
 
     const auto copied_vector = principal_stresses.CopyTo<TypeParam>();
 
@@ -84,11 +83,11 @@ TYPED_TEST(TestPrincipalStressFixture, PrincipalStressesCanBeCopiedToAnyVectorWi
 
 TEST_F(KratosGeoMechanicsFastSuiteWithoutKernel, PrincipalStresses_CanBeChangedDirectly)
 {
-    auto stresses = Geo::PrincipalStresses{1.0, 2.0, 3.0};
+    auto stresses = Geo::PrincipalStresses{3.0, 2.0, 1.0};
 
     stresses.Values()[0] = 4.0;
 
-    KRATOS_EXPECT_VECTOR_NEAR(stresses.Values(), (std::vector{4.0, 2.0, 3.0}), Defaults::absolute_tolerance);
+    KRATOS_EXPECT_VECTOR_NEAR(stresses.Values(), (std::vector{4.0, 2.0, 1.0}), Defaults::absolute_tolerance);
 }
 
 TEST_F(KratosGeoMechanicsFastSuiteWithoutKernel, PrincipalStresses_SupportsCompoundAssignment)


### PR DESCRIPTION
**📝 Description**
Since principal stresses are conceptually sorted, it's a good idea to have the unit tests reflect that. Moreover, if we decide to add sorting functionality to the principal stress vector, these unit tests won't have to change anymore.

