### PR TITLE
[GeoMechanicsApplication] Improve self reference check in the neighbour finder

### DIFF
--- a/applications/GeoMechanicsApplication/custom_utilities/neighbouring_element_finder.cpp
+++ b/applications/GeoMechanicsApplication/custom_utilities/neighbouring_element_finder.cpp
@@ -14,18 +14,6 @@
 #include "geometry_utilities.h"
 #include <algorithm>
 
-namespace
-{
-using namespace Kratos;
-
-bool IsSameEntity(const GeometricalObject& rFirstEntity, const GeometricalObject& rSecondEntity)
-{
-    return GeometricalObject::HasSameType(rFirstEntity, rSecondEntity) &&
-           rFirstEntity.Id() == rSecondEntity.Id();
-}
-
-} // namespace
-
 namespace Kratos
 {
 
@@ -94,7 +82,7 @@ void NeighbouringElementFinder::SetElementAsNeighbourOfAllEntitiesWithIdenticalN
     for (auto it = start; it != end; ++it) {
         const auto& r_entities = it->second;
         for (auto& rp_entity : r_entities) {
-            if (IsSameEntity(*pElement, *rp_entity)) continue;
+            if (pElement == rp_entity.get()) continue;
             rp_entity->GetValue(NEIGHBOUR_ELEMENTS).push_back(Element::WeakPointer{pElement});
         }
     }

--- a/applications/GeoMechanicsApplication/custom_utilities/neighbouring_element_finder.cpp
+++ b/applications/GeoMechanicsApplication/custom_utilities/neighbouring_element_finder.cpp
@@ -14,6 +14,18 @@
 #include "geometry_utilities.h"
 #include <algorithm>
 
+namespace
+{
+using namespace Kratos;
+
+bool isSameEntity(const GeometricalObject& rFirstEntity, const GeometricalObject& rSecondEntity)
+{
+    return GeometricalObject::HasSameType(rFirstEntity, rSecondEntity) &&
+           rFirstEntity.Id() == rSecondEntity.Id();
+}
+
+} // namespace
+
 namespace Kratos
 {
 
@@ -82,9 +94,7 @@ void NeighbouringElementFinder::SetElementAsNeighbourOfAllEntitiesWithIdenticalN
     for (auto it = start; it != end; ++it) {
         const auto& r_entities = it->second;
         for (auto& rp_entity : r_entities) {
-            if (GeometricalObject::HasSameType(*rp_entity, *pElement) && rp_entity->Id() == pElement->Id()) {
-                continue; // An entity should not be a neighbour of itself
-            }
+            if (isSameEntity(*pElement, *rp_entity)) continue;
             rp_entity->GetValue(NEIGHBOUR_ELEMENTS).push_back(Element::WeakPointer{pElement});
         }
     }

--- a/applications/GeoMechanicsApplication/custom_utilities/neighbouring_element_finder.cpp
+++ b/applications/GeoMechanicsApplication/custom_utilities/neighbouring_element_finder.cpp
@@ -18,7 +18,7 @@ namespace
 {
 using namespace Kratos;
 
-bool isSameEntity(const GeometricalObject& rFirstEntity, const GeometricalObject& rSecondEntity)
+bool IsSameEntity(const GeometricalObject& rFirstEntity, const GeometricalObject& rSecondEntity)
 {
     return GeometricalObject::HasSameType(rFirstEntity, rSecondEntity) &&
            rFirstEntity.Id() == rSecondEntity.Id();
@@ -94,7 +94,7 @@ void NeighbouringElementFinder::SetElementAsNeighbourOfAllEntitiesWithIdenticalN
     for (auto it = start; it != end; ++it) {
         const auto& r_entities = it->second;
         for (auto& rp_entity : r_entities) {
-            if (isSameEntity(*pElement, *rp_entity)) continue;
+            if (IsSameEntity(*pElement, *rp_entity)) continue;
             rp_entity->GetValue(NEIGHBOUR_ELEMENTS).push_back(Element::WeakPointer{pElement});
         }
     }

--- a/applications/GeoMechanicsApplication/custom_utilities/neighbouring_element_finder.cpp
+++ b/applications/GeoMechanicsApplication/custom_utilities/neighbouring_element_finder.cpp
@@ -82,7 +82,9 @@ void NeighbouringElementFinder::SetElementAsNeighbourOfAllEntitiesWithIdenticalN
     for (auto it = start; it != end; ++it) {
         const auto& r_entities = it->second;
         for (auto& rp_entity : r_entities) {
-            if (rp_entity->GetGeometry().Id() == pElement->GetGeometry().Id()) continue;
+            if (GeometricalObject::HasSameType(*rp_entity, *pElement) && rp_entity->Id() == pElement->Id()) {
+                continue; // An entity should not be a neighbour of itself
+            }
             rp_entity->GetValue(NEIGHBOUR_ELEMENTS).push_back(Element::WeakPointer{pElement});
         }
     }

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_utilities/test_neighbouring_element_finder.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_utilities/test_neighbouring_element_finder.cpp
@@ -248,4 +248,30 @@ KRATOS_TEST_CASE_IN_SUITE(NeighbouringElementFinder_FindsNeighboursBetweenQuadra
     EXPECT_EQ(p_interface_element->GetValue(NEIGHBOUR_ELEMENTS)[0].GetId(), 1);
 }
 
+KRATOS_TEST_CASE_IN_SUITE(NeighbouringElementFinder_FindsNeighbourElementOfConditionWithTheSameGeometry,
+                          KratosGeoMechanicsFastSuiteWithoutKernel)
+{
+    Model model;
+
+    auto& r_model_part_for_entities_for_finding = model.CreateModelPart("main");
+    auto  nodes                                 = Testing::ModelSetupUtilities::CreateNodes(
+        r_model_part_for_entities_for_finding, {{1, {0.0, 0.0, 0.0}}, {2, {1.0, 0.0, 0.0}}});
+    auto r_node_definitions = ElementSetupUtilities::CreatePointsFor2D2NElement();
+    auto geometry           = Kratos::make_shared<Line2D2<Node>>(nodes);
+
+    auto p_element   = Kratos::make_intrusive<Element>(1, geometry);
+    auto p_condition = Kratos::make_intrusive<Condition>(1, geometry);
+
+    r_model_part_for_entities_for_finding.AddCondition(p_condition);
+    r_model_part_for_entities_for_finding.AddElement(p_element);
+
+    NeighbouringElementFinder::BoundaryGeneratorByLocalDim boundary_generators;
+    boundary_generators[std::size_t{1}] = std::make_unique<EdgesGenerator>();
+    NeighbouringElementFinder finder;
+    finder.FindEntityNeighbours(r_model_part_for_entities_for_finding.Conditions(),
+                                r_model_part_for_entities_for_finding.Elements(), boundary_generators);
+
+    EXPECT_EQ(r_model_part_for_entities_for_finding.GetCondition(1).GetValue(NEIGHBOUR_ELEMENTS).size(), 1);
+}
+
 } // namespace Kratos::Testing

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_utilities/test_neighbouring_element_finder.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_utilities/test_neighbouring_element_finder.cpp
@@ -251,27 +251,25 @@ KRATOS_TEST_CASE_IN_SUITE(NeighbouringElementFinder_FindsNeighboursBetweenQuadra
 KRATOS_TEST_CASE_IN_SUITE(NeighbouringElementFinder_FindsNeighbourElementOfConditionWithTheSameGeometry,
                           KratosGeoMechanicsFastSuiteWithoutKernel)
 {
+    // Arrange
     Model model;
+    auto& r_model_part = model.CreateModelPart("main");
+    auto  nodes        = Testing::ModelSetupUtilities::CreateNodes(
+        r_model_part, {{1, {0.0, 0.0, 0.0}}, {2, {1.0, 0.0, 0.0}}});
+    auto geometry = Kratos::make_shared<Line2D2<Node>>(nodes);
 
-    auto& r_model_part_for_entities_for_finding = model.CreateModelPart("main");
-    auto  nodes                                 = Testing::ModelSetupUtilities::CreateNodes(
-        r_model_part_for_entities_for_finding, {{1, {0.0, 0.0, 0.0}}, {2, {1.0, 0.0, 0.0}}});
-    auto r_node_definitions = ElementSetupUtilities::CreatePointsFor2D2NElement();
-    auto geometry           = Kratos::make_shared<Line2D2<Node>>(nodes);
-
-    auto p_element   = Kratos::make_intrusive<Element>(1, geometry);
-    auto p_condition = Kratos::make_intrusive<Condition>(1, geometry);
-
-    r_model_part_for_entities_for_finding.AddCondition(p_condition);
-    r_model_part_for_entities_for_finding.AddElement(p_element);
+    r_model_part.AddElement(Kratos::make_intrusive<Element>(1, geometry));
+    r_model_part.AddCondition(Kratos::make_intrusive<Condition>(1, geometry));
 
     NeighbouringElementFinder::BoundaryGeneratorByLocalDim boundary_generators;
     boundary_generators[std::size_t{1}] = std::make_unique<EdgesGenerator>();
     NeighbouringElementFinder finder;
-    finder.FindEntityNeighbours(r_model_part_for_entities_for_finding.Conditions(),
-                                r_model_part_for_entities_for_finding.Elements(), boundary_generators);
 
-    EXPECT_EQ(r_model_part_for_entities_for_finding.GetCondition(1).GetValue(NEIGHBOUR_ELEMENTS).size(), 1);
+    // Act
+    finder.FindEntityNeighbours(r_model_part.Conditions(), r_model_part.Elements(), boundary_generators);
+
+    // Assert
+    EXPECT_EQ(r_model_part.GetCondition(1).GetValue(NEIGHBOUR_ELEMENTS).size(), 1);
 }
 
 } // namespace Kratos::Testing


### PR DESCRIPTION
**📝 Description**
An issue was found where if an element and condition have the same geometry, they are not flagged as neighbours. The check is improved now to avoid this issue.