### PR TITLE
[Future][Core] Adding preconditioner base class

### DIFF
--- a/kratos/future/preconditioners/preconditioner.h
+++ b/kratos/future/preconditioners/preconditioner.h
@@ -1,0 +1,322 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:		 BSD License
+//					 Kratos default license: kratos/license.txt
+//
+//  Main authors:    Ruben Zorrilla
+//
+
+#pragma once
+
+// System includes
+#include <string>
+#include <iostream>
+
+// External includes
+
+// Project includes
+#include "includes/define.h"
+#include "includes/model_part.h"
+#include "future/linear_operators/linear_operator.h"
+
+namespace Kratos::Future
+{
+
+///@name Kratos Globals
+///@{
+
+///@}
+///@name Type Definitions
+///@{
+
+///@}
+///@name  Enum's
+///@{
+
+///@}
+///@name  Functions
+///@{
+
+///@}
+///@name Kratos Classes
+///@{
+
+/**
+ * @brief Base class for preconditioners
+ * @details This class defines the interface for preconditioners to be used in iterative linear solvers.
+ * It provides virtual methods for initialization, application, and finalization of the preconditioner.
+ * If additional data is required (i.e., reference model part and DOFs container), methods to set it are also provided.
+ * The actual implementation of the preconditioner must be done in derived classes as this is a do nothing implementation.
+ * @tparam TLinearAlgebra The struct containing the linear algebra types
+ */
+template<class TLinearAlgebra>
+class Preconditioner
+{
+public:
+    ///@name Type Definitions
+    ///@{
+
+    KRATOS_CLASS_POINTER_DEFINITION(Preconditioner);
+
+    using DataType = typename TLinearAlgebra::DataType;
+
+    using VectorType = typename TLinearAlgebra::VectorType;
+
+    using DofsArrayType = ModelPart::DofsArrayType;
+
+    using LinearOperatorType = LinearOperator<TLinearAlgebra>;
+
+    ///@}
+    ///@name Life Cycle
+    ///@{
+
+    /// Default constructor.
+    Preconditioner() = default;
+
+    /// Constructor with parameters
+    Preconditioner(Parameters Settings)
+    {
+    }
+
+    /// Copy constructor.
+    Preconditioner(const Preconditioner& Other) = default;
+
+    /// Destructor.
+    virtual ~Preconditioner() = default;
+
+    ///@}
+    ///@name Operators
+    ///@{
+
+    /// Assignment operator.
+    Preconditioner& operator=(const Preconditioner& Other)
+    {
+        return *this;
+    }
+
+    ///@}
+    ///@name Operations
+    ///@{
+
+    /**
+     * @brief Initialize the preconditioner with the linear operator.
+     * This method is called once at the beginning of the solve to set up the preconditioner.
+     * Note that a LinearOperator (@see LinearOperator) enables both matrix-free and matrix-based implementations.
+     * @param rpLinearOperator Unique pointer to the linear operator representing the system matrix.
+     */
+    virtual void Initialize(const typename LinearOperatorType::UniquePointer& rpLinearOperator)
+    {
+    }
+
+    /**
+     * @brief Initialize the preconditioner for the current solution step.
+     * This method is called every time the coefficients change in the system, for example at the beginning of each solve.
+     * For example, if we are implementing a direct solver, this is the place to do the factorization
+     * so that then the backward substitution can be performed effectively more than once.
+     * @param rpLinearOperator Unique pointer to the linear operator representing the system matrix.
+     */
+    virtual void InitializeSolutionStep(const typename LinearOperatorType::UniquePointer& rpLinearOperator)
+    {
+    }
+
+    /**
+     * @brief Applies the preconditioner to the given vector.
+     * This represents the operation y = M^{-1} x, being M^{-1} an approximation of the linear system matrix inverse.
+     * @param rX The vector to be preconditioned.
+     * @param rY The vector to store the result.
+     */
+    virtual void Apply(
+        const VectorType& rX,
+        VectorType& rY)
+    {
+        rY = rX;
+    }
+
+    /**
+     * @brief Applies the transpose of the preconditioner to the given vector.
+     * This represents the operation y = M^{-T} x, being M^{-T} an approximation of the linear system matrix transpose inverse.
+     * @param rX The vector to be preconditioned.
+     * @param rY The vector to store the result.
+     */
+    virtual void ApplyTranspose(
+        const VectorType& rX,
+        VectorType& rY)
+    {
+        rY = rX;
+    }
+
+    /**
+     * @brief Finalizes the preconditioner for the current solution step.
+     * This method is designed to be called at the end of the step.
+     * @param rpLinearOperator Unique pointer to the linear operator representing the system matrix.
+     */
+    virtual void FinalizeSolutionStep(const typename LinearOperatorType::UniquePointer& rpLinearOperator)
+    {
+    }
+
+    /**
+     * @brief Clears the preconditioner.
+     * This method is designed to clean up all internal data in the preconditioner.
+     * After a clear a new Initialize is needed as well as to eventually set the additional data (@see SetAdditionalData)
+     */
+    virtual void Clear()
+    {
+    }
+
+    ///@}
+    ///@name Access
+    ///@{
+
+    /**
+     * @brief Set the Additional Data
+     * @details Some solvers may require a minimum degree of knowledge of the structure of the matrix.
+     * For example, when solving a mixed u-p problem, it is important to identify the row associated with v and p.
+     * Another example is the automatic prescription of rotation null-space for smoothed-aggregation solvers,
+     * which require knowledge of the spatial position of the nodes associated with a given degree of freedom (DOF).
+     * This function provides the opportunity to provide such data if needed.
+     * @param rModelPart The model part from which the linear system is built
+     * @param rDofSet The dofs array of the linear system
+     */
+    void SetAdditionalData(
+        ModelPart& rModelPart,
+        DofsArrayType& rDofSet)
+    {
+        KRATOS_WARNING_IF("Preconditioner", HasAdditionalData()) << "Additional data is already set. Overwriting it" << std::endl;
+        mpDofSet = &rDofSet;
+        mpModelPart = &rModelPart;
+    }
+
+
+    ///@}
+    ///@name Inquiry
+    ///@{
+
+    /**
+     * @brief Checks if additional physical data is needed by the preconditioner.
+     * @details Some preconditioners may require a minimum degree of knowledge of the structure of the matrix.
+     * For instance, when solving a mixed u-p problem, it is important to identify the row associated with v and p.
+     * Another example is the automatic prescription of rotation null-space for smoothed-aggregation solvers,
+     * which require knowledge of the spatial position of the nodes associated with a given degree of freedom (DOF).
+     * @return True if additional physical data is needed, false otherwise.
+     */
+    virtual bool RequiresAdditionalData() const
+    {
+        return false;
+    }
+
+    /**
+     * @brief Check if the preconditioner has additional data (model part and dofs)
+     * @return true if the preconditioner has additional data
+     * @return false if the preconditioner does not have additional data
+     */
+    bool HasAdditionalData() const
+    {
+        return mpModelPart != nullptr && mpDofSet != nullptr;
+    }
+
+    ///@}
+    ///@name Input and output
+    ///@{
+
+    /// Turn back information as a string.
+    virtual std::string Info() const
+    {
+        return "Preconditioner";
+    }
+
+    /// Print information about this object.
+    virtual void PrintInfo(std::ostream& rOStream) const
+    {
+        rOStream << "Preconditioner";
+    }
+
+    /// Print object's data.
+    virtual void PrintData(std::ostream& rOStream) const
+    {
+    }
+
+    ///@}
+    ///@name Friends
+    ///@{
+
+
+    ///@}
+protected:
+    ///@name Protected static Member Variables
+    ///@{
+
+
+    ///@}
+    ///@name Protected member Variables
+    ///@{
+
+    ModelPart* mpModelPart = nullptr; // Model part of the preconditioner
+
+    typename ModelPart::DofsArrayType* mpDofSet = nullptr; // Dofs of the preconditioner
+
+    ///@}
+    ///@name Protected Operators
+    ///@{
+
+
+    ///@}
+    ///@name Protected Operations
+    ///@{
+
+
+    ///@}
+    ///@name Protected  Access
+    ///@{
+
+
+    ///@}
+    ///@name Protected Inquiry
+    ///@{
+
+
+    ///@}
+    ///@name Protected LifeCycle
+    ///@{
+
+
+    ///@}
+}; // Class Preconditioner
+
+///@}
+///@name Type Definitions
+///@{
+
+
+///@}
+///@name Input and output
+///@{
+
+/// input stream function
+template<class TLinearAlgebra>
+inline std::istream& operator >> (
+    std::istream& IStream,
+    Preconditioner<TLinearAlgebra>& rThis)
+{
+    return IStream;
+}
+
+/// output stream function
+template<class TLinearAlgebra>
+inline std::ostream& operator << (
+    std::ostream& OStream,
+    const Preconditioner<TLinearAlgebra>& rThis)
+{
+    rThis.PrintInfo(OStream);
+    OStream << std::endl;
+    rThis.PrintData(OStream);
+
+    return OStream;
+}
+
+///@}
+
+}  // namespace Kratos::Future.

