### PR TITLE
[MAPPING] Fix bugs in RBF Mapper implementation

### DIFF
--- a/applications/MappingApplication/custom_mappers/radial_basis_function_mapper.cpp
+++ b/applications/MappingApplication/custom_mappers/radial_basis_function_mapper.cpp
@@ -271,8 +271,15 @@ void RadialBasisFunctionMapper<TSparseSpace, TDenseSpace>::InitializeInterface(K
     const bool precompute_mapping_matrix = mMapperSettings["precompute_mapping_matrix"].GetBool();
 
     // Get the global space dimension
-    const IndexType dimension = mMapperSettings["global_space_dimension"].GetInt();
-    KRATOS_ERROR_IF(dimension > 3) << "global_space_dimension cannot be greater than 3" << std::endl;
+    mDimension = mMapperSettings["global_space_dimension"].GetInt();
+    KRATOS_ERROR_IF(mDimension > 3) << "global_space_dimension cannot be greater than 3" << std::endl;
+
+    // Calculate the number of polynomial terms depending on the dimension
+     if (mDimension == 2){
+        mNumberOfPolynomialTerms = (mPolynomialDegree + 2) * (mPolynomialDegree + 1) / 2;
+    } else {
+        mNumberOfPolynomialTerms = (mPolynomialDegree + 3) * (mPolynomialDegree + 2) * (mPolynomialDegree + 1) / 6;
+    }
 
     // Read the RBF type from the settings
     std::string rbf_type = mMapperSettings["radial_basis_function_type"].GetString();

--- a/applications/MappingApplication/custom_mappers/radial_basis_function_mapper.cpp
+++ b/applications/MappingApplication/custom_mappers/radial_basis_function_mapper.cpp
@@ -270,6 +270,10 @@ void RadialBasisFunctionMapper<TSparseSpace, TDenseSpace>::InitializeInterface(K
 
     const bool precompute_mapping_matrix = mMapperSettings["precompute_mapping_matrix"].GetBool();
 
+    // Get the global space dimension
+    const IndexType dimension = mMapperSettings["global_space_dimension"].GetInt();
+    KRATOS_ERROR_IF(dimension > 3) << "global_space_dimension cannot be greater than 3" << std::endl;
+
     // Read the RBF type from the settings
     std::string rbf_type = mMapperSettings["radial_basis_function_type"].GetString();
     std::transform(rbf_type.begin(), rbf_type.end(), rbf_type.begin(), ::tolower);

--- a/applications/MappingApplication/custom_mappers/radial_basis_function_mapper.cpp
+++ b/applications/MappingApplication/custom_mappers/radial_basis_function_mapper.cpp
@@ -300,7 +300,7 @@ void RadialBasisFunctionMapper<TSparseSpace, TDenseSpace>::InitializeInterface(K
     KRATOS_ERROR_IF(destination_is_iga)<< "This mapper is not yet available when the destination domain is discretized with IGA" << std::endl;
 
     bool use_all_support_points = false;
-    if (mMapperSettings["search_settings"].Has("use_all_rbf_support_points")) {
+    if (mMapperSettings.Has("use_all_rbf_support_points")) {
         use_all_support_points = mMapperSettings["use_all_rbf_support_points"].GetBool();
     }
 

--- a/applications/MappingApplication/custom_mappers/radial_basis_function_mapper.cpp
+++ b/applications/MappingApplication/custom_mappers/radial_basis_function_mapper.cpp
@@ -143,7 +143,7 @@ void RadialBasisFunctionMapperLocalSystem::CalculateAll(MatrixType& rLocalMappin
             rLocalMappingMatrix(0, j) = phi;
         }
 
-        const std::vector<double> polynomial = EvaluatePolynomialBasis(this->Coordinates(), mPolynomialDegree);
+        const std::vector<double> polynomial = EvaluatePolynomialBasis(this->Coordinates(), mPolynomialDegree, mDimension);
 
         for (IndexType k = 0; k < mNumberOfPolynomialTerms; ++k) {
             rLocalMappingMatrix(0, rbf_support_points_number + k) = polynomial[k];
@@ -198,7 +198,7 @@ void RadialBasisFunctionMapperLocalSystem::CalculateAll(MatrixType& rLocalMappin
             rLocalMappingMatrix(0, j) = phi;
         }
 
-        const std::vector<double> polynomial = EvaluatePolynomialBasis(this->Coordinates(), mPolynomialDegree);
+        const std::vector<double> polynomial = EvaluatePolynomialBasis(this->Coordinates(), mPolynomialDegree, mDimension);
 
         for (IndexType k = 0; k < mNumberOfPolynomialTerms; ++k) {
             rLocalMappingMatrix(0, rbf_support_points_number + k) = polynomial[k];
@@ -210,25 +210,39 @@ void RadialBasisFunctionMapperLocalSystem::CalculateAll(MatrixType& rLocalMappin
 
 std::vector<double> RadialBasisFunctionMapperLocalSystem::EvaluatePolynomialBasis(
     const CoordinatesArrayType& rCoords, 
-    unsigned int degree) const
+    unsigned int degree,
+    const IndexType dimension) const
 {
     std::vector<double> polynomial_values;
-    polynomial_values.reserve((degree + 3) * (degree + 2) * (degree + 1) / 6); // number of monomials in 3D
+    IndexType number_of_polynomial_terms = 0;
+    if (dimension == 2){
+        number_of_polynomial_terms = (degree + 2) * (degree + 1) / 2;
+    } else{
+        number_of_polynomial_terms = (degree + 3) * (degree + 2) * (degree + 1) / 6;
+    }
+    polynomial_values.reserve(number_of_polynomial_terms); // number of monomials in either 2D or 3D
 
     const double x = rCoords[0];
     const double y = rCoords[1];
     const double z = rCoords[2];
 
-    for (unsigned int n = 0; n <= degree; ++n) {
-        // i = exponente de x
-        for (int i = static_cast<int>(n); i >= 0; --i) {
-            // j = exponente de y
-            for (int j = static_cast<int>(n - i); j >= 0; --j) {
-                unsigned int k = n - i - j; // exponente de z
-                polynomial_values.push_back(std::pow(x, i) * std::pow(y, j) * std::pow(z, k));
+    if (dimension == 2) {
+        for (unsigned int n = 0; n <= degree; ++n) {
+            for (int i = static_cast<int>(n); i >= 0; --i) {
+                const unsigned int j = n - i;
+                polynomial_values.push_back(std::pow(x, i) * std::pow(y, j));
             }
         }
-    }
+    } else if (dimension == 3) {
+        for (unsigned int n = 0; n <= degree; ++n) {
+            for (int i = static_cast<int>(n); i >= 0; --i) {
+                for (int j = static_cast<int>(n - i); j >= 0; --j) {
+                    const unsigned int k = n - i - j;
+                    polynomial_values.push_back(std::pow(x, i) * std::pow(y, j) * std::pow(z, k));
+                }
+            }
+        }
+    } 
 
     return polynomial_values;
 }
@@ -270,17 +284,6 @@ void RadialBasisFunctionMapper<TSparseSpace, TDenseSpace>::InitializeInterface(K
 
     const bool precompute_mapping_matrix = mMapperSettings["precompute_mapping_matrix"].GetBool();
 
-    // Get the global space dimension
-    mDimension = mMapperSettings["global_space_dimension"].GetInt();
-    KRATOS_ERROR_IF(mDimension > 3) << "global_space_dimension cannot be greater than 3" << std::endl;
-
-    // Calculate the number of polynomial terms depending on the dimension
-     if (mDimension == 2){
-        mNumberOfPolynomialTerms = (mPolynomialDegree + 2) * (mPolynomialDegree + 1) / 2;
-    } else {
-        mNumberOfPolynomialTerms = (mPolynomialDegree + 3) * (mPolynomialDegree + 2) * (mPolynomialDegree + 1) / 6;
-    }
-
     // Read the RBF type from the settings
     std::string rbf_type = mMapperSettings["radial_basis_function_type"].GetString();
     std::transform(rbf_type.begin(), rbf_type.end(), rbf_type.begin(), ::tolower);
@@ -300,9 +303,17 @@ void RadialBasisFunctionMapper<TSparseSpace, TDenseSpace>::InitializeInterface(K
 
     mRBFTypeEnum = it->second;
 
-    // Obtain the polynomial degree and calculate number of polynomial terms
+    // Obtain the polynomial degree and the dimension and calculate number of polynomial terms 
     mPolynomialDegree = mMapperSettings["additional_polynomial_degree"].GetInt();
-    mNumberOfPolynomialTerms = (mPolynomialDegree + 3) * (mPolynomialDegree + 2) * (mPolynomialDegree + 1) / 6;
+    mDimension = mMapperSettings["global_space_dimension"].GetInt();
+    KRATOS_ERROR_IF(mDimension > 3) << "global_space_dimension cannot be greater than 3" << std::endl;
+
+    // Calculate the number of polynomial terms depending on the dimension
+     if (mDimension == 2){
+        mNumberOfPolynomialTerms = (mPolynomialDegree + 2) * (mPolynomialDegree + 1) / 2;
+    } else {
+        mNumberOfPolynomialTerms = (mPolynomialDegree + 3) * (mPolynomialDegree + 2) * (mPolynomialDegree + 1) / 6;
+    }
 
     // Determine whether the destination domain is IGA or not
     const bool destination_is_iga = mMapperSettings["destination_is_iga"].GetBool();

--- a/applications/MappingApplication/custom_mappers/radial_basis_function_mapper.cpp
+++ b/applications/MappingApplication/custom_mappers/radial_basis_function_mapper.cpp
@@ -353,8 +353,8 @@ void RadialBasisFunctionMapper<TSparseSpace, TDenseSpace>::InitializeInterface(K
     }
 
     // Create dummy local systems for the origin and destination domains
-    RadialBasisFunctionMapperLocalSystem origin_local_system{nullptr, nullptr, true, mOriginIsIga, mRBFTypeEnum, mPolynomialDegree, &mPolynomialEquationIdsOrigin};
-    RadialBasisFunctionMapperLocalSystem destination_local_system{nullptr, nullptr, false, mOriginIsIga, mRBFTypeEnum, mPolynomialDegree, &mPolynomialEquationIdsOrigin};
+    RadialBasisFunctionMapperLocalSystem origin_local_system{nullptr, nullptr, true, mOriginIsIga, mRBFTypeEnum, mPolynomialDegree, mDimension, &mPolynomialEquationIdsOrigin};
+    RadialBasisFunctionMapperLocalSystem destination_local_system{nullptr, nullptr, false, mOriginIsIga, mRBFTypeEnum, mPolynomialDegree, mDimension, &mPolynomialEquationIdsOrigin};
 
     // Create the local systems for the origin and destination domains
     if (mOriginIsIga) {

--- a/applications/MappingApplication/custom_mappers/radial_basis_function_mapper.h
+++ b/applications/MappingApplication/custom_mappers/radial_basis_function_mapper.h
@@ -303,35 +303,38 @@ public:
 
     // Construct from a node and a geometry (dummy constructor needed)
     explicit RadialBasisFunctionMapperLocalSystem(NodePointerType pNode, GeometryPointerType pGeometry, bool BuildOriginInterpolationMatrix, bool OriginIsIga, RadialBasisFunctionsUtilities::RBFType RBFTypeEnum, IndexType PolynomialDegree,
-                                                  const std::vector<IndexType>* pPolynomialEquationIds)
+                                                  const IndexType dimension, const std::vector<IndexType>* pPolynomialEquationIds)
             : mpNode(pNode), 
               mpGeometry(pGeometry),
               mBuildOriginInterpolationMatrix(BuildOriginInterpolationMatrix),
               mOriginIsIga(OriginIsIga),
               mRBFTypeEnum(RBFTypeEnum),
               mPolynomialDegree(PolynomialDegree), 
+              mDimension(dimension),
               mNumberOfPolynomialTerms((PolynomialDegree + 3) * (PolynomialDegree + 2) * (PolynomialDegree + 1) / 6),
               mpPolynomialEquationIds(pPolynomialEquationIds){}
 
     // Construct from a node
-    explicit RadialBasisFunctionMapperLocalSystem(NodePointerType pNode, bool BuildOriginInterpolationMatrix, bool OriginIsIga, RadialBasisFunctionsUtilities::RBFType RBFTypeEnum, IndexType PolynomialDegree, const std::vector<IndexType>* pPolynomialEquationIds): 
+    explicit RadialBasisFunctionMapperLocalSystem(NodePointerType pNode, bool BuildOriginInterpolationMatrix, bool OriginIsIga, RadialBasisFunctionsUtilities::RBFType RBFTypeEnum, IndexType PolynomialDegree, const IndexType dimension, const std::vector<IndexType>* pPolynomialEquationIds): 
              mpNode(std::move(pNode)), 
              mpGeometry(nullptr),
              mBuildOriginInterpolationMatrix(BuildOriginInterpolationMatrix),
              mOriginIsIga(OriginIsIga),
              mRBFTypeEnum(RBFTypeEnum),
              mPolynomialDegree(PolynomialDegree),
+             mDimension(dimension),
              mNumberOfPolynomialTerms((PolynomialDegree + 3) * (PolynomialDegree + 2) * (PolynomialDegree + 1) / 6),
              mpPolynomialEquationIds(pPolynomialEquationIds){}
 
     // Construct from a geometry (e.g. an integration-point “geometry” in IGA)
-    explicit RadialBasisFunctionMapperLocalSystem(GeometryPointerType pGeometry, bool BuildOriginInterpolationMatrix, bool OriginIsIga, RadialBasisFunctionsUtilities::RBFType RBFTypeEnum, IndexType PolynomialDegree, const std::vector<IndexType>* pPolynomialEquationIds): 
+    explicit RadialBasisFunctionMapperLocalSystem(GeometryPointerType pGeometry, bool BuildOriginInterpolationMatrix, bool OriginIsIga, RadialBasisFunctionsUtilities::RBFType RBFTypeEnum, IndexType PolynomialDegree, const IndexType dimension, const std::vector<IndexType>* pPolynomialEquationIds): 
              mpNode(nullptr), 
              mpGeometry(std::move(pGeometry)),
              mBuildOriginInterpolationMatrix(BuildOriginInterpolationMatrix),
              mOriginIsIga(OriginIsIga),
              mRBFTypeEnum(RBFTypeEnum),
              mPolynomialDegree(PolynomialDegree),
+             mDimension(dimension),
              mNumberOfPolynomialTerms((PolynomialDegree + 3) * (PolynomialDegree + 2) * (PolynomialDegree + 1) / 6),
              mpPolynomialEquationIds(pPolynomialEquationIds){}
 
@@ -361,13 +364,13 @@ public:
     MapperLocalSystemUniquePointer Create(NodePointerType pNode) const override
     {
        KRATOS_DEBUG_ERROR_IF(!pNode) << "Create(Node) received nullptr" << std::endl;
-       return Kratos::make_unique<RadialBasisFunctionMapperLocalSystem>(pNode, mBuildOriginInterpolationMatrix, mOriginIsIga, mRBFTypeEnum, mPolynomialDegree, mpPolynomialEquationIds);
+       return Kratos::make_unique<RadialBasisFunctionMapperLocalSystem>(pNode, mBuildOriginInterpolationMatrix, mOriginIsIga, mRBFTypeEnum, mPolynomialDegree, mDimension, mpPolynomialEquationIds);
     }
 
     MapperLocalSystemUniquePointer Create(GeometryPointerType pGeometry) const override
     {
         KRATOS_DEBUG_ERROR_IF(!pGeometry) << "Create(Geometry) received nullptr" << std::endl;
-        return Kratos::make_unique<RadialBasisFunctionMapperLocalSystem>(pGeometry, mBuildOriginInterpolationMatrix, mOriginIsIga, mRBFTypeEnum, mPolynomialDegree, mpPolynomialEquationIds);
+        return Kratos::make_unique<RadialBasisFunctionMapperLocalSystem>(pGeometry, mBuildOriginInterpolationMatrix, mOriginIsIga, mRBFTypeEnum, mPolynomialDegree, mDimension, mpPolynomialEquationIds);
     }
 
     void AddInterfaceInfo(MapperInterfaceInfoPointerType pInterfaceInfo) override 
@@ -385,6 +388,7 @@ private:
 
     bool mBuildOriginInterpolationMatrix{};
     bool mOriginIsIga = false;
+    IndexType mDimension = 0;
 
     using RBFVariant = std::variant<
         RadialBasisFunctionsUtilities::InverseMultiquadric,

--- a/applications/MappingApplication/custom_mappers/radial_basis_function_mapper.h
+++ b/applications/MappingApplication/custom_mappers/radial_basis_function_mapper.h
@@ -822,6 +822,7 @@ private:
         return Parameters(R"({
             "echo_level"                     : 0,
             "radial_basis_function_type"     : "thin_plate_spline",
+            "global_space_dimension"         : 3,
             "additional_polynomial_degree"   : 0,
             "origin_is_iga"                  : false,
             "destination_is_iga"             : false,

--- a/applications/MappingApplication/custom_mappers/radial_basis_function_mapper.h
+++ b/applications/MappingApplication/custom_mappers/radial_basis_function_mapper.h
@@ -738,6 +738,7 @@ private:
     ModelPart& mrModelPartDestination;
     bool mOriginIsIga = false;
     IndexType mRequiredRBFSupportPoints;
+    IndexType mDimension = 0;
 
     ModelPart* mpCouplingMP = nullptr;
     ModelPart* mpCouplingInterfaceOrigin = nullptr;

--- a/applications/MappingApplication/custom_mappers/radial_basis_function_mapper.h
+++ b/applications/MappingApplication/custom_mappers/radial_basis_function_mapper.h
@@ -70,6 +70,7 @@ class RBFSupportAccumulator {
             node_candidate.mCoordinates = rCoordinates;
 
             mCandidates.push_back(std::move(node_candidate));
+            mNumNeighbors++;
             mNotOrdered = true;
         }
 
@@ -81,6 +82,7 @@ class RBFSupportAccumulator {
             geometry_candidate.mCoordinates = rCoordinates;
 
             mCandidates.push_back(std::move(geometry_candidate)); 
+            mNumNeighbors++;
             mNotOrdered = true;
         }
 
@@ -89,10 +91,15 @@ class RBFSupportAccumulator {
             if (!mNotOrdered) return;
 
             std::stable_sort(mCandidates.begin(), mCandidates.end(),
-                [](const Candidate& a, const Candidate& b){ return a.mDistance < b.mDistance; });
+                [](const Candidate& a, const Candidate& b){
+                    return a.mDistance < b.mDistance;
+                });
+
+            if (mCandidates.size() > mRequiredRBFSupportPoints) {
+                mCandidates.resize(mRequiredRBFSupportPoints);
+            }
 
             mNumNeighbors = mCandidates.size();
-
             mNotOrdered = false;
         }
 

--- a/applications/MappingApplication/custom_mappers/radial_basis_function_mapper.h
+++ b/applications/MappingApplication/custom_mappers/radial_basis_function_mapper.h
@@ -388,7 +388,6 @@ private:
 
     bool mBuildOriginInterpolationMatrix{};
     bool mOriginIsIga = false;
-    IndexType mDimension = 0;
 
     using RBFVariant = std::variant<
         RadialBasisFunctionsUtilities::InverseMultiquadric,
@@ -403,10 +402,11 @@ private:
 
     RadialBasisFunctionsUtilities::RBFType mRBFTypeEnum;
     IndexType mPolynomialDegree = 0;
+    IndexType mDimension = 0;
     IndexType mNumberOfPolynomialTerms;
     const std::vector<IndexType>* mpPolynomialEquationIds; // reference to the polynomial ids
 
-    std::vector<double> EvaluatePolynomialBasis(const CoordinatesArrayType& rCoords, unsigned int degree) const;
+    std::vector<double> EvaluatePolynomialBasis(const CoordinatesArrayType& rCoords, unsigned int degree, const IndexType dimension) const;
 
     void InitializeRBFKernel(const Matrix& coords) const
     {


### PR DESCRIPTION
## Fix bugs in RBF Mapper

This PR fixes several issues identified in the **Radial Basis Function (RBF) mapper** in the `MappingApplication`.

### Changes
- Fix incorrect reading of the parameter `use_all_rbf_support_points` from the input settings.
- Add a new parameter `global_space_dimension`, required to correctly define the **polynomial augmentation** of the RBF system.
- Fix potential singularity in the interpolation matrix when using a **3D polynomial basis in 2D cases**, which previously introduced a row of zeros.