### PR TITLE
[GeoMechanicsApplication] Make stress state classes more similar

### DIFF
--- a/applications/GeoMechanicsApplication/custom_constitutive/p_q.cpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/p_q.cpp
@@ -7,7 +7,6 @@
 //
 //  License:         geo_mechanics_application/license.txt
 //
-//
 //  Main authors:    Anne van de Graaf
 //
 

--- a/applications/GeoMechanicsApplication/custom_constitutive/p_q.cpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/p_q.cpp
@@ -32,4 +32,16 @@ double PQ::Q() const noexcept { return mValues[1]; }
 
 double& PQ::Q() noexcept { return mValues[1]; }
 
+PQ& PQ::operator+=(const PQ& rRhs)
+{
+    std::ranges::transform(mValues, rRhs.mValues, mValues.begin(), std::plus{});
+    return *this;
+}
+
+PQ operator+(PQ Lhs, const PQ& rRhs)
+{
+    Lhs += rRhs;
+    return Lhs;
+}
+
 } // namespace Kratos::Geo

--- a/applications/GeoMechanicsApplication/custom_constitutive/p_q.hpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/p_q.hpp
@@ -7,7 +7,6 @@
 //
 //  License:         geo_mechanics_application/license.txt
 //
-//
 //  Main authors:    Anne van de Graaf
 //
 

--- a/applications/GeoMechanicsApplication/custom_constitutive/p_q.hpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/p_q.hpp
@@ -59,6 +59,10 @@ public:
         return result;
     }
 
+    PQ& operator+=(const PQ& rRhs);
+    KRATOS_API(GEO_MECHANICS_APPLICATION)
+    friend PQ operator+(PQ Lhs, const PQ& rRhs);
+
 private:
     InternalVectorType mValues = ZeroVector{msVectorSize};
 };

--- a/applications/GeoMechanicsApplication/custom_constitutive/principal_stresses.cpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/principal_stresses.cpp
@@ -21,9 +21,12 @@ PrincipalStresses::PrincipalStresses(double Sigma1, double Sigma2, double Sigma3
     mValues[2] = Sigma3;
 }
 
-const PrincipalStresses::InternalVectorType& PrincipalStresses::Values() const { return mValues; }
+const PrincipalStresses::InternalVectorType& PrincipalStresses::Values() const noexcept
+{
+    return mValues;
+}
 
