### PR TITLE
[CORE] Fix IsInside of Truss_3D_2

### DIFF
--- a/kratos/geometries/line_3d_2.h
+++ b/kratos/geometries/line_3d_2.h
@@ -839,6 +839,10 @@ public:
         const double Tolerance = std::numeric_limits<double>::epsilon()
         ) const override
     {
+        const double distance = this->CalculateDistance(rPoint, Tolerance);
+        if (distance > std::max(Tolerance, 1.0e-6 * Length())) {
+            return false;
+        }
         PointLocalCoordinates( rResult, rPoint );
 
         if ( std::abs( rResult[0] ) <= (1.0 + Tolerance) ) {
@@ -873,22 +877,33 @@ public:
         const CoordinatesArrayType& rPoint
         ) const override
     {
-        rResult = ZeroVector(3);
+        rResult.clear();
 
         const TPointType& r_first_point  = BaseType::GetPoint(0);
         const TPointType& r_second_point = BaseType::GetPoint(1);
 
-        const array_1d<double, 3> line_direction = r_second_point - r_first_point;
-        const double length_squared = inner_prod(line_direction, line_direction);
-        KRATOS_ERROR_IF(length_squared <= std::numeric_limits<double>::epsilon())
-            << "PointLocalCoordinates called on a line geometry with zero length.";
+        // Project point
+        const double tolerance = 1e-14; // Tolerance
 
-        const array_1d<double, 3> vector_from_first_point_to_input = rPoint - r_first_point;
-        const double projection_parameter = inner_prod(vector_from_first_point_to_input, line_direction) / length_squared;
+        const double length = Length();
 
-        rResult[0] = 2.0 * projection_parameter - 1.0;
+        const double length_1 = std::sqrt( std::pow(rPoint[0] - r_first_point[0], 2)
+                    + std::pow(rPoint[1] - r_first_point[1], 2) + std::pow(rPoint[2] - r_first_point[2], 2));
 
-        return rResult;
+        const double length_2 = std::sqrt( std::pow(rPoint[0] - r_second_point[0], 2)
+                    + std::pow(rPoint[1] - r_second_point[1], 2) + std::pow(rPoint[2] - r_second_point[2], 2));
+
+        if (length_1 <= (length + tolerance) && length_2 <= (length + tolerance)) {
+            rResult[0] = 2.0 * length_1/(length + tolerance) - 1.0;
+        } else if (length_1 > (length + tolerance)) {
+            rResult[0] = 2.0 * length_1/(length + tolerance) - 1.0; // NOTE: The same value as before, but it will be > than 1
+        } else if (length_2 > (length + tolerance)) {
+            rResult[0] = 1.0 - 2.0 * length_2/(length + tolerance);
+        } else {
+            rResult[0] = 2.0; // Out of the line!!!
+        }
+
+        return rResult ;
     }
 
     ///@}

--- a/kratos/geometries/line_3d_2.h
+++ b/kratos/geometries/line_3d_2.h
@@ -842,6 +842,12 @@ public:
         PointLocalCoordinates( rResult, rPoint );
 
         if ( std::abs( rResult[0] ) <= (1.0 + Tolerance) ) {
+            // Check if point is too far away from the line, if so, return false
+            const double distance = this->CalculateDistance(rPoint, Tolerance);
+            const double length = Length();
+            if (distance > std::max(Tolerance, 1e-6 * length)) { 
+                return false;
+            }
             return true;
         }
 
@@ -881,13 +887,6 @@ public:
         // Project point
         const double tolerance = 1e-14; // Tolerance
         const double length = Length();
-
-        // Check if point is too far away from the line, if so, return false
-        const double distance = this->CalculateDistance(rPoint, tolerance);
-        if (distance > std::max(tolerance, 1.0e-6 * length)) { 
-            rResult[0] = 2.0;
-            return rResult;
-        }
 
         const double length_1 = std::sqrt( std::pow(rPoint[0] - r_first_point[0], 2)
                     + std::pow(rPoint[1] - r_first_point[1], 2) + std::pow(rPoint[2] - r_first_point[2], 2));

--- a/kratos/geometries/line_3d_2.h
+++ b/kratos/geometries/line_3d_2.h
@@ -873,33 +873,22 @@ public:
         const CoordinatesArrayType& rPoint
         ) const override
     {
-        rResult.clear();
+        rResult = ZeroVector(3);
 
         const TPointType& r_first_point  = BaseType::GetPoint(0);
         const TPointType& r_second_point = BaseType::GetPoint(1);
 
-        // Project point
-        const double tolerance = 1e-14; // Tolerance
+        const array_1d<double, 3> line_direction = r_second_point - r_first_point;
+        const double length_squared = inner_prod(line_direction, line_direction);
+        KRATOS_ERROR_IF(length_squared <= std::numeric_limits<double>::epsilon())
+            << "PointLocalCoordinates called on a line geometry with zero length.";
 
-        const double length = Length();
+        const array_1d<double, 3> vector_from_first_point_to_input = rPoint - r_first_point;
+        const double projection_parameter = inner_prod(vector_from_first_point_to_input, line_direction) / length_squared;
 
-        const double length_1 = std::sqrt( std::pow(rPoint[0] - r_first_point[0], 2)
-                    + std::pow(rPoint[1] - r_first_point[1], 2) + std::pow(rPoint[2] - r_first_point[2], 2));
+        rResult[0] = 2.0 * projection_parameter - 1.0;
 
-        const double length_2 = std::sqrt( std::pow(rPoint[0] - r_second_point[0], 2)
-                    + std::pow(rPoint[1] - r_second_point[1], 2) + std::pow(rPoint[2] - r_second_point[2], 2));
-
-        if (length_1 <= (length + tolerance) && length_2 <= (length + tolerance)) {
-            rResult[0] = 2.0 * length_1/(length + tolerance) - 1.0;
-        } else if (length_1 > (length + tolerance)) {
-            rResult[0] = 2.0 * length_1/(length + tolerance) - 1.0; // NOTE: The same value as before, but it will be > than 1
-        } else if (length_2 > (length + tolerance)) {
-            rResult[0] = 1.0 - 2.0 * length_2/(length + tolerance);
-        } else {
-            rResult[0] = 2.0; // Out of the line!!!
-        }
-
-        return rResult ;
+        return rResult;
     }
 
     ///@}

