### PR TITLE
[GeoMechanicsApplication] Fixed a compilation error when constructing a `PQ` object from a vector expression

### DIFF
--- a/applications/GeoMechanicsApplication/custom_constitutive/p_q.hpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/p_q.hpp
@@ -34,11 +34,15 @@ public:
     template <typename VectorType>
     explicit PQ(const VectorType& rValues)
     {
-        KRATOS_DEBUG_ERROR_IF(std::ranges::distance(rValues) != msVectorSize)
+        // For some reason, the `std::ranges` versions of the below algorithms don't play nicely
+        // with UBlas vector expressions. Therefore, we're using the iterator-style algorithms.
+        auto first = std::begin(rValues);
+        auto last  = std::end(rValues);
+        KRATOS_DEBUG_ERROR_IF(std::distance(first, last) != msVectorSize)
             << "Cannot construct a PQ instance: expected " << msVectorSize << " values, but got "
-            << std::ranges::distance(rValues) << " value(s)\n";
+            << std::distance(first, last) << " value(s)\n";
 
-        std::ranges::copy(rValues, mValues.begin());
+        std::copy(first, last, mValues.begin());
     }
 
     [[nodiscard]] const InternalVectorType& Values() const noexcept;

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_constitutive/test_p_q.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_constitutive/test_p_q.cpp
@@ -68,6 +68,20 @@ TEST_F(KratosGeoMechanicsFastSuiteWithoutKernel, PQ_RaisesADebugErrorWhenAttempt
     EXPECT_THROW(Geo::PQ{too_long}, Exception);
 }
 
+TEST_F(KratosGeoMechanicsFastSuiteWithoutKernel, PQ_CanBeConstructedFromAVectorExpression)
+{
+    // Arrange
+    const auto     some_matrix = UblasUtilities::CreateMatrix({{1.0, 2.0}, {3.0, 4.0}});
+    const auto     some_vector = UblasUtilities::CreateVector({2.0, 3.0});
+    constexpr auto some_scalar = 1.5;
+
+    // Act & Assert
+    // The following code won't compile when the template constructor of class `PQ` (which receives
+    // a vector-like object) uses `std::ranges` algorithms when a UBlas vector expression is given.
+    KRATOS_EXPECT_VECTOR_NEAR(Geo::PQ{some_scalar * prod(some_matrix, some_vector)}.Values(),
+                              (std::vector{12.0, 27.0}), Defaults::absolute_tolerance);
+}
+
 TEST_F(KratosGeoMechanicsFastSuiteWithoutKernel, PQ_CanBeConstructedFromFromTwoValues)
 {
     EXPECT_NEAR((Geo::PQ{1.0, 2.0}.P()), 1.0, Defaults::absolute_tolerance);


### PR DESCRIPTION
**📝 Description**
Apparently, the STL ranges algorithms don't play nicely with Boost UBlas's vector expressions. Use iterator-style STL algorithms to overcome the resultant compilation error.