### PR TITLE
[Core] Change starting radius in GeometricalObjectsBins::SearchNearestInRadius method

### DIFF
--- a/kratos/spatial_containers/geometrical_objects_bins.cpp
+++ b/kratos/spatial_containers/geometrical_objects_bins.cpp
@@ -124,12 +124,13 @@ GeometricalObjectsBins::ResultType GeometricalObjectsBins::SearchNearestInRadius
     ResultType current_result;
     current_result.SetDistance(std::numeric_limits<double>::max());
 
+    const double starting_radius = *std::min_element(mCellSizes.begin(), mCellSizes.end());
     const double radius_increment = *std::max_element(mCellSizes.begin(), mCellSizes.end());
 
     array_1d<std::size_t, Dimension> min_position;
     array_1d<std::size_t, Dimension> max_position;
 
-    for(double current_radius = radius_increment ; current_radius < Radius + radius_increment ; current_radius += radius_increment){
+    for(double current_radius = starting_radius ; current_radius < Radius + radius_increment ; current_radius += radius_increment){
         current_radius = (current_radius > Radius) ? Radius : current_radius;
         for(unsigned int i = 0; i < Dimension; i++ ) {
             min_position[i] = CalculatePosition(rPoint[i] - current_radius, i);


### PR DESCRIPTION
**📝 Description**
- use min cellsize as starting search radius instead of radius increment
- in the case of geometries with anisotropic bounding boxes, e.g. thin plate, radius increment will be set to 1/3 of average length using std::max_element of cell sizes, making the search to include sometimes orders of magnitude more cells than necessary.
- Tested with thin plate model in a mold filling simulation where performance is improved with the current fix.
- Tested with thick plate where bounding box is more or less isotropic and performance is not affected.

Please mark the PR with appropriate tags: 
- Api Breaker, Mpi, etc...

**🆕 Changelog**
Please summarize the changes in one list to generate the changelog:
E.g.
- Added feature X to Y
- Added Foo Application
- Fixed X (#XXXX Reference to issue if apply) 
- etc...
