### PR TITLE
[OptApp] Add HDF5 output for OptimizationProblem

### DIFF
--- a/applications/OptimizationApplication/python_scripts/algorithms/algorithm_gradient_projection.py
+++ b/applications/OptimizationApplication/python_scripts/algorithms/algorithm_gradient_projection.py
@@ -237,7 +237,8 @@ class AlgorithmGradientProjection(Algorithm):
 
                 ListLogger("Convergence info", self._convergence_criteria.GetInfo())
 
-                self._optimization_problem.AdvanceStep()
+                if not self.converged:
+                    self._optimization_problem.AdvanceStep()
 
         return self.converged
 

--- a/applications/OptimizationApplication/python_scripts/algorithms/algorithm_relaxed_gradient_projection.py
+++ b/applications/OptimizationApplication/python_scripts/algorithms/algorithm_relaxed_gradient_projection.py
@@ -257,6 +257,7 @@ class AlgorithmRelaxedGradientProjection(AlgorithmGradientProjection):
 
                 ListLogger("Convergence info", self._convergence_criteria.GetInfo())
 
-                self._optimization_problem.AdvanceStep()
+                if not self.converged:
+                    self._optimization_problem.AdvanceStep()
 
         return self.converged

--- a/applications/OptimizationApplication/python_scripts/algorithms/algorithm_steepest_descent.py
+++ b/applications/OptimizationApplication/python_scripts/algorithms/algorithm_steepest_descent.py
@@ -154,7 +154,8 @@ class AlgorithmSteepestDescent(Algorithm):
 
                 ListLogger("Convergence info", self._convergence_criteria.GetInfo())
 
-                self._optimization_problem.AdvanceStep()
+                if not self.converged:
+                    self._optimization_problem.AdvanceStep()
 
         return self.converged
 

--- a/applications/OptimizationApplication/python_scripts/processes/optimization_problem_field_output_process.py
+++ b/applications/OptimizationApplication/python_scripts/processes/optimization_problem_field_output_process.py
@@ -1,0 +1,123 @@
+from typing import Union
+import abc
+
+import KratosMultiphysics as Kratos
+from KratosMultiphysics.OptimizationApplication.responses.response_function import ResponseFunction
+from KratosMultiphysics.OptimizationApplication.controls.control import Control
+from KratosMultiphysics.OptimizationApplication.execution_policies.execution_policy import ExecutionPolicy
+from KratosMultiphysics.OptimizationApplication.utilities.optimization_problem import OptimizationProblem
+from KratosMultiphysics.OptimizationApplication.utilities.component_data_view import ComponentDataView
+from KratosMultiphysics.OptimizationApplication.utilities.optimization_problem_utilities import GetAllComponentFullNamesWithData
+from KratosMultiphysics.OptimizationApplication.utilities.optimization_problem_utilities import GetComponentHavingDataByFullName
+from KratosMultiphysics.OptimizationApplication.utilities.optimization_problem_utilities import TensorAdaptorData
+from KratosMultiphysics.OptimizationApplication.utilities.optimization_problem_utilities import CombinedTensorAdaptorData
+
+class TensorAdaptorOutput(abc.ABC):
+    @abc.abstractmethod
+    def AddTensorAdaptorData(self, tensor_adaptor_data: TensorAdaptorData) -> bool:
+        pass
+
+    @abc.abstractmethod
+    def WriteOutput(self):
+        pass
+
+class OptimizationProblemFieldOutputProcess(Kratos.OutputProcess):
+    def __init__(self, model: Kratos.Model, parameters: Kratos.Parameters, optimization_problem: OptimizationProblem) -> None:
+        super().__init__()
+        parameters.ValidateAndAssignDefaults(self.GetDefaultParameters())
+
+        self.model = model
+        self.optimization_problem = optimization_problem
+        self.parameters = parameters
+
+        self.list_of_component_names = parameters["list_of_output_components"].GetStringArray()
+        self.echo_level = parameters["echo_level"].GetInt()
+        self.output_interval = parameters["output_interval"].GetInt()
+
+        self.list_of_tensor_adaptor_outputs: 'list[TensorAdaptorOutput]' = []
+        self.initialized_vtu_outputs = False
+        self.last_step_written = -1
+
+    def IsOutputStep(self) -> bool:
+        return self.optimization_problem.GetStep() % self.output_interval == 0
+
+    def PrintOutput(self) -> None:
+        if not self.initialized_vtu_outputs:
+            self.InitializeVtuOutputIO()
+            self.initialized_vtu_outputs = True
+
+        for tensor_adaptor_vtu_output in self.list_of_tensor_adaptor_outputs:
+            tensor_adaptor_vtu_output.WriteOutput()
+
+        self.last_step_written = self.optimization_problem.GetStep()
+
+    def ExecuteFinalize(self) -> None:
+        if self.last_step_written != self.optimization_problem.GetStep():
+            # force the last step be written if it is not already written by normal interval based writing.
+            self.PrintOutput()
+
+    def InitializeVtuOutputIO(self) -> None:
+        # get all the component names at the first writing point
+        if len(self.list_of_component_names) == 1 and self.list_of_component_names[0] == "all":
+            self.list_of_component_names = GetAllComponentFullNamesWithData(self.optimization_problem)
+
+        list_of_components: 'list[Union[str, ResponseFunction, Control, ExecutionPolicy]]' = []
+        for component_name in self.list_of_component_names:
+            list_of_components.append(GetComponentHavingDataByFullName(component_name, self.optimization_problem))
+
+        global_values_map = self.optimization_problem.GetProblemDataContainer().GetMap()
+        for global_k, global_v in global_values_map.items():
+             # first check whether this is part of requested list of components
+            found_valid_component = False
+            for component in list_of_components:
+                component_data = ComponentDataView(component, self.optimization_problem)
+                if global_k.startswith(component_data.GetDataPath()):
+                     found_valid_component = True
+                     break
+
+            # if a valid component is found, add the tensor adaptor
+            if found_valid_component:
+                if isinstance(global_v, Kratos.TensorAdaptors.DoubleCombinedTensorAdaptor):
+                    for i, _ in enumerate(global_v.GetTensorAdaptors()):
+                        self.__AddTensorAdaptor(CombinedTensorAdaptorData(global_k, global_v, i))
+                elif isinstance(global_v, Kratos.TensorAdaptors.DoubleTensorAdaptor) or  \
+                     isinstance(global_v, Kratos.TensorAdaptors.IntTensorAdaptor) or \
+                     isinstance(global_v, Kratos.TensorAdaptors.BoolTensorAdaptor):
+                    self.__AddTensorAdaptor(TensorAdaptorData(global_k, global_v))
+
+    def _GetModelPart(self, container) -> Kratos.ModelPart:
+        def get_model_part(container, model_part: Kratos.ModelPart):
+            if container in [model_part.Nodes, model_part.Conditions, model_part.Elements]:
+                return model_part
+
+            for sub_model_part_name in model_part.GetSubModelPartNames():
+                root_model_part = get_model_part(container, model_part.GetSubModelPart(sub_model_part_name))
+                if root_model_part is not None:
+                    return root_model_part
+
+            return None
+
+        for model_part_name in self.model.GetModelPartNames():
+            root_model_part = get_model_part(container, self.model[model_part_name])
+            if root_model_part is not None:
+                return root_model_part
+
+        raise RuntimeError(f"No model part contains the provided container.")
+
+    def __AddTensorAdaptor(self, tensor_adaptor_data: TensorAdaptorData) -> bool:
+        found_vtu_output = False
+        for tensor_adaptor_vtu_output in self.list_of_tensor_adaptor_outputs:
+            if tensor_adaptor_vtu_output.AddTensorAdaptorData(tensor_adaptor_data):
+                found_vtu_output = True
+                break
+
+        if not found_vtu_output:
+            tensor_adaptor_output = self._CreateTensorAdaptorOutput(tensor_adaptor_data)
+            tensor_adaptor_output.AddTensorAdaptorData(tensor_adaptor_data)
+            self.list_of_tensor_adaptor_outputs.append(tensor_adaptor_output)
+            if self.echo_level > 0:
+                Kratos.Logger.PrintInfo(self.__class__.__name__, f"Created tensor adaptor output {tensor_adaptor_output}.")
+
+    def _CreateTensorAdaptorOutput(self, _: TensorAdaptorData) -> TensorAdaptorOutput:
+        raise NotImplementedError("_CreateTensorAdaptorOutput needs to be implemented in the derived class")
+

