### PR TITLE
[CMake] Add `FindTBB.cmake` module to better locate Intel TBB library

### DIFF
--- a/cmake_modules/FindTBB.cmake
+++ b/cmake_modules/FindTBB.cmake
@@ -1,0 +1,101 @@
+# FindTBB.cmake
+# Finds the Intel Threading Building Blocks (TBB) library and creates the
+# imported target TBB::tbb used by Kratos when KRATOS_USE_TBB is ON.
+#
+# This module sets the following variables:
+#   TBB_FOUND        - TRUE if TBB headers and library were found
+#   TBB_INCLUDE_DIRS - Directory containing TBB headers
+#   TBB_LIBRARIES    - Full path to the TBB library
+#
+# And defines the imported target:
+#   TBB::tbb         - The TBB library target
+
+# Search for the TBB header
+find_path(TBB_INCLUDE_DIR
+    NAMES tbb/tbb.h
+    HINTS
+        ${TBB_DIR}
+        ${TBB_ROOT}
+        $ENV{TBB_DIR}
+        $ENV{TBB_ROOT}
+        $ENV{TBBROOT}
+    PATHS
+        /usr/include
+        /usr/local/include
+        /opt/intel/tbb/include
+        /opt/tbb/include
+)
+
+# Search for the TBB library
+find_library(TBB_LIBRARY
+    NAMES tbb
+    HINTS
+        ${TBB_DIR}
+        ${TBB_ROOT}
+        $ENV{TBB_DIR}
+        $ENV{TBB_ROOT}
+        $ENV{TBBROOT}
+    PATH_SUFFIXES
+        lib
+        lib64
+        lib/intel64
+        lib/intel64/gcc4.8
+    PATHS
+        /usr/lib
+        /usr/lib64
+        /usr/local/lib
+        /usr/local/lib64
+        /opt/intel/tbb/lib
+        /opt/tbb/lib
+)
+
+find_library(TBB_MALLOC_LIBRARY
+    NAMES tbbmalloc
+    HINTS
+        ${TBB_DIR}
+        ${TBB_ROOT}
+        $ENV{TBB_DIR}
+        $ENV{TBB_ROOT}
+        $ENV{TBBROOT}
+    PATH_SUFFIXES
+        lib
+        lib64
+        lib/intel64
+        lib/intel64/gcc4.8
+    PATHS
+        /usr/lib
+        /usr/lib64
+        /usr/local/lib
+        /usr/local/lib64
+        /opt/intel/tbb/lib
+        /opt/tbb/lib
+)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(TBB
+    REQUIRED_VARS TBB_LIBRARY TBB_INCLUDE_DIR
+)
+
+if(TBB_FOUND)
+    set(TBB_INCLUDE_DIRS ${TBB_INCLUDE_DIR})
+    set(TBB_LIBRARIES    ${TBB_LIBRARY})
+
+    if(NOT TARGET TBB::tbb)
+        add_library(TBB::tbb UNKNOWN IMPORTED)
+        set_target_properties(TBB::tbb PROPERTIES
+            IMPORTED_LOCATION             "${TBB_LIBRARY}"
+            INTERFACE_INCLUDE_DIRECTORIES "${TBB_INCLUDE_DIR}"
+            INTERFACE_COMPILE_DEFINITIONS "KRATOS_USE_TBB"
+        )
+    endif()
+
+    if(TBB_MALLOC_LIBRARY AND NOT TARGET TBB::tbbmalloc)
+        add_library(TBB::tbbmalloc UNKNOWN IMPORTED)
+        set_target_properties(TBB::tbbmalloc PROPERTIES
+            IMPORTED_LOCATION             "${TBB_MALLOC_LIBRARY}"
+            INTERFACE_INCLUDE_DIRECTORIES "${TBB_INCLUDE_DIR}"
+        )
+    endif()
+endif()
+
+mark_as_advanced(TBB_INCLUDE_DIR TBB_LIBRARY TBB_MALLOC_LIBRARY)


### PR DESCRIPTION
## **📝 Description**

The `cmake_modules/FindTBB.cmake` module was missing, causing CMake configuration to fail with an error when `KRATOS_USE_TBB=ON` because `find_package(TBB REQUIRED)` had no module to resolve the `TBB::tbb` imported target required by `kratos/CMakeLists.txt`.

### **📌 Details**

The new module:
- Searches standard system paths as well as `TBB_DIR`, `TBB_ROOT`, and the `TBBROOT` environment variable for the TBB headers (`tbb/tbb.h`) and the `tbb`/`tbbmalloc` shared libraries.
- Creates the `TBB::tbb` imported target with `INTERFACE_COMPILE_DEFINITIONS KRATOS_USE_TBB`, activating the `#ifdef KRATOS_USE_TBB` guards used throughout the Kratos C++ source.
- Creates the optional `TBB::tbbmalloc` imported target.
- Exposes the legacy `TBB_FOUND`, `TBB_INCLUDE_DIRS`, and `TBB_LIBRARIES` variables for any consumers using the variable-based API (e.g. Boost.Compute benchmarks).

### **✅ Testing**

Verified on Rocky Linux 8 with `tbb-devel-2018.2-10.el8_10.1.x86_64` — CMake correctly resolves:
- Headers: `/usr/include/tbb/tbb.h`
- Library: `/usr/lib64/libtbb.so`

## **🆕 Changelog**

- [Added `cmake_modules/FindTBB.cmake` with full support for locating TBB headers and libraries and creating the `TBB::tbb` and `TBB::tbbmalloc` imported targets](https://github.com/KratosMultiphysics/Kratos/commit/8994c3697877de97cabfc08f987e51a6c86c11fe)