### PR TITLE
[HDF5] Add runtime hdf5 lib installation at the libs folder

### DIFF
--- a/applications/HDF5Application/CMakeLists.txt
+++ b/applications/HDF5Application/CMakeLists.txt
@@ -144,6 +144,7 @@ file(TO_CMAKE_PATH "${HDF5_ROOT}/bin" HDF5_ROOT_DEP_BIN)
 # Install targets
 install(TARGETS KratosHDF5Core DESTINATION libs)
 install(TARGETS KratosHDF5Application DESTINATION libs)
+install(IMPORTED_RUNTIME_ARTIFACTS ${HDF5_C_LIBRARIES} RUNTIME DESTINATION libs)
 
 # Install dependent libraries
 # Note: Please be carefull to enable this option if MED or HDF5 are system wide dependencies as it will


### PR DESCRIPTION
**📝 Description**
This PR installs the dynamic library which was used at the linking time as well in the Kratos install directory. The stub generation of the HDF5 application in Windows was failing due to the fact that `hdf5.dll` could not be located. This PR fixes it.

The `IMPORTED_RUNTIME_ARTIFACTS ` is a cmake 3.21 feature. This PR is also meant to check if the CI passes with cmake 3.21.

```cmake
install(IMPORTED_RUNTIME_ARTIFACTS ${HDF5_C_LIBRARIES} RUNTIME DESTINATION libs)
```

**🆕 Changelog**
- Now linking hdf5 libs are automatically installed in the kratos install dir.
