### PR TITLE
[ConvectionDiffusionApplication] [IgaApplication] conv diff solver -> skipping geometry check when IGA

### DIFF
--- a/applications/ConvectionDiffusionApplication/python_scripts/convection_diffusion_solver.py
+++ b/applications/ConvectionDiffusionApplication/python_scripts/convection_diffusion_solver.py
@@ -154,7 +154,7 @@ class ConvectionDiffusionSolver(PythonSolver):
             "processes_sub_model_part_list": [""],
             "auxiliary_variables_list" : [],
             "assign_neighbour_elements_to_conditions" : true,
-            "skip_fem_model_part_preparation_for_iga" : false
+            "skip_entities_replace_and_check" : false
         }
         """)
         default_settings.AddMissingParameters(super().GetDefaultParameters())
@@ -310,7 +310,7 @@ class ConvectionDiffusionSolver(PythonSolver):
 
     def PrepareModelPart(self):
         assign_neighbour_elements = self.settings["assign_neighbour_elements_to_conditions"].GetBool()
-        skip_fem_model_part_preparation = self.settings["skip_fem_model_part_preparation_for_iga"].GetBool()
+        skip_entities_replace_and_check = self.settings["skip_entities_replace_and_check"].GetBool()
         if not self.is_restarted():
             # Import material properties
             materials_imported = self.import_materials()
@@ -319,10 +319,10 @@ class ConvectionDiffusionSolver(PythonSolver):
             else:
                 KratosMultiphysics.Logger.PrintInfo("::[ConvectionDiffusionSolver]:: ", "Materials were not imported.")
 
-            if skip_fem_model_part_preparation:
+            if skip_entities_replace_and_check:
                 KratosMultiphysics.Logger.PrintInfo(
                     "::[ConvectionDiffusionSolver]:: ",
-                    "Skipping FEM model-part preparation (ReplaceElementsAndConditionsProcess and TetrahedralMeshOrientationCheck).")
+                    "Skipping entities model part replace and check (ReplaceElementsAndConditionsProcess and TetrahedralMeshOrientationCheck).")
             else:
                 KratosMultiphysics.ReplaceElementsAndConditionsProcess(
                     self.main_model_part,

--- a/applications/ConvectionDiffusionApplication/python_scripts/convection_diffusion_solver.py
+++ b/applications/ConvectionDiffusionApplication/python_scripts/convection_diffusion_solver.py
@@ -153,7 +153,8 @@ class ConvectionDiffusionSolver(PythonSolver):
             "problem_domain_sub_model_part_list": [""],
             "processes_sub_model_part_list": [""],
             "auxiliary_variables_list" : [],
-            "assign_neighbour_elements_to_conditions" : true
+            "assign_neighbour_elements_to_conditions" : true,
+            "skip_fem_model_part_preparation_for_iga" : false
         }
         """)
         default_settings.AddMissingParameters(super().GetDefaultParameters())
@@ -309,6 +310,7 @@ class ConvectionDiffusionSolver(PythonSolver):
 
     def PrepareModelPart(self):
         assign_neighbour_elements = self.settings["assign_neighbour_elements_to_conditions"].GetBool()
+        skip_fem_model_part_preparation = self.settings["skip_fem_model_part_preparation_for_iga"].GetBool()
         if not self.is_restarted():
             # Import material properties
             materials_imported = self.import_materials()
@@ -317,16 +319,23 @@ class ConvectionDiffusionSolver(PythonSolver):
             else:
                 KratosMultiphysics.Logger.PrintInfo("::[ConvectionDiffusionSolver]:: ", "Materials were not imported.")
 
-            KratosMultiphysics.ReplaceElementsAndConditionsProcess(self.main_model_part,self._get_element_condition_replace_settings()).Execute()
-
-            tmoc = KratosMultiphysics.TetrahedralMeshOrientationCheck
-            throw_errors = False
-            flags = (tmoc.COMPUTE_NODAL_NORMALS).AsFalse() | (tmoc.COMPUTE_CONDITION_NORMALS).AsFalse()
-            if assign_neighbour_elements:
-                flags |= tmoc.ASSIGN_NEIGHBOUR_ELEMENTS_TO_CONDITIONS
+            if skip_fem_model_part_preparation:
+                KratosMultiphysics.Logger.PrintInfo(
+                    "::[ConvectionDiffusionSolver]:: ",
+                    "Skipping FEM model-part preparation (ReplaceElementsAndConditionsProcess and TetrahedralMeshOrientationCheck).")
             else:
-                flags |= (tmoc.ASSIGN_NEIGHBOUR_ELEMENTS_TO_CONDITIONS).AsFalse()
-            tmoc(self.main_model_part,throw_errors, flags).Execute()
+                KratosMultiphysics.ReplaceElementsAndConditionsProcess(
+                    self.main_model_part,
+                    self._get_element_condition_replace_settings()).Execute()
+
+                tmoc = KratosMultiphysics.TetrahedralMeshOrientationCheck
+                throw_errors = False
+                flags = (tmoc.COMPUTE_NODAL_NORMALS).AsFalse() | (tmoc.COMPUTE_CONDITION_NORMALS).AsFalse()
+                if assign_neighbour_elements:
+                    flags |= tmoc.ASSIGN_NEIGHBOUR_ELEMENTS_TO_CONDITIONS
+                else:
+                    flags |= (tmoc.ASSIGN_NEIGHBOUR_ELEMENTS_TO_CONDITIONS).AsFalse()
+                tmoc(self.main_model_part, throw_errors, flags).Execute()
 
             self._set_and_fill_buffer()
 


### PR DESCRIPTION
📝 Description
This PR introduces an optional IGA-specific switch in the Convection Diffusion solver to skip FEM-only model-part preparation steps.

A new setting, "skip_fem_model_part_preparation_for_iga" (default false), is added to ConvectionDiffusionSolver parameters.
When enabled, PrepareModelPart() skips:

ReplaceElementsAndConditionsProcess
TetrahedralMeshOrientationCheck

Tags:

IgaApplication
ConvectionDiffusionApplication
