### PR TITLE
[Core] Fix GCC 11 ICE in `GeometryMetricsTensorAdaptor` template instantiation

### DIFF
--- a/kratos/tensor_adaptors/geometry_metrics_tensor_adaptor.cpp
+++ b/kratos/tensor_adaptors/geometry_metrics_tensor_adaptor.cpp
@@ -31,7 +31,7 @@ DenseVector<unsigned int> GetShape(
     const GeometryMetricsTensorAdaptor::Metric CurrentMetric)
 {
     switch (CurrentMetric) {
-        case GeometryMetricsTensorAdaptor::DomainSize:
+        case GeometryMetricsTensorAdaptor::Metric::DomainSize:
             return DenseVector<unsigned int>(1, NumberOfEntities);
     }
 
@@ -65,7 +65,7 @@ void FillData(
     const TContainerType& rContainer)
 {
     switch (CurrentMetric) {
-        case GeometryMetricsTensorAdaptor::DomainSize:
+        case GeometryMetricsTensorAdaptor::Metric::DomainSize:
             FillDomainSize(DataSpan, rContainer);
             break;
     }
@@ -145,7 +145,7 @@ std::string GeometryMetricsTensorAdaptor::Info() const
     info << "GeometryMetricsTensorAdaptor:";
     info << " Metric = ";
     switch (mMetric) {
-        case DomainSize: info << "DomainSize"; break;
+        case Metric::DomainSize: info << "DomainSize"; break;
     }
     info << ", " << BaseType::Info();
     return info.str();


### PR DESCRIPTION
## **📝 Description**

Fix GCC 11 ICE in `GeometryMetricsTensorAdaptor` template instantiation

### Problem

GCC 11 triggers an internal compiler error (`tsubst_copy` at `cp/pt.c:16686`) when a C++20 `using enum` declaration imports enum enumerators into a class scope, and those enumerators are then referenced via the unqualified class name (`GeometryMetricsTensorAdaptor::DomainSize`) inside a template function instantiated through `std::visit`.

Error message:
```
kratos/tensor_adaptors/geometry_metrics_tensor_adaptor.cpp:68:44: internal compiler error: in tsubst_copy, at cp/pt.c:16686
   68 |         case GeometryMetricsTensorAdaptor::DomainSize:
```

### Fix

Replace all `GeometryMetricsTensorAdaptor::DomainSize` references in the `.cpp` file with the fully scoped form `GeometryMetricsTensorAdaptor::Metric::DomainSize`. This bypasses the buggy code path in GCC 11's template substitution logic while remaining valid C++20.

### Affected files

- `kratos/tensor_adaptors/geometry_metrics_tensor_adaptor.cpp`

## **🆕 Changelog**

- [Fix GCC 11 ICE in `GeometryMetricsTensorAdaptor` template instantiation](https://github.com/KratosMultiphysics/Kratos/commit/247e66f59f3ee7bb9dc0f960c6684ba90072221f)