--- a/kratos/future/preconditioners/preconditioner.h
+++ b/kratos/future/preconditioners/preconditioner.h
@@ -13,13 +13,10 @@
 #pragma once
 
 // System includes
-#include <string>
-#include <iostream>
 
 // External includes
 
 // Project includes
-#include "includes/define.h"
 #include "includes/model_part.h"
 #include "future/linear_operators/linear_operator.h"
 
@@ -190,7 +187,6 @@ public:
         mpModelPart = &rModelPart;
     }
 
-
     ///@}
     ///@name Inquiry
     ///@{
@@ -243,12 +239,10 @@ public:
     ///@name Friends
     ///@{
 
-
     ///@}
 protected:
     ///@name Protected static Member Variables
     ///@{
-
 
     ///@}
     ///@name Protected member Variables
@@ -262,26 +256,21 @@ protected:
     ///@name Protected Operators
     ///@{
 
-
     ///@}
     ///@name Protected Operations
     ///@{
-
 
     ///@}
     ///@name Protected  Access
     ///@{
 
-
     ///@}
     ///@name Protected Inquiry
     ///@{
 
-
     ///@}
     ///@name Protected LifeCycle
     ///@{
-
 
     ///@}
 }; // Class Preconditioner

--- a/kratos/future/python/add_preconditioners_to_python.cpp
+++ b/kratos/future/python/add_preconditioners_to_python.cpp
@@ -1,0 +1,50 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
+//
+//  Main authors:    Ruben Zorrilla
+//
+
+// System includes
+
+// External includes
+
+// Project includes
+#include "includes/define_python.h"
+#include "includes/kratos_parameters.h"
+
+// Future Extensions
+#include "future/containers/define_linear_algebra_serial.h"
+#include "future/preconditioners/preconditioner.h"
+#include "future/python/add_preconditioners_to_python.h"
+
+namespace Kratos::Future::Python
+{
+
+namespace py = pybind11;
+
+void AddPreconditionersToPython(py::module& m)
+{
+    using PreconditionerType = Future::Preconditioner<Future::SerialLinearAlgebraTraits>;
+    py::class_<PreconditionerType, py::smart_holder>(m, "Preconditioner")
+        .def(py::init<>())
+        .def(py::init<Parameters>())
+        .def("Initialize", &PreconditionerType::Initialize)
+        .def("InitializeSolutionStep", &PreconditionerType::InitializeSolutionStep)
+        .def("Apply", &PreconditionerType::Apply)
+        .def("ApplyTranspose", &PreconditionerType::ApplyTranspose)
+        .def("FinalizeSolutionStep", &PreconditionerType::FinalizeSolutionStep)
+        .def("Clear", &PreconditionerType::Clear)
+        .def("SetAdditionalData", &PreconditionerType::SetAdditionalData)
+        .def("RequiresAdditionalData", &PreconditionerType::RequiresAdditionalData)
+        .def("HasAdditionalData", &PreconditionerType::HasAdditionalData)
+        .def("Info", &PreconditionerType::Info)
+        .def("__str__", PrintObject<PreconditionerType>);
+}
+
+} // namespace Kratos::Future::Python

