### PR TITLE
[LINEAR SOLVERS] Add multi-RHS Solve(A, X, B) implementation and tests for Eigen-based direct linear solvers

### DIFF
--- a/applications/LinearSolversApplication/custom_solvers/eigen_direct_solver.h
+++ b/applications/LinearSolversApplication/custom_solvers/eigen_direct_solver.h
@@ -139,9 +139,42 @@ public:
      * @param rB Right hand side matrix
      * @return true if solution found, otherwise false
      */
-    bool Solve(SparseMatrixType &rA, DenseMatrixType &rX, DenseMatrixType &rB) override
+    bool Solve(SparseMatrixType& rA, DenseMatrixType& rX, DenseMatrixType& rB) override
     {
-        return false;
+        KRATOS_TRY
+    
+        typename TSparseSpaceType::VectorType solution, rhs;
+        TSparseSpaceType::Resize(solution, TSparseSpaceType::Size1(rA));
+        TSparseSpaceType::Resize(rhs, TSparseSpaceType::Size1(rA));
+    
+        const std::size_t system_size = TSparseSpaceType::Size1(rA);
+        const std::size_t n_rhs = TDenseSpaceType::Size2(rB);
+    
+        KRATOS_ERROR_IF(TDenseSpaceType::Size1(rB) != system_size) << "RHS has wrong number of rows." << std::endl;
+    
+        if (TDenseSpaceType::Size1(rX) != system_size || TDenseSpaceType::Size2(rX) != n_rhs) {
+            TDenseSpaceType::Resize(rX, system_size, n_rhs);
+        }
+    
+        this->InitializeSolutionStep(rA, solution, rhs);
+    
+        bool success = true;
+    
+        for (std::size_t i_column = 0ul; i_column < n_rhs; ++i_column) {
+            noalias(rhs) = column(rB, i_column);
+            TSparseSpaceType::SetToZero(solution);
+    
+            const bool col_success = this->PerformSolutionStep(rA, solution, rhs);
+            success = success && col_success;
+    
+            noalias(column(rX, i_column)) = solution;
+        }
+    
+        this->FinalizeSolutionStep(rA, solution, rhs);
+    
+        return success;
+    
+        KRATOS_CATCH("")
     }
 
     /**

--- a/applications/LinearSolversApplication/custom_solvers/eigen_direct_solver.h
+++ b/applications/LinearSolversApplication/custom_solvers/eigen_direct_solver.h
@@ -142,32 +142,35 @@ public:
     bool Solve(SparseMatrixType& rA, DenseMatrixType& rX, DenseMatrixType& rB) override
     {
         KRATOS_TRY
+
+        const std::size_t system_size = TSparseSpaceType::Size1(rA);
+        const std::size_t n_rhs = TDenseSpaceType::Size2(rB);
     
         typename TSparseSpaceType::VectorType solution, rhs;
         TSparseSpaceType::Resize(solution, TSparseSpaceType::Size1(rA));
         TSparseSpaceType::Resize(rhs, TSparseSpaceType::Size1(rA));
-    
-        const std::size_t system_size = TSparseSpaceType::Size1(rA);
-        const std::size_t n_rhs = TDenseSpaceType::Size2(rB);
     
         KRATOS_ERROR_IF(TDenseSpaceType::Size1(rB) != system_size) << "RHS has wrong number of rows." << std::endl;
     
         if (TDenseSpaceType::Size1(rX) != system_size || TDenseSpaceType::Size2(rX) != n_rhs) {
             TDenseSpaceType::Resize(rX, system_size, n_rhs);
         }
-    
+
+        rhs = column(rB, 0);
         this->InitializeSolutionStep(rA, solution, rhs);
     
         bool success = true;
     
-        for (std::size_t i_column = 0ul; i_column < n_rhs; ++i_column) {
-            noalias(rhs) = column(rB, i_column);
+        for (std::size_t i_column = 0ul; i_column < n_rhs; ++i_column)
+        {
+            rhs = column(rB, i_column);
+
             TSparseSpaceType::SetToZero(solution);
-    
+
             const bool col_success = this->PerformSolutionStep(rA, solution, rhs);
             success = success && col_success;
-    
-            noalias(column(rX, i_column)) = solution;
+
+            column(rX, i_column) = solution;
         }
     
         this->FinalizeSolutionStep(rA, solution, rhs);

--- a/applications/LinearSolversApplication/custom_solvers/eigen_direct_solver.h
+++ b/applications/LinearSolversApplication/custom_solvers/eigen_direct_solver.h
@@ -9,6 +9,9 @@
 
 #pragma once
 
+// System includes
+#include <format>
+
 // External includes
 #include <Eigen/Core>
 #include <Eigen/Sparse>
@@ -150,11 +153,11 @@ public:
         TSparseSpaceType::Resize(solution, TSparseSpaceType::Size1(rA));
         TSparseSpaceType::Resize(rhs, TSparseSpaceType::Size1(rA));
     
-        KRATOS_ERROR_IF(TDenseSpaceType::Size1(rB) != system_size) << "RHS has wrong number of rows." << std::endl;
+        KRATOS_ERROR_IF(TDenseSpaceType::Size1(rB) != system_size) << std::format(
+            "expecting the right hand side matrix to have {} rows, but it has {}",
+            system_size, TDenseSpaceType::Size1(rB));
     
-        if (TDenseSpaceType::Size1(rX) != system_size || TDenseSpaceType::Size2(rX) != n_rhs) {
-            TDenseSpaceType::Resize(rX, system_size, n_rhs);
-        }
+        TDenseSpaceType::Resize(rX, system_size, n_rhs);
 
         rhs = column(rB, 0);
         this->InitializeSolutionStep(rA, solution, rhs);

--- a/applications/LinearSolversApplication/custom_solvers/eigen_direct_solver.h
+++ b/applications/LinearSolversApplication/custom_solvers/eigen_direct_solver.h
@@ -9,9 +9,6 @@
 
 #pragma once
 
-// System includes
-#include <format>
-
 // External includes
 #include <Eigen/Core>
 #include <Eigen/Sparse>
@@ -153,9 +150,11 @@ public:
         TSparseSpaceType::Resize(solution, TSparseSpaceType::Size1(rA));
         TSparseSpaceType::Resize(rhs, TSparseSpaceType::Size1(rA));
     
-        KRATOS_ERROR_IF(TDenseSpaceType::Size1(rB) != system_size) << std::format(
-            "expecting the right hand side matrix to have {} rows, but it has {}",
-            system_size, TDenseSpaceType::Size1(rB));
+        KRATOS_ERROR_IF(TDenseSpaceType::Size1(rB) != system_size)
+            << "Expecting the right hand side matrix to have "
+            << system_size
+            << " rows, but it has "
+            << TDenseSpaceType::Size1(rB) << ".";
     
         TDenseSpaceType::Resize(rX, system_size, n_rhs);
 

--- a/applications/LinearSolversApplication/tests/test_eigen_direct_solver.py
+++ b/applications/LinearSolversApplication/tests/test_eigen_direct_solver.py
@@ -84,8 +84,20 @@ class TestEigenDirectSolver(KratosUnittest.TestCase):
         solver.Solve(a, x, b_exp)
     
         b_act = KratosMultiphysics.Matrix(dimension, num_rhs)
-        space.Mult(a, x, b_act)
-    
+
+        for j in range(num_rhs):
+            x_col = KratosMultiphysics.Vector(dimension)
+            b_col = KratosMultiphysics.Vector(dimension)
+
+            for i in range(dimension):
+                x_col[i] = x[i, j]
+
+            space.Mult(a, x_col, b_col)
+
+            for i in range(dimension):
+                b_act[i, j] = b_col[i]
+
+        # check solution
         for i in range(dimension):
             for j in range(num_rhs):
                 self.assertAlmostEqual(b_act[i, j], b_exp[i, j], 7)

--- a/applications/LinearSolversApplication/tests/test_eigen_direct_solver.py
+++ b/applications/LinearSolversApplication/tests/test_eigen_direct_solver.py
@@ -44,6 +44,52 @@ class TestEigenDirectSolver(KratosUnittest.TestCase):
         for i in range(dimension):
             self.assertAlmostEqual(b_act[i], b_exp[i], 7)
 
+    def __ExecuteEigenDirectSolverMatrixRHSTest(self, solver_type: str) -> None:
+        space = KratosMultiphysics.UblasSparseSpace()
+    
+        settings = KratosMultiphysics.Parameters(
+            '{ "solver_type" : "LinearSolversApplication.' + solver_type + '" }'
+        )
+        solver = ConstructSolver(settings)
+    
+        a = KratosMultiphysics.CompressedMatrix()
+    
+        this_file_dir = os.path.dirname(os.path.realpath(__file__))
+        base_dir = os.path.dirname(os.path.dirname(os.path.dirname(this_file_dir)))
+        matrix_file_path = os.path.join(
+            base_dir,
+            "kratos",
+            "tests",
+            "auxiliar_files_for_python_unittest",
+            "sparse_matrix_files",
+            "A.mm"
+        )
+    
+        file_read = KratosMultiphysics.ReadMatrixMarketMatrix(matrix_file_path, a)
+        self.assertTrue(file_read, msg="The MatrixFile could not be read")
+    
+        dimension = a.Size1()
+        self.assertEqual(dimension, 900)
+    
+        num_rhs = 3
+        b_exp = KratosMultiphysics.Matrix(dimension, num_rhs)
+    
+        for i in range(dimension):
+            b_exp[i, 0] = i + 1
+            b_exp[i, 1] = 2 * (i + 1)
+            b_exp[i, 2] = (-1)**i * (i + 1)
+    
+        x = KratosMultiphysics.Matrix(dimension, num_rhs)
+    
+        solver.Solve(a, x, b_exp)
+    
+        b_act = KratosMultiphysics.Matrix(dimension, num_rhs)
+        space.Mult(a, x, b_act)
+    
+        for i in range(dimension):
+            for j in range(num_rhs):
+                self.assertAlmostEqual(b_act[i, j], b_exp[i, j], 7)
+
     def __ExecuteEigenDirectComplexSolverTest(self,
                                               class_name: str,
                                               solver_type: str) -> None:
@@ -85,19 +131,33 @@ class TestEigenDirectSolver(KratosUnittest.TestCase):
     def test_EigenSparseLU(self):
         self.__ExecuteEigenDirectSolverTest('SparseLUSolver', 'sparse_lu')
 
+    def test_EigenSparseLU_MatrixRHS(self):
+        self.__ExecuteEigenDirectSolverMatrixRHSTest('sparse_lu')
+
     def test_EigenSparseCG(self):
         self.__ExecuteEigenDirectSolverTest('SparseCGSolver', 'sparse_cg')
 
     def test_EigenSparseQR(self):
         self.__ExecuteEigenDirectSolverTest('SparseQRSolver', 'sparse_qr')
 
+    def test_EigenSparseQR_MatrixRHS(self):
+        self.__ExecuteEigenDirectSolverMatrixRHSTest('sparse_qr')
+
     @KratosUnittest.skipIf(not LinearSolversApplication.HasMKL(), "Kratos was compiled without MKL support.")
     def test_EigenPardisoLU(self):
         self.__ExecuteEigenDirectSolverTest('PardisoLUSolver', 'pardiso_lu')
 
     @KratosUnittest.skipIf(not LinearSolversApplication.HasMKL(), "Kratos was compiled without MKL support.")
+    def test_EigenPardisoLU_MatrixRHS(self):
+        self.__ExecuteEigenDirectSolverMatrixRHSTest('pardiso_lu')
+
+    @KratosUnittest.skipIf(not LinearSolversApplication.HasMKL(), "Kratos was compiled without MKL support.")
     def test_EigenPardisoLDLT(self):
         self.__ExecuteEigenDirectSolverTest('PardisoLDLTSolver', 'pardiso_ldlt')
+
+    @KratosUnittest.skipIf(not LinearSolversApplication.HasMKL(), "Kratos was compiled without MKL support.")
+    def test_EigenPardisoLDLT_MatrixRHS(self):
+        self.__ExecuteEigenDirectSolverMatrixRHSTest('pardiso_ldlt')
 
     @KratosUnittest.skipIf(not LinearSolversApplication.HasMKL(), "Kratos was compiled without MKL support.")
     def test_EigenPardisoLLT(self):

--- a/applications/LinearSolversApplication/tests/test_eigen_direct_solver.py
+++ b/applications/LinearSolversApplication/tests/test_eigen_direct_solver.py
@@ -1,4 +1,4 @@
-
+from pathlib import Path
 import os
 import KratosMultiphysics
 
@@ -18,11 +18,18 @@ class TestEigenDirectSolver(KratosUnittest.TestCase):
 
         a = KratosMultiphysics.CompressedMatrix()
 
-        this_file_dir = os.path.dirname(os.path.realpath(__file__))
-        base_dir = os.path.dirname(os.path.dirname(os.path.dirname(this_file_dir)))
-        matrix_file_path = os.path.join(base_dir, "kratos", "tests", "auxiliar_files_for_python_unittest", "sparse_matrix_files", "A.mm")
+        base_dir = Path(__file__).resolve().parents[3]
 
-        file_read = KratosMultiphysics.ReadMatrixMarketMatrix(matrix_file_path, a) # symmetric test matrix
+        matrix_file_path = (
+            base_dir
+            / "kratos"
+            / "tests"
+            / "auxiliar_files_for_python_unittest"
+            / "sparse_matrix_files"
+            / "A.mm"
+        )
+
+        file_read = KratosMultiphysics.ReadMatrixMarketMatrix(str(matrix_file_path), a)
         self.assertTrue(file_read, msg="The MatrixFile could not be read")
 
         dimension = a.Size1()

--- a/kratos/python/add_linear_solvers_to_python.cpp
+++ b/kratos/python/add_linear_solvers_to_python.cpp
@@ -78,6 +78,7 @@ void  AddLinearSolversToPython(pybind11::module& m)
     using ComplexSkylineLUSolverType = SkylineLUCustomScalarSolver<ComplexSpaceType, ComplexLocalSpaceType>;
 
     bool (LinearSolverType::*pointer_to_solve)(LinearSolverType::SparseMatrixType& rA, LinearSolverType::VectorType& rX, LinearSolverType::VectorType& rB) = &LinearSolverType::Solve;
+    bool (LinearSolverType::*pointer_to_multi_solve)(LinearSolverType::SparseMatrixType& rA,LinearSolverType::DenseMatrixType& rX, LinearSolverType::DenseMatrixType& rB) = &LinearSolverType::Solve;
     void (LinearSolverType::*pointer_to_solve_eigen)(LinearSolverType::SparseMatrixType& rK, LinearSolverType::SparseMatrixType& rM,LinearSolverType::DenseVectorType& Eigenvalues, LinearSolverType::DenseMatrixType& Eigenvectors) = &LinearSolverType::Solve;
     bool (ComplexLinearSolverType::*pointer_to_complex_solve)(ComplexLinearSolverType::SparseMatrixType& rA, ComplexLinearSolverType::VectorType& rX, ComplexLinearSolverType::VectorType& rB) = &ComplexLinearSolverType::Solve;
     void (ComplexLinearSolverType::*pointer_to_complex_solve_eigen)(ComplexLinearSolverType::SparseMatrixType& rK, ComplexLinearSolverType::SparseMatrixType& rM, ComplexLinearSolverType::DenseVectorType& Eigenvalues, ComplexLinearSolverType::DenseMatrixType& Eigenvectors) = &ComplexLinearSolverType::Solve;
@@ -119,6 +120,7 @@ void  AddLinearSolversToPython(pybind11::module& m)
     .def("Initialize",&LinearSolverType::Initialize)
     .def("Solve",pointer_to_solve)
     .def("Solve",pointer_to_solve_eigen)
+    .def("Solve",pointer_to_multi_solve)
     .def("Clear",&LinearSolverType::Clear)
     .def("__str__", PrintObject<LinearSolverType>)
     .def( "GetIterationsNumber",&LinearSolverType::GetIterationsNumber)


### PR DESCRIPTION
## Description

This PR adds support for solving linear systems with multiple right-hand sides in the Eigen-based direct linear solvers by implementing the interface

```cpp
Solve(A, X, B)
```

where `B` is a dense matrix containing several RHS vectors and `X` is the corresponding solution matrix.

Previously, the test suite only verified the vector version of the interface:

```cpp
Solve(A, x, b)
```

while the matrix-RHS overload was not covered by tests. This PR implements the multi-RHS solve by looping over the columns of `B`, solving each system, and storing the corresponding solution in the columns of `X`.

In addition, new tests are introduced to verify the correct behavior of this interface. The tests reuse the existing MatrixMarket test matrix (`A.mm`) already used in the current solver tests.

---

## Motivation

Some applications require solving linear systems with several RHS while the LHS does not change. This interface allows reusing the same solver infrastructure for such cases while keeping compatibility with the existing vector-based API.

---

## Changes

- Implemented the `Solve(A, X, B)` interface for Eigen-based linear solvers.
- Added tests for the matrix RHS case.

---

## Tests added

The following tests were added:

- `test_EigenSparseLU_MatrixRHS`
- `test_EigenSparseQR_MatrixRHS`
- `test_EigenPardisoLU_MatrixRHS`
- `test_EigenPardisoLDLT_MatrixRHS`

These tests solve a system with multiple RHS and verify the result by checking that `A * X` reproduces the original matrix `B`.

Tests for MKL-based solvers (`Pardiso`) are conditionally executed depending on whether Kratos was compiled with MKL support, following the existing pattern in the test suite.