### PR TITLE
[MPM] Cleanup elements

### DIFF
--- a/applications/MPMApplication/custom_elements/mpm_updated_lagrangian.cpp
+++ b/applications/MPMApplication/custom_elements/mpm_updated_lagrangian.cpp
@@ -56,9 +56,6 @@ MPMUpdatedLagrangian::MPMUpdatedLagrangian( IndexType NewId, GeometryType::Point
     : Element( NewId, pGeometry, pProperties )
     , mMP()
 {
-    mFinalizedStep = true;
-
-
 }
 //******************************COPY CONSTRUCTOR**************************************
 //************************************************************************************
@@ -69,7 +66,6 @@ MPMUpdatedLagrangian::MPMUpdatedLagrangian( MPMUpdatedLagrangian const& rOther)
     ,mDeformationGradientF0(rOther.mDeformationGradientF0)
     ,mDeterminantF0(rOther.mDeterminantF0)
     ,mConstitutiveLawVector(rOther.mConstitutiveLawVector)
-    ,mFinalizedStep(rOther.mFinalizedStep)
 {
 }
 
@@ -817,13 +813,6 @@ void MPMUpdatedLagrangian::CalculateLocalSystem(
         rCurrentProcessInfo, true, true);
 }
 
-//*******************************************************************************************
-//*******************************************************************************************
-void MPMUpdatedLagrangian::InitializeSolutionStep(const ProcessInfo& rCurrentProcessInfo )
-{
-    mFinalizedStep = false; // FIXME: this doesn't seem to be used anywhere
-}
-
 
 void MPMUpdatedLagrangian::AddExplicitContribution(const ProcessInfo& rCurrentProcessInfo)
 {
@@ -913,8 +902,6 @@ void MPMUpdatedLagrangian::FinalizeSolutionStep(const ProcessInfo& rCurrentProce
 
     // Call the element internal variables update
     this->FinalizeStepVariables(Variables, rCurrentProcessInfo);
-
-    mFinalizedStep = true;
 
     KRATOS_CATCH( "" )
 }

--- a/applications/MPMApplication/custom_elements/mpm_updated_lagrangian.cpp
+++ b/applications/MPMApplication/custom_elements/mpm_updated_lagrangian.cpp
@@ -31,14 +31,6 @@
 namespace Kratos
 {
 
-/**
- * Flags related to the element computation
- */
-KRATOS_CREATE_LOCAL_FLAG( MPMUpdatedLagrangian, COMPUTE_RHS_VECTOR,                 0 );
-KRATOS_CREATE_LOCAL_FLAG( MPMUpdatedLagrangian, COMPUTE_LHS_MATRIX,                 1 );
-KRATOS_CREATE_LOCAL_FLAG( MPMUpdatedLagrangian, COMPUTE_RHS_VECTOR_WITH_COMPONENTS, 2 );
-KRATOS_CREATE_LOCAL_FLAG( MPMUpdatedLagrangian, COMPUTE_LHS_MATRIX_WITH_COMPONENTS, 3 );
-
 //******************************CONSTRUCTOR*******************************************
 //************************************************************************************
 

--- a/applications/MPMApplication/custom_elements/mpm_updated_lagrangian.cpp
+++ b/applications/MPMApplication/custom_elements/mpm_updated_lagrangian.cpp
@@ -12,22 +12,22 @@
 
 
 // System includes
-#include <omp.h>
-#include <sstream>
 
 // External includes
 
 // Project includes
 #include "includes/define.h"
-#include "custom_elements/mpm_updated_lagrangian.hpp"
 #include "utilities/math_utils.h"
 #include "utilities/atomic_utilities.h"
 #include "includes/constitutive_law.h"
-#include "mpm_application_variables.h"
 #include "includes/checks.h"
+
+// Application includes
+#include "mpm_application_variables.h"
 #include "custom_utilities/mpm_energy_calculation_utility.h"
 #include "custom_utilities/mpm_explicit_utilities.h"
 #include "custom_utilities/mpm_math_utilities.h"
+#include "custom_elements/mpm_updated_lagrangian.hpp"
 
 namespace Kratos
 {

--- a/applications/MPMApplication/custom_elements/mpm_updated_lagrangian.cpp
+++ b/applications/MPMApplication/custom_elements/mpm_updated_lagrangian.cpp
@@ -21,6 +21,7 @@
 #include "includes/define.h"
 #include "custom_elements/mpm_updated_lagrangian.hpp"
 #include "utilities/math_utils.h"
+#include "utilities/atomic_utilities.h"
 #include "includes/constitutive_law.h"
 #include "mpm_application_variables.h"
 #include "includes/checks.h"
@@ -855,11 +856,9 @@ void MPMUpdatedLagrangian::AddExplicitContribution(const ProcessInfo& rCurrentPr
             }
         }
 
-        r_geometry[i].SetLock();
-        r_geometry[i].FastGetSolutionStepValue(NODAL_MOMENTUM, 0) += nodal_momentum;
-        r_geometry[i].FastGetSolutionStepValue(NODAL_INERTIA, 0)  += nodal_inertia;
-        r_geometry[i].FastGetSolutionStepValue(NODAL_MASS, 0) += r_N(0, i) * mMP.mass;
-        r_geometry[i].UnSetLock();
+        AtomicAdd(r_geometry[i].FastGetSolutionStepValue(NODAL_MOMENTUM, 0), nodal_momentum);
+        AtomicAdd(r_geometry[i].FastGetSolutionStepValue(NODAL_INERTIA, 0), nodal_inertia);
+        AtomicAdd(r_geometry[i].FastGetSolutionStepValue(NODAL_MASS, 0), r_N(0, i)*mMP.mass);
     }
 }
 

