### PR TITLE
[Core] Fix C++23 `size_t` literal in `test_atomic_utilities.cpp` when compiling with `KRATOS_USE_TBB`

### DIFF
--- a/kratos/tests/cpp_tests/utilities/test_atomic_utilities.cpp
+++ b/kratos/tests/cpp_tests/utilities/test_atomic_utilities.cpp
@@ -24,7 +24,6 @@
 #include "utilities/parallel_utilities.h"
 #include "utilities/atomic_utilities.h"
 
-
 namespace Kratos::Testing {
 
 KRATOS_TEST_CASE(AtomicAdd)
@@ -62,7 +61,7 @@ KRATOS_TEST_CASE(AtomicMult)
     double sum = 5;
 
 #ifdef KRATOS_USE_TBB
-    auto range = std::ranges::views::iota(0uz, size);
+    auto range = std::ranges::views::iota(static_cast<std::size_t>(0), size);
     std::for_each(std::execution::par_unseq, range.begin(), range.end(), [&sum, exp](int x) {
         AtomicMult(sum, exp);
     });


### PR DESCRIPTION
## **📝 Description**

This PR addresses a compilation error encountered when building Kratos with `KRATOS_USE_TBB` defined, on compilers that do not yet fully support C++23 features, specifically the uz literal suffix for `std::size_t`.

The line `auto range = std::ranges::views::iota(0uz, size);` within the `#ifdef KRATOS_USE_TBB` block in `kratos/tests/cpp_tests/utilities/test_atomic_utilities.cpp` was causing a build failure with the error `error: use of C++23 size_t integer constant [-Werror]`. **This specific syntax (`0uz`) is a C++23 feature.**

To resolve this, the `0uz` literal has been replaced with an explicit `static_cast<std::size_t>(0)`. This ensures compatibility with C++20 compilers while maintaining the correct type for the `iota` range generation. The change only affects the code path when `KRATOS_USE_TBB` is enabled.

### **🛠️ Changes made**

Modified `kratos/tests/cpp_tests/utilities/test_atomic_utilities.cpp` line 65 (within the `KRATOS_USE_TBB` block):

~~~~c++
Before: auto range = std::ranges::views::iota(0uz, size);
After: auto range = std::ranges::views::iota(static_cast<std::size_t>(0), size);
~~~~

This change maintains the intended functionality of the test case and resolves the build error for configurations using *TBB*, allowing for successful compilation across different C++ standard configurations.

## **🆕 Changelog**

- [Fix C++23 `size_t` literal in `test_atomic_utilities.cpp` when compiling with `KRATOS_USE_TBB`](https://github.com/KratosMultiphysics/Kratos/commit/44c734444b0b9db8871b6403ee31deff30974011)
