### PR TITLE
[ContactStructuralMechanicsApplication] Adding missing guards in covergence criteria

### DIFF
--- a/applications/ContactStructuralMechanicsApplication/custom_strategies/custom_convergencecriterias/displacement_contact_criteria.h
+++ b/applications/ContactStructuralMechanicsApplication/custom_strategies/custom_convergencecriterias/displacement_contact_criteria.h
@@ -236,15 +236,15 @@ public:
                 return std::make_tuple(0.0,0.0,0,0.0,0.0,0);
             });
 
-            if(disp_increase_norm == 0.0) disp_increase_norm = 1.0;
-            if(disp_solution_norm == 0.0) disp_solution_norm = 1.0;
-            if(rot_increase_norm == 0.0) rot_increase_norm = 1.0;
-            if(rot_solution_norm == 0.0) rot_solution_norm = 1.0;
+            if (disp_increase_norm == 0.0) disp_increase_norm = 1.0;
+            if (disp_solution_norm == 0.0) disp_solution_norm = 1.0;
+            if (rot_increase_norm == 0.0) rot_increase_norm = 1.0;
+            if (rot_solution_norm == 0.0) rot_solution_norm = 1.0;
 
             const double disp_ratio = std::sqrt(disp_increase_norm/disp_solution_norm);
-            const double disp_abs = std::sqrt(disp_increase_norm)/ static_cast<double>(disp_dof_num);
+            const double disp_abs = (disp_dof_num > 0) ? std::sqrt(disp_increase_norm)/ static_cast<double>(disp_dof_num) : 0.0;
             const double rot_ratio = std::sqrt(rot_increase_norm/rot_solution_norm);
-            const double rot_abs = std::sqrt(rot_increase_norm)/ static_cast<double>(rot_dof_num);
+            const double rot_abs = (rot_dof_num > 0) ? std::sqrt(rot_increase_norm)/ static_cast<double>(rot_dof_num) : 0.0;
 
             // The process info of the model part
             ProcessInfo& r_process_info = rModelPart.GetProcessInfo();
@@ -317,9 +317,9 @@ public:
                 }
                 return false;
             }