--- a/applications/MPMApplication/custom_elements/mpm_updated_lagrangian.hpp
+++ b/applications/MPMApplication/custom_elements/mpm_updated_lagrangian.hpp
@@ -306,11 +306,6 @@ public:
     void Initialize(const ProcessInfo& rCurrentProcessInfo) override;
 
     /**
-     * Called at the beginning of each solution step
-     */
-    void InitializeSolutionStep(const ProcessInfo& rCurrentProcessInfo) override;
-
-    /**
      * This is a first and temporary attempt to move Particle to Grid Mapping from InitializeSolutionStep.
      * This will be moved to an utility in the future, after restructuring of MPM's internal variables data structure.
      * this is called at predict before doing the actual predict
@@ -493,12 +488,6 @@ protected:
      * Container for constitutive law instances on each integration point
      */
     ConstitutiveLaw::Pointer mConstitutiveLawVector;
-
-
-    /**
-     * Finalize and Initialize label
-     */
-    bool mFinalizedStep;
 
     ///@}
     ///@name Protected Operators

--- a/applications/MPMApplication/custom_elements/mpm_updated_lagrangian.hpp
+++ b/applications/MPMApplication/custom_elements/mpm_updated_lagrangian.hpp
@@ -11,8 +11,7 @@
 //
 
 
-#if !defined(KRATOS_UPDATED_LAGRANGIAN_H_INCLUDED )
-#define  KRATOS_UPDATED_LAGRANGIAN_H_INCLUDED
+#pragma once
 
 // System includes
 
@@ -733,4 +732,3 @@ private:
 ///@}
 
 } // namespace Kratos.
-#endif // KRATOS_UPDATED_LAGRANGIAN_H_INCLUDED  defined

--- a/applications/MPMApplication/custom_elements/mpm_updated_lagrangian.hpp
+++ b/applications/MPMApplication/custom_elements/mpm_updated_lagrangian.hpp
@@ -74,15 +74,6 @@ public:
 
 protected:
 
-    /**
-     * Flags related to the element computation
-     */
-
-    KRATOS_DEFINE_LOCAL_FLAG( COMPUTE_RHS_VECTOR );
-    KRATOS_DEFINE_LOCAL_FLAG( COMPUTE_LHS_MATRIX );
-    KRATOS_DEFINE_LOCAL_FLAG( COMPUTE_RHS_VECTOR_WITH_COMPONENTS );
-    KRATOS_DEFINE_LOCAL_FLAG( COMPUTE_LHS_MATRIX_WITH_COMPONENTS );
-
     struct MaterialPointVariables
     {
     public:

--- a/applications/MPMApplication/custom_elements/mpm_updated_lagrangian_PQ.cpp
+++ b/applications/MPMApplication/custom_elements/mpm_updated_lagrangian_PQ.cpp
@@ -12,24 +12,22 @@
 
 
 // System includes
-#include <omp.h>
-#include <sstream>
 
 // External includes
 
 // Project includes
 #include "includes/define.h"
-#include "custom_elements/mpm_updated_lagrangian_PQ.hpp"
 #include "utilities/math_utils.h"
 #include "utilities/atomic_utilities.h"
 #include "includes/constitutive_law.h"
-#include "mpm_application_variables.h"
 #include "includes/checks.h"
 
-
+// Application includes
+#include "mpm_application_variables.h"
 #include "custom_utilities/mpm_explicit_utilities.h"
 #include "custom_utilities/mpm_math_utilities.h"
 #include "custom_utilities/mpm_energy_calculation_utility.h"
+#include "custom_elements/mpm_updated_lagrangian_PQ.hpp"
 
 
 namespace Kratos

--- a/applications/MPMApplication/custom_elements/mpm_updated_lagrangian_PQ.cpp
+++ b/applications/MPMApplication/custom_elements/mpm_updated_lagrangian_PQ.cpp
@@ -21,6 +21,7 @@
 #include "includes/define.h"
 #include "custom_elements/mpm_updated_lagrangian_PQ.hpp"
 #include "utilities/math_utils.h"
+#include "utilities/atomic_utilities.h"
 #include "includes/constitutive_law.h"
 #include "mpm_application_variables.h"
 #include "includes/checks.h"
@@ -138,12 +139,9 @@ void MPMUpdatedLagrangianPQ::AddExplicitContribution(const ProcessInfo& rCurrent
                     }
                 }
 
