### PR TITLE
[IGA] Expose knot vector accessors for `BrepSurface`

### DIFF
--- a/kratos/geometries/brep_surface.h
+++ b/kratos/geometries/brep_surface.h
@@ -340,6 +340,22 @@ public:
         return mpNurbsSurface->PolynomialDegree(LocalDirectionIndex);
     }
 
+    /// Return knot spans in U-direction
+    std::vector<double> KnotsU() const
+    {
+        std::vector<double> spans_u;
+        mpNurbsSurface->SpansLocalSpace(spans_u, 0);
+        return spans_u;
+    }
+
+    /// Return knot spans in V-direction
+    std::vector<double> KnotsV() const
+    {
+        std::vector<double> spans_v;
+        mpNurbsSurface->SpansLocalSpace(spans_v, 1);
+        return spans_v;
+    }
+
     ///@}
     ///@name Information
     ///@{

--- a/kratos/python/add_geometries_to_python.cpp
+++ b/kratos/python/add_geometries_to_python.cpp
@@ -383,8 +383,17 @@ void  AddGeometriesToPython(pybind11::module& m)
             },
             py::arg("local_coordinates"),
             py::arg("derivative_order") = 0
+        )
+        .def("KnotsU", [](const BrepSurfaceType& self)
+            {
+                return self.KnotsU();
+            }
+        )
+        .def("KnotsV", [](const BrepSurfaceType& self)
+        {
+            return self.KnotsV();
+        }
         );
-
 
     py::class_<SurfaceInNurbsVolumeGeometry<3, NodeContainerType>, SurfaceInNurbsVolumeGeometry<3, NodeContainerType>::Pointer, GeometryType>(m, "SurfaceInNurbsVolumeGeometry")
         .def(py::init<NurbsVolumeGeometry<NodeContainerType>::Pointer, GeometryType::Pointer>())

--- a/kratos/tests/cpp_tests/geometries/test_brep_surface.cpp
+++ b/kratos/tests/cpp_tests/geometries/test_brep_surface.cpp
@@ -169,6 +169,24 @@ namespace Testing {
 
         auto brep_surface = BrepSurface<PointerVector<NodeType>, false, PointerVector<Point>>(
             p_surface, outer_loops, inner_loops);
+        
+        // Check the knot spans
+        auto spans_u = brep_surface.KnotsU();
+        auto spans_v = brep_surface.KnotsV();
+
+        std::vector<double> expected_spans_u = {0.0, 15.707963267948966, 31.415926535897931};
+        std::vector<double> expected_spans_v = {0.0, 10.0};
+
+        KRATOS_EXPECT_EQ(spans_u.size(), expected_spans_u.size());
+        KRATOS_EXPECT_EQ(spans_v.size(), expected_spans_v.size());
+
+        for (std::size_t i = 0; i < spans_u.size(); ++i) {
+            KRATOS_EXPECT_NEAR(spans_u[i], expected_spans_u[i], 1e-12);
+        }
+
+        for (std::size_t i = 0; i < spans_v.size(); ++i) {
+            KRATOS_EXPECT_NEAR(spans_v[i], expected_spans_v[i], 1e-12);
+        }
 
         //// Check general information, input to ouput
         KRATOS_EXPECT_EQ(brep_surface.WorkingSpaceDimension(), 3);
@@ -178,22 +196,6 @@ namespace Testing {
         const auto geometry_type = GeometryData::KratosGeometryType::Kratos_Brep_Surface;
         KRATOS_EXPECT_EQ(brep_surface.GetGeometryFamily(), geometry_family);
         KRATOS_EXPECT_EQ(brep_surface.GetGeometryType(), geometry_type);
-        //array_1d<double, 3> coords(3, 0.0);
-        //coords[0] = 1.0;
-        //Vector N;
-
-        //p_brep_curve_on_surface.ShapeFunctionsValues(N, coords);
-        //KRATOS_WATCH(N)
-        //Matrix DN_De;
-        //p_brep_curve_on_surface.ShapeFunctionsLocalGradients(DN_De, coords);
-        //KRATOS_WATCH(DN_De)
-
-        //array_1d<double, 3> result(3, 0.0);
-        //p_brep_curve_on_surface.GlobalCoordinates(result, coords);
-        //KRATOS_WATCH(result)
-
-        //auto results = p_brep_curve_on_surface.GlobalDerivatives(coords, 3);
-        //KRATOS_WATCH(results[0])
     }
 
     KRATOS_TEST_CASE_IN_SUITE(NurbsBrepSurfaceSurrogate, KratosCoreGeometriesFastSuite)


### PR DESCRIPTION
## Description

This PR adds the methods `KnotsU()` and `KnotsV()` to `BrepSurface` so that the knot vectors can be accessed directly from the BRep surface without requiring direct access to the underlying `NurbsSurfaceGeometry`.

The methods were also exposed to Python to allow accessing the knot vectors from Python workflows.

Additionally, a test was added to verify the correct retrieval of the knot vectors from the `BrepSurface`.