### PR TITLE
[Scripts] 🐳 Adding Docker script for Ubuntu 24.04 (Noble)

### DIFF
--- a/scripts/docker_files/docker_file_ci_ubuntu_24_04/DockerFile
+++ b/scripts/docker_files/docker_file_ci_ubuntu_24_04/DockerFile
@@ -1,0 +1,116 @@
+FROM ubuntu:noble
+
+ENV HOME=/root
+
+# Update and install necessary packages
+RUN apt-get update -y && apt-get upgrade -y
+RUN apt-get -y install --no-install-recommends gnupg2 software-properties-common wget ca-certificates
+
+# Adding Intel oneAPI repository (updated method - apt-key is deprecated in Ubuntu 24.04)
+RUN wget -qO /etc/apt/keyrings/intel-oneapi.asc \
+        https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB && \
+    echo "deb [signed-by=/etc/apt/keyrings/intel-oneapi.asc] https://apt.repos.intel.com/oneapi all main" \
+        > /etc/apt/sources.list.d/oneAPI.list
+
+# Update again with the new ppa
+RUN add-apt-repository ppa:git-core/ppa && \
+    apt-get -y update
+
+# Install packages
+# Notes:
+#   - g++-13 (default in Noble), clang-18 (default in Noble)
+#   - gfortran-13
+RUN apt-get install -y --no-install-recommends \
+    sudo                            \
+    build-essential                 \
+    g++-13                          \
+    gfortran-13                     \
+    clang-18                        \
+    libomp-dev                      \
+    cmake                           \
+    gfortran                        \
+    git                             \
+    intel-oneapi-compiler-dpcpp-cpp \
+    intel-oneapi-mkl-devel          \
+    libboost-dev                    \
+    libhdf5-dev                     \
+    libhdf5-openmpi-dev             \
+    libmetis-dev                    \
+    libopenmpi-dev                  \
+    libscotch-dev                   \
+    trilinos-all-dev                \
+    libsuitesparse-dev              \
+    libmedc-dev                     \
+    openmpi-bin                     \
+    python3-dev                     \
+    python3-h5py                    \
+    python3-pip                     \
+    python3-venv
+
+# Upgrade Pip using a virtual environment (PEP 668 enforced in Ubuntu 24.04)
+RUN python3 -m venv /opt/venv
+ENV PATH="/opt/venv/bin:$PATH"
+RUN pip install --break-system-packages --upgrade pip
+
+# Install Python packages
+RUN pip install --break-system-packages numpy scipy sympy parameterized
+
+# install MMG 5.5
+RUN git clone -b 'v5.5.1' --depth 1 https://github.com/MmgTools/mmg /tmp/mmg_5_5_1 && \
+    mkdir /tmp/mmg_5_5_1/build && \
+    mkdir -p /external_libraries/mmg/mmg_5_5_1 && \
+    cd /tmp/mmg_5_5_1/build && \
+    cmake .. \
+        -DCMAKE_RULE_MESSAGES=OFF \
+        -DCMAKE_C_FLAGS="-w" \
+        -DCMAKE_CXX_FLAGS="-w" \
+        -DCMAKE_INSTALL_PREFIX="/external_libraries/mmg/mmg_5_5_1" \
+        -DUSE_SCOTCH=OFF \
+        -DLIBMMG3D_SHARED=ON \
+        -DLIBMMG2D_SHARED=ON \
+        -DLIBMMGS_SHARED=ON \
+        -DLIBMMG_SHARED=ON && \
+    make -j2 install && \
+    cd /
+
+# install PARMMG
+RUN git clone https://github.com/MmgTools/ParMmg /tmp/ParMmg_5ffc6ad && \
+    mkdir /tmp/ParMmg_5ffc6ad/build && \
+    mkdir -p /external_libraries/ParMmg_5ffc6ad && \
+    cd /tmp/ParMmg_5ffc6ad && \
+    git checkout 5ffc6ada4afb1af50a43e1fa6f4c409cff2ea25c && \
+    cd build && \
+    cmake .. \
+        -DCMAKE_RULE_MESSAGES=OFF \
+        -DCMAKE_C_FLAGS="-w" \
+        -DCMAKE_CXX_FLAGS="-w" \
+        -DCMAKE_INSTALL_PREFIX="/external_libraries/ParMmg_5ffc6ad" \
+        -DUSE_SCOTCH=OFF \
+        -DLIBPARMMG_SHARED=ON \
+        -DDOWNLOAD_MMG=OFF \
+        -DMMG_DIR="/tmp/mmg_5_5_1" \
+        -DMMG_BUILDDIR="/tmp/mmg_5_5_1/build" \
+        -DDOWNLOAD_METIS=OFF \
+        -DMETIS_DIR="/usr/include" && \
+    make -j2 install && \
+    rm -r /tmp/mmg_5_5_1 && \
+    rm -r /tmp/ParMmg_5ffc6ad && \
+    cd /
+
+# Install Boost (from zip)
+RUN mkdir -p /workspace/boost && \
+    wget -P /workspace/boost https://archives.boost.io/release/1.87.0/source/boost_1_87_0.tar.gz && \
+    tar -C /workspace/boost -xzf /workspace/boost/boost_1_87_0.tar.gz && \
+    rm /workspace/boost/boost_1_87_0.tar.gz
+
+# Remove unnecessary packages
+RUN apt-get -y remove \
+        gnupg2 \
+        software-properties-common \
+        wget && \
+    apt-get -y autoremove && \
+    apt-get clean
+
+CMD [ "/bin/bash" ]
+
+WORKDIR $HOME


### PR DESCRIPTION
**📝 Description**

This PR adds the base Docker image or ubuntu:noble (24.04 LTS) to stay aligned with the latest Ubuntu LTS release, ensuring access to newer toolchains, security patches, and long-term support.

**🆕 Changelog**

- [🐳 Adding Docker script for Ubuntu 24.04 (Noble)](https://github.com/KratosMultiphysics/Kratos/commit/030e0d5b0a5c2348fd9450e7d2a0554a6ef64d5f)