-PrincipalStresses::InternalVectorType& PrincipalStresses::Values() { return mValues; }
+PrincipalStresses::InternalVectorType& PrincipalStresses::Values() noexcept { return mValues; }
 
 PrincipalStresses& PrincipalStresses::operator+=(const PrincipalStresses& rRhs)
 {

--- a/applications/GeoMechanicsApplication/custom_constitutive/principal_stresses.cpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/principal_stresses.cpp
@@ -14,9 +14,11 @@
 
 namespace Kratos::Geo
 {
-PrincipalStresses::PrincipalStresses(const std::initializer_list<double>& rValues)
-    : PrincipalStresses{std::begin(rValues), std::end(rValues)}
+PrincipalStresses::PrincipalStresses(double Sigma1, double Sigma2, double Sigma3)
 {
+    mValues[0] = Sigma1;
+    mValues[1] = Sigma2;
+    mValues[2] = Sigma3;
 }
 
 const PrincipalStresses::InternalVectorType& PrincipalStresses::Values() const { return mValues; }

--- a/applications/GeoMechanicsApplication/custom_constitutive/principal_stresses.hpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/principal_stresses.hpp
@@ -17,8 +17,6 @@
 #include "includes/ublas_interface.h"
 
 #include <algorithm>
-#include <initializer_list>
-#include <iterator>
 
 namespace Kratos::Geo
 {
@@ -39,18 +37,14 @@ public:
 
     template <typename VectorType>
     explicit PrincipalStresses(const VectorType& rStressVector)
-        : PrincipalStresses{std::begin(rStressVector), std::end(rStressVector)}
     {
-    }
-
-    template <std::forward_iterator InputIt>
-    PrincipalStresses(InputIt First, InputIt Last)
-    {
-        KRATOS_DEBUG_ERROR_IF(std::distance(First, Last) != msVectorSize)
+        auto first = std::begin(rStressVector);
+        auto last  = std::end(rStressVector);
+        KRATOS_DEBUG_ERROR_IF(std::distance(first, last) != msVectorSize)
             << "Cannot construct a PrincipalStresses instance: expected " << msVectorSize
-            << " values, but got " << std::distance(First, Last) << " value(s)\n";
+            << " values, but got " << std::distance(first, last) << " value(s)\n";
 
-        std::copy(First, Last, mValues.begin());
+        std::copy(first, last, mValues.begin());
     }
 
     template <typename VectorType>

--- a/applications/GeoMechanicsApplication/custom_constitutive/principal_stresses.hpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/principal_stresses.hpp
@@ -36,12 +36,12 @@ public:
     PrincipalStresses(double Sigma1, double Sigma2, double Sigma3);
 
     template <typename VectorType>
-    explicit PrincipalStresses(const VectorType& rStressVector)
+    explicit PrincipalStresses(const VectorType& rValues)
     {
         // For some reason, the `std::ranges` versions of the below algorithms don't play nicely
         // with UBlas vector expressions. Therefore, we're using the iterator-style algorithms.
-        auto first = std::begin(rStressVector);
-        auto last  = std::end(rStressVector);
+        auto first = std::begin(rValues);
+        auto last  = std::end(rValues);
         KRATOS_DEBUG_ERROR_IF(std::distance(first, last) != msVectorSize)
             << "Cannot construct a PrincipalStresses instance: expected " << msVectorSize
             << " values, but got " << std::distance(first, last) << " value(s)\n";

--- a/applications/GeoMechanicsApplication/custom_constitutive/principal_stresses.hpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/principal_stresses.hpp
@@ -35,6 +35,7 @@ public:
     using InternalVectorType                  = BoundedVector<double, msVectorSize>;
 
     PrincipalStresses() = default;
+    PrincipalStresses(double Sigma1, double Sigma2, double Sigma3);
 
     template <typename VectorType>
     explicit PrincipalStresses(const VectorType& rStressVector)
@@ -51,8 +52,6 @@ public:
 
         std::copy(First, Last, mValues.begin());
     }
-
-    explicit PrincipalStresses(const std::initializer_list<double>& rValues);
 
     template <typename VectorType>
     VectorType CopyTo()

--- a/applications/GeoMechanicsApplication/custom_constitutive/principal_stresses.hpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/principal_stresses.hpp
@@ -38,6 +38,8 @@ public:
     template <typename VectorType>
     explicit PrincipalStresses(const VectorType& rStressVector)
     {
+        // For some reason, the `std::ranges` versions of the below algorithms don't play nicely
+        // with UBlas vector expressions. Therefore, we're using the iterator-style algorithms.
         auto first = std::begin(rStressVector);
         auto last  = std::end(rStressVector);
         KRATOS_DEBUG_ERROR_IF(std::distance(first, last) != msVectorSize)
@@ -47,16 +49,16 @@ public:
         std::copy(first, last, mValues.begin());
     }
 
+    [[nodiscard]] const InternalVectorType& Values() const noexcept;
+    [[nodiscard]] InternalVectorType&       Values() noexcept;
+
     template <typename VectorType>
-    VectorType CopyTo()
+    VectorType CopyTo() const
     {
         VectorType result(msVectorSize);
         std::ranges::copy(mValues, result.begin());
         return result;
     }
-
-    [[nodiscard]] const InternalVectorType& Values() const;
-    [[nodiscard]] InternalVectorType&       Values();
 
     PrincipalStresses& operator+=(const PrincipalStresses& rRhs);
     KRATOS_API(GEO_MECHANICS_APPLICATION)

--- a/applications/GeoMechanicsApplication/custom_constitutive/sigma_tau.cpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/sigma_tau.cpp
@@ -16,31 +16,32 @@
 namespace Kratos::Geo
 {
 
-SigmaTau::SigmaTau(const std::initializer_list<double>& rValues)
-    : SigmaTau{rValues.begin(), rValues.end()}
+SigmaTau::SigmaTau(double Sigma, double Tau)
 {
+    mValues[0] = Sigma;
+    mValues[1] = Tau;
 }
 
-const SigmaTau::InternalVectorType& SigmaTau::Values() const { return mValues; }
+const SigmaTau::InternalVectorType& SigmaTau::Values() const noexcept { return mValues; }
 
-double SigmaTau::Sigma() const { return mValues[0]; }
+double SigmaTau::Sigma() const noexcept { return mValues[0]; }
 
-double& SigmaTau::Sigma() { return mValues[0]; }
+double& SigmaTau::Sigma() noexcept { return mValues[0]; }
 
-double SigmaTau::Tau() const { return mValues[1]; }
+double SigmaTau::Tau() const noexcept { return mValues[1]; }
 
-double& SigmaTau::Tau() { return mValues[1]; }
+double& SigmaTau::Tau() noexcept { return mValues[1]; }
 
-SigmaTau& SigmaTau::operator+=(const SigmaTau& rRhsTraction)
+SigmaTau& SigmaTau::operator+=(const SigmaTau& rRhs)
 {
-    std::ranges::transform(mValues, rRhsTraction.mValues, mValues.begin(), std::plus{});
+    std::ranges::transform(mValues, rRhs.mValues, mValues.begin(), std::plus{});
     return *this;
 }
 
-SigmaTau operator+(SigmaTau LhsTraction, const SigmaTau& rRhsTraction)
+SigmaTau operator+(SigmaTau Lhs, const SigmaTau& rRhs)
 {
-    LhsTraction += rRhsTraction;
-    return LhsTraction;
+    Lhs += rRhs;
+    return Lhs;
 }
 
 } // namespace Kratos::Geo

--- a/applications/GeoMechanicsApplication/custom_constitutive/sigma_tau.cpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/sigma_tau.cpp
@@ -7,7 +7,6 @@
 //
 //  License:         geo_mechanics_application/license.txt
 //
-//
 //  Main authors:    Anne van de Graaf
 //
 

--- a/applications/GeoMechanicsApplication/custom_constitutive/sigma_tau.hpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/sigma_tau.hpp
@@ -7,7 +7,6 @@
 //
 //  License:         geo_mechanics_application/license.txt
 //
-//
 //  Main authors:    Anne van de Graaf
 //
 

--- a/applications/GeoMechanicsApplication/custom_constitutive/sigma_tau.hpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/sigma_tau.hpp
@@ -18,8 +18,6 @@
 #include "includes/ublas_interface.h"
 
 #include <algorithm>
-#include <initializer_list>
-#include <iterator>
 
 namespace Kratos::Geo
 {
@@ -31,19 +29,27 @@ public:
     using InternalVectorType                  = BoundedVector<double, msVectorSize>;
 
     SigmaTau() = default;
+    SigmaTau(double Sigma, double Tau);
 
     template <typename VectorType>
-    explicit SigmaTau(const VectorType& rValues) : SigmaTau{std::begin(rValues), std::end(rValues)}
+    explicit SigmaTau(const VectorType& rValues)
     {
+        // For some reason, the `std::ranges` versions of the below algorithms don't play nicely
+        // with UBlas vector expressions. Therefore, we're using the iterator-style algorithms.
+        auto first = std::begin(rValues);
+        auto last  = std::end(rValues);
+        KRATOS_DEBUG_ERROR_IF(std::distance(first, last) != msVectorSize)
+            << "Cannot construct a SigmaTau instance: expected " << msVectorSize
+            << " values, but got " << std::distance(first, last) << " value(s)\n";
+
+        std::copy(first, last, mValues.begin());
     }
 
-    explicit SigmaTau(const std::initializer_list<double>& rValues);
-
-    [[nodiscard]] const InternalVectorType& Values() const;
-    [[nodiscard]] double                    Sigma() const;
-    double&                                 Sigma();
-    [[nodiscard]] double                    Tau() const;
-    double&                                 Tau();
+    [[nodiscard]] const InternalVectorType& Values() const noexcept;
+    [[nodiscard]] double                    Sigma() const noexcept;
+    double&                                 Sigma() noexcept;
+    [[nodiscard]] double                    Tau() const noexcept;
+    double&                                 Tau() noexcept;
 
     template <typename VectorType>
     VectorType CopyTo() const
@@ -53,21 +59,11 @@ public:
         return result;
     }
 
-    SigmaTau& operator+=(const SigmaTau& rRhsTraction);
+    SigmaTau& operator+=(const SigmaTau& rRhs);
     KRATOS_API(GEO_MECHANICS_APPLICATION)
-    friend SigmaTau operator+(SigmaTau LhsTraction, const SigmaTau& rRhsTraction);
+    friend SigmaTau operator+(SigmaTau Lhs, const SigmaTau& rRhs);
 
 private:
-    template <std::forward_iterator Iter>
-    SigmaTau(Iter First, Iter Last)
-    {
-        KRATOS_DEBUG_ERROR_IF(std::distance(First, Last) != msVectorSize)
-            << "Cannot construct a SigmaTau instance: expected " << msVectorSize
-            << " values, but got " << std::distance(First, Last) << " value(s)\n";
-
-        std::copy(First, Last, mValues.begin());
-    }
-
     InternalVectorType mValues = ZeroVector{msVectorSize};
 };
 

--- a/applications/GeoMechanicsApplication/custom_utilities/stress_strain_utilities.cpp
+++ b/applications/GeoMechanicsApplication/custom_utilities/stress_strain_utilities.cpp
@@ -240,8 +240,8 @@ Geo::SigmaTau StressStrainUtilities::TransformPrincipalStressesToSigmaTau(const 
 Geo::PrincipalStresses StressStrainUtilities::TransformSigmaTauToPrincipalStresses(
     const Geo::SigmaTau& rSigmaTau, const Geo::PrincipalStresses& rPrincipalStresses)
 {
-    return Geo::PrincipalStresses{{rSigmaTau.Sigma() + rSigmaTau.Tau(), rPrincipalStresses.Values()[1],
-                                   rSigmaTau.Sigma() - rSigmaTau.Tau()}};
+    return Geo::PrincipalStresses{rSigmaTau.Sigma() + rSigmaTau.Tau(), rPrincipalStresses.Values()[1],
+                                  rSigmaTau.Sigma() - rSigmaTau.Tau()};
 }
 
 Geo::PQ StressStrainUtilities::TransformPrincipalStressesToPandQ(const Geo::PrincipalStresses& rPrincipalStresses)

--- a/applications/GeoMechanicsApplication/custom_utilities/stress_strain_utilities.cpp
+++ b/applications/GeoMechanicsApplication/custom_utilities/stress_strain_utilities.cpp
@@ -233,8 +233,8 @@ Vector StressStrainUtilities::RotatePrincipalStresses(const Vector& rPrincipalSt
 
 Geo::SigmaTau StressStrainUtilities::TransformPrincipalStressesToSigmaTau(const Geo::PrincipalStresses& rPrincipalStresses)
 {
-    return Geo::SigmaTau{{0.5 * (rPrincipalStresses.Values()[0] + rPrincipalStresses.Values()[2]),
-                          0.5 * (rPrincipalStresses.Values()[0] - rPrincipalStresses.Values()[2])}};
+    return Geo::SigmaTau{0.5 * (rPrincipalStresses.Values()[0] + rPrincipalStresses.Values()[2]),
+                         0.5 * (rPrincipalStresses.Values()[0] - rPrincipalStresses.Values()[2])};
 }
 
 Geo::PrincipalStresses StressStrainUtilities::TransformSigmaTauToPrincipalStresses(

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_constitutive/test_p_q.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_constitutive/test_p_q.cpp
@@ -33,8 +33,8 @@ class TestPQFixture : public ::testing::Test
 {
 };
 
-using TestVectorTypes = ::testing::Types<Vector, BoundedVector<double, 2>, std::vector<double>>;
-TYPED_TEST_SUITE(TestPQFixture, TestVectorTypes);
+using VectorTypesForTypedPQTest = ::testing::Types<Vector, BoundedVector<double, 2>, std::vector<double>>;
+TYPED_TEST_SUITE(TestPQFixture, VectorTypesForTypedPQTest);
 
 TYPED_TEST(TestPQFixture, PQ_CanBeConstructedFromAnyVectorWithSizeOf2)
 {

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_constitutive/test_p_q.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_constitutive/test_p_q.cpp
@@ -115,4 +115,25 @@ TYPED_TEST(TestPQFixture, PQ_CanBeCopiedToAnyVectorTypeWithSizeOf2)
     KRATOS_EXPECT_VECTOR_NEAR(stress_state.CopyTo<TypeParam>(), (std::vector{1.0, 2.0}), Defaults::absolute_tolerance);
 }
 
+TEST_F(KratosGeoMechanicsFastSuiteWithoutKernel, PQ_SupportsCompoundAssignment)
+{
+    // Arrange
+    auto stress_state = Geo::PQ{1.0, 2.0};
+
+    // Act
+    stress_state += Geo::PQ{3.0, 4.0};
+
+    // Assert
+    KRATOS_EXPECT_VECTOR_NEAR(stress_state.Values(), (std::vector{4.0, 6.0}), Defaults::absolute_tolerance);
+}
+
+TEST_F(KratosGeoMechanicsFastSuiteWithoutKernel, PQ_SupportsAdditionOfTwoInstances)
+{
+    // Arrange & Act
+    const auto summed_stress_state = Geo::PQ{2.0, 1.0} + Geo::PQ{3.0, 4.0};
+
+    // Assert
+    KRATOS_EXPECT_VECTOR_NEAR(summed_stress_state.Values(), (std::vector{5.0, 5.0}), Defaults::absolute_tolerance);
+}
+
 } // namespace Kratos::Testing

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_constitutive/test_p_q.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_constitutive/test_p_q.cpp
@@ -7,7 +7,6 @@
 //
 //  License:         geo_mechanics_application/license.txt
 //
-//
 //  Main authors:    Anne van de Graaf
 //
 

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_constitutive/test_p_q.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_constitutive/test_p_q.cpp
@@ -130,10 +130,10 @@ TEST_F(KratosGeoMechanicsFastSuiteWithoutKernel, PQ_SupportsCompoundAssignment)
 TEST_F(KratosGeoMechanicsFastSuiteWithoutKernel, PQ_SupportsAdditionOfTwoInstances)
 {
     // Arrange & Act
-    const auto summed_stress_state = Geo::PQ{2.0, 1.0} + Geo::PQ{3.0, 4.0};
+    const auto summed_stress_state = Geo::PQ{1.0, 3.0} + Geo::PQ{2.0, 4.0};
 
     // Assert
-    KRATOS_EXPECT_VECTOR_NEAR(summed_stress_state.Values(), (std::vector{5.0, 5.0}), Defaults::absolute_tolerance);
+    KRATOS_EXPECT_VECTOR_NEAR(summed_stress_state.Values(), (std::vector{3.0, 7.0}), Defaults::absolute_tolerance);
 }
 
 } // namespace Kratos::Testing

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_constitutive/test_principal_stresses.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_constitutive/test_principal_stresses.cpp
@@ -73,26 +73,15 @@ TEST_F(KratosGeoMechanicsFastSuiteWithoutKernel, PrincipalStresses_CanBeConstruc
                               (std::vector{30.0, 25.5, 25.5}), Defaults::absolute_tolerance);
 }
 
-TEST_F(KratosGeoMechanicsFastSuiteWithoutKernel, PrincipalStresses_CanBeConstructedFromAStdInitializerListWithSize3)
+TEST_F(KratosGeoMechanicsFastSuiteWithoutKernel, PrincipalStresses_CanBeConstructedFromFromThreeValues)
 {
     KRATOS_EXPECT_VECTOR_NEAR((Geo::PrincipalStresses{3.0, 2.0, 1.0}.Values()),
                               (std::vector{3.0, 2.0, 1.0}), Defaults::absolute_tolerance);
 }
 
-TEST_F(KratosGeoMechanicsFastSuiteWithoutKernel,
-       PrincipalStress_RaisesADebugErrorWhenAttemptingToConstructFromANonEmptyStdInitializerListWithSizeUnequalTo3)
-{
-#ifndef KRATOS_DEBUG
-    GTEST_SKIP() << "This test requires a debug build";
-#endif
-
-    EXPECT_THROW((Geo::PrincipalStresses{2.0, 1.0}), Exception);
-    EXPECT_THROW((Geo::PrincipalStresses{4.0, 3.0, 2.0, 1.0}), Exception);
-}
-
 TYPED_TEST(TestPrincipalStressFixture, PrincipalStressesCanBeCopiedToAnyVectorWithSize3)
 {
-    Geo::PrincipalStresses principal_stresses{std::vector{3.0, 2.0, 1.0}};
+    Geo::PrincipalStresses principal_stresses{3.0, 2.0, 1.0};
 
     const auto copied_vector = principal_stresses.CopyTo<TypeParam>();
 

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_constitutive/test_principal_stresses.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_constitutive/test_principal_stresses.cpp
@@ -30,9 +30,9 @@ class TestPrincipalStressFixture : public ::testing::Test
 {
 };
 
-using TestVectorTypesPrincipalStress =
+using VectorTypesForTypedPrincipalStressesTest =
     ::testing::Types<Vector, BoundedVector<double, 3>, std::vector<double>>;
-TYPED_TEST_SUITE(TestPrincipalStressFixture, TestVectorTypesPrincipalStress);
+TYPED_TEST_SUITE(TestPrincipalStressFixture, VectorTypesForTypedPrincipalStressesTest);
 
 TYPED_TEST(TestPrincipalStressFixture, PrincipalStresses_CanBeConstructedFromAnyVectorWithSizeOf3)
 {

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_constitutive/test_principal_stresses.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_constitutive/test_principal_stresses.cpp
@@ -11,9 +11,12 @@
 //
 
 #include "custom_constitutive/principal_stresses.hpp"
+#include "custom_utilities/ublas_utilities.h"
 #include "includes/expect.h"
 #include "tests/cpp_tests/geo_mechanics_fast_suite_without_kernel.h"
 #include "tests/cpp_tests/test_utilities.h"
+
+#include <vector>
 
 namespace Kratos::Testing
 {
@@ -49,10 +52,25 @@ TEST_F(KratosGeoMechanicsFastSuiteWithoutKernel, PrincipalStresses_ThrowsWhenSiz
     GTEST_SKIP() << "This test requires a debug build";
 #endif
 
-    const auto too_short = {2.0, 1.0};
-    const auto too_long  = {4.0, 3.0, 2.0, 1.0};
+    const auto too_short = UblasUtilities::CreateVector({2.0, 1.0});
+    const auto too_long  = UblasUtilities::CreateVector({4.0, 3.0, 2.0, 1.0});
     EXPECT_THROW(Geo::PrincipalStresses{too_long}, Exception);
     EXPECT_THROW(Geo::PrincipalStresses{too_short}, Exception);
+}
+
+TEST_F(KratosGeoMechanicsFastSuiteWithoutKernel, PrincipalStresses_CanBeConstructedFromAVectorExpression)
+{
+    // Arrange
+    const auto some_matrix =
+        UblasUtilities::CreateMatrix({{1.0, 2.0, 3.0}, {2.0, 3.0, 1.0}, {3.0, 1.0, 2.0}});
+    const auto     some_vector = UblasUtilities::CreateVector({2.0, 3.0, 4.0});
+    constexpr auto some_scalar = 1.5;
+
+    // Act & Assert
+    // The following code won't compile when the template constructor of class `PrincipalStresses` (which receives
+    // a vector-like object) uses `std::ranges` algorithms when a UBlas vector expression is given.
+    KRATOS_EXPECT_VECTOR_NEAR(Geo::PrincipalStresses{some_scalar * prod(some_matrix, some_vector)}.Values(),
+                              (std::vector{30.0, 25.5, 25.5}), Defaults::absolute_tolerance);
 }
 
 TEST_F(KratosGeoMechanicsFastSuiteWithoutKernel, PrincipalStresses_CanBeConstructedFromAStdInitializerListWithSize3)

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_constitutive/test_sigma_tau.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_constitutive/test_sigma_tau.cpp
@@ -131,10 +131,10 @@ TEST_F(KratosGeoMechanicsFastSuiteWithoutKernel, SigmaTau_SupportsCompoundAssign
 TEST_F(KratosGeoMechanicsFastSuiteWithoutKernel, SigmaTau_SupportsAdditionOfTwoInstances)
 {
     // Arrange & Act
-    const auto summed_traction = Geo::SigmaTau{2.0, 1.0} + Geo::SigmaTau{3.0, 4.0};
+    const auto summed_traction = Geo::SigmaTau{1.0, 3.0} + Geo::SigmaTau{2.0, 4.0};
 
     // Assert
-    KRATOS_EXPECT_VECTOR_NEAR(summed_traction.Values(), (std::vector{5.0, 5.0}), Defaults::absolute_tolerance);
+    KRATOS_EXPECT_VECTOR_NEAR(summed_traction.Values(), (std::vector{3.0, 7.0}), Defaults::absolute_tolerance);
 }
 
 } // namespace Kratos::Testing

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_constitutive/test_sigma_tau.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_constitutive/test_sigma_tau.cpp
@@ -24,7 +24,7 @@ namespace Kratos::Testing
 
 TEST_F(KratosGeoMechanicsFastSuiteWithoutKernel, SigmaTau_HasZeroesAsValuesWhenDefaultConstructed)
 {
-    KRATOS_EXPECT_VECTOR_NEAR(Geo::SigmaTau().Values(), Vector(2, 0.0), Defaults::absolute_tolerance);
+    KRATOS_EXPECT_VECTOR_NEAR(Geo::SigmaTau().Values(), (std::vector{0.0, 0.0}), Defaults::absolute_tolerance);
     EXPECT_NEAR(Geo::SigmaTau{}.Sigma(), 0.0, Defaults::absolute_tolerance);
     EXPECT_NEAR(Geo::SigmaTau{}.Tau(), 0.0, Defaults::absolute_tolerance);
 }
@@ -69,21 +69,24 @@ TEST_F(KratosGeoMechanicsFastSuiteWithoutKernel,
     EXPECT_THROW(Geo::SigmaTau{too_long}, Exception);
 }
 
-TEST_F(KratosGeoMechanicsFastSuiteWithoutKernel, SigmaTau_CanBeConstructedFromAStdInitializerListWithSize2)
+TEST_F(KratosGeoMechanicsFastSuiteWithoutKernel, SigmaTau_CanBeConstructedFromAVectorExpression)
+{
+    // Arrange
+    const auto     some_matrix = UblasUtilities::CreateMatrix({{1.0, 2.0}, {3.0, 4.0}});
+    const auto     some_vector = UblasUtilities::CreateVector({2.0, 3.0});
+    constexpr auto some_scalar = 1.5;
+
+    // Act & Assert
+    // The following code won't compile when the template constructor of class `SigmaTau` (which receives
+    // a vector-like object) uses `std::ranges` algorithms when a UBlas vector expression is given.
+    KRATOS_EXPECT_VECTOR_NEAR(Geo::SigmaTau{some_scalar * prod(some_matrix, some_vector)}.Values(),
+                              (std::vector{12.0, 27.0}), Defaults::absolute_tolerance);
+}
+
+TEST_F(KratosGeoMechanicsFastSuiteWithoutKernel, SigmaTau_CanBeConstructedFromFromTwoValues)
 {
     EXPECT_NEAR((Geo::SigmaTau{1.0, 2.0}.Sigma()), 1.0, Defaults::absolute_tolerance);
     EXPECT_NEAR((Geo::SigmaTau{1.0, 2.0}.Tau()), 2.0, Defaults::absolute_tolerance);
-}
-
-TEST_F(KratosGeoMechanicsFastSuiteWithoutKernel,
-       SigmaTau_RaisesADebugErrorWhenAttemptingToConstructFromAnStdInitializerListWithSizeUnequalTo2)
-{
-#ifndef KRATOS_DEBUG
-    GTEST_SKIP() << "This test requires a debug build";
-#endif
-
-    EXPECT_THROW(Geo::SigmaTau{1.0}, Exception);
-    EXPECT_THROW((Geo::SigmaTau{2.0, 3.0, 4.0}), Exception);
 }
 
 TEST_F(KratosGeoMechanicsFastSuiteWithoutKernel, SigmaTau_ComponentsCanBeModifiedDirectly)

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_constitutive/test_sigma_tau.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_constitutive/test_sigma_tau.cpp
@@ -33,8 +33,9 @@ class TestSigmaTauFixture : public ::testing::Test
 {
 };
 
-using TestVectorTypes = ::testing::Types<Vector, BoundedVector<double, 2>, std::vector<double>>;
-TYPED_TEST_SUITE(TestSigmaTauFixture, TestVectorTypes);
+using VectorTypesForTypedSigmaTauTest =
+    ::testing::Types<Vector, BoundedVector<double, 2>, std::vector<double>>;
+TYPED_TEST_SUITE(TestSigmaTauFixture, VectorTypesForTypedSigmaTauTest);
 
 TYPED_TEST(TestSigmaTauFixture, SigmaTau_CanBeConstructedFromAnyVectorWithSizeOf2)
 {

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_constitutive/test_sigma_tau.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_constitutive/test_sigma_tau.cpp
@@ -7,7 +7,6 @@
 //
 //  License:         geo_mechanics_application/license.txt
 //
-//
 //  Main authors:    Anne van de Graaf
 //
 


### PR DESCRIPTION
**📝 Description**
Make stress state classes `PQ`, `SigmaTau` and `PrincipalStresses` more similar.

**🆕 Changelog**
- Made value getters `noexcept`.
- Added addition operations to class `PQ`.
- The constructors of the three stress state classes are now similar. Initializer list constructors have been removed.