-        }
-        else // In this case all the displacements are imposed!
+        } else { // In this case all the displacements are imposed!
             return true;
+        }
     }
 
     /**

--- a/applications/ContactStructuralMechanicsApplication/custom_strategies/custom_convergencecriterias/displacement_lagrangemultiplier_contact_criteria.h
+++ b/applications/ContactStructuralMechanicsApplication/custom_strategies/custom_convergencecriterias/displacement_lagrangemultiplier_contact_criteria.h
@@ -263,20 +263,20 @@ public:
                 return std::make_tuple(0.0,0.0,0.0,0.0,0.0,0.0,0,0,0);
             });
 
-            if(disp_increase_norm < Tolerance) disp_increase_norm = 1.0;
-            if(rot_increase_norm < Tolerance) rot_increase_norm = 1.0;
-            if(lm_increase_norm < Tolerance) lm_increase_norm = 1.0;
-            if(disp_solution_norm < Tolerance) disp_solution_norm = 1.0;
+            if (disp_increase_norm < Tolerance) disp_increase_norm = 1.0;
+            if (rot_increase_norm < Tolerance) rot_increase_norm = 1.0;
+            if (lm_increase_norm < Tolerance) lm_increase_norm = 1.0;
+            if (disp_solution_norm < Tolerance) disp_solution_norm = 1.0;
 
             KRATOS_ERROR_IF(mOptions.Is(DisplacementLagrangeMultiplierContactCriteria::ENSURE_CONTACT) && lm_solution_norm < Tolerance) << "WARNING::CONTACT LOST::ARE YOU SURE YOU ARE SUPPOSED TO HAVE CONTACT?" << std::endl;
 
             const double disp_ratio = std::sqrt(disp_increase_norm/disp_solution_norm);
             const double rot_ratio = std::sqrt(rot_increase_norm/rot_solution_norm);
-            const double lm_ratio = lm_solution_norm > Tolerance ? std::sqrt(lm_increase_norm/lm_solution_norm) : 0.0;
+            const double lm_ratio = (lm_solution_norm > Tolerance) ? std::sqrt(lm_increase_norm/lm_solution_norm) : 0.0;
 
-            const double disp_abs = std::sqrt(disp_increase_norm)/static_cast<double>(disp_dof_num);
-            const double rot_abs = std::sqrt(rot_increase_norm)/static_cast<double>(rot_dof_num);
-            const double lm_abs = std::sqrt(lm_increase_norm)/static_cast<double>(lm_dof_num);
+            const double disp_abs = (disp_dof_num > 0) ? std::sqrt(disp_increase_norm)/static_cast<double>(disp_dof_num) : 0.0;
+            const double rot_abs = (rot_dof_num > 0) ? std::sqrt(rot_increase_norm)/static_cast<double>(rot_dof_num) : 0.0;
+            const double lm_abs = (lm_dof_num > 0) ? std::sqrt(lm_increase_norm)/static_cast<double>(lm_dof_num) : 0.0;
 
             // The process info of the model part
             ProcessInfo& r_process_info = rModelPart.GetProcessInfo();
@@ -352,9 +352,9 @@ public:
                 }
                 return false;
             }
-        }
-        else // In this case all the displacements are imposed!
+        } else { // In this case all the displacements are imposed!
             return true;
+        }
     }
 
     /**

--- a/applications/ContactStructuralMechanicsApplication/custom_strategies/custom_convergencecriterias/displacement_lagrangemultiplier_frictional_contact_criteria.h
+++ b/applications/ContactStructuralMechanicsApplication/custom_strategies/custom_convergencecriterias/displacement_lagrangemultiplier_frictional_contact_criteria.h
@@ -312,26 +312,26 @@ public:
                 return std::make_tuple(0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0,0,0,0,0);
             });
 
-            if(disp_increase_norm < Tolerance) disp_increase_norm = 1.0;
-            if(rot_increase_norm < Tolerance) rot_increase_norm = 1.0;
-            if(normal_lm_increase_norm < Tolerance) normal_lm_increase_norm = 1.0;
-            if(tangent_lm_stick_increase_norm < Tolerance) tangent_lm_stick_increase_norm = 1.0;
-            if(tangent_lm_slip_increase_norm < Tolerance) tangent_lm_slip_increase_norm = 1.0;
-            if(disp_solution_norm < Tolerance) disp_solution_norm = 1.0;
+            if (disp_increase_norm < Tolerance) disp_increase_norm = 1.0;
+            if (rot_increase_norm < Tolerance) rot_increase_norm = 1.0;
+            if (normal_lm_increase_norm < Tolerance) normal_lm_increase_norm = 1.0;
+            if (tangent_lm_stick_increase_norm < Tolerance) tangent_lm_stick_increase_norm = 1.0;
+            if (tangent_lm_slip_increase_norm < Tolerance) tangent_lm_slip_increase_norm = 1.0;
+            if (disp_solution_norm < Tolerance) disp_solution_norm = 1.0;
 
             KRATOS_ERROR_IF(mOptions.Is(DisplacementLagrangeMultiplierFrictionalContactCriteria::ENSURE_CONTACT) && normal_lm_solution_norm < Tolerance) << "WARNING::CONTACT LOST::ARE YOU SURE YOU ARE SUPPOSED TO HAVE CONTACT?" << std::endl;
 
             const double disp_ratio = std::sqrt(disp_increase_norm/disp_solution_norm);
             const double rot_ratio = std::sqrt(rot_increase_norm/rot_solution_norm);
-            const double normal_lm_ratio = normal_lm_solution_norm > Tolerance ? std::sqrt(normal_lm_increase_norm/normal_lm_solution_norm) : 0.0;
-            const double tangent_lm_stick_ratio = tangent_lm_stick_solution_norm > Tolerance ? std::sqrt(tangent_lm_stick_increase_norm/tangent_lm_stick_solution_norm) : 0.0;
-            const double tangent_lm_slip_ratio = tangent_lm_slip_solution_norm > Tolerance ? std::sqrt(tangent_lm_slip_increase_norm/tangent_lm_slip_solution_norm) : 0.0;
+            const double normal_lm_ratio = (normal_lm_solution_norm > Tolerance) ? std::sqrt(normal_lm_increase_norm/normal_lm_solution_norm) : 0.0;
+            const double tangent_lm_stick_ratio = (tangent_lm_stick_solution_norm > Tolerance) ? std::sqrt(tangent_lm_stick_increase_norm/tangent_lm_stick_solution_norm) : 0.0;
+            const double tangent_lm_slip_ratio = (tangent_lm_slip_solution_norm > Tolerance) ? std::sqrt(tangent_lm_slip_increase_norm/tangent_lm_slip_solution_norm) : 0.0;
 
-            const double disp_abs = std::sqrt(disp_increase_norm)/ static_cast<double>(disp_dof_num);
-            const double rot_abs = std::sqrt(rot_increase_norm)/ static_cast<double>(rot_dof_num);
-            const double normal_lm_abs = std::sqrt(normal_lm_increase_norm)/ static_cast<double>(lm_dof_num);
-            const double tangent_lm_stick_abs = lm_stick_dof_num > 0 ?  std::sqrt(tangent_lm_stick_increase_norm)/ static_cast<double>(lm_stick_dof_num) : 0.0;
-            const double tangent_lm_slip_abs = lm_slip_dof_num > 0 ? std::sqrt(tangent_lm_slip_increase_norm)/ static_cast<double>(lm_slip_dof_num) : 0.0;
+            const double disp_abs = (disp_dof_num > 0) ? std::sqrt(disp_increase_norm)/ static_cast<double>(disp_dof_num) : 0.0;
+            const double rot_abs = (rot_dof_num > 0) ? std::sqrt(rot_increase_norm)/ static_cast<double>(rot_dof_num) : 0.0;
+            const double normal_lm_abs = (lm_dof_num > 0) ? std::sqrt(normal_lm_increase_norm)/ static_cast<double>(lm_dof_num) : 0.0;
+            const double tangent_lm_stick_abs = (lm_stick_dof_num > 0) ?  std::sqrt(tangent_lm_stick_increase_norm)/ static_cast<double>(lm_stick_dof_num) : 0.0;
+            const double tangent_lm_slip_abs = (lm_slip_dof_num > 0) ? std::sqrt(tangent_lm_slip_increase_norm)/ static_cast<double>(lm_slip_dof_num) : 0.0;
 
             const double normal_tangent_stick_ratio = tangent_lm_stick_abs/normal_lm_abs;
             const double normal_tangent_slip_ratio = tangent_lm_slip_abs/normal_lm_abs;
@@ -411,9 +411,9 @@ public:
                 }
                 return false;
             }
-        }
-        else // In this case all the displacements are imposed!
+        } else { // In this case all the displacements are imposed!
             return true;
+        }
     }
 
     /**

--- a/applications/ContactStructuralMechanicsApplication/custom_strategies/custom_convergencecriterias/displacement_lagrangemultiplier_mixed_contact_criteria.h
+++ b/applications/ContactStructuralMechanicsApplication/custom_strategies/custom_convergencecriterias/displacement_lagrangemultiplier_mixed_contact_criteria.h
@@ -275,8 +275,8 @@ public:
 
             mDispCurrentResidualNorm = disp_residual_solution_norm;
             mRotCurrentResidualNorm = rot_residual_solution_norm;
-            const double lm_ratio = lm_solution_norm > Tolerance ? std::sqrt(lm_increase_norm/lm_solution_norm) : 0.0;
-            const double lm_abs = std::sqrt(lm_increase_norm)/static_cast<double>(lm_dof_num);
+            const double lm_ratio = (lm_solution_norm > Tolerance) ? std::sqrt(lm_increase_norm/lm_solution_norm) : 0.0;
+            const double lm_abs = (lm_dof_num > 0) ? std::sqrt(lm_increase_norm)/static_cast<double>(lm_dof_num) : 0.0;
 
             double residual_disp_ratio, residual_rot_ratio;
 
@@ -298,8 +298,8 @@ public:
             residual_rot_ratio = mRotCurrentResidualNorm/mRotInitialResidualNorm;
 
             // We calculate the absolute norms
-            double residual_disp_abs = mDispCurrentResidualNorm/disp_dof_num;
-            double residual_rot_abs = mRotCurrentResidualNorm/rot_dof_num;
+            const double residual_disp_abs = (disp_dof_num > 0) ? mDispCurrentResidualNorm/static_cast<double>(disp_dof_num) : 0.0;
+            const double residual_rot_abs = (rot_dof_num > 0) ? mRotCurrentResidualNorm/static_cast<double>(rot_dof_num) : 0.0;
 
             // The process info of the model part
             ProcessInfo& r_process_info = rModelPart.GetProcessInfo();
@@ -378,8 +378,9 @@ public:
                 }
                 return false;
             }
-        } else // In this case all the displacements are imposed!
+        } else { // In this case all the displacements are imposed!
             return true;
+        }
     }
 
     /**

--- a/applications/ContactStructuralMechanicsApplication/custom_strategies/custom_convergencecriterias/displacement_lagrangemultiplier_mixed_frictional_contact_criteria.h
+++ b/applications/ContactStructuralMechanicsApplication/custom_strategies/custom_convergencecriterias/displacement_lagrangemultiplier_mixed_frictional_contact_criteria.h
@@ -333,9 +333,9 @@ public:
             const double tangent_lm_slip_ratio = tangent_lm_slip_solution_norm > Tolerance ? std::sqrt(tangent_lm_slip_increase_norm/tangent_lm_slip_solution_norm) : 0.0;
             const double tangent_lm_stick_ratio = tangent_lm_stick_solution_norm > Tolerance ? std::sqrt(tangent_lm_stick_increase_norm/tangent_lm_stick_solution_norm) : 0.0;
 
-            const double normal_lm_abs = std::sqrt(normal_lm_increase_norm)/static_cast<double>(lm_dof_num);
-            const double tangent_lm_stick_abs = lm_stick_dof_num > 0 ?  std::sqrt(tangent_lm_stick_increase_norm)/ static_cast<double>(lm_stick_dof_num) : 0.0;
-            const double tangent_lm_slip_abs = lm_slip_dof_num > 0 ? std::sqrt(tangent_lm_slip_increase_norm)/ static_cast<double>(lm_slip_dof_num) : 0.0;
+            const double normal_lm_abs = (lm_dof_num > 0) ? std::sqrt(normal_lm_increase_norm)/static_cast<double>(lm_dof_num) : 0.0;
+            const double tangent_lm_stick_abs = (lm_stick_dof_num > 0) ? std::sqrt(tangent_lm_stick_increase_norm)/ static_cast<double>(lm_stick_dof_num) : 0.0;
+            const double tangent_lm_slip_abs = (lm_slip_dof_num > 0) ? std::sqrt(tangent_lm_slip_increase_norm)/ static_cast<double>(lm_slip_dof_num) : 0.0;
 
             const double normal_tangent_stick_ratio = tangent_lm_stick_abs/normal_lm_abs;
             const double normal_tangent_slip_ratio = tangent_lm_slip_abs/normal_lm_abs;
@@ -360,8 +360,8 @@ public:
             residual_rot_ratio = mRotCurrentResidualNorm/mRotInitialResidualNorm;
 
             // We calculate the absolute norms
-            double residual_disp_abs = mDispCurrentResidualNorm/disp_dof_num;
-            double residual_rot_abs = mRotCurrentResidualNorm/rot_dof_num;
+            const double residual_disp_abs = (disp_dof_num > 0) ? mDispCurrentResidualNorm/static_cast<double>(disp_dof_num) : 0.0;
+            const double residual_rot_abs = (rot_dof_num > 0) ? mRotCurrentResidualNorm/static_cast<double>(rot_dof_num) : 0.0;
 
             // We print the results // TODO: Replace for the new log
             if (rModelPart.GetCommunicator().MyPID() == 0 && this->GetEchoLevel() > 0) {
@@ -450,8 +450,9 @@ public:
                 }
                 return false;
             }
-        } else // In this case all the displacements are imposed!
+        } else { // In this case all the displacements are imposed!
             return true;
+        }
     }
 
     /**

--- a/applications/ContactStructuralMechanicsApplication/custom_strategies/custom_convergencecriterias/displacement_lagrangemultiplier_residual_contact_criteria.h
+++ b/applications/ContactStructuralMechanicsApplication/custom_strategies/custom_convergencecriterias/displacement_lagrangemultiplier_residual_contact_criteria.h
@@ -300,9 +300,9 @@ public:
             KRATOS_ERROR_IF(mOptions.Is(DisplacementLagrangeMultiplierResidualContactCriteria::ENSURE_CONTACT) && residual_lm_ratio == 0.0) << "ERROR::CONTACT LOST::ARE YOU SURE YOU ARE SUPPOSED TO HAVE CONTACT?" << std::endl;
 
             // We calculate the absolute norms
-            const double residual_disp_abs = mDispCurrentResidualNorm/disp_dof_num;
-            const double residual_rot_abs = mRotCurrentResidualNorm/rot_dof_num;
-            const double residual_lm_abs = mLMCurrentResidualNorm/lm_dof_num;
+            const double residual_disp_abs = (disp_dof_num > 0) ? mDispCurrentResidualNorm/static_cast<double>(disp_dof_num) : 0.0;
+            const double residual_rot_abs = (rot_dof_num > 0) ? mRotCurrentResidualNorm/static_cast<double>(rot_dof_num) : 0.0;
+            const double residual_lm_abs = (lm_dof_num > 0) ? mLMCurrentResidualNorm/static_cast<double>(lm_dof_num) : 0.0;
 
             // The process info of the model part
             ProcessInfo& r_process_info = rModelPart.GetProcessInfo();
@@ -381,8 +381,9 @@ public:
                 }
                 return false;
             }
-        } else // In this case all the displacements are imposed!
+        } else { // In this case all the displacements are imposed!
             return true;
+        }
     }
 
     /**

--- a/applications/ContactStructuralMechanicsApplication/custom_strategies/custom_convergencecriterias/displacement_lagrangemultiplier_residual_frictional_contact_criteria.h
+++ b/applications/ContactStructuralMechanicsApplication/custom_strategies/custom_convergencecriterias/displacement_lagrangemultiplier_residual_frictional_contact_criteria.h
@@ -416,13 +416,13 @@ public:
             KRATOS_ERROR_IF(mOptions.Is(DisplacementLagrangeMultiplierResidualFrictionalContactCriteria::ENSURE_CONTACT) && residual_normal_lm_ratio < ZeroTolerance) << "ERROR::CONTACT LOST::ARE YOU SURE YOU ARE SUPPOSED TO HAVE CONTACT?" << std::endl;
 
             // We calculate the absolute norms
-            const double residual_disp_abs = mDispCurrentResidualNorm/static_cast<double>(disp_dof_num);
-            const double residual_rot_abs = mRotCurrentResidualNorm/static_cast<double>(rot_dof_num);
-            const double residual_normal_lm_abs = mLMNormalCurrentResidualNorm/static_cast<double>(lm_dof_num);
-            const double residual_tangent_lm_stick_abs = lm_stick_dof_num > 0 ? mLMTangentStickCurrentResidualNorm/static_cast<double>(lm_dof_num) : 0.0;
-//             const double residual_tangent_lm_stick_abs = lm_stick_dof_num > 0 ? mLMTangentStickCurrentResidualNorm/static_cast<double>(lm_stick_dof_num) : 0.0;
-            const double residual_tangent_lm_slip_abs = lm_slip_dof_num > 0 ? mLMTangentSlipCurrentResidualNorm/static_cast<double>(lm_dof_num) : 0.0;
-//             const double residual_tangent_lm_slip_abs = lm_slip_dof_num > 0 ? mLMTangentSlipCurrentResidualNorm/static_cast<double>(lm_slip_dof_num) : 0.0;
+            const double residual_disp_abs = (disp_dof_num > 0) ? mDispCurrentResidualNorm/static_cast<double>(disp_dof_num) : 0.0;
+            const double residual_rot_abs = (rot_dof_num > 0) ? mRotCurrentResidualNorm/static_cast<double>(rot_dof_num) : 0.0;
+            const double residual_normal_lm_abs = (lm_dof_num > 0) ?  mLMNormalCurrentResidualNorm/static_cast<double>(lm_dof_num) : 0.0;
+            const double residual_tangent_lm_stick_abs = (lm_stick_dof_num > 0) ? mLMTangentStickCurrentResidualNorm/static_cast<double>(lm_dof_num) : 0.0;
+            // const double residual_tangent_lm_stick_abs = (lm_stick_dof_num > 0) ? mLMTangentStickCurrentResidualNorm/static_cast<double>(lm_stick_dof_num) : 0.0;
+            const double residual_tangent_lm_slip_abs = (lm_slip_dof_num > 0) ? mLMTangentSlipCurrentResidualNorm/static_cast<double>(lm_dof_num) : 0.0;
+            // const double residual_tangent_lm_slip_abs = (lm_slip_dof_num > 0) ? mLMTangentSlipCurrentResidualNorm/static_cast<double>(lm_slip_dof_num) : 0.0;
             const double normal_tangent_stick_ratio = residual_tangent_lm_stick_abs/residual_normal_lm_abs;
             const double normal_tangent_slip_ratio = residual_tangent_lm_slip_abs/residual_normal_lm_abs;
 

--- a/applications/ContactStructuralMechanicsApplication/custom_strategies/custom_convergencecriterias/displacement_residual_contact_criteria.h
+++ b/applications/ContactStructuralMechanicsApplication/custom_strategies/custom_convergencecriterias/displacement_residual_contact_criteria.h
@@ -263,8 +263,8 @@ public:
             residual_rot_ratio = mRotCurrentResidualNorm/mRotInitialResidualNorm;
 
             // We calculate the absolute norms
-            const double residual_disp_abs = mDispCurrentResidualNorm/disp_dof_num;
-            const double residual_rot_abs = mRotCurrentResidualNorm/rot_dof_num;
+            const double residual_disp_abs = (disp_dof_num > 0) ? mDispCurrentResidualNorm/static_cast<double>(disp_dof_num) : 0.0;
+            const double residual_rot_abs = (rot_dof_num > 0) ? mRotCurrentResidualNorm/static_cast<double>(rot_dof_num) : 0.0;
 
             // The process info of the model part
             ProcessInfo& r_process_info = rModelPart.GetProcessInfo();
@@ -340,8 +340,9 @@ public:
                 }
                 return false;
             }
-        } else // In this case all the displacements are imposed!
+        } else { // In this case all the displacements are imposed!
             return true;
+        }
     }
 
     /**


### PR DESCRIPTION
**📝 Description**

Fixes #14242

Adding guards to the convergence criteria checking tan the number of dofs is not zero. IMHO this is already included implicitily as it checks the size of the RHS, and there are others checks for DoF that may be zero like frictional DoF. Adding as it is true that may happend for problems with not rotational dofs or not well defined.

**🆕 Changelog**

- [Adding missing guards in covergence criteria](https://github.com/KratosMultiphysics/Kratos/commit/705ddd0069e2b507e348652d8a1e8a56ec58917f)