--- a/kratos/future/python/add_preconditioners_to_python.h
+++ b/kratos/future/python/add_preconditioners_to_python.h
@@ -1,0 +1,27 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
+//
+//  Main authors:    Ruben Zorrilla
+//
+
+#pragma once
+
+// System includes
+
+// External includes
+#include <pybind11/pybind11.h>
+
+// Project includes
+
+namespace Kratos::Future::Python
+{
+
+void AddPreconditionersToPython(pybind11::module& m);
+
+} // namespace Kratos::Future::Python

--- a/kratos/future/python/kratos_python.cpp
+++ b/kratos/future/python/kratos_python.cpp
@@ -24,6 +24,7 @@
 #include "future/python/add_io_to_python.h"
 #include "future/python/add_linear_operators_to_python.h"
 #include "future/python/add_linear_solvers_to_python.h"
+#include "future/python/add_preconditioners_to_python.h"
 #include "future/python/add_processes_to_python.h"
 #include "future/python/add_strategies_to_python.h"
 
@@ -39,6 +40,8 @@ void AddFutureToPython(py::module& m)
     AddIOToPython(m);
 
     AddLinearOperatorsToPython(m);
+
+    AddPreconditionersToPython(m);
 
     AddLinearSolversToPython(m);
 

--- a/kratos/future/tests/cpp_tests/test_preconditioners.cpp
+++ b/kratos/future/tests/cpp_tests/test_preconditioners.cpp
@@ -1,0 +1,58 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
+//
+//  Main authors:    Ruben Zorrilla
+//
+
+// Project includes
+#include "testing/testing.h"
+#include "future/containers/define_linear_algebra_serial.h"
+#include "future/containers/linear_system.h"
+#include "future/linear_operators/linear_operator.h"
+#include "future/preconditioners/preconditioner.h"
+
+namespace Kratos::Testing
+{
+
+KRATOS_TEST_CASE_IN_SUITE(Preconditioner, KratosCoreFutureSuite)
+{
+    // Set up a fake linear system to test the preconditioner
+    auto p_LHS = Kratos::make_shared<CsrMatrix<> >();
+    DenseVector<double> aux_data(5);
+    aux_data[0] = 3.0;
+    aux_data[1] = 7.0;
+    aux_data[2] = 2.0;
+    aux_data[3] = 5.0;
+    aux_data[4] = 1.0;
+    SystemVector<> input(aux_data);
+    SystemVector<> output(5);
+
+    // Set a linear operator from the fake LHS matrix
+    Future::LinearOperator<Future::SerialLinearAlgebraTraits>::UniquePointer p_lhs_lin_op = Kratos::make_unique<Future::SparseMatrixLinearOperator<Future::SerialLinearAlgebraTraits> >(p_LHS);
+
+    // Set up the preconditioner
+    Future::Preconditioner<Future::SerialLinearAlgebraTraits> preconditioner;
+
+    // Check preconditioner features
+    KRATOS_EXPECT_FALSE(preconditioner.RequiresAdditionalData());
+    KRATOS_EXPECT_FALSE(preconditioner.HasAdditionalData());
+
+    // Call the preconditioner sequence
+    preconditioner.Initialize(p_lhs_lin_op);
+    preconditioner.InitializeSolutionStep(p_lhs_lin_op);
+    preconditioner.Apply(input, output);
+    preconditioner.FinalizeSolutionStep(p_lhs_lin_op);
+    preconditioner.Clear();
+
+    // Check the obtained results
+    std::vector<double> ref_output = {3.0, 7.0, 2.0, 5.0, 1.0};
+    KRATOS_EXPECT_VECTOR_NEAR(output.data(), ref_output, 1e-12);
+}
+
+}


### PR DESCRIPTION
**📝 Description**
This PR adds a new `Preconditioner` base class to the `Future` namespace. Main features are:
- Much simpler design when compared to current implementation. The use of the preconditioner is done by the `Apply` and `ApplyTranspose` methods so the logic on how to apply it is left to the linear solver.
- The LHS to which the preconditioner refers is provided as a linear operator, so it can support matrix-free implementations.
- Additional information about the linear system can be optionally provided by the model part and DOFs set of reference.

Tests and Python exposure have been added accordingly.

The integration within the `Future` linear solvers will come in a subsequent PR.