### PR TITLE
[MAPPING] Improve performance of RBF mapper by solving linear system with matrix RHS

### DIFF
--- a/applications/MappingApplication/custom_mappers/radial_basis_function_mapper.cpp
+++ b/applications/MappingApplication/custom_mappers/radial_basis_function_mapper.cpp
@@ -647,7 +647,6 @@ void RadialBasisFunctionMapper<TSparseSpace, TDenseSpace>::CalculateMappingMatri
 
     // Mapping matrix
     auto pMappingMatrixGP = Kratos::make_unique<MappingMatrixType>(n_dest, n_support);
-    DenseMatrixType mapping_dense(n_dest, n_support, 0.0);
 
     // Factorize LHS once
     mpLinearSolver->InitializeSolutionStep(*mpOriginInterpolationMatrix, sol, rhs);
@@ -669,20 +668,13 @@ void RadialBasisFunctionMapper<TSparseSpace, TDenseSpace>::CalculateMappingMatri
     
         // Store result into dense mapping matrix
         for (IndexType i = 0; i < n_dest; ++i) {
-            mapping_dense(i, j) = column_values[i];
-        }
-    }
-    
-    mpLinearSolver->FinalizeSolutionStep(*mpOriginInterpolationMatrix, sol, rhs);
-
-    for (IndexType i = 0; i < n_dest; ++i) {
-        for (IndexType j = 0; j < n_support; ++j) {
-            const double value = mapping_dense(i, j);
-            if (std::abs(value) > 1e-16) {
+           if (std::abs(value) > 1e-15) {
                 (*pMappingMatrixGP)(i, j) = value;
             }
         }
     }
+    
+    mpLinearSolver->FinalizeSolutionStep(*mpOriginInterpolationMatrix, sol, rhs);
     
     // If IGA origin, project from GP-based to CP-based mapping:
     // M = M_tilde * N_reduced

--- a/applications/MappingApplication/custom_mappers/radial_basis_function_mapper.cpp
+++ b/applications/MappingApplication/custom_mappers/radial_basis_function_mapper.cpp
@@ -614,9 +614,6 @@ void RadialBasisFunctionMapper<TSparseSpace, TDenseSpace>::MapInternalTranspose(
 template<class TSparseSpace, class TDenseSpace>
 void RadialBasisFunctionMapper<TSparseSpace, TDenseSpace>::CalculateMappingMatrix()
 {
-    // Dense matrix type for multi-RHS solve
-    using DenseMatrixType = boost::numeric::ublas::matrix<double>;
-
     KRATOS_DEBUG_ERROR_IF_NOT(mpOriginInterpolationMatrix)
         << "CalculateMappingMatrix: mpOriginInterpolationMatrix is nullptr." << std::endl;
     KRATOS_DEBUG_ERROR_IF_NOT(mpDestinationEvaluationMatrix)

--- a/applications/MappingApplication/custom_mappers/radial_basis_function_mapper.cpp
+++ b/applications/MappingApplication/custom_mappers/radial_basis_function_mapper.cpp
@@ -634,23 +634,43 @@ void RadialBasisFunctionMapper<TSparseSpace, TDenseSpace>::CalculateMappingMatri
         // IGA origin: one center per interface integration point (condition)
         n_support = mpCouplingInterfaceOrigin->NumberOfConditions();
     }
+    
+    // Temporary RHS and solution vectors
+    typename TSparseSpace::VectorType rhs;
+    typename TSparseSpace::VectorType sol;
 
-    // Allocate dense RHS and solution matrices
-    DenseMatrixType rhs_mat(system_size, n_support, 0.0);
-    DenseMatrixType sol_mat(system_size, n_support, 0.0);
+    TSparseSpace::Resize(rhs, system_size);
+    TSparseSpace::Resize(sol, system_size);
 
-    // Build RHS matrix with identity in the RBF part and zeros in the polynomial part
-    for (IndexType j = 0; j < n_support; ++j) {
-        rhs_mat(j, j) = 1.0;
-    }
+    TSparseSpace::SetToZero(rhs);
+    TSparseSpace::SetToZero(sol);
 
-    // This requires that the concrete linear solver supports
-    // Solve(SparseMatrixType, DenseMatrixType, DenseMatrixType)
-    mpLinearSolver->Solve(*mpOriginInterpolationMatrix, sol_mat, rhs_mat);
-
+    // Mapping matrix
     auto pMappingMatrixGP = Kratos::make_unique<MappingMatrixType>(n_dest, n_support);
     DenseMatrixType mapping_dense(n_dest, n_support, 0.0);
-    noalias(mapping_dense) = prod(*mpDestinationEvaluationMatrix, sol_mat);
+
+    // Factorize LHS once
+    mpLinearSolver->InitializeSolutionStep(*mpOriginInterpolationMatrix, sol, rhs);
+
+    // Solve A x = e_j for each column
+    for (IndexType j = 0; j < n_support; ++j) {
+
+        TSparseSpace::SetToZero(rhs);
+        rhs[j] = 1.0;
+
+        mpLinearSolver->PerformSolutionStep(*mpOriginInterpolationMatrix, sol, rhs);
+
+        // Compute column j of mapping matrix: B * sol
+        for (IndexType i = 0; i < n_dest; ++i) {
+            double value = 0.0;
+            for (IndexType k = 0; k < system_size; ++k) {
+                value += (*mpDestinationEvaluationMatrix)(i, k) * sol[k];
+            }
+            mapping_dense(i, j) = value;
+        }
+    }
+
+    mpLinearSolver->FinalizeSolutionStep(*mpOriginInterpolationMatrix, sol, rhs);
 
     for (IndexType i = 0; i < n_dest; ++i) {
         for (IndexType j = 0; j < n_support; ++j) {

--- a/applications/MappingApplication/custom_mappers/radial_basis_function_mapper.cpp
+++ b/applications/MappingApplication/custom_mappers/radial_basis_function_mapper.cpp
@@ -651,25 +651,28 @@ void RadialBasisFunctionMapper<TSparseSpace, TDenseSpace>::CalculateMappingMatri
 
     // Factorize LHS once
     mpLinearSolver->InitializeSolutionStep(*mpOriginInterpolationMatrix, sol, rhs);
-
-    // Solve A x = e_j for each column
+    
+    typename TSparseSpace::VectorType column_values(n_dest);
+    TSparseSpace::Resize(column_values, n_dest);
+    
     for (IndexType j = 0; j < n_support; ++j) {
-
+    
         TSparseSpace::SetToZero(rhs);
         rhs[j] = 1.0;
-
+    
+        // Solve A x = e_j
         mpLinearSolver->PerformSolutionStep(*mpOriginInterpolationMatrix, sol, rhs);
-
-        // Compute column j of mapping matrix: B * sol
+    
+        // Compute column j of mapping matrix: column_values = B * sol
+        TSparseSpace::SetToZero(column_values);
+        TSparseSpace::Mult(*mpDestinationEvaluationMatrix, sol, column_values);
+    
+        // Store result into dense mapping matrix
         for (IndexType i = 0; i < n_dest; ++i) {
-            double value = 0.0;
-            for (IndexType k = 0; k < system_size; ++k) {
-                value += (*mpDestinationEvaluationMatrix)(i, k) * sol[k];
-            }
-            mapping_dense(i, j) = value;
+            mapping_dense(i, j) = column_values[i];
         }
     }
-
+    
     mpLinearSolver->FinalizeSolutionStep(*mpOriginInterpolationMatrix, sol, rhs);
 
     for (IndexType i = 0; i < n_dest; ++i) {

--- a/applications/MappingApplication/custom_mappers/radial_basis_function_mapper.cpp
+++ b/applications/MappingApplication/custom_mappers/radial_basis_function_mapper.cpp
@@ -668,6 +668,8 @@ void RadialBasisFunctionMapper<TSparseSpace, TDenseSpace>::CalculateMappingMatri
     
         // Store result into dense mapping matrix
         for (IndexType i = 0; i < n_dest; ++i) {
+           const double value = column_values[i];
+            
            if (std::abs(value) > 1e-15) {
                 (*pMappingMatrixGP)(i, j) = value;
             }

--- a/applications/MappingApplication/custom_mappers/radial_basis_function_mapper.cpp
+++ b/applications/MappingApplication/custom_mappers/radial_basis_function_mapper.cpp
@@ -614,6 +614,9 @@ void RadialBasisFunctionMapper<TSparseSpace, TDenseSpace>::MapInternalTranspose(
 template<class TSparseSpace, class TDenseSpace>
 void RadialBasisFunctionMapper<TSparseSpace, TDenseSpace>::CalculateMappingMatrix()
 {
+    // Dense matrix type for multi-RHS solve
+    using DenseMatrixType = boost::numeric::ublas::matrix<double>;
+
     KRATOS_DEBUG_ERROR_IF_NOT(mpOriginInterpolationMatrix)
         << "CalculateMappingMatrix: mpOriginInterpolationMatrix is nullptr." << std::endl;
     KRATOS_DEBUG_ERROR_IF_NOT(mpDestinationEvaluationMatrix)
@@ -632,36 +635,32 @@ void RadialBasisFunctionMapper<TSparseSpace, TDenseSpace>::CalculateMappingMatri
         n_support = mpCouplingInterfaceOrigin->NumberOfConditions();
     }
 
-    // Build GP-based mapping matrix H_tilde: (n_dest x n_support)
-    auto pMappingMatrixGP = Kratos::make_unique<MappingMatrixType>(n_dest, n_support);
-    noalias(*pMappingMatrixGP) = ZeroMatrix(n_dest, n_support);
+    // Allocate dense RHS and solution matrices
+    DenseMatrixType rhs_mat(system_size, n_support, 0.0);
+    DenseMatrixType sol_mat(system_size, n_support, 0.0);
 
-    Vector rhs(system_size);
-    Vector solution(system_size);
-    Vector dest_column(n_dest);
-
-    for (IndexType j = 0; j < n_support; ++j)
-    {
-        // rhs = [ e_j ; 0 ]
-        noalias(rhs) = ZeroVector(system_size);
-        rhs[j] = 1.0;
-
-        // Solve A * solution = rhs
-        mpLinearSolver->Solve(*mpOriginInterpolationMatrix, solution, rhs);
-
-        // dest_column = B * solution
-        TSparseSpace::Mult(
-            *mpDestinationEvaluationMatrix,
-            solution,
-            dest_column
-        );
-
-        // Column j of H_tilde
-        for (IndexType i = 0; i < n_dest; ++i) {
-            (*pMappingMatrixGP)(i, j) = dest_column[i];
-        }
+    // Build RHS matrix with identity in the RBF part and zeros in the polynomial part
+    for (IndexType j = 0; j < n_support; ++j) {
+        rhs_mat(j, j) = 1.0;
     }
 
+    // This requires that the concrete linear solver supports
+    // Solve(SparseMatrixType, DenseMatrixType, DenseMatrixType)
+    mpLinearSolver->Solve(*mpOriginInterpolationMatrix, sol_mat, rhs_mat);
+
+    auto pMappingMatrixGP = Kratos::make_unique<MappingMatrixType>(n_dest, n_support);
+    DenseMatrixType mapping_dense(n_dest, n_support, 0.0);
+    noalias(mapping_dense) = prod(*mpDestinationEvaluationMatrix, sol_mat);
+
+    for (IndexType i = 0; i < n_dest; ++i) {
+        for (IndexType j = 0; j < n_support; ++j) {
+            const double value = mapping_dense(i, j);
+            if (std::abs(value) > 1e-16) {
+                (*pMappingMatrixGP)(i, j) = value;
+            }
+        }
+    }
+    
     // If IGA origin, project from GP-based to CP-based mapping:
     // M = M_tilde * N_reduced
     if (mOriginIsIga) {
@@ -741,13 +740,41 @@ RadialBasisFunctionMapper<TSparseSpace, TDenseSpace>::ComputeMappingMatrixIgaOnC
 template<class TSparseSpace, class TDenseSpace>
 void RadialBasisFunctionMapper<TSparseSpace, TDenseSpace>::CreateLinearSolver()
 {
+    // Create the linear solver factory
+    LinearSolverFactory<TSparseSpace, TDenseSpace> solver_factory;
+
     if (mMapperSettings["linear_solver_settings"].Has("solver_type")) {
-        mpLinearSolver = LinearSolverFactory<TSparseSpace, TDenseSpace>().Create(mMapperSettings["linear_solver_settings"]);
+        const std::string solver_type =
+            mMapperSettings["linear_solver_settings"]["solver_type"].GetString();
+
+        KRATOS_INFO("Radial Basis Functions Mapper")
+            << "Using specified linear solver: " << solver_type << std::endl;
+
+        mpLinearSolver = solver_factory.Create(mMapperSettings["linear_solver_settings"]);
     }
     else {
-        // TODO - replicate 'get fastest solver'
-        mMapperSettings.AddString("solver_type", "pardiso_lu");
-        mpLinearSolver = LinearSolverFactory<TSparseSpace, TDenseSpace>().Create(mMapperSettings);
+        if (solver_factory.Has("pardiso_lu")) {
+            KRATOS_INFO("Radial Basis Functions Mapper")
+                << "No linear solver specified. Using PardisoLU." << std::endl;
+
+            Parameters default_settings(R"(
+            {
+                "solver_type": "pardiso_lu"
+            })");
+
+            mpLinearSolver = solver_factory.Create(default_settings);
+        }
+        else {
+            KRATOS_WARNING("Radial Basis Functions Mapper")
+                << "PardisoLU not available. Falling back to skyline_lu_factorization." << std::endl;
+
+            Parameters default_settings(R"(
+            {
+                "solver_type": "skyline_lu_factorization"
+            })");
+
+            mpLinearSolver = solver_factory.Create(default_settings);
+        }
     }
 }
 

--- a/applications/MappingApplication/custom_mappers/radial_basis_function_mapper.h
+++ b/applications/MappingApplication/custom_mappers/radial_basis_function_mapper.h
@@ -311,7 +311,11 @@ public:
               mRBFTypeEnum(RBFTypeEnum),
               mPolynomialDegree(PolynomialDegree), 
               mDimension(dimension),
-              mNumberOfPolynomialTerms((PolynomialDegree + 3) * (PolynomialDegree + 2) * (PolynomialDegree + 1) / 6),
+              mNumberOfPolynomialTerms(
+                dimension == 2 ?
+                    (PolynomialDegree + 2) * (PolynomialDegree + 1) / 2 :
+                    (PolynomialDegree + 3) * (PolynomialDegree + 2) * (PolynomialDegree + 1) / 6
+              ),
               mpPolynomialEquationIds(pPolynomialEquationIds){}
 
     // Construct from a node
@@ -323,7 +327,11 @@ public:
              mRBFTypeEnum(RBFTypeEnum),
              mPolynomialDegree(PolynomialDegree),
              mDimension(dimension),
-             mNumberOfPolynomialTerms((PolynomialDegree + 3) * (PolynomialDegree + 2) * (PolynomialDegree + 1) / 6),
+             mNumberOfPolynomialTerms(
+                dimension == 2 ?
+                    (PolynomialDegree + 2) * (PolynomialDegree + 1) / 2 :
+                    (PolynomialDegree + 3) * (PolynomialDegree + 2) * (PolynomialDegree + 1) / 6
+             ),
              mpPolynomialEquationIds(pPolynomialEquationIds){}
 
     // Construct from a geometry (e.g. an integration-point “geometry” in IGA)
@@ -335,7 +343,11 @@ public:
              mRBFTypeEnum(RBFTypeEnum),
              mPolynomialDegree(PolynomialDegree),
              mDimension(dimension),
-             mNumberOfPolynomialTerms((PolynomialDegree + 3) * (PolynomialDegree + 2) * (PolynomialDegree + 1) / 6),
+             mNumberOfPolynomialTerms(
+                dimension == 2 ?
+                    (PolynomialDegree + 2) * (PolynomialDegree + 1) / 2 :
+                    (PolynomialDegree + 3) * (PolynomialDegree + 2) * (PolynomialDegree + 1) / 6
+             ),
              mpPolynomialEquationIds(pPolynomialEquationIds){}
 
     void CalculateAll(MatrixType& rLocalMappingMatrix,


### PR DESCRIPTION
## Summary

This PR improves the performance of the `RadialBasisFunctionMapper` by solving the linear system with a **matrix RHS** when constructing the mapping matrix.

## Details

Instead of solving multiple systems with vector RHS, the system is now solved as:

$A X = B$

This allows the solver to **factorize the LHS only once and reuse the factorization for all RHS columns**, significantly improving the performance of the mapping matrix construction.

No changes to the user interface are introduced.

**This PR is connected to #14263**