### PR TITLE
[ConstitutiveLawsApplication] Fix name hiding for `GetValue`/`SetValue` in `ThicknessIntegratedIsotropicConstitutiveLaw`. Fixes GCC 13 compilation issue

### DIFF
--- a/applications/ConstitutiveLawsApplication/custom_constitutive/structural_elements_constitutive_laws/thickness_integrated_isotropic_constitutive_law.h
+++ b/applications/ConstitutiveLawsApplication/custom_constitutive/structural_elements_constitutive_laws/thickness_integrated_isotropic_constitutive_law.h
@@ -67,6 +67,9 @@ public:
     /// The definition of the CL base class
     using BaseType = ConstitutiveLaw;
 
+    /// Unhide the base class SetValue overloads
+    using BaseType::SetValue;
+
     /// The definition of the size type
     using SizeType = std::size_t;
 

--- a/applications/ConstitutiveLawsApplication/custom_constitutive/structural_elements_constitutive_laws/thickness_integrated_isotropic_constitutive_law.h
+++ b/applications/ConstitutiveLawsApplication/custom_constitutive/structural_elements_constitutive_laws/thickness_integrated_isotropic_constitutive_law.h
@@ -70,6 +70,9 @@ public:
     /// Unhide the base class SetValue overloads
     using BaseType::SetValue;
 
+    /// Unhide the base class GetValue overloads
+    using BaseType::GetValue;
+
     /// The definition of the size type
     using SizeType = std::size_t;
 


### PR DESCRIPTION
## **📝 Description**

This PR addresses a name-hiding issue in the `ThicknessIntegratedIsotropicConstitutiveLaw` class.

In C++, when a derived class defines a function with the same name as a function in the base class, it "hides" all overloads of that function from the base class scope. This often leads to compilation errors or unexpected behavior when trying to access base class overloads that weren't explicitly overridden in the derived class.

### Justification

**GCC 13** and other modern compilers have become increasingly strict regarding `-Woverloaded-virtual` and name lookup rules. By explicitly unhiding these methods, we ensure that all overloads of `GetValue` and `SetValue` defined in the `ConstitutiveLaw` base class (or intermediate base classes) remain accessible.

This prevents build failures in downstream applications or unit tests that rely on the standard `GetValue`/`SetValue` interface which this specific constitutive law does not directly override.

### Technical Note

Without these `using` declarations, a call like `law.GetValue(VARIABLE, value)` might fail to resolve if the derived class only implements a different signature (e.g., one taking a `ProcessInfo` object), even if the base class version is public.

## **🆕 Changelog**

- [Added `using BaseType::SetValue;` to the `ThicknessIntegratedIsotropicConstitutiveLaw` class](https://github.com/KratosMultiphysics/Kratos/commit/6785abda02057a54f5d9420289deb3d5eae1a323)
- [Added `using BaseType::GetValue;` to the `ThicknessIntegratedIsotropicConstitutiveLaw` class](https://github.com/KratosMultiphysics/Kratos/commit/6bf4cbe1323d0859710771b5c947f8ac2a171e86)
