### PR TITLE
Memory safe SBMworkflow

### DIFF
--- a/applications/IgaApplication/custom_modelers/iga_modeler_sbm.cpp
+++ b/applications/IgaApplication/custom_modelers/iga_modeler_sbm.cpp
@@ -37,7 +37,8 @@ void IgaModelerSbm::SetupModelPart()
     CreateIntegrationDomain(
         analysis_model_part,
         iga_physics_parameters);
-
+    
+    ActivateNodesInElementsAndCleanRoot(analysis_model_part);
 }
 
 ///@}
@@ -1018,6 +1019,34 @@ void IgaModelerSbm::CreateConditions(
     }
     
     r_layer_model_part.AddConditions(new_condition_list.begin(), new_condition_list.end());
+}
+
+void IgaModelerSbm::ActivateNodesInElementsAndCleanRoot(ModelPart& rAnalysisModelPart) const
+{
+    for (auto& r_node : rAnalysisModelPart.Nodes()) {
+        r_node.Set(ACTIVE, false);
+    }
+
+    for (auto& r_elem : rAnalysisModelPart.Elements()) {
+        auto& r_geom = r_elem.GetGeometry();
+        for (auto& r_node : r_geom) {
+            r_node.Set(ACTIVE, true);
+        }
+    }
+
+    ModelPart& r_root = rAnalysisModelPart.GetRootModelPart();
+    std::vector<ModelPart::IndexType> node_ids_to_remove;
+    node_ids_to_remove.reserve(r_root.NumberOfNodes());
+
+    for (auto& r_node : r_root.Nodes()) {
+        if (r_node.IsDefined(ACTIVE) && r_node.IsNot(ACTIVE)) {
+            node_ids_to_remove.push_back(r_node.Id());
+        }
+    }
+
+    for (const auto node_id : node_ids_to_remove) {
+        r_root.RemoveNode(node_id);
+    }
 }
 
 ///@}

--- a/applications/IgaApplication/custom_modelers/iga_modeler_sbm.h
+++ b/applications/IgaApplication/custom_modelers/iga_modeler_sbm.h
@@ -238,6 +238,14 @@ private:
     ///@}
     ///@name Utility
     ///@{
+    
+    /**
+     * @brief Activate all nodes in elements and clean the root model part.
+     *
+     * @param rAnalysisModelPart The model part to modify.
+     */
+    void ActivateNodesInElementsAndCleanRoot(ModelPart& rAnalysisModelPart) const;
+
 
 
     ///@}

