### PR TITLE
[MPM] Allow `"use_input_model_part"` in `"model_import_settings"` `ProjectParameters.json`

### DIFF
--- a/applications/MPMApplication/python_scripts/mpm_solver.py
+++ b/applications/MPMApplication/python_scripts/mpm_solver.py
@@ -312,19 +312,14 @@ class MPMSolver(PythonSolver):
 
     def _ModelPartReading(self):
         # reading the model part of the background grid
-        if(self.settings["grid_model_import_settings"]["input_type"].GetString() == "mdpa"):
-            self._ImportModelPart(self.grid_model_part, self.settings["grid_model_import_settings"])
-        else:
-            raise Exception("Other input options are not implemented yet.")
+        self._ImportModelPart(self.grid_model_part, self.settings["grid_model_import_settings"])
 
         # reading the model part of the material point
-        if(self.settings["model_import_settings"]["input_type"].GetString() == "mdpa"):
-            self._ImportModelPart(self.initial_mesh_model_part, self.settings["model_import_settings"])
-        elif(self.settings["model_import_settings"]["input_type"].GetString() == "rest"):
+        if (self.settings["model_import_settings"]["input_type"].GetString() == "rest"):
             self.settings["model_import_settings"]["input_filename"].SetString("MPM_Material")
             self._ImportModelPart(self.material_point_model_part, self.settings["model_import_settings"])
         else:
-            raise Exception("Other input options are not implemented yet.")
+            self._ImportModelPart(self.initial_mesh_model_part, self.settings["model_import_settings"])
 
     def _AddDofsToModelPart(self, model_part):
         KratosMultiphysics.VariableUtils().AddDof(KratosMultiphysics.DISPLACEMENT_X, KratosMultiphysics.REACTION_X, model_part)

--- a/applications/MPMApplication/python_scripts/mpm_solver.py
+++ b/applications/MPMApplication/python_scripts/mpm_solver.py
@@ -312,7 +312,10 @@ class MPMSolver(PythonSolver):
 
     def _ModelPartReading(self):
         # reading the model part of the background grid
-        self._ImportModelPart(self.grid_model_part, self.settings["grid_model_import_settings"])
+        if (self.settings["grid_model_import_settings"]["input_type"].GetString() == "rest"):
+            raise Exception("\"input_type\" cannot be equal to \"rest\" for background grid model part")
+        else:
+            self._ImportModelPart(self.grid_model_part, self.settings["grid_model_import_settings"])
 
         # reading the model part of the material point
         if (self.settings["model_import_settings"]["input_type"].GetString() == "rest"):


### PR DESCRIPTION
**📝 Description**
Allow `ProjectParameters.json` to contain
```json
 "model_import_settings"           : {
     "input_type" : "use_input_model_part"
 },
 "grid_model_import_settings"      : {
     "input_type" : "use_input_model_part"
 },
```
* The value `"use_input_model_part"` is used when using modelers to laod `MDPA` files.
* Up to now it was not possible to use `"use_input_model_part"` because an exception was raised if `"input_type"` was different from `"mdpa"`/`"rest"`.
* The check on the value of `"input_type"` is still performed in `_ImportModelPart`, so an exception is still raised if the value is not `"mdpa"`/`"rest"`/`"use_input_model_part"`.

Related to KratosMultiphysics/GiDInterface#1004 and KratosMultiphysics/GiDInterface#1026.

FYI @jginternational 