### PR TITLE
[IGA] Expose active CP indices and higher-order derivatives at arbitrary local coordinates for BRep Surfaces

### DIFF
--- a/kratos/geometries/brep_surface.h
+++ b/kratos/geometries/brep_surface.h
@@ -547,6 +547,18 @@ public:
         return rResult;
     }
 
+    void ShapeFunctionsValuesAndCPIndices(
+        const CoordinatesArrayType& rCoordinates,
+        std::vector<IndexType>& rControlPointIndices,
+        Vector& rShapeFunctionsValues,
+        const IndexType DerivativeOrder = 0,
+        DenseVector<Matrix>* pShapeFunctionDerivatives = nullptr
+    ) const
+    {
+        mpNurbsSurface->ShapeFunctionsValuesAndCPIndices(
+            rCoordinates, rControlPointIndices, rShapeFunctionsValues, DerivativeOrder, pShapeFunctionDerivatives);
+    }
+
     ///@}
     ///@name Geometry Family
     ///@{

--- a/kratos/geometries/nurbs_surface_geometry.h
+++ b/kratos/geometries/nurbs_surface_geometry.h
@@ -731,16 +731,14 @@ public:
             return;
         }
 
-        if (pShapeFunctionDerivatives && DerivativeOrder > 0) {
+        if (DerivativeOrder > 0) {
 
             pShapeFunctionDerivatives->resize(DerivativeOrder);
 
             IndexType shape_derivative_index = 1; // first derivative block starts after values
 
             for (IndexType n = 0; n < DerivativeOrder; ++n) {
-
-                const IndexType order   = n + 1;
-                const IndexType n_terms = order + 1;
+                const IndexType n_terms = n + 2;
 
                 (*pShapeFunctionDerivatives)[n].resize(num_nonzero_cps, n_terms, false);
 

--- a/kratos/geometries/nurbs_surface_geometry.h
+++ b/kratos/geometries/nurbs_surface_geometry.h
@@ -667,6 +667,96 @@ public:
         }
     }
 
+    /* Returns shape functions values, shape functions derivatives and active CP indices at a given 
+     * position in the surface parameter space. 
+     * @param return rCoordinates parameter space coordinates 
+     * @param rControlPointIndices indices of the active control points
+     * @param rShapeFunctionsValues vector of shape functions
+     * @param NumberOfShapeFunctionDerivatives number of required derivatives
+     * @param pShapeFunctionDerivatives shape functions derivatives
+     */
+    void ShapeFunctionsValuesAndCPIndices(
+        const CoordinatesArrayType& rCoordinates,
+        std::vector<IndexType>& rControlPointIndices,
+        Vector& rShapeFunctionsValues,
+        const IndexType DerivativeOrder = 0,
+        DenseVector<Matrix>* pShapeFunctionDerivatives = nullptr
+    ) const
+    {
+        const double u = rCoordinates[0];
+        const double v = rCoordinates[1];
+
+        const IndexType max_supported_order = std::min(mPolynomialDegreeU, mPolynomialDegreeV);
+
+        KRATOS_WARNING_IF("ShapeFunctionsValuesAndCPIndices",
+            DerivativeOrder > max_supported_order)
+            << "Requested derivative order (" << DerivativeOrder
+            << ") exceeds polynomial degree limit (" << max_supported_order
+            << "). Higher derivatives may be zero or undefined." << std::endl;
+
+        NurbsSurfaceShapeFunction shape_function_container(
+            mPolynomialDegreeU,
+            mPolynomialDegreeV,
+            DerivativeOrder + 1);
+
+        if (mIsRational) {
+            shape_function_container.ComputeNurbsShapeFunctionValues(
+                mKnotsU, mKnotsV, mWeights, u, v);
+        } else {
+            shape_function_container.ComputeBSplineShapeFunctionValues(
+                mKnotsU, mKnotsV, u, v);
+        }
+
+        const SizeType num_nonzero_cps = shape_function_container.NumberOfNonzeroControlPoints();
+
+        // CP indices 
+        const auto cp_indices = shape_function_container.ControlPointIndices(
+            NumberOfControlPointsU(), NumberOfControlPointsV());
+
+        rControlPointIndices.resize(cp_indices.size());
+        for (IndexType i = 0; i < cp_indices.size(); ++i) {
+            rControlPointIndices[i] = static_cast<IndexType>(cp_indices[i]);
+        }
+
+        // Shape Functions
+        if (rShapeFunctionsValues.size() != num_nonzero_cps) {
+            rShapeFunctionsValues.resize(num_nonzero_cps, false);
+        }
+        for (IndexType j = 0; j < num_nonzero_cps; ++j) {
+            rShapeFunctionsValues[j] = shape_function_container(j, 0);
+        }
+
+        // Derivatives 
+        if (!pShapeFunctionDerivatives || DerivativeOrder == 0) {
+            return;
+        }
+
+        // --- Derivatives ---
+        if (pShapeFunctionDerivatives && DerivativeOrder > 0) {
+
+            pShapeFunctionDerivatives->resize(DerivativeOrder);
+
+            IndexType shape_derivative_index = 1; // first derivative block starts after values
+
+            for (IndexType n = 0; n < DerivativeOrder; ++n) {
+
+                const IndexType order   = n + 1;
+                const IndexType n_terms = order + 1;
+
+                (*pShapeFunctionDerivatives)[n].resize(num_nonzero_cps, n_terms, false);
+
+                for (IndexType k = 0; k < n_terms; ++k) {
+                    for (IndexType j = 0; j < num_nonzero_cps; ++j) {
+                        (*pShapeFunctionDerivatives)[n](j, k) =
+                            shape_function_container(j, shape_derivative_index + k);
+                    }
+                }
+
+                shape_derivative_index += n_terms;
+            }
+        }
+    }
+
     ///@}
     ///@name Operations
     ///@{

--- a/kratos/geometries/nurbs_surface_geometry.h
+++ b/kratos/geometries/nurbs_surface_geometry.h
@@ -731,7 +731,6 @@ public:
             return;
         }
 