-                r_geometry[i].SetLock();
-                r_geometry[i].FastGetSolutionStepValue(NODAL_MOMENTUM, 0) += nodal_momentum;
-                r_geometry[i].FastGetSolutionStepValue(NODAL_INERTIA, 0) += nodal_inertia;
-                r_geometry[i].FastGetSolutionStepValue(NODAL_MASS, 0) += r_geometry.ShapeFunctionValue(int_p, i)
-                    * mMP.mass * weight;
-                r_geometry[i].UnSetLock();
+                AtomicAdd(r_geometry[i].FastGetSolutionStepValue(NODAL_MOMENTUM, 0), nodal_momentum);
+                AtomicAdd(r_geometry[i].FastGetSolutionStepValue(NODAL_INERTIA, 0), nodal_inertia);
+                AtomicAdd(r_geometry[i].FastGetSolutionStepValue(NODAL_MASS, 0), r_geometry.ShapeFunctionValue(int_p, i) * mMP.mass * weight);
             }
         }
     }

--- a/applications/MPMApplication/custom_elements/mpm_updated_lagrangian_PQ.cpp
+++ b/applications/MPMApplication/custom_elements/mpm_updated_lagrangian_PQ.cpp
@@ -44,7 +44,7 @@ MPMUpdatedLagrangianPQ::MPMUpdatedLagrangianPQ( IndexType NewId, GeometryType::P
 
 MPMUpdatedLagrangianPQ::MPMUpdatedLagrangianPQ( IndexType NewId, GeometryType::Pointer pGeometry, PropertiesType::Pointer pProperties )
     : MPMUpdatedLagrangian( NewId, pGeometry, pProperties )
-{ mFinalizedStep = true; }
+{ }
 
 MPMUpdatedLagrangianPQ::MPMUpdatedLagrangianPQ(MPMUpdatedLagrangianPQ const& rOther)
     :MPMUpdatedLagrangian(rOther)
@@ -105,8 +105,6 @@ void MPMUpdatedLagrangianPQ::AddExplicitContribution(const ProcessInfo& rCurrent
     GeometryType& r_geometry = GetGeometry();
     const unsigned int dimension = r_geometry.WorkingSpaceDimension();
     const unsigned int number_of_nodes = r_geometry.PointsNumber();
-
-    mFinalizedStep = false;
 
     // Calculating shape functions
     array_1d<double, 3> nodal_momentum = ZeroVector(3);

--- a/applications/MPMApplication/custom_elements/mpm_updated_lagrangian_PQ.hpp
+++ b/applications/MPMApplication/custom_elements/mpm_updated_lagrangian_PQ.hpp
@@ -12,8 +12,7 @@
 
 
 
-#if !defined(KRATOS_UPDATED_LAGRANGIAN_PQ_H_INCLUDED )
-#define  KRATOS_UPDATED_LAGRANGIAN_PQ_H_INCLUDED
+#pragma once
 
 // System includes
 
@@ -145,4 +144,3 @@ private:
 
 }; // Class MPMUpdatedLagrangianPQ
 } // namespace Kratos.
-#endif // KRATOS_UPDATED_LAGRANGIAN_PQ_H_INCLUDED  defined

