### PR TITLE
Change windows pipeline generator to Ninja

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -523,7 +523,7 @@ jobs:
           -DKRATOS_USE_PCH=OFF                                ^
           -DFORCE_LOCAL_ZLIB_COMPILATION=ON                   || goto :error
 
-        cmake --build "%KRATOS_BUILD%\%KRATOS_BUILD_TYPE%" --target all install || goto :error
+        cmake --build "%KRATOS_BUILD%\%KRATOS_BUILD_TYPE%" && cmake --install "%KRATOS_BUILD%\%KRATOS_BUILD_TYPE%" --config %KRATOS_BUILD_TYPE% || goto :error
 
         goto :EOF
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -514,7 +514,7 @@ jobs:
         del /F /Q "%KRATOS_BUILD%\%KRATOS_BUILD_TYPE%\CMakeFiles"
 
         cmake                                                 ^
-          -G"Visual Studio 17 2022"                           ^
+          -G"Ninja"                                           ^
           -H"%KRATOS_SOURCE%"                                 ^
           -B"%KRATOS_BUILD%\%KRATOS_BUILD_TYPE%"              ^
           -DBOOST_ROOT="%TEMP%\boost"                         ^
@@ -523,8 +523,8 @@ jobs:
           -DKRATOS_USE_PCH=OFF                                ^
           -DFORCE_LOCAL_ZLIB_COMPILATION=ON                   || goto :error
 
-        cmake --build "%KRATOS_BUILD%\%KRATOS_BUILD_TYPE%" --target all_build -- /property:configuration=%KRATOS_BUILD_TYPE% /p:Platform=x64 || goto :error
-        cmake --build "%KRATOS_BUILD%\%KRATOS_BUILD_TYPE%" --target install -- /property:configuration=%KRATOS_BUILD_TYPE% /p:Platform=x64 || goto :error
+        cmake --build "%KRATOS_BUILD%\%KRATOS_BUILD_TYPE%" --target all || goto :error
+        cmake --install "%KRATOS_BUILD%\%KRATOS_BUILD_TYPE%" --config %KRATOS_BUILD_TYPE% || goto :error
 
         goto :EOF
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -521,10 +521,11 @@ jobs:
           -DCMAKE_CXX_FLAGS="/Od /we4661 /we4804 /WX /wd4996" ^
           -DCMAKE_POLICY_VERSION_MINIMUM=3.5                  ^
           -DKRATOS_USE_PCH=OFF                                ^
+          -DCMAKE_BUILD_TYPE=%KRATOS_BUILD_TYPE%              ^
           -DFORCE_LOCAL_ZLIB_COMPILATION=ON                   || goto :error
 
-        cmake --build "%KRATOS_BUILD%\%KRATOS_BUILD_TYPE%" && cmake --install "%KRATOS_BUILD%\%KRATOS_BUILD_TYPE%" --config %KRATOS_BUILD_TYPE% || goto :error
-
+        cmake --build "%KRATOS_BUILD%\%KRATOS_BUILD_TYPE%" --target all || goto :error
+        cmake --build "%KRATOS_BUILD%\%KRATOS_BUILD_TYPE%" --target install || goto :error
         goto :EOF
 
         :error

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -523,8 +523,7 @@ jobs:
           -DKRATOS_USE_PCH=OFF                                ^
           -DFORCE_LOCAL_ZLIB_COMPILATION=ON                   || goto :error
 
-        cmake --build "%KRATOS_BUILD%\%KRATOS_BUILD_TYPE%" --target all || goto :error
-        cmake --install "%KRATOS_BUILD%\%KRATOS_BUILD_TYPE%" --config %KRATOS_BUILD_TYPE% || goto :error
+        cmake --build "%KRATOS_BUILD%\%KRATOS_BUILD_TYPE%" --target all install || goto :error
 
         goto :EOF
 

--- a/.github/workflows/configure.cmd
+++ b/.github/workflows/configure.cmd
@@ -53,7 +53,7 @@ cmake                                                 ^
   -DFORCE_LOCAL_ZLIB_COMPILATION=ON                   ^
   -DCMAKE_UNITY_BUILD=ON                                    || goto :error
 
-cmake --build "%KRATOS_BUILD%\%KRATOS_BUILD_TYPE%" --target all install || goto :error
+cmake --build "%KRATOS_BUILD%\%KRATOS_BUILD_TYPE%" && cmake --install "%KRATOS_BUILD%\%KRATOS_BUILD_TYPE%" --config %KRATOS_BUILD_TYPE% || goto :error
 
 goto :EOF
 

--- a/.github/workflows/configure.cmd
+++ b/.github/workflows/configure.cmd
@@ -53,7 +53,7 @@ cmake                                                 ^
   -DFORCE_LOCAL_ZLIB_COMPILATION=ON                   ^
   -DCMAKE_UNITY_BUILD=ON                                    || goto :error
 