--- a/applications/OptimizationApplication/python_scripts/processes/optimization_problem_hdf5_output_process.py
+++ b/applications/OptimizationApplication/python_scripts/processes/optimization_problem_hdf5_output_process.py
@@ -1,0 +1,81 @@
+import KratosMultiphysics as Kratos
+import KratosMultiphysics.HDF5Application as KratosHDF5
+from KratosMultiphysics.HDF5Application.core.file_io import OpenHDF5File
+from KratosMultiphysics.OptimizationApplication.utilities.optimization_problem import OptimizationProblem
+from KratosMultiphysics.OptimizationApplication.utilities.optimization_problem_utilities import TensorAdaptorData
+from KratosMultiphysics.OptimizationApplication.processes.optimization_problem_field_output_process import TensorAdaptorOutput, OptimizationProblemFieldOutputProcess
+
+def Factory(model: Kratos.Model, parameters: Kratos.Parameters, optimization_problem: OptimizationProblem) -> Kratos.OutputProcess:
+    if not parameters.Has("settings"):
+        raise RuntimeError(f"OptimizationProblemHDF5OutputProcess instantiation requires a \"settings\" in parameters [ parameters = {parameters}].")
+    return OptimizationProblemHDF5OutputProcess(model, parameters["settings"], optimization_problem)
+
+class TensorAdaptorHDF5Output(TensorAdaptorOutput):
+    def __init__(self, model_part: Kratos.ModelPart, parameters: Kratos.Parameters, optimization_problem: OptimizationProblem):
+
+        default_parameters = Kratos.Parameters("""{
+            "file_name"       : "PLEASE_SPECIFY_HDF5_FILENAME",
+            "file_access_mode": "exclusive",
+            "echo_level"      : 0
+        }""")
+
+        self.model_part = model_part
+        self.optimization_problem = optimization_problem
+        self.output_parameters = parameters["output_file_settings"]
+        self.output_path_prefix = parameters["hdf5_output_path_prefix"].GetString()
+        self.list_of_tensor_adaptor_data: 'list[TensorAdaptorData]' = []
+
+        self.output_parameters.ValidateAndAssignDefaults(default_parameters)
+        self.output_parameters["file_name"].SetString(self.output_parameters["file_name"].GetString().replace("<model_part_full_name>", self.model_part.FullName()))
+        self.output_parameters["file_name"].SetString(self.output_parameters["file_name"].GetString().replace("<model_part_name>", self.model_part.Name))
+        self.output_path_prefix = self.output_path_prefix.replace("<model_part_full_name>", self.model_part.FullName())
+        self.output_path_prefix = self.output_path_prefix.replace("<model_part_name>", self.model_part.Name)
+
+    def AddTensorAdaptorData(self, tensor_adaptor_data: TensorAdaptorData) -> bool:
+        if tensor_adaptor_data.GetContainer() in [self.model_part.Nodes, self.model_part.Conditions, self.model_part.Elements]:
+            self.list_of_tensor_adaptor_data.append(tensor_adaptor_data)
+            return True
+        return False
+
+    def WriteOutput(self):
+        current_output_parameters = self.output_parameters.Clone()
+        current_output_parameters["file_name"].SetString(current_output_parameters["file_name"].GetString().replace("<step>", str(self.optimization_problem.GetStep())))
+
+        tensor_io_settings = Kratos.Parameters("""{ "prefix": "" }""")
+        tensor_io_settings["prefix"].SetString(self.output_path_prefix.replace("<step>", str(self.optimization_problem.GetStep())))
+
+        with OpenHDF5File(current_output_parameters, self.model_part) as hdf5_file:
+            tensor_io = KratosHDF5.TensorAdaptorIO(tensor_io_settings, hdf5_file)
+            for tensor_adaptor_data in self.list_of_tensor_adaptor_data:
+                ta =  tensor_adaptor_data.GetTensorAdaptor(self.optimization_problem)
+                prefix = ""
+                if isinstance(ta.GetContainer(), Kratos.NodesArray):
+                    prefix = "Nodal"
+                elif isinstance(ta.GetContainer(), Kratos.ConditionsArray):
+                    prefix = "Conditions"
+                elif isinstance(ta.GetContainer(), Kratos.ElementsArray):
+                    prefix = "Elements"
+                else:
+                    raise RuntimeError(f"Unsupported container type used in the tensor adaptor [ tensor adaptor name  = {tensor_adaptor_data.GetTensorAdaptorName()}, tensor_adaptor = {ta} ].")
+                tensor_io.Write(f"{prefix}/{tensor_adaptor_data.GetTensorAdaptorName()}", ta)
+
+class OptimizationProblemHDF5OutputProcess(OptimizationProblemFieldOutputProcess):
+    def GetDefaultParameters(self):
+        return Kratos.Parameters(
+            """
+            {
+                "list_of_output_components": ["all"],
+                "hdf5_output_path_prefix"  : "Optimization_Results",
+                "output_interval"          : 1,
+                "echo_level"               : 0,
+                "output_file_settings"     : {
+                    "file_name"       : "PLEASE_SPECIFY_HDF5_FILENAME",
+                    "file_access_mode": "exclusive",
+                    "echo_level"      : 0
+                }
+            }
+            """
+        )
+
+    def _CreateTensorAdaptorOutput(self, tensor_adaptor_data: TensorAdaptorData) -> TensorAdaptorOutput:
+        return TensorAdaptorHDF5Output(self._GetModelPart(tensor_adaptor_data.GetContainer()), self.parameters.Clone(), self.optimization_problem)