--- a/applications/MPMApplication/custom_elements/mpm_updated_lagrangian_UP.cpp
+++ b/applications/MPMApplication/custom_elements/mpm_updated_lagrangian_UP.cpp
@@ -28,14 +28,6 @@
 namespace Kratos
 {
 
-///**
-//* Flags related to the element computation
-//*/
-//KRATOS_CREATE_LOCAL_FLAG( MPMUpdatedLagrangian, COMPUTE_RHS_VECTOR,                 0 );
-//KRATOS_CREATE_LOCAL_FLAG( MPMUpdatedLagrangian, COMPUTE_LHS_MATRIX,                 1 );
-//KRATOS_CREATE_LOCAL_FLAG( MPMUpdatedLagrangian, COMPUTE_RHS_VECTOR_WITH_COMPONENTS, 2 );
-//KRATOS_CREATE_LOCAL_FLAG( MPMUpdatedLagrangian, COMPUTE_LHS_MATRIX_WITH_COMPONENTS, 3 );
-
 //******************************CONSTRUCTOR*******************************************
 //************************************************************************************
 

--- a/applications/MPMApplication/custom_elements/mpm_updated_lagrangian_UP.cpp
+++ b/applications/MPMApplication/custom_elements/mpm_updated_lagrangian_UP.cpp
@@ -21,6 +21,7 @@
 #include "includes/define.h"
 #include "custom_elements/mpm_updated_lagrangian_UP.hpp"
 #include "utilities/math_utils.h"
+#include "utilities/atomic_utilities.h"
 #include "includes/constitutive_law.h"
 #include "mpm_application_variables.h"
 #include "includes/checks.h"
@@ -360,13 +361,10 @@ void MPMUpdatedLagrangianUP::AddExplicitContribution(const ProcessInfo& rCurrent
             nodal_inertia[j]  = r_N(0, i) * mMP.acceleration[j] * mMP.mass;
         }
 
-        r_geometry[i].SetLock();
-        r_geometry[i].FastGetSolutionStepValue(NODAL_MOMENTUM, 0)  += nodal_momentum;
-        r_geometry[i].FastGetSolutionStepValue(NODAL_INERTIA, 0)   += nodal_inertia;
-        r_geometry[i].FastGetSolutionStepValue(NODAL_MPRESSURE, 0) += nodal_mpressure;
-
-        r_geometry[i].FastGetSolutionStepValue(NODAL_MASS, 0) += r_N(0, i) * mMP.mass;
-        r_geometry[i].UnSetLock();
+        AtomicAdd(r_geometry[i].FastGetSolutionStepValue(NODAL_MOMENTUM, 0), nodal_momentum);
+        AtomicAdd(r_geometry[i].FastGetSolutionStepValue(NODAL_INERTIA, 0), nodal_inertia);
+        AtomicAdd(r_geometry[i].FastGetSolutionStepValue(NODAL_MPRESSURE, 0), nodal_mpressure);
+        AtomicAdd(r_geometry[i].FastGetSolutionStepValue(NODAL_MASS, 0), r_N(0, i)*mMP.mass);
     }
 }
 //************************************************************************************

--- a/applications/MPMApplication/custom_elements/mpm_updated_lagrangian_UP.cpp
+++ b/applications/MPMApplication/custom_elements/mpm_updated_lagrangian_UP.cpp
@@ -12,19 +12,19 @@
 
 
 // System includes
-#include <omp.h>
-#include <sstream>
 
 // External includes
 
 // Project includes
 #include "includes/define.h"
-#include "custom_elements/mpm_updated_lagrangian_UP.hpp"
 #include "utilities/math_utils.h"
 #include "utilities/atomic_utilities.h"
 #include "includes/constitutive_law.h"
-#include "mpm_application_variables.h"
 #include "includes/checks.h"