--- a/kratos/geometries/line_3d_2.h
+++ b/kratos/geometries/line_3d_2.h
@@ -839,10 +839,6 @@ public:
         const double Tolerance = std::numeric_limits<double>::epsilon()
         ) const override
     {
-        const double distance = this->CalculateDistance(rPoint, Tolerance);
-        if (distance > std::max(Tolerance, 1.0e-6 * Length())) {
-            return false;
-        }
         PointLocalCoordinates( rResult, rPoint );
 
         if ( std::abs( rResult[0] ) <= (1.0 + Tolerance) ) {
@@ -884,8 +880,14 @@ public:
 
         // Project point
         const double tolerance = 1e-14; // Tolerance
-
         const double length = Length();
+
+        // Check if point is too far away from the line, if so, return false
+        const double distance = this->CalculateDistance(rPoint, tolerance);
+        if (distance > std::max(tolerance, 1.0e-6 * length)) { 
+            rResult[0] = 2.0;
+            return rResult;
+        }
 
         const double length_1 = std::sqrt( std::pow(rPoint[0] - r_first_point[0], 2)
                     + std::pow(rPoint[1] - r_first_point[1], 2) + std::pow(rPoint[2] - r_first_point[2], 2));

--- a/kratos/tests/cpp_tests/geometries/test_line_3d_2.cpp
+++ b/kratos/tests/cpp_tests/geometries/test_line_3d_2.cpp
@@ -57,6 +57,16 @@ namespace Testing {
         );
     }
 
+    /** Generates a point type sample Line3D2N
+    * @return  Pointer to a Line3D2N
+    */
+    Line3D2<Point>::Pointer GenerateCornerCasePointsLine3D2() {
+        return Kratos::make_shared<Line3D2<Point>>(
+        Kratos::make_shared<Point>(-20.0, 0.0, 0.0),
+        Kratos::make_shared<Point>(-20.0, 5.0, 0.0)
+        );
+    }
+
     /** Generates a point type sample Line3D2N.
     * @return  Pointer to a Line3D2N
     */
@@ -121,6 +131,11 @@ namespace Testing {
         KRATOS_EXPECT_FALSE(p_geom->IsInside(PointOutside, LocalCoords, EPSILON));
         KRATOS_EXPECT_TRUE(p_geom->IsInside(PointInVertex, LocalCoords, EPSILON));
         KRATOS_EXPECT_TRUE(p_geom->IsInside(PointInEdge, LocalCoords, EPSILON));
+
+        // testing Corner Case
+        Geometry<Point>::Pointer p_geom2 = GenerateCornerCasePointsLine3D2();
+        Point PointOutside2(-16.0, 2.5, 0.0);
+        KRATOS_EXPECT_FALSE(p_geom2->IsInside(PointOutside2, LocalCoords, EPSILON));
     }
 
     /** Checks the point local coordinates for a given point respect to the


### PR DESCRIPTION
**📝 Description**
Fix the Point Projection onto the truss element in the 3D case by adding the distance check. 

Corner Case:

Point (-16, 2.5, 0)

r_element : Element #21 : 
    Working space dimension : 3
    Local space dimension   : 1

	Point 1	 :  (-20, 0, 0)
    Dofs :
        Free TEMPERATURE degree of freedom
        Free DISPLACEMENT_X degree of freedom
        Free DISPLACEMENT_Y degree of freedom
        Free DISPLACEMENT_Z degree of freedom

	Point 2	 :  (-20, 5, 0)
    Dofs :
        Free TEMPERATURE degree of freedom
        Free DISPLACEMENT_X degree of freedom
        Free DISPLACEMENT_Y degree of freedom
        Free DISPLACEMENT_Z degree of freedom

	Center	 :  (-20, 2.5, 0)

rResult[0] : 0.886796

Expected to be False, Returns True. 