--- a/applications/OptimizationApplication/python_scripts/processes/optimization_problem_hdf5_output_process.py
+++ b/applications/OptimizationApplication/python_scripts/processes/optimization_problem_hdf5_output_process.py
@@ -59,6 +59,9 @@ class TensorAdaptorHDF5Output(TensorAdaptorOutput):
                     raise RuntimeError(f"Unsupported container type used in the tensor adaptor [ tensor adaptor name  = {tensor_adaptor_data.GetTensorAdaptorName()}, tensor_adaptor = {ta} ].")
                 tensor_io.Write(f"{prefix}/{tensor_adaptor_data.GetTensorAdaptorName()}", ta)
 
+    def __str__(self) -> str:
+        return f"TensorAdaptorHDF5Output with \"{self.model_part.FullName()}\""
+
 class OptimizationProblemHDF5OutputProcess(OptimizationProblemFieldOutputProcess):
     def GetDefaultParameters(self):
         return Kratos.Parameters(

--- a/applications/OptimizationApplication/python_scripts/processes/optimization_problem_vtu_output_process.py
+++ b/applications/OptimizationApplication/python_scripts/processes/optimization_problem_vtu_output_process.py
@@ -1,72 +1,23 @@
-from typing import Any, Union
 from pathlib import Path
 
 import KratosMultiphysics as Kratos
 import KratosMultiphysics.kratos_utilities as kratos_utils
-from KratosMultiphysics.OptimizationApplication.responses.response_function import ResponseFunction
-from KratosMultiphysics.OptimizationApplication.controls.control import Control
-from KratosMultiphysics.OptimizationApplication.execution_policies.execution_policy import ExecutionPolicy
 from KratosMultiphysics.OptimizationApplication.utilities.optimization_problem import OptimizationProblem
-from KratosMultiphysics.OptimizationApplication.utilities.component_data_view import ComponentDataView
-from KratosMultiphysics.OptimizationApplication.utilities.optimization_problem_utilities import GetAllComponentFullNamesWithData
-from KratosMultiphysics.OptimizationApplication.utilities.optimization_problem_utilities import GetComponentHavingDataByFullName
+from KratosMultiphysics.OptimizationApplication.utilities.optimization_problem_utilities import TensorAdaptorData
+from KratosMultiphysics.OptimizationApplication.processes.optimization_problem_field_output_process import TensorAdaptorOutput, OptimizationProblemFieldOutputProcess
 
-def Factory(model: Kratos.Model, parameters: Kratos.Parameters, optimization_problem: OptimizationProblem) -> Any:
+def Factory(model: Kratos.Model, parameters: Kratos.Parameters, optimization_problem: OptimizationProblem) -> Kratos.OutputProcess:
     if not parameters.Has("settings"):
         raise RuntimeError(f"OptimizationProblemVtuOutputProcess instantiation requires a \"settings\" in parameters [ parameters = {parameters}].")
     return OptimizationProblemVtuOutputProcess(model, parameters["settings"], optimization_problem)
 
-class TensorAdaptorData:
-    def __init__(self, tensor_adaptor_path: str, tensor_adaptor: Kratos.TensorAdaptors.DoubleTensorAdaptor) -> None:
-        self.tensor_adaptor_path = tensor_adaptor_path
-        self.container = tensor_adaptor.GetContainer()
-
-    def GetTensorAdaptorName(self) -> str:
-        return self.tensor_adaptor_path[self.tensor_adaptor_path.rfind("/")+1:]
-
-    def GetTensorAdaptorPath(self) -> str:
-        return self.tensor_adaptor_path
-
-    def GetContainer(self):
-        return self.container
-
-    def GetTensorAdaptor(self, optimization_problem: OptimizationProblem) -> Kratos.TensorAdaptors.DoubleTensorAdaptor:
-        data = optimization_problem.GetProblemDataContainer()[self.tensor_adaptor_path]
-
-        if not isinstance(data, Kratos.TensorAdaptors.DoubleTensorAdaptor):
-            raise RuntimeError(f"The data type at \"{self.tensor_adaptor_path}\" changed from {Kratos.TensorAdaptors.DoubleTensorAdaptor.__name__} to {type(data).__class__.__name__}. Found data = {data}")
-        if not data.HasContainer():
-            raise RuntimeError(f"The data at \"{self.tensor_adaptor_path}\" does not represent a {Kratos.TensorAdaptors.DoubleTensorAdaptor.__name__} with a container. Found data = {data}")
-        if data.GetContainer() != self.container:
-            raise RuntimeError(f"The container at \"{self.tensor_adaptor_path}\" mismatch with the original container. Found data = {data}")
-
-        return data
-
-class CombinedTensorAdaptorData(TensorAdaptorData):
-    def __init__(self, combined_tensor_adaptor_path: str, combined_tensor_adaptor: Kratos.TensorAdaptors.DoubleCombinedTensorAdaptor, tensor_adaptor_index: int) -> None:
-        super().__init__(combined_tensor_adaptor_path, combined_tensor_adaptor.GetTensorAdaptors()[tensor_adaptor_index])
-        self.tensor_adaptor_index = tensor_adaptor_index
-
-    def GetTensorAdaptor(self, optimization_problem: OptimizationProblem) -> Kratos.TensorAdaptors.DoubleTensorAdaptor:
-        data = optimization_problem.GetProblemDataContainer()[self.tensor_adaptor_path]
-
-        if not isinstance(data, Kratos.TensorAdaptors.DoubleCombinedTensorAdaptor):
-            raise RuntimeError(f"The data type at \"{self.tensor_adaptor_path}\" changed from {Kratos.TensorAdaptors.DoubleCombinedTensorAdaptor.__name__} to {type(data).__class__.__name__}. Found data = {data}")
-        if not data.GetTensorAdaptors()[self.tensor_adaptor_index].HasContainer():
-            raise RuntimeError(f"The tensor adaptor at \"{self.tensor_adaptor_path}\" with index = {self.tensor_adaptor_index} does not represent a {Kratos.TensorAdaptors.DoubleTensorAdaptor.__name__} with a container. Found data = {data}")
-        if data.GetTensorAdaptors()[self.tensor_adaptor_index].GetContainer() != self.container:
-            raise RuntimeError(f"The container from tensor adaptor \"{self.tensor_adaptor_path}\" with index = {self.tensor_adaptor_index} mismatch with the original container. Found data = {data}")
-
-        return data.GetTensorAdaptors()[self.tensor_adaptor_index]
-
-class TensorAdaptorVtuOutput:
-    def __init__(self, parameters: 'dict[str, Any]', model_part: Kratos.ModelPart, optimization_problem: OptimizationProblem):
-        self.model_part = model_part
+class TensorAdaptorVtuOutput(TensorAdaptorOutput):
+    def __init__(self,  model_part: Kratos.ModelPart, parameters: Kratos.Parameters, optimization_problem: OptimizationProblem):
+        self.model_part = model_part.GetRootModelPart()
         self.optimization_problem = optimization_problem
-        self.output_file_name_prefix: str = parameters["output_file_name_prefix"]
 
-        if parameters["save_output_files_in_folder"]:
-            self.output_path = Path(parameters["output_path"])
+        if parameters["save_output_files_in_folder"].GetBool():
+            self.output_path = Path(parameters["output_path"].GetString())
             if not self.model_part.ProcessInfo[Kratos.IS_RESTARTED]:
                 kratos_utils.DeleteDirectoryIfExisting(str(self.output_path))
             self.model_part.GetCommunicator().GetDataCommunicator().Barrier()
@@ -75,7 +26,28 @@ class TensorAdaptorVtuOutput:
         else:
             self.output_path = Path(".")
 
-        self.vtu_output: Kratos.VtuOutput = Kratos.VtuOutput(model_part, parameters["is_initial_configuration"], parameters["writer_format"], parameters["precision"], output_sub_model_parts=True, echo_level=parameters["echo_level"], write_ids=parameters["write_ids"])
+        file_format = parameters["file_format"].GetString()
+        if file_format == "ascii":
+            self.writer_format = Kratos.VtuOutput.ASCII
+        elif file_format == "binary":
+            self.writer_format = Kratos.VtuOutput.BINARY
+        elif file_format == "raw":
+            self.writer_format = Kratos.VtuOutput.RAW
+        elif file_format == "compressed_raw":
+            self.writer_format = Kratos.VtuOutput.COMPRESSED_RAW
+        else:
+            raise RuntimeError(f"Only supports \"ascii\", \"binary\", \"raw\", and \"compressed_raw\" file_format. [ provided file_format = \"{file_format}\" ].")
+
+        self.output_file_name_prefix = parameters["file_name"].GetString()
+        self.vtu_output: Kratos.VtuOutput = Kratos.VtuOutput(
+                                                model_part,
+                                                not parameters["write_deformed_configuration"].GetBool(),
+                                                self.writer_format,
+                                                parameters["output_precision"].GetInt(),
+                                                output_sub_model_parts=True,
+                                                echo_level=parameters["echo_level"].GetInt(),
+                                                write_ids=parameters["write_ids"].GetBool())
+
         self.list_of_tensor_adaptor_data: 'list[TensorAdaptorData]' = []
 
     def AddTensorAdaptorData(self, tensor_adaptor_data: TensorAdaptorData) -> bool:
@@ -93,7 +65,7 @@ class TensorAdaptorVtuOutput:
         output_file_name = output_file_name.replace("<model_part_name>", self.model_part.Name)
         self.vtu_output.PrintOutput(str(self.output_path / output_file_name))
 
-class OptimizationProblemVtuOutputProcess(Kratos.OutputProcess):
+class OptimizationProblemVtuOutputProcess(OptimizationProblemFieldOutputProcess):
     def GetDefaultParameters(self):
         return Kratos.Parameters(
             """
@@ -112,115 +84,5 @@ class OptimizationProblemVtuOutputProcess(Kratos.OutputProcess):
             """
         )
 
-    def __init__(self, model: Kratos.Model, parameters: Kratos.Parameters, optimization_problem: OptimizationProblem) -> None:
-        super().__init__()
-
-        parameters.ValidateAndAssignDefaults(self.GetDefaultParameters())
-
-        self.model = model
-        self.optimization_problem = optimization_problem
-
-        self.echo_level = parameters["echo_level"].GetInt()
-        self.file_name = parameters["file_name"].GetString()
-        self.output_path = parameters["output_path"].GetString()
-        self.save_output_files_in_folder = parameters["save_output_files_in_folder"].GetBool()
-        self.output_precision = parameters["output_precision"].GetInt()
-        self.write_ids = parameters["write_ids"].GetBool()
-        file_format = parameters["file_format"].GetString()
-        if file_format == "ascii":
-            self.writer_format = Kratos.VtuOutput.ASCII
-        elif file_format == "binary":
-            self.writer_format = Kratos.VtuOutput.BINARY
-        elif file_format == "raw":
-            self.writer_format = Kratos.VtuOutput.RAW
-        elif file_format == "compressed_raw":
-            self.writer_format = Kratos.VtuOutput.COMPRESSED_RAW
-        else:
-            raise RuntimeError(f"Only supports \"ascii\", \"binary\", \"raw\", and \"compressed_raw\" file_format. [ provided file_format = \"{file_format}\" ].")
-
-        self.is_initial_configuration = not parameters["write_deformed_configuration"].GetBool()
-
-        self.list_of_component_names = parameters["list_of_output_components"].GetStringArray()
-        self.list_of_tensor_adaptor_vtu_outputs: 'list[TensorAdaptorVtuOutput]' = []
-        self.initialized_vtu_outputs = False
-
-    def PrintOutput(self) -> None:
-        if not self.initialized_vtu_outputs:
-            self.InitializeVtuOutputIO()
-            self.initialized_vtu_outputs = True
-
-        for tensor_adaptor_vtu_output in self.list_of_tensor_adaptor_vtu_outputs:
-            tensor_adaptor_vtu_output.WriteOutput()
-
-    def InitializeVtuOutputIO(self) -> None:
-        # get all the component names at the first writing point
-        if len(self.list_of_component_names) == 1 and self.list_of_component_names[0] == "all":
-            self.list_of_component_names = GetAllComponentFullNamesWithData(self.optimization_problem)
-
-        list_of_components: 'list[Union[str, ResponseFunction, Control, ExecutionPolicy]]' = []
-        for component_name in self.list_of_component_names:
-            list_of_components.append(GetComponentHavingDataByFullName(component_name, self.optimization_problem))
-
-        global_values_map = self.optimization_problem.GetProblemDataContainer().GetMap()
-        for global_k, global_v in global_values_map.items():
-             # first check whether this is part of requested list of components
-            found_valid_component = False
-            for component in list_of_components:
-                component_data = ComponentDataView(component, self.optimization_problem)
-                if global_k.startswith(component_data.GetDataPath()):
-                     found_valid_component = True
-                     break
-
-            # if a valid component is found, add the tensor adaptor
-            if found_valid_component:
-                if isinstance(global_v, Kratos.TensorAdaptors.DoubleCombinedTensorAdaptor):
-                    for i, _ in enumerate(global_v.GetTensorAdaptors()):
-                        self._AddContainerTensorAdaptor(CombinedTensorAdaptorData(global_k, global_v, i))
-                elif isinstance(global_v, Kratos.TensorAdaptors.DoubleTensorAdaptor) or  \
-                     isinstance(global_v, Kratos.TensorAdaptors.IntTensorAdaptor) or \
-                     isinstance(global_v, Kratos.TensorAdaptors.BoolTensorAdaptor):
-                    self._AddContainerTensorAdaptor(TensorAdaptorData(global_k, global_v))
-
-    def _AddContainerTensorAdaptor(self, tensor_adaptor_data: TensorAdaptorData):
-        found_vtu_output = False
-        for tensor_adaptor_vtu_output in self.list_of_tensor_adaptor_vtu_outputs:
-            if tensor_adaptor_vtu_output.AddTensorAdaptorData(tensor_adaptor_data):
-                found_vtu_output = True
-                break
-
-        if not found_vtu_output:
-            vtu_parameters = {
-                "output_file_name_prefix": self.file_name,
-                "is_initial_configuration": self.is_initial_configuration,
-                "writer_format": self.writer_format,
-                "precision": self.output_precision,
-                "save_output_files_in_folder": self.save_output_files_in_folder,
-                "output_path": self.output_path,
-                "echo_level": self.echo_level,
-                "write_ids": self.write_ids
-            }
-
-            tensor_adaptor_vtu_output = TensorAdaptorVtuOutput(vtu_parameters, self.__GetRootModelPart(tensor_adaptor_data.GetContainer()), self.optimization_problem)
-            tensor_adaptor_vtu_output.AddTensorAdaptorData(tensor_adaptor_data)
-            self.list_of_tensor_adaptor_vtu_outputs.append(tensor_adaptor_vtu_output)
-            if self.echo_level > 0:
-                Kratos.Logger.PrintInfo(self.__class__.__name__, f"Created tensor adaptor vtu output for {tensor_adaptor_vtu_output.vtu_output.GetModelPart().FullName()}.")
-
-    def __GetRootModelPart(self, container) -> Kratos.ModelPart:
-        def get_model_part(container, model_part: Kratos.ModelPart):
-            if container in [model_part.Nodes, model_part.Conditions, model_part.Elements]:
-                return model_part.GetRootModelPart()
-
-            for sub_model_part_name in model_part.GetSubModelPartNames():
-                root_model_part = get_model_part(container, model_part.GetSubModelPart(sub_model_part_name))
-                if root_model_part is not None:
-                    return root_model_part
-
-            return None
-
-        for model_part_name in self.model.GetModelPartNames():
-            root_model_part = get_model_part(container, self.model[model_part_name])
-            if root_model_part is not None:
-                return root_model_part
-
-        raise RuntimeError(f"No model part contains the provided container.")
+    def _CreateTensorAdaptorOutput(self, tensor_adaptor_data: TensorAdaptorData) -> TensorAdaptorOutput:
+        return TensorAdaptorVtuOutput(self._GetModelPart(tensor_adaptor_data.GetContainer()), self.parameters.Clone(), self.optimization_problem)

--- a/applications/OptimizationApplication/python_scripts/processes/optimization_problem_vtu_output_process.py
+++ b/applications/OptimizationApplication/python_scripts/processes/optimization_problem_vtu_output_process.py
@@ -65,6 +65,9 @@ class TensorAdaptorVtuOutput(TensorAdaptorOutput):
         output_file_name = output_file_name.replace("<model_part_name>", self.model_part.Name)
         self.vtu_output.PrintOutput(str(self.output_path / output_file_name))
 
+    def __str__(self) -> str:
+        return f"TensorAdaptorVtuOutput with \"{self.vtu_output.GetModelPart().FullName()}\""
+
 class OptimizationProblemVtuOutputProcess(OptimizationProblemFieldOutputProcess):
     def GetDefaultParameters(self):
         return Kratos.Parameters(

--- a/applications/OptimizationApplication/python_scripts/utilities/optimization_problem_utilities.py
+++ b/applications/OptimizationApplication/python_scripts/utilities/optimization_problem_utilities.py
@@ -1,11 +1,13 @@
-from pathlib import Path
 from importlib import import_module
-from typing import Any
+from typing import Any, Union
 
 import KratosMultiphysics as Kratos
 from KratosMultiphysics.OptimizationApplication.utilities.optimization_problem import OptimizationProblem
 from KratosMultiphysics.OptimizationApplication.responses.response_routine import ResponseRoutine
 from KratosMultiphysics.OptimizationApplication.utilities.component_data_view import ComponentDataView
+from KratosMultiphysics.OptimizationApplication.responses.response_function import ResponseFunction
+from KratosMultiphysics.OptimizationApplication.controls.control import Control
+from KratosMultiphysics.OptimizationApplication.execution_policies.execution_policy import ExecutionPolicy
 
 def OptimizationComponentFactory(model: Kratos.Model, parameters: Kratos.Parameters, optimization_problem: OptimizationProblem):
     if not parameters.Has("type"):
@@ -121,3 +123,115 @@ def OutputGradientFields(response: ResponseRoutine, optimization_problem: Optimi
         for control in response.GetMasterControl().GetListOfControls():
             variable_name = f"d{response.GetResponseName()}_d{control.GetName()}"
             unbuffered_data.SetValue(variable_name, control.GetEmptyField(), overwrite=True)
+
+class TensorAdaptorData:
+    def __init__(self, tensor_adaptor_path: str, tensor_adaptor: Kratos.TensorAdaptors.DoubleTensorAdaptor) -> None:
+        self.tensor_adaptor_path = tensor_adaptor_path
+        self.container = tensor_adaptor.GetContainer()
+
+    def GetTensorAdaptorName(self) -> str:
+        return self.tensor_adaptor_path[self.tensor_adaptor_path.rfind("/")+1:]
+
+    def GetTensorAdaptorPath(self) -> str:
+        return self.tensor_adaptor_path
+
+    def GetContainer(self):
+        return self.container
+
+    def GetTensorAdaptor(self, optimization_problem: OptimizationProblem) -> Kratos.TensorAdaptors.DoubleTensorAdaptor:
+        data = optimization_problem.GetProblemDataContainer()[self.tensor_adaptor_path]
+
+        if not isinstance(data, Kratos.TensorAdaptors.DoubleTensorAdaptor):
+            raise RuntimeError(f"The data type at \"{self.tensor_adaptor_path}\" changed from {Kratos.TensorAdaptors.DoubleTensorAdaptor.__name__} to {type(data).__class__.__name__}. Found data = {data}")
+        if not data.HasContainer():
+            raise RuntimeError(f"The data at \"{self.tensor_adaptor_path}\" does not represent a {Kratos.TensorAdaptors.DoubleTensorAdaptor.__name__} with a container. Found data = {data}")
+        if data.GetContainer() != self.container:
+            raise RuntimeError(f"The container at \"{self.tensor_adaptor_path}\" mismatch with the original container. Found data = {data}")
+
+        return data
+
+class CombinedTensorAdaptorData(TensorAdaptorData):
+    def __init__(self, combined_tensor_adaptor_path: str, combined_tensor_adaptor: Kratos.TensorAdaptors.DoubleCombinedTensorAdaptor, tensor_adaptor_index: int) -> None:
+        super().__init__(combined_tensor_adaptor_path, combined_tensor_adaptor.GetTensorAdaptors()[tensor_adaptor_index])
+        self.tensor_adaptor_index = tensor_adaptor_index
+
+    def GetTensorAdaptor(self, optimization_problem: OptimizationProblem) -> Kratos.TensorAdaptors.DoubleTensorAdaptor:
+        data = optimization_problem.GetProblemDataContainer()[self.tensor_adaptor_path]
+
+        if not isinstance(data, Kratos.TensorAdaptors.DoubleCombinedTensorAdaptor):
+            raise RuntimeError(f"The data type at \"{self.tensor_adaptor_path}\" changed from {Kratos.TensorAdaptors.DoubleCombinedTensorAdaptor.__name__} to {type(data).__class__.__name__}. Found data = {data}")
+        if not data.GetTensorAdaptors()[self.tensor_adaptor_index].HasContainer():
+            raise RuntimeError(f"The tensor adaptor at \"{self.tensor_adaptor_path}\" with index = {self.tensor_adaptor_index} does not represent a {Kratos.TensorAdaptors.DoubleTensorAdaptor.__name__} with a container. Found data = {data}")
+        if data.GetTensorAdaptors()[self.tensor_adaptor_index].GetContainer() != self.container:
+            raise RuntimeError(f"The container from tensor adaptor \"{self.tensor_adaptor_path}\" with index = {self.tensor_adaptor_index} mismatch with the original container. Found data = {data}")
+
+        return data.GetTensorAdaptors()[self.tensor_adaptor_index]
+
+class TensorAdaptorDataManager:
+    def __init__(self, optimization_problem: OptimizationProblem):
+        self.optimization_problem = optimization_problem
+        self.list_of_component_names = ["all"]
+        self.list_of_tensor_adaptor_hdf5_outputs = []
+        self.create_method = None
+
+    def InitializeHDF5Output(self) -> None:
+        # get all the component names at the first writing point
+        if len(self.list_of_component_names) == 1 and self.list_of_component_names[0] == "all":
+            self.list_of_component_names = GetAllComponentFullNamesWithData(self.optimization_problem)
+
+        list_of_components: 'list[Union[str, ResponseFunction, Control, ExecutionPolicy]]' = []
+        for component_name in self.list_of_component_names:
+            list_of_components.append(GetComponentHavingDataByFullName(component_name, self.optimization_problem))
+
+        global_values_map = self.optimization_problem.GetProblemDataContainer().GetMap()
+        for global_k, global_v in global_values_map.items():
+             # first check whether this is part of requested list of components
+            found_valid_component = False
+            for component in list_of_components:
+                component_data = ComponentDataView(component, self.optimization_problem)
+                if global_k.startswith(component_data.GetDataPath()):
+                     found_valid_component = True
+                     break
+
+            # if a valid component is found, add the tensor adaptor
+            if found_valid_component:
+                if isinstance(global_v, Kratos.TensorAdaptors.DoubleCombinedTensorAdaptor):
+                    for i, _ in enumerate(global_v.GetTensorAdaptors()):
+                        self._AddContainerTensorAdaptor(CombinedTensorAdaptorData(global_k, global_v, i))
+                elif isinstance(global_v, Kratos.TensorAdaptors.DoubleTensorAdaptor) or  \
+                     isinstance(global_v, Kratos.TensorAdaptors.IntTensorAdaptor) or \
+                     isinstance(global_v, Kratos.TensorAdaptors.BoolTensorAdaptor):
+                    self._AddContainerTensorAdaptor(TensorAdaptorData(global_k, global_v))
+
+    def _AddContainerTensorAdaptor(self, tensor_adaptor_data: TensorAdaptorData):
+        found_vtu_output = False
+        for tensor_adaptor_hdf5_output in self.list_of_tensor_adaptor_hdf5_outputs:
+            if tensor_adaptor_hdf5_output.AddTensorAdaptorData(tensor_adaptor_data):
+                found_vtu_output = True
+                break
+
+        if not found_vtu_output:
+            tensor_adaptor_hdf5_output = self.create_method(self.__GetRootModelPart(tensor_adaptor_data.GetContainer()), self.optimization_problem)
+            tensor_adaptor_hdf5_output.AddTensorAdaptorData(tensor_adaptor_data)
+            self.list_of_tensor_adaptor_hdf5_outputs.append(tensor_adaptor_hdf5_output)
+            if self.echo_level > 0:
+                Kratos.Logger.PrintInfo(self.__class__.__name__, f"Created tensor adaptor hdf5 output for {tensor_adaptor_hdf5_output.model_part.FullName()}.")
+
+    def __GetRootModelPart(self, container) -> Kratos.ModelPart:
+        def get_model_part(container, model_part: Kratos.ModelPart):
+            if container in [model_part.Nodes, model_part.Conditions, model_part.Elements]:
+                return model_part.GetRootModelPart()
+
+            for sub_model_part_name in model_part.GetSubModelPartNames():
+                root_model_part = get_model_part(container, model_part.GetSubModelPart(sub_model_part_name))
+                if root_model_part is not None:
+                    return root_model_part
+
+            return None
+
+        for model_part_name in self.model.GetModelPartNames():
+            root_model_part = get_model_part(container, self.model[model_part_name])
+            if root_model_part is not None:
+                return root_model_part
+
+        raise RuntimeError(f"No model part contains the provided container.")

--- a/applications/OptimizationApplication/tests/process_tests/test_optimization_problem_field_output_process.py
+++ b/applications/OptimizationApplication/tests/process_tests/test_optimization_problem_field_output_process.py
@@ -8,6 +8,7 @@ from KratosMultiphysics.OptimizationApplication.responses.response_function impo
 from KratosMultiphysics.OptimizationApplication.controls.control import Control
 from KratosMultiphysics.OptimizationApplication.execution_policies.execution_policy import ExecutionPolicy
 from KratosMultiphysics.OptimizationApplication.processes.optimization_problem_vtu_output_process import OptimizationProblemVtuOutputProcess
+from KratosMultiphysics.OptimizationApplication.processes.optimization_problem_hdf5_output_process import OptimizationProblemHDF5OutputProcess
 from KratosMultiphysics.OptimizationApplication.utilities.component_data_view import ComponentDataView
 from KratosMultiphysics.OptimizationApplication.utilities.buffered_dict import BufferedDict
 from KratosMultiphysics.OptimizationApplication.utilities.optimization_problem import OptimizationProblem
@@ -15,7 +16,7 @@ from KratosMultiphysics.OptimizationApplication.utilities.union_utilities import
 from KratosMultiphysics.compare_two_files_check_process import CompareTwoFilesCheckProcess
 
 
-class TestOptimizationProblemVtuOutputProcess(kratos_unittest.TestCase):
+class TestOptimizationProblemFieldOutputProcess(kratos_unittest.TestCase):
     class DummyResponseFunction(ResponseFunction):
         def __init__(self, response_name: str, model_part: Kratos.ModelPart) -> None:
             super().__init__(response_name)
@@ -101,22 +102,23 @@ class TestOptimizationProblemVtuOutputProcess(kratos_unittest.TestCase):
         for element in cls.model_part2.Elements:
             element.SetValue(Kratos.ACCELERATION, Kratos.Array3([element.Id + 1, element.Id + 2, element.Id + 3]))
 
-        cls.optimization_problem = OptimizationProblem()
-        cls.components_list = []
+    def setUp(self):
+        self.optimization_problem = OptimizationProblem()
+        self.components_list = []
 
-        cls.components_list.append(TestOptimizationProblemVtuOutputProcess.DummyResponseFunction("resp_1", cls.model_part1))
-        cls.components_list.append(TestOptimizationProblemVtuOutputProcess.DummyResponseFunction("resp_2", cls.model_part2))
-        cls.components_list.append(TestOptimizationProblemVtuOutputProcess.DummyResponseFunction("resp_3", cls.model_part1))
-        cls.components_list.append(TestOptimizationProblemVtuOutputProcess.DummyControl("control_1", cls.model_part1))
-        cls.components_list.append(TestOptimizationProblemVtuOutputProcess.DummyControl("control_2", cls.model_part2))
-        cls.components_list.append(TestOptimizationProblemVtuOutputProcess.DummyControl("control_3", cls.model_part1))
-        cls.components_list.append(TestOptimizationProblemVtuOutputProcess.DummyExecutionPolicy("policy_1", cls.model_part1))
-        cls.components_list.append(TestOptimizationProblemVtuOutputProcess.DummyExecutionPolicy("policy_2", cls.model_part2))
-        cls.components_list.append(TestOptimizationProblemVtuOutputProcess.DummyExecutionPolicy("policy_3", cls.model_part1))
+        self.components_list.append(TestOptimizationProblemFieldOutputProcess.DummyResponseFunction("resp_1", self.model_part1))
+        self.components_list.append(TestOptimizationProblemFieldOutputProcess.DummyResponseFunction("resp_2", self.model_part2))
+        self.components_list.append(TestOptimizationProblemFieldOutputProcess.DummyResponseFunction("resp_3", self.model_part1))
+        self.components_list.append(TestOptimizationProblemFieldOutputProcess.DummyControl("control_1", self.model_part1))
+        self.components_list.append(TestOptimizationProblemFieldOutputProcess.DummyControl("control_2", self.model_part2))
+        self.components_list.append(TestOptimizationProblemFieldOutputProcess.DummyControl("control_3", self.model_part1))
+        self.components_list.append(TestOptimizationProblemFieldOutputProcess.DummyExecutionPolicy("policy_1", self.model_part1))
+        self.components_list.append(TestOptimizationProblemFieldOutputProcess.DummyExecutionPolicy("policy_2", self.model_part2))
+        self.components_list.append(TestOptimizationProblemFieldOutputProcess.DummyExecutionPolicy("policy_3", self.model_part1))
 
-        for component in cls.components_list:
-            cls.optimization_problem.AddComponent(component)
-            ComponentDataView(component, cls.optimization_problem).SetDataBuffer(2)
+        for component in self.components_list:
+            self.optimization_problem.AddComponent(component)
+            ComponentDataView(component, self.optimization_problem).SetDataBuffer(2)
 
     def __AddData(self, buffered_dict: BufferedDict, is_buffered_data: bool, component):
         step_v = self.optimization_problem.GetStep() + 1
@@ -142,6 +144,7 @@ class TestOptimizationProblemVtuOutputProcess(kratos_unittest.TestCase):
         Kratos.TensorAdaptors.DoubleCombinedTensorAdaptor(combined_data, perform_store_data_recursively=False, copy=False).StoreData()
         buffered_dict[f"{component.GetName()}_combined_element_{is_buffered_data}"] = combined_data
 
+    @kratos_unittest.skipIfApplicationsNotAvailable("HDF5Application")
     def test_OptimizationProblemVtuOutputProcess(self):
         parameters = Kratos.Parameters(
             """
@@ -166,13 +169,15 @@ class TestOptimizationProblemVtuOutputProcess(kratos_unittest.TestCase):
 
         with kratos_unittest.WorkFolderScope(".", __file__):
             number_of_steps = 10
-            for _ in range(number_of_steps):
+            for i in range(number_of_steps):
                 # initialize the buffered data
                 for component in self.components_list:
                     self.__AddData(ComponentDataView(component, self.optimization_problem).GetBufferedData(), True, component)
 
                 process.PrintOutput()
-                self.optimization_problem.AdvanceStep()
+
+                if i != number_of_steps - 1:
+                    self.optimization_problem.AdvanceStep()
 
             process.ExecuteFinalize()
 
@@ -191,6 +196,62 @@ class TestOptimizationProblemVtuOutputProcess(kratos_unittest.TestCase):
                 "remove_output_file"    : true,
                 "comparison_type"       : "vtu"
             }""")).Execute()
+
+    def test_OptimizationProblemHDF5OutputProcess(self):
+        parameters = Kratos.Parameters(
+            """
+            {
+                "list_of_output_components": ["all"],
+                "hdf5_output_path_prefix"  : "/Optimization_Results/<step>/",
+                "output_interval"          : 1,
+                "echo_level"               : 0,
+                "output_file_settings"     : {
+                    "file_name"       : "Optimization_Results/output.h5",
+                    "file_access_mode": "read_write",
+                    "echo_level"      : 0
+                }
+            }
+            """
+        )
+
+        process = OptimizationProblemHDF5OutputProcess(self.model, parameters, self.optimization_problem)
+        process.ExecuteInitialize()
+
+        # initialize unbuffered data
+        for component in self.components_list:
+            self.__AddData(ComponentDataView(component, self.optimization_problem).GetUnBufferedData(), False, component)
+
+        with kratos_unittest.WorkFolderScope(".", __file__):
+            number_of_steps = 10
+            for i in range(number_of_steps):
+                # initialize the buffered data
+                for component in self.components_list:
+                    self.__AddData(ComponentDataView(component, self.optimization_problem).GetBufferedData(), True, component)
+
+                process.PrintOutput()
+
+                if i != number_of_steps - 1:
+                    self.optimization_problem.AdvanceStep()
+
+            process.ExecuteFinalize()
+
+            # now checking the hdf5 output
+            from KratosMultiphysics.HDF5Application.core.file_io import OpenHDF5File
+            for i in range(number_of_steps):
+                h5_parameters = Kratos.Parameters("""{
+                    "file_name"       : "Optimization_Results/output.h5",
+                    "file_access_mode": "read_only"
+                }""")
+                with OpenHDF5File(h5_parameters, self.model_part1) as h5_file:
+                    for i in range(number_of_steps):
+                        for j in range(3):
+                            for k in range(2):
+                                if k % 2 == 0:
+                                    k_text = "True"
+                                else:
+                                    k_text = "False"
+                                self.assertTrue(h5_file.IsDataSet(f"/Optimization_Results/{i}/Elements/control_{j + 1}_combined_element_{k_text}"))
+                                self.assertTrue(h5_file.IsDataSet(f"/Optimization_Results/{i}/Nodal/control_{j + 1}_combined_element_{k_text}"))
 
     @classmethod
     def tearDownClass(cls):

--- a/applications/OptimizationApplication/tests/process_tests/test_optimization_problem_field_output_process.py
+++ b/applications/OptimizationApplication/tests/process_tests/test_optimization_problem_field_output_process.py
@@ -8,7 +8,6 @@ from KratosMultiphysics.OptimizationApplication.responses.response_function impo
 from KratosMultiphysics.OptimizationApplication.controls.control import Control
 from KratosMultiphysics.OptimizationApplication.execution_policies.execution_policy import ExecutionPolicy
 from KratosMultiphysics.OptimizationApplication.processes.optimization_problem_vtu_output_process import OptimizationProblemVtuOutputProcess
-from KratosMultiphysics.OptimizationApplication.processes.optimization_problem_hdf5_output_process import OptimizationProblemHDF5OutputProcess
 from KratosMultiphysics.OptimizationApplication.utilities.component_data_view import ComponentDataView
 from KratosMultiphysics.OptimizationApplication.utilities.buffered_dict import BufferedDict
 from KratosMultiphysics.OptimizationApplication.utilities.optimization_problem import OptimizationProblem
@@ -144,7 +143,6 @@ class TestOptimizationProblemFieldOutputProcess(kratos_unittest.TestCase):
         Kratos.TensorAdaptors.DoubleCombinedTensorAdaptor(combined_data, perform_store_data_recursively=False, copy=False).StoreData()
         buffered_dict[f"{component.GetName()}_combined_element_{is_buffered_data}"] = combined_data
 
-    @kratos_unittest.skipIfApplicationsNotAvailable("HDF5Application")
     def test_OptimizationProblemVtuOutputProcess(self):
         parameters = Kratos.Parameters(
             """
@@ -197,7 +195,9 @@ class TestOptimizationProblemFieldOutputProcess(kratos_unittest.TestCase):
                 "comparison_type"       : "vtu"
             }""")).Execute()
 
+    @kratos_unittest.skipIfApplicationsNotAvailable("HDF5Application")
     def test_OptimizationProblemHDF5OutputProcess(self):
+        from KratosMultiphysics.OptimizationApplication.processes.optimization_problem_hdf5_output_process import OptimizationProblemHDF5OutputProcess
         parameters = Kratos.Parameters(
             """
             {

--- a/applications/OptimizationApplication/tests/test_OptimizationApplication.py
+++ b/applications/OptimizationApplication/tests/test_OptimizationApplication.py
@@ -42,7 +42,7 @@ import control.material.test_simp_control
 import filtering.implicit_filters_tests
 import filtering.explicit_filters_tests
 import test_component_data_view
-import process_tests.test_optimization_problem_vtu_output_process
+import process_tests.test_optimization_problem_field_output_process
 import process_tests.test_optimization_problem_ascii_output_process
 import process_tests.test_optimization_problem_graph_output_process
 import algorithm_tests.test_convergence
@@ -117,7 +117,7 @@ def AssembleTestSuites():
     smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([filtering.implicit_filters_tests.HelmholtzAnalysisTest]))
     smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([filtering.explicit_filters_tests.TestExplicitFilterConsistency]))
     smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([filtering.explicit_filters_tests.TestExplicitFilterReference]))
-    smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([process_tests.test_optimization_problem_vtu_output_process.TestOptimizationProblemVtuOutputProcess]))
+    smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([process_tests.test_optimization_problem_field_output_process.TestOptimizationProblemFieldOutputProcess]))
     smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([process_tests.test_optimization_problem_ascii_output_process.TestOptimizationProblemAsciiOutputProcess]))
     smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([process_tests.test_optimization_problem_graph_output_process.TestOptimizationProblemGraphOutputProcess]))
 


### PR DESCRIPTION
**📝 Description**
This PR adds the possibility of outputting the results of `OptimizationProblem` to HDF5. 
 - This PR also removes all the algorithms making an additional step advance at the convergence. Up until now, all the algorihms advance one step further even the algorithm `is_converged` state is true. This PR removes it.
 - Now correctly uses the `interval` for outputting data.
 - Now all the vtu and hdf5 outputs will be written at the convergence no matter the convergence step is one of the interval step or not.

**🆕 Changelog**
- Refactor `OptimizationProblemVtuOutputProcess`
- Introduce `OptimizationProblemHDF5OutputProcess`
- Refactor unit tests
- Introduce unit tests
- Remove additinal step marching of `OptimizationProblem` at the convergence.
- Always write the converged step results in vtu and/or hdf5 irrespective of the specified `interval`.