-cmake --build "%KRATOS_BUILD%\%KRATOS_BUILD_TYPE%" --target all_build || goto :error
+cmake --build "%KRATOS_BUILD%\%KRATOS_BUILD_TYPE%" --target all || goto :error
 cmake --build "%KRATOS_BUILD%\%KRATOS_BUILD_TYPE%" --target install || goto :error
 
 goto :EOF

--- a/.github/workflows/configure.cmd
+++ b/.github/workflows/configure.cmd
@@ -54,7 +54,7 @@ cmake                                                 ^
   -DCMAKE_UNITY_BUILD=ON                                    || goto :error
 
 cmake --build "%KRATOS_BUILD%\%KRATOS_BUILD_TYPE%" --target all || goto :error
-cmake --build "%KRATOS_BUILD%\%KRATOS_BUILD_TYPE%" --target install || goto :error
+cmake --install "%KRATOS_BUILD%\%KRATOS_BUILD_TYPE%" --config %KRATOS_BUILD_TYPE% || goto :error
 
 goto :EOF
 

--- a/.github/workflows/configure.cmd
+++ b/.github/workflows/configure.cmd
@@ -53,8 +53,8 @@ cmake                                                 ^
   -DFORCE_LOCAL_ZLIB_COMPILATION=ON                   ^
   -DCMAKE_UNITY_BUILD=ON                                    || goto :error
 
-cmake --build "%KRATOS_BUILD%\%KRATOS_BUILD_TYPE%" --target all_build -- /property:configuration=%KRATOS_BUILD_TYPE% /p:Platform=x64 || goto :error
-cmake --build "%KRATOS_BUILD%\%KRATOS_BUILD_TYPE%" --target install -- /property:configuration=%KRATOS_BUILD_TYPE% /p:Platform=x64 || goto :error
+cmake --build "%KRATOS_BUILD%\%KRATOS_BUILD_TYPE%" --target all_build || goto :error
+cmake --build "%KRATOS_BUILD%\%KRATOS_BUILD_TYPE%" --target install || goto :error
 
 goto :EOF
 

--- a/.github/workflows/configure.cmd
+++ b/.github/workflows/configure.cmd
@@ -51,9 +51,11 @@ cmake                                                 ^
   -DCMAKE_CXX_FLAGS="/Od /we4661 /we4804 /WX /wd4996" ^
   -DCMAKE_POLICY_VERSION_MINIMUM=3.5                  ^
   -DFORCE_LOCAL_ZLIB_COMPILATION=ON                   ^
+  -DCMAKE_BUILD_TYPE=%KRATOS_BUILD_TYPE%              ^
   -DCMAKE_UNITY_BUILD=ON                                    || goto :error
 
-cmake --build "%KRATOS_BUILD%\%KRATOS_BUILD_TYPE%" && cmake --install "%KRATOS_BUILD%\%KRATOS_BUILD_TYPE%" --config %KRATOS_BUILD_TYPE% || goto :error
+cmake --build "%KRATOS_BUILD%\%KRATOS_BUILD_TYPE%" --target all || goto :error
+cmake --build "%KRATOS_BUILD%\%KRATOS_BUILD_TYPE%" --target install || goto :error
 
 goto :EOF
 

--- a/.github/workflows/configure.cmd
+++ b/.github/workflows/configure.cmd
@@ -44,7 +44,7 @@ del /F /Q "%KRATOS_BUILD%\%KRATOS_BUILD_TYPE%\CMakeCache.txt"
 del /F /Q "%KRATOS_BUILD%\%KRATOS_BUILD_TYPE%\CMakeFiles"
 
 cmake                                                 ^
-  -G"Visual Studio 17 2022"                           ^
+  -G"Ninja"                                           ^
   -H"%KRATOS_SOURCE%"                                 ^
   -B"%KRATOS_BUILD%\%KRATOS_BUILD_TYPE%"              ^
   -DBOOST_ROOT="%TEMP%\boost"                         ^

--- a/.github/workflows/configure.cmd
+++ b/.github/workflows/configure.cmd
@@ -53,8 +53,7 @@ cmake                                                 ^
   -DFORCE_LOCAL_ZLIB_COMPILATION=ON                   ^
   -DCMAKE_UNITY_BUILD=ON                                    || goto :error
 
-cmake --build "%KRATOS_BUILD%\%KRATOS_BUILD_TYPE%" --target all || goto :error
-cmake --install "%KRATOS_BUILD%\%KRATOS_BUILD_TYPE%" --config %KRATOS_BUILD_TYPE% || goto :error
+cmake --build "%KRATOS_BUILD%\%KRATOS_BUILD_TYPE%" --target all install || goto :error
 
 goto :EOF
 


### PR DESCRIPTION
**📝 Description**
In our pipelines, we've seen a significant speed-up in build times when using Ninja instead of the MSVC generator. Especially since the windows builds are the slowest in the pipelines, this should help with our waiting times.