### PR TITLE
[GeoMechanicsApplication] Fix thread safety issue in geo process

### DIFF
--- a/applications/GeoMechanicsApplication/custom_processes/apply_final_stresses_of_previous_stage_to_initial_state.cpp
+++ b/applications/GeoMechanicsApplication/custom_processes/apply_final_stresses_of_previous_stage_to_initial_state.cpp
@@ -36,7 +36,7 @@ ApplyFinalStressesOfPreviousStageToInitialState::ApplyFinalStressesOfPreviousSta
 void ApplyFinalStressesOfPreviousStageToInitialState::ExecuteInitialize()
 {
     for (const auto& r_model_part : mrModelParts) {
-        block_for_each(r_model_part.get().Elements(), [&r_model_part, this](Element& rElement) {
+        for (auto& rElement : r_model_part.get().Elements()) {
             std::vector<Vector> stresses_on_integration_points;
             rElement.CalculateOnIntegrationPoints(PK2_STRESS_VECTOR, stresses_on_integration_points,
                                                   r_model_part.get().GetProcessInfo());
@@ -50,7 +50,7 @@ void ApplyFinalStressesOfPreviousStageToInitialState::ExecuteInitialize()
 
             CheckRetrievedElementData(constitutive_laws, stresses_on_integration_points, rElement.GetId());
             mStressesByElementId[rElement.GetId()] = stresses_on_integration_points;
-        });
+        }
     }
 }
 

--- a/applications/GeoMechanicsApplication/custom_processes/apply_final_stresses_of_previous_stage_to_initial_state.cpp
+++ b/applications/GeoMechanicsApplication/custom_processes/apply_final_stresses_of_previous_stage_to_initial_state.cpp
@@ -36,20 +36,20 @@ ApplyFinalStressesOfPreviousStageToInitialState::ApplyFinalStressesOfPreviousSta
 void ApplyFinalStressesOfPreviousStageToInitialState::ExecuteInitialize()
 {
     for (const auto& r_model_part : mrModelParts) {
-        for (auto& rElement : r_model_part.get().Elements()) {
+        for (auto& r_element : r_model_part.get().Elements()) {
             std::vector<Vector> stresses_on_integration_points;
-            rElement.CalculateOnIntegrationPoints(PK2_STRESS_VECTOR, stresses_on_integration_points,
-                                                  r_model_part.get().GetProcessInfo());
+            r_element.CalculateOnIntegrationPoints(PK2_STRESS_VECTOR, stresses_on_integration_points,
+                                                   r_model_part.get().GetProcessInfo());
             if (stresses_on_integration_points.empty()) {
-                rElement.CalculateOnIntegrationPoints(GEO_EFFECTIVE_TRACTION_VECTOR, stresses_on_integration_points,
-                                                      r_model_part.get().GetProcessInfo());
+                r_element.CalculateOnIntegrationPoints(GEO_EFFECTIVE_TRACTION_VECTOR, stresses_on_integration_points,
+                                                       r_model_part.get().GetProcessInfo());
             }
             std::vector<ConstitutiveLaw::Pointer> constitutive_laws;
-            rElement.CalculateOnIntegrationPoints(CONSTITUTIVE_LAW, constitutive_laws,
-                                                  r_model_part.get().GetProcessInfo());
+            r_element.CalculateOnIntegrationPoints(CONSTITUTIVE_LAW, constitutive_laws,
+                                                   r_model_part.get().GetProcessInfo());
 
-            CheckRetrievedElementData(constitutive_laws, stresses_on_integration_points, rElement.GetId());
-            mStressesByElementId[rElement.GetId()] = stresses_on_integration_points;
+            CheckRetrievedElementData(constitutive_laws, stresses_on_integration_points, r_element.GetId());
+            mStressesByElementId[r_element.GetId()] = stresses_on_integration_points;
         }
     }
 }


### PR DESCRIPTION
**📝 Description**
Due to the process writing data to a std::map in a block_for_each, the `ExecuteInitialize` function wasn't thread-safe. Since it happens only once per stage, for now a serial loop is acceptable and fixes the thread safety of the process.