-        // --- Derivatives ---
         if (pShapeFunctionDerivatives && DerivativeOrder > 0) {
 
             pShapeFunctionDerivatives->resize(DerivativeOrder);

--- a/kratos/python/add_geometries_to_python.cpp
+++ b/kratos/python/add_geometries_to_python.cpp
@@ -373,18 +373,6 @@ void  AddGeometriesToPython(pybind11::module& m)
     using PointContainerType = Kratos::PointerVector<Kratos::Point>;
     using BrepSurfaceType = Kratos::BrepSurface<NodeContainerType, false, PointContainerType>;
     py::class_<BrepSurfaceType, typename BrepSurfaceType::Pointer, GeometryType>(m, "BrepSurface")
-        .def("ProjectionPointGlobalToLocalSpace",
-            [](const BrepSurfaceType& self,
-            const CoordinatesArrayType& rGlobal,
-            CoordinatesArrayType& rLocal,
-            const double tolerance)
-            {
-                return self.ProjectionPointGlobalToLocalSpace(rGlobal, rLocal, tolerance);
-            },
-            py::arg("global_coordinates"),
-            py::arg("local_coordinates"),
-            py::arg("tolerance") = 1e-12
-        )
         .def("EvaluateShapeFunctionsAtLocalCoordinates",
             [](const BrepSurfaceType& self, const CoordinatesArrayType& rLocal, const IndexType derivative_order)
             {

--- a/kratos/python/add_geometries_to_python.cpp
+++ b/kratos/python/add_geometries_to_python.cpp
@@ -50,6 +50,7 @@
 #include "geometries/nurbs_curve_geometry.h"
 #include "geometries/nurbs_curve_on_surface_geometry.h"
 #include "geometries/surface_in_nurbs_volume_geometry.h"
+#include "geometries/brep_surface.h" 
 
 namespace Kratos::Python
 {
@@ -367,6 +368,34 @@ void  AddGeometriesToPython(pybind11::module& m)
             NurbsCurveOnSurfaceGeometry3DType::NurbsSurfaceType::Pointer,
             NurbsCurveOnSurfaceGeometry3DType::NurbsCurveType::Pointer>())
         ;
+
+    // BrepSurface
+    using PointContainerType = Kratos::PointerVector<Kratos::Point>;
+    using BrepSurfaceType = Kratos::BrepSurface<NodeContainerType, false, PointContainerType>;
+    py::class_<BrepSurfaceType, typename BrepSurfaceType::Pointer, GeometryType>(m, "BrepSurface")
+        .def("ProjectionPointGlobalToLocalSpace",
+            [](const BrepSurfaceType& self,
+            const CoordinatesArrayType& rGlobal,
+            CoordinatesArrayType& rLocal,
+            const double tolerance)
+            {
+                return self.ProjectionPointGlobalToLocalSpace(rGlobal, rLocal, tolerance);
+            },
+            py::arg("global_coordinates"),
+            py::arg("local_coordinates"),
+            py::arg("tolerance") = 1e-12
+        )
+        .def("EvaluateShapeFunctionsAtLocalCoordinates",
+            [](const BrepSurfaceType& self, const CoordinatesArrayType& rLocal, const IndexType derivative_order)
+            {
+                std::vector<IndexType> cp_ids;
+                Vector shape_functions_values;
+                self.ShapeFunctionsValuesAndCPIndices(rLocal, cp_ids, shape_functions_values, derivative_order, nullptr);
+                return py::make_tuple(cp_ids, shape_functions_values);
+            },
+            py::arg("local_coordinates"),
+            py::arg("derivative_order") = 0
+        );
 
 
     py::class_<SurfaceInNurbsVolumeGeometry<3, NodeContainerType>, SurfaceInNurbsVolumeGeometry<3, NodeContainerType>::Pointer, GeometryType>(m, "SurfaceInNurbsVolumeGeometry")

--- a/kratos/tests/cpp_tests/geometries/test_nurbs_surface.cpp
+++ b/kratos/tests/cpp_tests/geometries/test_nurbs_surface.cpp
@@ -779,5 +779,97 @@ namespace Testing {
         KRATOS_EXPECT_VECTOR_NEAR(derivatives[26], gradient26, TOLERANCE);
         KRATOS_EXPECT_VECTOR_NEAR(derivatives[27], gradient27, TOLERANCE);
     }
+
+    KRATOS_TEST_CASE_IN_SUITE(NurbsSurfaceShapeFunctionsValuesAndDerivativesAndCPIndices, KratosCoreNurbsGeometriesFastSuite)
+    {
+        using SurfaceType =  NurbsSurfaceGeometry<3, PointerVector<Point>>;
+        using IntegrationPointsArrayType = typename SurfaceType::IntegrationPointsArrayType;
+        using GeometriesArrayType        = typename SurfaceType::GeometriesArrayType;
+
+        // Get the NURBS Surface
+        auto surface = GenerateReferenceQuarterSphereGeometry();
+
+        // Pick an interior parametric point 
+        array_1d<double, 3> local_coords(0.0);
+        local_coords[0] = 0.25;
+        local_coords[1] = 0.75;
+
+        IntegrationPointsArrayType integration_points;
+        integration_points.push_back(typename SurfaceType::IntegrationPointType(
+            local_coords[0], local_coords[1], 1.0));
+
+        IntegrationInfo dummy_info = surface.GetDefaultIntegrationInfo();
+
+        GeometriesArrayType qps;
+        surface.CreateQuadraturePointGeometries(qps, 3, integration_points, dummy_info);
+
+        KRATOS_EXPECT_EQ(qps.size(), 1);
+
+        const auto& r_qp_geom = qps[0];
+        KRATOS_EXPECT_EQ(r_qp_geom.LocalSpaceDimension(), 2);
+
+        // Call the new function
+        std::vector<IndexType> cp_indices;
+        Vector ShapeFunctions;
+        DenseVector<Matrix> Derivatives; 
+
+        surface.ShapeFunctionsValuesAndCPIndices(
+            local_coords,
+            cp_indices,
+            ShapeFunctions,
+            2,
+            &Derivatives);
+
+        // Basic sanity
+        KRATOS_EXPECT_GT(cp_indices.size(), 0);
+        KRATOS_EXPECT_EQ(ShapeFunctions.size(), cp_indices.size());
+        KRATOS_EXPECT_EQ(Derivatives.size(), 2); 
+
+       // Compare shape function values
+        const Matrix& rShapeFunctionsValues_ref = r_qp_geom.ShapeFunctionsValues();
+        KRATOS_EXPECT_EQ(rShapeFunctionsValues_ref.size1(), 1);
+        KRATOS_EXPECT_EQ(rShapeFunctionsValues_ref.size2(), ShapeFunctions.size());
+
+        for (IndexType j = 0; j < ShapeFunctions.size(); ++j) {
+            KRATOS_EXPECT_NEAR(ShapeFunctions[j], rShapeFunctionsValues_ref(0, j), TOLERANCE);
+        }
+
+        // Compare 1st derivatives (
+        const Matrix& rFirstDerivativeValues_ref = r_qp_geom.ShapeFunctionLocalGradient(0);
+        KRATOS_EXPECT_EQ(rFirstDerivativeValues_ref.size1(), ShapeFunctions.size());
+        KRATOS_EXPECT_EQ(rFirstDerivativeValues_ref.size2(), 2);
+
+        KRATOS_EXPECT_EQ(Derivatives[0].size1(), ShapeFunctions.size());
+        KRATOS_EXPECT_EQ(Derivatives[0].size2(), 2);
+
+        for (IndexType j = 0; j < ShapeFunctions.size(); ++j) {
+            KRATOS_EXPECT_NEAR(Derivatives[0](j, 0), rFirstDerivativeValues_ref(j, 0), TOLERANCE); // dN/du
+            KRATOS_EXPECT_NEAR(Derivatives[0](j, 1), rFirstDerivativeValues_ref(j, 1), TOLERANCE); // dN/dv
+        }
+
+        // Compare 2nd derivatives
+        const Matrix& rSecondDerivativeValues_ref = r_qp_geom.ShapeFunctionDerivatives(2, 0); 
+        KRATOS_EXPECT_EQ(rSecondDerivativeValues_ref.size1(), ShapeFunctions.size());
+        KRATOS_EXPECT_EQ(rSecondDerivativeValues_ref.size2(), 3);
+
+        KRATOS_EXPECT_EQ(Derivatives[1].size1(), ShapeFunctions.size());
+        KRATOS_EXPECT_EQ(Derivatives[1].size2(), 3);
+
+        for (IndexType j = 0; j < ShapeFunctions.size(); ++j) {
+            KRATOS_EXPECT_NEAR(Derivatives[1](j, 0), rSecondDerivativeValues_ref(j, 0), TOLERANCE); // dN/duu
+            KRATOS_EXPECT_NEAR(Derivatives[1](j, 1), rSecondDerivativeValues_ref(j, 1), TOLERANCE); // dN/duv
+            KRATOS_EXPECT_NEAR(Derivatives[1](j, 2), rSecondDerivativeValues_ref(j, 2), TOLERANCE); // dN/dvv
+        }
+
+        // CP-index consistency check
+        KRATOS_EXPECT_EQ(r_qp_geom.PointsNumber(), cp_indices.size());
+        for (IndexType j = 0; j < cp_indices.size(); ++j) {
+            const auto& P_qp   = r_qp_geom[j];
+            const auto& P_surf = surface.pGetPoint(cp_indices[j]);
+            KRATOS_EXPECT_NEAR(P_qp.X(), P_surf->X(), TOLERANCE);
+            KRATOS_EXPECT_NEAR(P_qp.Y(), P_surf->Y(), TOLERANCE);
+            KRATOS_EXPECT_NEAR(P_qp.Z(), P_surf->Z(), TOLERANCE);
+        }
+    }
 } // namespace Testing.
 } // namespace Kratos.


### PR DESCRIPTION
**Motivation**

Currently, Kratos allows evaluating shape functions (and first derivatives) at arbitrary local coordinates on BRepSurfaces through `ShapeFunctionsValues()` and `ShapeFunctionsLocalGradients()`. However:
- The active control-point indices at a given parameter position are not accessible (only available through `QuadraturePointGeometry`).
- For non-quadrature points, derivatives are limited to first order via `ShapeFunctionLocalGradients()`, preventing access to higher-order derivatives.

**What this PR adds**
Extends the BrepSurface class with a routine called `ShapeFunctionsValuesAndCPIndices()` which returns the following values at a certain point in the surface parameter space:
- Active control-point indices
- Shape function values
- Higher-order derivatives (up to requested order)

**Comments**
- A test for this new functionality was added
- This new function was exposed to the python interface