+
+// Application includes
+#include "mpm_application_variables.h"
+#include "custom_elements/mpm_updated_lagrangian_UP.hpp"
 
 namespace Kratos
 {

--- a/applications/MPMApplication/custom_elements/mpm_updated_lagrangian_UP.cpp
+++ b/applications/MPMApplication/custom_elements/mpm_updated_lagrangian_UP.cpp
@@ -351,44 +351,18 @@ void MPMUpdatedLagrangianUP::AddExplicitContribution(const ProcessInfo& rCurrent
 
     mFinalizedStep = false;
 
-    array_1d<double,3> aux_MP_velocity = ZeroVector(3);
-    array_1d<double,3> aux_MP_acceleration = ZeroVector(3);
     array_1d<double,3> nodal_momentum = ZeroVector(3);
     array_1d<double,3> nodal_inertia = ZeroVector(3);
-    double aux_MP_pressure = 0.0;
-
-    for (unsigned int j=0; j<number_of_nodes; j++)
-    {
-        // These are the values of nodal velocity and nodal acceleration evaluated in the initialize solution step
-        array_1d<double, 3 > nodal_acceleration = ZeroVector(3);
-        if (r_geometry[j].SolutionStepsDataHas(ACCELERATION))
-            nodal_acceleration = r_geometry[j].FastGetSolutionStepValue(ACCELERATION,1);
-
-        array_1d<double, 3 > nodal_velocity = ZeroVector(3);
-        if (r_geometry[j].SolutionStepsDataHas(VELOCITY))
-            nodal_velocity = r_geometry[j].FastGetSolutionStepValue(VELOCITY,1);
-
-        // These are the values of nodal pressure evaluated in the initialize solution step
-        const double& nodal_pressure = r_geometry[j].FastGetSolutionStepValue(PRESSURE,1);
-
-        aux_MP_pressure += r_N(0, j) * nodal_pressure;
-
-        for (unsigned int k = 0; k < dimension; k++)
-        {
-            aux_MP_velocity[k] += r_N(0, j) * nodal_velocity[k];
-            aux_MP_acceleration[k] += r_N(0, j) * nodal_acceleration[k];
-        }
-    }
 
     // Here MP contribution in terms of momentum, inertia, mass-pressure and mass are added
     for ( unsigned int i = 0; i < number_of_nodes; i++ )
     {
-        double nodal_mpressure = r_N(0, i) * (m_mp_pressure - aux_MP_pressure) * mMP.mass;
+        double nodal_mpressure = r_N(0, i) * m_mp_pressure * mMP.mass;
 
         for (unsigned int j = 0; j < dimension; j++)
         {
-            nodal_momentum[j] = r_N(0, i) * (mMP.velocity[j] - aux_MP_velocity[j]) * mMP.mass;
-            nodal_inertia[j]  = r_N(0, i) * (mMP.acceleration[j] - aux_MP_acceleration[j]) * mMP.mass;
+            nodal_momentum[j] = r_N(0, i) * mMP.velocity[j] * mMP.mass;
+            nodal_inertia[j]  = r_N(0, i) * mMP.acceleration[j] * mMP.mass;
         }
 
         r_geometry[i].SetLock();

--- a/applications/MPMApplication/custom_elements/mpm_updated_lagrangian_UP.cpp
+++ b/applications/MPMApplication/custom_elements/mpm_updated_lagrangian_UP.cpp
@@ -53,9 +53,6 @@ MPMUpdatedLagrangianUP::MPMUpdatedLagrangianUP( IndexType NewId, GeometryType::P
     : MPMUpdatedLagrangian( NewId, pGeometry, pProperties )
     , m_mp_pressure(1.0)
 {
-    mFinalizedStep = true;
-
-
 }
 //******************************COPY CONSTRUCTOR**************************************
 //************************************************************************************
@@ -348,8 +345,6 @@ void MPMUpdatedLagrangianUP::AddExplicitContribution(const ProcessInfo& rCurrent
 
     // Calculating shape function
     const Matrix& r_N = GetGeometry().ShapeFunctionsValues();
-
-    mFinalizedStep = false;
 
     array_1d<double,3> nodal_momentum = ZeroVector(3);
     array_1d<double,3> nodal_inertia = ZeroVector(3);

--- a/applications/MPMApplication/custom_elements/mpm_updated_lagrangian_UP.hpp
+++ b/applications/MPMApplication/custom_elements/mpm_updated_lagrangian_UP.hpp
@@ -11,8 +11,7 @@
 //
 
 
-#if !defined(KRATOS_UPDATED_LAGRANGIAN_UP_H_INCLUDED )
-#define  KRATOS_UPDATED_LAGRANGIAN_UP_H_INCLUDED
+#pragma once
 
 // System includes
 
@@ -463,4 +462,3 @@ private:
 ///@}
 
 } // namespace Kratos.
-#endif // KRATOS_UPDATED_LAGRANGIAN_H_INCLUDED  defined


### PR DESCRIPTION
### **🆕 Changelog**
* Remove local flags that were not used (`COMPUTE_RHS_VECTOR`, `COMPUTE_LHS_MATRIX`, `COMPUTE_RHS_VECTOR_WITH_COMPONENTS`, `COMPUTE_LHS_VECTOR_WITH_COMPONENTS`)
* Remove variables `aux_MP_pressure`, `aux_MP_velocity` and `aux_MP_displacement` from `MPMUpdatedLagrangianUP` (these variables always have value zero)
* Remove variable `mFinalizedStep`
* Use `AtomicAdd` instead of `SetLock`/`SetUnlock`
* Use `#pragma once`