--- a/applications/IgaApplication/custom_processes/snake_sbm_process.cpp
+++ b/applications/IgaApplication/custom_processes/snake_sbm_process.cpp
@@ -1243,7 +1243,7 @@ void SnakeSbmProcess::MarkKnotSpansAvailable(
         " 0"  -> exterior knot spans OR very interior knot spans (more 
                     than one ks away from surrogate boundary)
     */
-void SnakeSbmProcess::CreateSurrogateBuondaryFromSnakeInner(
+   void SnakeSbmProcess::CreateSurrogateBuondaryFromSnakeInner(
     const int IdMatrix, 
     const ModelPart& rSkinModelPartInner, 
     DynamicBins& rPointsBinInner,
@@ -1259,22 +1259,30 @@ void SnakeSbmProcess::CreateSurrogateBuondaryFromSnakeInner(
 
     const double knot_step_u = rKnotVectorU[1]-rKnotVectorU[0];
     const double knot_step_v = rKnotVectorV[1]-rKnotVectorV[0];
-    
-    IndexType id_surrogate_first_node; 
-    if (rSurrogateModelPartInner.NumberOfNodes() == 0)
-    {
-        id_surrogate_first_node = rSurrogateModelPartInner.GetRootModelPart().NumberOfNodes() + 1;
-        IndexType idSurrogateNode = id_surrogate_first_node;
-        for (int j = 0; j < rNumberKnotSpans[1]; j++) {
-            for (int i = 0; i < rNumberKnotSpans[0]; i++) {
-                rSurrogateModelPartInner.CreateNewNode(idSurrogateNode, rKnotVectorU[i], rKnotVectorV[j], 0.0);
-                idSurrogateNode++;
+
+    IndexType id_surrogate_first_node;
+    const auto& r_root_model_part = rSurrogateModelPartInner.GetRootModelPart();
+    IndexType max_id = 0;
+    if (r_root_model_part.NumberOfNodes() > 0) {
+        for (auto it = r_root_model_part.NodesBegin(); it != r_root_model_part.NodesEnd(); ++it) {
+            const IndexType id = it->Id();
+            if (id > max_id) {
+                max_id = id;
             }
         }
-    } else 
-    {
-        id_surrogate_first_node = rSurrogateModelPartInner.GetRootModelPart().NumberOfNodes() - rNumberKnotSpans[1]*rNumberKnotSpans[0] + 1;
     }
+    id_surrogate_first_node = max_id + 1;
+
+    // checks if the node exists in the surrogate model part otherwise create it
+    auto ensure_surrogate_node = [&](IndexType node_id, int node_i, int node_j) {
+        if (!rSurrogateModelPartInner.HasNode(node_id)) {
+            auto p_new_node = rSurrogateModelPartInner.CreateNewNode(
+                node_id,
+                rKnotVectorU[node_i],
+                rKnotVectorV[node_j],
+                0.0);
+        }
+    };
     
     auto p_cond_prop = rSurrogateModelPartInner.pGetProperties(0);
     
@@ -1316,7 +1324,8 @@ void SnakeSbmProcess::CreateSurrogateBuondaryFromSnakeInner(
 
                     IndexType id_node_1 = id_surrogate_first_node + node1_i + node1_j*rNumberKnotSpans[0];
                     IndexType id_node_2 = id_surrogate_first_node + node2_i + node2_j*rNumberKnotSpans[0];
-
+                    ensure_surrogate_node(id_node_1, node1_i, node1_j);
+                    ensure_surrogate_node(id_node_2, node2_i, node2_j);
                     auto p_condition = rSurrogateModelPartInner.CreateNewCondition("LineCondition2D2N", id_surrogate_condition, {{id_node_2, id_node_1}}, p_cond_prop );
 
                     // BOUNDARY true means that the condition (i.e. the sbm face) is entering looking from x,y,z positive
@@ -1333,9 +1342,10 @@ void SnakeSbmProcess::CreateSurrogateBuondaryFromSnakeInner(
                 int node1_i = i; int node1_j = j;   
                 int node2_i = i; int node2_j = j+1; 
 
-                IndexType id_node_1 = id_surrogate_first_node + node1_i + node1_j*rNumberKnotSpans[0]; 
+                IndexType id_node_1 = id_surrogate_first_node + node1_i + node1_j*rNumberKnotSpans[0];
                 IndexType id_node_2 = id_surrogate_first_node + node2_i + node2_j*rNumberKnotSpans[0];
-
+                ensure_surrogate_node(id_node_1, node1_i, node1_j);
+                ensure_surrogate_node(id_node_2, node2_i, node2_j);
                 auto p_condition = rSurrogateModelPartInner.CreateNewCondition("LineCondition2D2N", id_surrogate_condition, {{id_node_2, id_node_1}}, p_cond_prop );
                 id_surrogate_condition++;
                 check_next_point = true;
@@ -1365,6 +1375,8 @@ void SnakeSbmProcess::CreateSurrogateBuondaryFromSnakeInner(
 
                     IndexType id_node_1 = id_surrogate_first_node + node1_i + node1_j*rNumberKnotSpans[0];
                     IndexType id_node_2 = id_surrogate_first_node + node2_i + node2_j*rNumberKnotSpans[0];
+                    ensure_surrogate_node(id_node_1, node1_i, node1_j);
+                    ensure_surrogate_node(id_node_2, node2_i, node2_j);
   
                     auto p_condition = rSurrogateModelPartInner.CreateNewCondition("LineCondition2D2N", id_surrogate_condition, {{id_node_1, id_node_2}}, p_cond_prop );
                     // BOUNDARY true means that the condition (i.e. the sbm face) is entering looking from x,y,z positive
@@ -1382,6 +1394,8 @@ void SnakeSbmProcess::CreateSurrogateBuondaryFromSnakeInner(
 
                 IndexType id_node_1 = id_surrogate_first_node + node1_i + node1_j*(rNumberKnotSpans[0]);
                 IndexType id_node_2 = id_surrogate_first_node + node2_i + node2_j*(rNumberKnotSpans[0]);
+                ensure_surrogate_node(id_node_1, node1_i, node1_j);
+                ensure_surrogate_node(id_node_2, node2_i, node2_j);
                 auto p_condition = rSurrogateModelPartInner.CreateNewCondition("LineCondition2D2N", id_surrogate_condition, {{id_node_1, id_node_2}}, p_cond_prop );
                 // surrogate_model_part_inner.AddCondition(p_cond);
                 id_surrogate_condition++;
@@ -1397,6 +1411,23 @@ void SnakeSbmProcess::CreateSurrogateBuondaryFromSnakeInner(
     // Create "fictituos element" to store starting and ending condition id for each surrogate boundary loop
     IndexType elem_id = rSurrogateModelPartInner.GetRootModelPart().NumberOfElements()+1;
     IndexType id_surrogate_last_condition = id_surrogate_condition-1;
+
+    // ensure the dummy nodes for the element containing the extreme conditions id are created
+    auto ensure_dummy_node = [&](IndexType node_id, const double x, const double y, const double z) {
+        if (rSurrogateModelPartInner.HasNode(node_id)) {
+            return rSurrogateModelPartInner.pGetNode(node_id);
+        }
+        auto& r_root = rSurrogateModelPartInner.GetRootModelPart();
+        if (r_root.HasNode(node_id)) {
+            auto p_node = r_root.pGetNode(node_id);
+            rSurrogateModelPartInner.AddNode(p_node);
+            return p_node;
+        } else {
+            return rSurrogateModelPartInner.CreateNewNode(node_id, x, y, z);
+        }
+    };
+    ensure_dummy_node(id_surrogate_first_condition, 0.0, 0.0, 0.0);
+    ensure_dummy_node(id_surrogate_last_condition, 1.0, 0.0, 0.0);
     std::vector<ModelPart::IndexType> elem_nodes{id_surrogate_first_condition, id_surrogate_last_condition};
     rSurrogateModelPartInner.CreateNewElement("Element2D2N", elem_id, elem_nodes, p_cond_prop);
 }
@@ -1408,8 +1439,8 @@ void SnakeSbmProcess::CreateSurrogateBuondaryFromSnakeOuter(
     const ModelPart& rSkinModelPartOuter,
     DynamicBins& rPointsBinOuter, 
     const std::vector<int>& rNumberKnotSpans, 
-    const Vector& knot_vector_u, 
-    const Vector& knot_vector_v, 
+    const Vector& rKnotVectorU, 
+    const Vector& rKnotVectorV, 
     const Vector& rStartingPositionUV,
     std::vector<std::vector<std::vector<int>>> & rKnotSpansAvailable,
     ModelPart& rSurrogateModelPartOuter)
@@ -1417,8 +1448,8 @@ void SnakeSbmProcess::CreateSurrogateBuondaryFromSnakeOuter(
     // CHECK ALL THE EXTERNAL KNOT SPANS
 
     // LEFT BOUNDARY
-    double knot_step_u = knot_vector_u[1]-knot_vector_u[0];
-    double knot_step_v = knot_vector_v[1]-knot_vector_v[0];
+    double knot_step_u = rKnotVectorU[1]-rKnotVectorU[0];
+    double knot_step_v = rKnotVectorV[1]-rKnotVectorV[0];
 
     for (int i = 0; i<2; i++) {
         for (int j = 0; j < (rNumberKnotSpans[0]); j++ ) {
@@ -1457,14 +1488,45 @@ void SnakeSbmProcess::CreateSurrogateBuondaryFromSnakeOuter(
     }
     
     // Snake 2D works with a raycasting technique from each of the two directions
-    IndexType id_surrogate_first_node = rSurrogateModelPartOuter.GetRootModelPart().NumberOfNodes() + 1;
-    IndexType idSurrogateNode = id_surrogate_first_node;
-    for (int j = 0; j < rNumberKnotSpans[1]+1; j++) {
-        for (int i = 0; i < rNumberKnotSpans[0]+1; i++) {
-            rSurrogateModelPartOuter.CreateNewNode(idSurrogateNode, knot_vector_u[i], knot_vector_v[j], 0.0);
-            idSurrogateNode++;
+    IndexType id_surrogate_first_node;
+    if (rSurrogateModelPartOuter.NumberOfNodes() == 0) {
+        const auto& r_root_model_part = rSurrogateModelPartOuter.GetRootModelPart();
+        IndexType max_id = 0;
+        if (r_root_model_part.NumberOfNodes() > 0) {
+            for (auto it = r_root_model_part.NodesBegin(); it != r_root_model_part.NodesEnd(); ++it) {
+                const IndexType id = it->Id();
+                if (id > max_id) {
+                    max_id = id;
+                }
+            }
         }
+        id_surrogate_first_node = max_id + 1;
+    } else {
+        KRATOS_ERROR << "::[SnakeSbmProcess]:: Multiple outer loops are not implemented \n";
     }
+
+    // checks if the node exists in the surrogate model part otherwise create it
+    auto ensure_surrogate_node = [&](IndexType node_id, int node_i, int node_j) {
+        if (!rSurrogateModelPartOuter.HasNode(node_id)) {
+            rSurrogateModelPartOuter.CreateNewNode(
+                node_id,
+                rKnotVectorU[node_i],
+                rKnotVectorV[node_j],
+                0.0);
+        }
+        else {
+            const auto& r_node = rSurrogateModelPartOuter.GetNode(node_id);
+            const double expected_x = rKnotVectorU[node_i];
+            const double expected_y = rKnotVectorV[node_j];
+            if (std::abs(r_node.X() - expected_x) > 1e-8 ||
+                std::abs(r_node.Y() - expected_y) > 1e-8) {
+                KRATOS_ERROR << "Existing surrogate node has unexpected coordinates. "
+                             << "NodeId: " << node_id
+                             << " Expected: (" << expected_x << ", " << expected_y << ")"
+                             << " Actual: (" << r_node.X() << ", " << r_node.Y() << ")";
+            }
+        }
+    };
     
     // Direction parallel to x
     
@@ -1512,6 +1574,8 @@ void SnakeSbmProcess::CreateSurrogateBuondaryFromSnakeOuter(
 
                     IndexType id_node_1 = id_surrogate_first_node + node1_i + node1_j*(rNumberKnotSpans[0]+1);
                     IndexType id_node_2 = id_surrogate_first_node + node2_i + node2_j*(rNumberKnotSpans[0]+1);
+                    ensure_surrogate_node(id_node_1, node1_i, node1_j);
+                    ensure_surrogate_node(id_node_2, node2_i, node2_j);
                         
                     auto p_condition = rSurrogateModelPartOuter.CreateNewCondition("LineCondition2D2N", id_surrogate_condition, {{id_node_1, id_node_2}}, p_cond_prop );
 
@@ -1530,6 +1594,8 @@ void SnakeSbmProcess::CreateSurrogateBuondaryFromSnakeOuter(
 
                 IndexType id_node_1 = id_surrogate_first_node + node1_i + node1_j*(rNumberKnotSpans[0]+1);
                 IndexType id_node_2 = id_surrogate_first_node + node2_i + node2_j*(rNumberKnotSpans[0]+1);
+                ensure_surrogate_node(id_node_1, node1_i, node1_j);
+                ensure_surrogate_node(id_node_2, node2_i, node2_j);
                     
                 auto p_condition = rSurrogateModelPartOuter.CreateNewCondition("LineCondition2D2N", id_surrogate_condition, {{id_node_1, id_node_2}}, p_cond_prop );
                 id_surrogate_condition++;
@@ -1547,6 +1613,8 @@ void SnakeSbmProcess::CreateSurrogateBuondaryFromSnakeOuter(
 
                 IndexType id_node_1 = id_surrogate_first_node + node1_i + node1_j*(rNumberKnotSpans[0]+1);
                 IndexType id_node_2 = id_surrogate_first_node + node2_i + node2_j*(rNumberKnotSpans[0]+1);
+                ensure_surrogate_node(id_node_1, node1_i, node1_j);
+                ensure_surrogate_node(id_node_2, node2_i, node2_j);
                     
                 auto p_condition = rSurrogateModelPartOuter.CreateNewCondition("LineCondition2D2N", id_surrogate_condition, {{id_node_1, id_node_2}}, p_cond_prop );
                 // BOUNDARY true means that the condition (i.e. the sbm face) is entering looking from x,y,z positive
@@ -1578,6 +1646,8 @@ void SnakeSbmProcess::CreateSurrogateBuondaryFromSnakeOuter(
 
                     IndexType id_node_1 = id_surrogate_first_node + node1_i + node1_j*(rNumberKnotSpans[0]+1);
                     IndexType id_node_2 = id_surrogate_first_node + node2_i + node2_j*(rNumberKnotSpans[0]+1);
+                    ensure_surrogate_node(id_node_1, node1_i, node1_j);
+                    ensure_surrogate_node(id_node_2, node2_i, node2_j);
                         
                     auto p_condition = rSurrogateModelPartOuter.CreateNewCondition("LineCondition2D2N", id_surrogate_condition, {{id_node_2, id_node_1}}, p_cond_prop );
                     // BOUNDARY true means that the condition (i.e. the sbm face) is entering looking from x,y,z positive
@@ -1593,6 +1663,8 @@ void SnakeSbmProcess::CreateSurrogateBuondaryFromSnakeOuter(
 
                 IndexType id_node_1 = id_surrogate_first_node + node1_i + node1_j*(rNumberKnotSpans[0]+1);
                 IndexType id_node_2 = id_surrogate_first_node + node2_i + node2_j*(rNumberKnotSpans[0]+1);
+                ensure_surrogate_node(id_node_1, node1_i, node1_j);
+                ensure_surrogate_node(id_node_2, node2_i, node2_j);
                 auto p_condition = rSurrogateModelPartOuter.CreateNewCondition("LineCondition2D2N", id_surrogate_condition, {{id_node_2, id_node_1}}, p_cond_prop );
                 id_surrogate_condition++;
                 check_next_point = true;
@@ -1609,6 +1681,8 @@ void SnakeSbmProcess::CreateSurrogateBuondaryFromSnakeOuter(
 
                 IndexType id_node_1 = id_surrogate_first_node + node1_i + node1_j*(rNumberKnotSpans[0]+1);
                 IndexType id_node_2 = id_surrogate_first_node + node2_i + node2_j*(rNumberKnotSpans[0]+1);
+                ensure_surrogate_node(id_node_1, node1_i, node1_j);
+                ensure_surrogate_node(id_node_2, node2_i, node2_j);
                     
                 auto p_condition = rSurrogateModelPartOuter.CreateNewCondition("LineCondition2D2N", id_surrogate_condition, {{id_node_2, id_node_1}}, p_cond_prop );
                 // BOUNDARY true means that the condition (i.e. the sbm face) is entering looking from x,y,z positive

--- a/applications/IgaApplication/custom_processes/snake_sbm_process.cpp
+++ b/applications/IgaApplication/custom_processes/snake_sbm_process.cpp
@@ -1236,6 +1236,35 @@ void SnakeSbmProcess::MarkKnotSpansAvailable(
     }
 }
 
+void SnakeSbmProcess::RetrieveOrCreateNodeInModelPart(
+    ModelPart& rModelPart,
+    const IndexType NodeId,
+    const int NodeI,
+    const int NodeJ,
+    const Vector& rKnotVectorU,
+    const Vector& rKnotVectorV)
+{
+    if (!rModelPart.HasNode(NodeId)) {
+        rModelPart.CreateNewNode(
+            NodeId,
+            rKnotVectorU[NodeI],
+            rKnotVectorV[NodeJ],
+            0.0);
+        return;
+    }
+
+    const auto& r_node = rModelPart.GetNode(NodeId);
+    const double expected_x = rKnotVectorU[NodeI];
+    const double expected_y = rKnotVectorV[NodeJ];
+    if (std::abs(r_node.X() - expected_x) > 1e-8 ||
+        std::abs(r_node.Y() - expected_y) > 1e-8) {
+        KRATOS_ERROR << "Existing surrogate node has unexpected coordinates. "
+                     << "NodeId: " << NodeId
+                     << " Expected: (" << expected_x << ", " << expected_y << ")"
+                     << " Actual: (" << r_node.X() << ", " << r_node.Y() << ")";
+    }
+}
+
 /**
     * summary of knot_spans_available:
         " 1"  -> interior knot spans                                  
@@ -1273,17 +1302,6 @@ void SnakeSbmProcess::MarkKnotSpansAvailable(
     }
     id_surrogate_first_node = max_id + 1;
 
-    // checks if the node exists in the surrogate model part otherwise create it
-    auto ensure_surrogate_node = [&](IndexType node_id, int node_i, int node_j) {
-        if (!rSurrogateModelPartInner.HasNode(node_id)) {
-            auto p_new_node = rSurrogateModelPartInner.CreateNewNode(
-                node_id,
-                rKnotVectorU[node_i],
-                rKnotVectorV[node_j],
-                0.0);
-        }
-    };
-    
     auto p_cond_prop = rSurrogateModelPartInner.pGetProperties(0);
     
     // Direction parallel to x
@@ -1324,8 +1342,8 @@ void SnakeSbmProcess::MarkKnotSpansAvailable(
 
                     IndexType id_node_1 = id_surrogate_first_node + node1_i + node1_j*rNumberKnotSpans[0];
                     IndexType id_node_2 = id_surrogate_first_node + node2_i + node2_j*rNumberKnotSpans[0];
-                    ensure_surrogate_node(id_node_1, node1_i, node1_j);
-                    ensure_surrogate_node(id_node_2, node2_i, node2_j);
+                    RetrieveOrCreateNodeInModelPart(rSurrogateModelPartInner, id_node_1, node1_i, node1_j, rKnotVectorU, rKnotVectorV);
+                    RetrieveOrCreateNodeInModelPart(rSurrogateModelPartInner, id_node_2, node2_i, node2_j, rKnotVectorU, rKnotVectorV);
                     auto p_condition = rSurrogateModelPartInner.CreateNewCondition("LineCondition2D2N", id_surrogate_condition, {{id_node_2, id_node_1}}, p_cond_prop );
 
                     // BOUNDARY true means that the condition (i.e. the sbm face) is entering looking from x,y,z positive
@@ -1344,8 +1362,8 @@ void SnakeSbmProcess::MarkKnotSpansAvailable(
 
                 IndexType id_node_1 = id_surrogate_first_node + node1_i + node1_j*rNumberKnotSpans[0];
                 IndexType id_node_2 = id_surrogate_first_node + node2_i + node2_j*rNumberKnotSpans[0];
-                ensure_surrogate_node(id_node_1, node1_i, node1_j);
-                ensure_surrogate_node(id_node_2, node2_i, node2_j);
+                RetrieveOrCreateNodeInModelPart(rSurrogateModelPartInner, id_node_1, node1_i, node1_j, rKnotVectorU, rKnotVectorV);
+                RetrieveOrCreateNodeInModelPart(rSurrogateModelPartInner, id_node_2, node2_i, node2_j, rKnotVectorU, rKnotVectorV);
                 auto p_condition = rSurrogateModelPartInner.CreateNewCondition("LineCondition2D2N", id_surrogate_condition, {{id_node_2, id_node_1}}, p_cond_prop );
                 id_surrogate_condition++;
                 check_next_point = true;
@@ -1375,8 +1393,8 @@ void SnakeSbmProcess::MarkKnotSpansAvailable(
 
                     IndexType id_node_1 = id_surrogate_first_node + node1_i + node1_j*rNumberKnotSpans[0];
                     IndexType id_node_2 = id_surrogate_first_node + node2_i + node2_j*rNumberKnotSpans[0];
-                    ensure_surrogate_node(id_node_1, node1_i, node1_j);
-                    ensure_surrogate_node(id_node_2, node2_i, node2_j);
+                    RetrieveOrCreateNodeInModelPart(rSurrogateModelPartInner, id_node_1, node1_i, node1_j, rKnotVectorU, rKnotVectorV);
+                    RetrieveOrCreateNodeInModelPart(rSurrogateModelPartInner, id_node_2, node2_i, node2_j, rKnotVectorU, rKnotVectorV);
   
                     auto p_condition = rSurrogateModelPartInner.CreateNewCondition("LineCondition2D2N", id_surrogate_condition, {{id_node_1, id_node_2}}, p_cond_prop );
                     // BOUNDARY true means that the condition (i.e. the sbm face) is entering looking from x,y,z positive
@@ -1394,8 +1412,8 @@ void SnakeSbmProcess::MarkKnotSpansAvailable(
 
                 IndexType id_node_1 = id_surrogate_first_node + node1_i + node1_j*(rNumberKnotSpans[0]);
                 IndexType id_node_2 = id_surrogate_first_node + node2_i + node2_j*(rNumberKnotSpans[0]);
-                ensure_surrogate_node(id_node_1, node1_i, node1_j);
-                ensure_surrogate_node(id_node_2, node2_i, node2_j);
+                RetrieveOrCreateNodeInModelPart(rSurrogateModelPartInner, id_node_1, node1_i, node1_j, rKnotVectorU, rKnotVectorV);
+                RetrieveOrCreateNodeInModelPart(rSurrogateModelPartInner, id_node_2, node2_i, node2_j, rKnotVectorU, rKnotVectorV);
                 auto p_condition = rSurrogateModelPartInner.CreateNewCondition("LineCondition2D2N", id_surrogate_condition, {{id_node_1, id_node_2}}, p_cond_prop );
                 // surrogate_model_part_inner.AddCondition(p_cond);
                 id_surrogate_condition++;
@@ -1505,29 +1523,6 @@ void SnakeSbmProcess::CreateSurrogateBuondaryFromSnakeOuter(
         KRATOS_ERROR << "::[SnakeSbmProcess]:: Multiple outer loops are not implemented \n";
     }
 
-    // checks if the node exists in the surrogate model part otherwise create it
-    auto ensure_surrogate_node = [&](IndexType node_id, int node_i, int node_j) {
-        if (!rSurrogateModelPartOuter.HasNode(node_id)) {
-            rSurrogateModelPartOuter.CreateNewNode(
-                node_id,
-                rKnotVectorU[node_i],
-                rKnotVectorV[node_j],
-                0.0);
-        }
-        else {
-            const auto& r_node = rSurrogateModelPartOuter.GetNode(node_id);
-            const double expected_x = rKnotVectorU[node_i];
-            const double expected_y = rKnotVectorV[node_j];
-            if (std::abs(r_node.X() - expected_x) > 1e-8 ||
-                std::abs(r_node.Y() - expected_y) > 1e-8) {
-                KRATOS_ERROR << "Existing surrogate node has unexpected coordinates. "
-                             << "NodeId: " << node_id
-                             << " Expected: (" << expected_x << ", " << expected_y << ")"
-                             << " Actual: (" << r_node.X() << ", " << r_node.Y() << ")";
-            }
-        }
-    };
-    
     // Direction parallel to x
     
     IndexType id_surrogate_condition = rSurrogateModelPartOuter.GetRootModelPart().NumberOfConditions() + 1;
@@ -1574,8 +1569,8 @@ void SnakeSbmProcess::CreateSurrogateBuondaryFromSnakeOuter(
 
                     IndexType id_node_1 = id_surrogate_first_node + node1_i + node1_j*(rNumberKnotSpans[0]+1);
                     IndexType id_node_2 = id_surrogate_first_node + node2_i + node2_j*(rNumberKnotSpans[0]+1);
-                    ensure_surrogate_node(id_node_1, node1_i, node1_j);
-                    ensure_surrogate_node(id_node_2, node2_i, node2_j);
+                    RetrieveOrCreateNodeInModelPart(rSurrogateModelPartOuter, id_node_1, node1_i, node1_j, rKnotVectorU, rKnotVectorV);
+                    RetrieveOrCreateNodeInModelPart(rSurrogateModelPartOuter, id_node_2, node2_i, node2_j, rKnotVectorU, rKnotVectorV);
                         
                     auto p_condition = rSurrogateModelPartOuter.CreateNewCondition("LineCondition2D2N", id_surrogate_condition, {{id_node_1, id_node_2}}, p_cond_prop );
 
@@ -1594,8 +1589,8 @@ void SnakeSbmProcess::CreateSurrogateBuondaryFromSnakeOuter(
 
                 IndexType id_node_1 = id_surrogate_first_node + node1_i + node1_j*(rNumberKnotSpans[0]+1);
                 IndexType id_node_2 = id_surrogate_first_node + node2_i + node2_j*(rNumberKnotSpans[0]+1);
-                ensure_surrogate_node(id_node_1, node1_i, node1_j);
-                ensure_surrogate_node(id_node_2, node2_i, node2_j);
+                RetrieveOrCreateNodeInModelPart(rSurrogateModelPartOuter, id_node_1, node1_i, node1_j, rKnotVectorU, rKnotVectorV);
+                RetrieveOrCreateNodeInModelPart(rSurrogateModelPartOuter, id_node_2, node2_i, node2_j, rKnotVectorU, rKnotVectorV);
                     
                 auto p_condition = rSurrogateModelPartOuter.CreateNewCondition("LineCondition2D2N", id_surrogate_condition, {{id_node_1, id_node_2}}, p_cond_prop );
                 id_surrogate_condition++;
@@ -1613,8 +1608,8 @@ void SnakeSbmProcess::CreateSurrogateBuondaryFromSnakeOuter(
 
                 IndexType id_node_1 = id_surrogate_first_node + node1_i + node1_j*(rNumberKnotSpans[0]+1);
                 IndexType id_node_2 = id_surrogate_first_node + node2_i + node2_j*(rNumberKnotSpans[0]+1);
-                ensure_surrogate_node(id_node_1, node1_i, node1_j);
-                ensure_surrogate_node(id_node_2, node2_i, node2_j);
+                RetrieveOrCreateNodeInModelPart(rSurrogateModelPartOuter, id_node_1, node1_i, node1_j, rKnotVectorU, rKnotVectorV);
+                RetrieveOrCreateNodeInModelPart(rSurrogateModelPartOuter, id_node_2, node2_i, node2_j, rKnotVectorU, rKnotVectorV);
                     
                 auto p_condition = rSurrogateModelPartOuter.CreateNewCondition("LineCondition2D2N", id_surrogate_condition, {{id_node_1, id_node_2}}, p_cond_prop );
                 // BOUNDARY true means that the condition (i.e. the sbm face) is entering looking from x,y,z positive
@@ -1646,8 +1641,8 @@ void SnakeSbmProcess::CreateSurrogateBuondaryFromSnakeOuter(
 
                     IndexType id_node_1 = id_surrogate_first_node + node1_i + node1_j*(rNumberKnotSpans[0]+1);
                     IndexType id_node_2 = id_surrogate_first_node + node2_i + node2_j*(rNumberKnotSpans[0]+1);
-                    ensure_surrogate_node(id_node_1, node1_i, node1_j);
-                    ensure_surrogate_node(id_node_2, node2_i, node2_j);
+                    RetrieveOrCreateNodeInModelPart(rSurrogateModelPartOuter, id_node_1, node1_i, node1_j, rKnotVectorU, rKnotVectorV);
+                    RetrieveOrCreateNodeInModelPart(rSurrogateModelPartOuter, id_node_2, node2_i, node2_j, rKnotVectorU, rKnotVectorV);
                         
                     auto p_condition = rSurrogateModelPartOuter.CreateNewCondition("LineCondition2D2N", id_surrogate_condition, {{id_node_2, id_node_1}}, p_cond_prop );
                     // BOUNDARY true means that the condition (i.e. the sbm face) is entering looking from x,y,z positive
@@ -1663,8 +1658,8 @@ void SnakeSbmProcess::CreateSurrogateBuondaryFromSnakeOuter(
 
                 IndexType id_node_1 = id_surrogate_first_node + node1_i + node1_j*(rNumberKnotSpans[0]+1);
                 IndexType id_node_2 = id_surrogate_first_node + node2_i + node2_j*(rNumberKnotSpans[0]+1);
-                ensure_surrogate_node(id_node_1, node1_i, node1_j);
-                ensure_surrogate_node(id_node_2, node2_i, node2_j);
+                RetrieveOrCreateNodeInModelPart(rSurrogateModelPartOuter, id_node_1, node1_i, node1_j, rKnotVectorU, rKnotVectorV);
+                RetrieveOrCreateNodeInModelPart(rSurrogateModelPartOuter, id_node_2, node2_i, node2_j, rKnotVectorU, rKnotVectorV);
                 auto p_condition = rSurrogateModelPartOuter.CreateNewCondition("LineCondition2D2N", id_surrogate_condition, {{id_node_2, id_node_1}}, p_cond_prop );
                 id_surrogate_condition++;
                 check_next_point = true;
@@ -1681,8 +1676,8 @@ void SnakeSbmProcess::CreateSurrogateBuondaryFromSnakeOuter(
 
                 IndexType id_node_1 = id_surrogate_first_node + node1_i + node1_j*(rNumberKnotSpans[0]+1);
                 IndexType id_node_2 = id_surrogate_first_node + node2_i + node2_j*(rNumberKnotSpans[0]+1);
-                ensure_surrogate_node(id_node_1, node1_i, node1_j);
-                ensure_surrogate_node(id_node_2, node2_i, node2_j);
+                RetrieveOrCreateNodeInModelPart(rSurrogateModelPartOuter, id_node_1, node1_i, node1_j, rKnotVectorU, rKnotVectorV);
+                RetrieveOrCreateNodeInModelPart(rSurrogateModelPartOuter, id_node_2, node2_i, node2_j, rKnotVectorU, rKnotVectorV);
                     
                 auto p_condition = rSurrogateModelPartOuter.CreateNewCondition("LineCondition2D2N", id_surrogate_condition, {{id_node_2, id_node_1}}, p_cond_prop );
                 // BOUNDARY true means that the condition (i.e. the sbm face) is entering looking from x,y,z positive

--- a/applications/IgaApplication/custom_processes/snake_sbm_process.h
+++ b/applications/IgaApplication/custom_processes/snake_sbm_process.h
@@ -227,6 +227,24 @@ protected:
         return false;
     }
 
+    /**
+     * @brief Retrieves or creates a node in the specified model part.
+     * 
+     * @param rModelPart The model part to search in.
+     * @param NodeId The ID of the node to retrieve or create.
+     * @param NodeI The I coordinate of the node.
+     * @param NodeJ The J coordinate of the node.
+     * @param rKnotVectorU The U knot vector.
+     * @param rKnotVectorV The V knot vector.
+     */
+    static void RetrieveOrCreateNodeInModelPart(
+        ModelPart& rModelPart,
+        const IndexType NodeId,
+        const int NodeI,
+        const int NodeJ,
+        const Vector& rKnotVectorU,
+        const Vector& rKnotVectorV);
+
 private:
 
     /**

--- a/applications/IgaApplication/tests/cpp_tests/test_sbm_3d_workflow.cpp
+++ b/applications/IgaApplication/tests/cpp_tests/test_sbm_3d_workflow.cpp
@@ -436,7 +436,7 @@ KRATOS_TEST_CASE_IN_SUITE(IgaModelerSbmSupportInner3D, KratosIgaFastSuite)
     auto& r_support_model_part = model.GetModelPart("IgaModelPart.SBM_Support_inner");
 
     KRATOS_EXPECT_EQ(r_surrogate_inner.NumberOfConditions(), 48);
-    KRATOS_EXPECT_EQ(r_surrogate_inner.NumberOfNodes(), 125);
+    KRATOS_EXPECT_EQ(r_surrogate_inner.NumberOfNodes(), 0);
     KRATOS_EXPECT_EQ(r_surrogate_inner.NumberOfElements(), 1);
     KRATOS_EXPECT_EQ(r_support_model_part.NumberOfConditions(), 192);
     KRATOS_EXPECT_EQ(r_support_model_part.NumberOfNodes(), 0);

--- a/applications/IgaApplication/tests/test_modelers_sbm.py
+++ b/applications/IgaApplication/tests/test_modelers_sbm.py
@@ -108,7 +108,8 @@ class TestModelersSbm(KratosUnittest.TestCase):
         self.assertEqual(computational_model_part.GetElements()[13].Info(), "LaplacianElement #13")
         self.assertEqual(computational_model_part.GetElements()[40].Info(), "LaplacianElement #40")
 
-    
+        self.assertEqual(iga_model_part.NumberOfElements(), 100)
+
     def test_iga_modeler_inner_outer_sbm(self):
         current_model = KratosMultiphysics.Model()
         # Create Inner skin boundary
@@ -224,7 +225,7 @@ class TestModelersSbm(KratosUnittest.TestCase):
         self.assertEqual(support_model_part_outer.GetConditions()[301].Info(), "\"SbmLaplacianConditionNeumann\" #301")
         self.assertEqual(computational_model_part.GetElements()[13].Info(), "LaplacianElement #13")
         self.assertEqual(computational_model_part.GetElements()[40].Info(), "LaplacianElement #40")
-
+        self.assertEqual(iga_model_part.NumberOfElements(), 811)
     
     # test the call to the nurbs_geometry_modeler_sbm to create a rectangle + the breps
     def test_nurbs_geometry_2d_modeler_control_points(self):
@@ -797,6 +798,7 @@ class TestModelersSbm(KratosUnittest.TestCase):
 
         self.assertEqual(support_model_part.GetConditions()[55].Info(), "\"SbmLaplacianConditionDirichlet\" #55")
         self.assertEqual(support_model_part.GetConditions()[28].Info(), "\"SbmLaplacianConditionNeumann\" #28")
+        self.assertEqual(iga_model_part.NumberOfElements(), 64)
 
     def test_iga_modeler_outer_sbm_layers_unordered_curves(self):
         current_model = KratosMultiphysics.Model()
@@ -889,6 +891,7 @@ class TestModelersSbm(KratosUnittest.TestCase):
         # Spot-check two conditions types to ensure mapping still holds
         self.assertEqual(support_model_part.GetConditions()[55].Info(), "\"SbmLaplacianConditionDirichlet\" #55")
         self.assertEqual(support_model_part.GetConditions()[28].Info(), "\"SbmLaplacianConditionNeumann\" #28")
+        self.assertEqual(iga_model_part.NumberOfElements(), 64)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
**📝 Description**
Avoid the creation of useless Nodes and control points of the background mesh

**🆕 Changelog**

-SnakeSbmProcess::CreateSurrogateBuondaryFromSnakeInner/Outer:
                      - Creates the surrogate nodes directly in the loop for the construction of the surrogate edges
                      - ensure_surrogate_node function to check if the nodes are already created in the modelPart
- IgaModelerSbm::
                      - Additional method ActivateNodesInElementsAndCleanRoot
                      - Remove all the Control Points (Nodes) which are not included in the elements created
