### PR TITLE
[IgaApplication] bug ShapeFunctionsLocalGradients in nurbs_surface_geometry

### DIFF
--- a/kratos/geometries/nurbs_surface_geometry.h
+++ b/kratos/geometries/nurbs_surface_geometry.h
@@ -920,7 +920,7 @@ public:
         Matrix& rResult,
         const CoordinatesArrayType& rCoordinates) const override
     {
-        NurbsSurfaceShapeFunction shape_function_container(mPolynomialDegreeU, mPolynomialDegreeV, 0);
+        NurbsSurfaceShapeFunction shape_function_container(mPolynomialDegreeU, mPolynomialDegreeV, 1);
 
         if (mIsRational) {
             shape_function_container.ComputeNurbsShapeFunctionValues(mKnotsU, mKnotsV, mWeights, rCoordinates[0], rCoordinates[1]);
@@ -929,13 +929,13 @@ public:
             shape_function_container.ComputeBSplineShapeFunctionValues(mKnotsU, mKnotsV, rCoordinates[0], rCoordinates[1]);
         }
 
-        if (rResult.size1() != 2
-            && rResult.size2() != shape_function_container.NumberOfNonzeroControlPoints())
-            rResult.resize(2, shape_function_container.NumberOfNonzeroControlPoints());
+        if (rResult.size2() != 2
+            || rResult.size1() != shape_function_container.NumberOfNonzeroControlPoints())
+            rResult.resize(shape_function_container.NumberOfNonzeroControlPoints(), 2);
 
         for (IndexType i = 0; i < shape_function_container.NumberOfNonzeroControlPoints(); i++) {
-            rResult(0, i) = shape_function_container(i, 1);
-            rResult(1, i) = shape_function_container(i, 2);
+            rResult(i, 0) = shape_function_container(i, 1);
+            rResult(i, 1) = shape_function_container(i, 2);
         }
 
         return rResult;


### PR DESCRIPTION
**📝 Description**
This PR fixes a bug in `NurbsSurfaceGeometry::ShapeFunctionsLocalGradients` (`kratos/geometries/nurbs_surface_geometry.h`).

The method was building the shape-function container with derivative order `0` while later reading gradient components, and it was also writing the output matrix with swapped dimensions/indexing.  

Tags:
- `Core`
- `IGA`
- `Bugfix`