### PR TITLE
[Core] Add parallel try catch to remaining raw omp loops in builder and solver

### DIFF
--- a/kratos/solving_strategies/builder_and_solvers/residualbased_block_builder_and_solver.h
+++ b/kratos/solving_strategies/builder_and_solvers/residualbased_block_builder_and_solver.h
@@ -223,11 +223,15 @@ public:
         // Assemble all elements
         const auto timer = BuiltinTimer();
 
+        KRATOS_PREPARE_CATCH_THREAD_EXCEPTION
+
         #pragma omp parallel firstprivate(nelements,nconditions, LHS_Contribution, RHS_Contribution, EquationId )
         {
             # pragma omp for  schedule(guided, 512) nowait
-            for (int k = 0; k < nelements; k++) {
-                auto it_elem = el_begin + k;
+            for (int i = 0; i < nelements; i++) {
+                KRATOS_TRY
+
+                auto it_elem = el_begin + i;
 
                 if (it_elem->IsActive()) {
                     // Calculate elemental contribution
@@ -237,11 +241,14 @@ public:
                     Assemble(A, b, LHS_Contribution, RHS_Contribution, EquationId);
                 }
 
+                KRATOS_CATCH_THREAD_EXCEPTION
             }
 
             #pragma omp for  schedule(guided, 512)
-            for (int k = 0; k < nconditions; k++) {
-                auto it_cond = cond_begin + k;
+            for (int i = 0; i < nconditions; i++) {
+                KRATOS_TRY
+
+                auto it_cond = cond_begin + i;
 
                 if (it_cond->IsActive()) {
                     // Calculate elemental contribution
@@ -250,8 +257,12 @@ public:
                     // Assemble the elemental contribution
                     Assemble(A, b, LHS_Contribution, RHS_Contribution, EquationId);
                 }
+                KRATOS_CATCH_THREAD_EXCEPTION
+
             }
         }
+
+        KRATOS_CHECK_AND_THROW_THREAD_EXCEPTION
 
         KRATOS_INFO_IF("ResidualBasedBlockBuilderAndSolver", this->GetEchoLevel() >= 1) << "Build time: " << timer << std::endl;
 
@@ -297,11 +308,15 @@ public:
         // Assemble all elements
         const auto timer = BuiltinTimer();
 
+        KRATOS_PREPARE_CATCH_THREAD_EXCEPTION
+
         #pragma omp parallel firstprivate(nelements, nconditions, lhs_contribution, equation_id )
         {
             # pragma omp for  schedule(guided, 512) nowait
-            for (int k = 0; k < nelements; ++k) {
-                auto it_elem = it_elem_begin + k;
+            for (int i = 0; i < nelements; ++i) {
+                KRATOS_TRY
+
+                auto it_elem = it_elem_begin + i;
 
                 // Detect if the element is active or not. If the user did not make any choice the element is active by default
                 if (it_elem->IsActive()) {
@@ -311,11 +326,15 @@ public:
                     // Assemble the elemental contribution
                     AssembleLHS(rA, lhs_contribution, equation_id);
                 }
+
+                KRATOS_CATCH_THREAD_EXCEPTION
             }
 
             #pragma omp for  schedule(guided, 512)
-            for (int k = 0; k < nconditions; ++k) {
-                auto it_cond = it_cond_begin + k;
+            for (int i = 0; i < nconditions; ++i) {
+                KRATOS_TRY
+
+                auto it_cond = it_cond_begin + i;
 
                 // Detect if the element is active or not. If the user did not make any choice the element is active by default
                 if (it_cond->IsActive()) {
@@ -325,8 +344,12 @@ public:
                     // Assemble the elemental contribution
                     AssembleLHS(rA, lhs_contribution, equation_id);
                 }
+
+                KRATOS_CATCH_THREAD_EXCEPTION
             }
         }
+
+        KRATOS_CHECK_AND_THROW_THREAD_EXCEPTION
 
         KRATOS_INFO_IF("ResidualBasedBlockBuilderAndSolver", this->GetEchoLevel() >= 1) << "Build time LHS: " << timer << std::endl;
 

--- a/kratos/solving_strategies/builder_and_solvers/residualbased_block_builder_and_solver.h
+++ b/kratos/solving_strategies/builder_and_solvers/residualbased_block_builder_and_solver.h
@@ -241,7 +241,7 @@ public:
                     Assemble(A, b, LHS_Contribution, RHS_Contribution, EquationId);
                 }
 
-                KRATOS_CATCH_THREAD_EXCEPTION
+                KRATOS_CATCH_THREAD_EXCEPTION(omp_get_thread_num())
             }
 
             #pragma omp for  schedule(guided, 512)
@@ -257,7 +257,7 @@ public:
                     // Assemble the elemental contribution
                     Assemble(A, b, LHS_Contribution, RHS_Contribution, EquationId);
                 }
-                KRATOS_CATCH_THREAD_EXCEPTION
+                KRATOS_CATCH_THREAD_EXCEPTION(omp_get_thread_num())
 
             }
         }
@@ -327,7 +327,7 @@ public:
                     AssembleLHS(rA, lhs_contribution, equation_id);
                 }
 
-                KRATOS_CATCH_THREAD_EXCEPTION
+                KRATOS_CATCH_THREAD_EXCEPTION(omp_get_thread_num())
             }
 
             #pragma omp for  schedule(guided, 512)
@@ -345,7 +345,7 @@ public:
                     AssembleLHS(rA, lhs_contribution, equation_id);
                 }
 
-                KRATOS_CATCH_THREAD_EXCEPTION
+                KRATOS_CATCH_THREAD_EXCEPTION(omp_get_thread_num())
             }
         }
 
@@ -1218,7 +1218,7 @@ protected:
                     AssembleRHS(b, RHS_Contribution, EquationId);
                 }
 
-                KRATOS_CATCH_THREAD_EXCEPTION
+                KRATOS_CATCH_THREAD_EXCEPTION(omp_get_thread_num())
             }
 
             LHS_Contribution.resize(0, 0, false);
@@ -1240,7 +1240,7 @@ protected:
                     AssembleRHS(b, RHS_Contribution, EquationId);
                 }
 
-                KRATOS_CATCH_THREAD_EXCEPTION
+                KRATOS_CATCH_THREAD_EXCEPTION(omp_get_thread_num())
             }
         }
 
@@ -1282,7 +1282,7 @@ protected:
                         temp_indices[id_i].insert(master_ids.begin(), master_ids.end());
                     }
 
-                    KRATOS_CATCH_THREAD_EXCEPTION
+                    KRATOS_CATCH_THREAD_EXCEPTION(omp_get_thread_num())
                 }
 
                 // Merging all the temporal indexes
@@ -1400,7 +1400,7 @@ protected:
                         auxiliar_inactive_slave_dofs.insert(slave_equation_ids.begin(), slave_equation_ids.end());
                     }
 
-                    KRATOS_CATCH_THREAD_EXCEPTION
+                    KRATOS_CATCH_THREAD_EXCEPTION(omp_get_thread_num())
                 }
 
                 // We merge all the sets in one thread

--- a/kratos/solving_strategies/builder_and_solvers/residualbased_block_builder_and_solver.h
+++ b/kratos/solving_strategies/builder_and_solvers/residualbased_block_builder_and_solver.h
@@ -241,7 +241,7 @@ public:
                     Assemble(A, b, LHS_Contribution, RHS_Contribution, EquationId);
                 }
 
-                KRATOS_CATCH_THREAD_EXCEPTION(omp_get_thread_num())
+                KRATOS_CATCH_THREAD_EXCEPTION(GetCurrentThreadId())
             }
 
             #pragma omp for  schedule(guided, 512)
@@ -257,7 +257,7 @@ public:
                     // Assemble the elemental contribution
                     Assemble(A, b, LHS_Contribution, RHS_Contribution, EquationId);
                 }
-                KRATOS_CATCH_THREAD_EXCEPTION(omp_get_thread_num())
+                KRATOS_CATCH_THREAD_EXCEPTION(GetCurrentThreadId())
 
             }
         }
@@ -327,7 +327,7 @@ public:
                     AssembleLHS(rA, lhs_contribution, equation_id);
                 }
 
-                KRATOS_CATCH_THREAD_EXCEPTION(omp_get_thread_num())
+                KRATOS_CATCH_THREAD_EXCEPTION(GetCurrentThreadId())
             }
 
             #pragma omp for  schedule(guided, 512)
@@ -345,7 +345,7 @@ public:
                     AssembleLHS(rA, lhs_contribution, equation_id);
                 }
 
-                KRATOS_CATCH_THREAD_EXCEPTION(omp_get_thread_num())
+                KRATOS_CATCH_THREAD_EXCEPTION(GetCurrentThreadId())
             }
         }
 
@@ -1218,7 +1218,7 @@ protected:
                     AssembleRHS(b, RHS_Contribution, EquationId);
                 }
 
-                KRATOS_CATCH_THREAD_EXCEPTION(omp_get_thread_num())
+                KRATOS_CATCH_THREAD_EXCEPTION(GetCurrentThreadId())
             }
 
             LHS_Contribution.resize(0, 0, false);
@@ -1240,7 +1240,7 @@ protected:
                     AssembleRHS(b, RHS_Contribution, EquationId);
                 }
 
-                KRATOS_CATCH_THREAD_EXCEPTION(omp_get_thread_num())
+                KRATOS_CATCH_THREAD_EXCEPTION(GetCurrentThreadId())
             }
         }
 
@@ -1282,7 +1282,7 @@ protected:
                         temp_indices[id_i].insert(master_ids.begin(), master_ids.end());
                     }
 
-                    KRATOS_CATCH_THREAD_EXCEPTION(omp_get_thread_num())
+                    KRATOS_CATCH_THREAD_EXCEPTION(GetCurrentThreadId())
                 }
 
                 // Merging all the temporal indexes
@@ -1400,7 +1400,7 @@ protected:
                         auxiliar_inactive_slave_dofs.insert(slave_equation_ids.begin(), slave_equation_ids.end());
                     }
 
-                    KRATOS_CATCH_THREAD_EXCEPTION(omp_get_thread_num())
+                    KRATOS_CATCH_THREAD_EXCEPTION(GetCurrentThreadId())
                 }
 
                 // We merge all the sets in one thread
@@ -1742,6 +1742,15 @@ private:
         unsigned int pos = start;
         while(id_to_find != index_vector[pos]) pos--;
         return pos;
+    }
+
+    int GetCurrentThreadId() const
+    {
+#ifdef KRATOS_SMP_OPENMP
+        return omp_get_thread_num();
+#else
+        return 0;
+#endif
     }
 
     ///@}

--- a/kratos/solving_strategies/builder_and_solvers/residualbased_block_builder_and_solver.h
+++ b/kratos/solving_strategies/builder_and_solvers/residualbased_block_builder_and_solver.h
@@ -1262,6 +1262,8 @@ protected:
 
             std::vector<LockObject> lock_array(indices.size());
 
+            KRATOS_PREPARE_CATCH_THREAD_EXCEPTION
+
             #pragma omp parallel
             {
                 Element::EquationIdVectorType slave_ids(3);
@@ -1269,14 +1271,18 @@ protected:
                 std::unordered_map<IndexType, std::unordered_set<IndexType>> temp_indices;
 
                 #pragma omp for schedule(guided, 512) nowait
-                for (int i_const = 0; i_const < static_cast<int>(rModelPart.MasterSlaveConstraints().size()); ++i_const) {
-                    auto it_const = it_const_begin + i_const;
+                for (int i = 0; i < static_cast<int>(rModelPart.MasterSlaveConstraints().size()); ++i) {
+                    KRATOS_TRY
+
+                    auto it_const = it_const_begin + i;
                     it_const->EquationIdVector(slave_ids, master_ids, r_current_process_info);
 
                     // Slave DoFs
                     for (auto &id_i : slave_ids) {
                         temp_indices[id_i].insert(master_ids.begin(), master_ids.end());
                     }
+
+                    KRATOS_CATCH_THREAD_EXCEPTION
                 }
 
                 // Merging all the temporal indexes
@@ -1286,6 +1292,8 @@ protected:
                     lock_array[pair_temp_indices.first].unlock();
                 }
             }
+
+            KRATOS_CHECK_AND_THROW_THREAD_EXCEPTION
 
             mSlaveIds.clear();
             mMasterIds.clear();
@@ -1360,13 +1368,17 @@ protected:
             // We clear the set
             mInactiveSlaveDofs.clear();
 
+            KRATOS_PREPARE_CATCH_THREAD_EXCEPTION
+
             #pragma omp parallel firstprivate(transformation_matrix, constant_vector, slave_equation_ids, master_equation_ids)
             {
                 std::unordered_set<IndexType> auxiliar_inactive_slave_dofs;
 
                 #pragma omp for schedule(guided, 512)
-                for (int i_const = 0; i_const < number_of_constraints; ++i_const) {
-                    auto it_const = rModelPart.MasterSlaveConstraints().begin() + i_const;
+                for (int i = 0; i < number_of_constraints; ++i) {
+                    KRATOS_TRY
+
+                    auto it_const = rModelPart.MasterSlaveConstraints().begin() + i;
                     it_const->EquationIdVector(slave_equation_ids, master_equation_ids, r_current_process_info);
 
                     // If the constraint is active
@@ -1387,6 +1399,8 @@ protected:
                     } else { // Taking into account inactive constraints
                         auxiliar_inactive_slave_dofs.insert(slave_equation_ids.begin(), slave_equation_ids.end());
                     }
+
+                    KRATOS_CATCH_THREAD_EXCEPTION
                 }
 
                 // We merge all the sets in one thread
@@ -1395,6 +1409,8 @@ protected:
                     mInactiveSlaveDofs.insert(auxiliar_inactive_slave_dofs.begin(), auxiliar_inactive_slave_dofs.end());
                 }
             }
+
+            KRATOS_CHECK_AND_THROW_THREAD_EXCEPTION
 
             // Setting the master dofs into the T and C system
             for (auto eq_id : mMasterIds) {

--- a/kratos/utilities/parallel_utilities.h
+++ b/kratos/utilities/parallel_utilities.h
@@ -41,16 +41,16 @@
 #define KRATOS_PREPARE_CATCH_THREAD_EXCEPTION std::stringstream err_stream;
 
 #ifndef KRATOS_NO_TRY_CATCH
-    #define KRATOS_CATCH_THREAD_EXCEPTION \
+    #define KRATOS_CATCH_THREAD_EXCEPTION(ThreadNumber) \
     } catch(Exception& e) { \
         KRATOS_CRITICAL_SECTION \
-        err_stream << "Thread #" << i << " caught exception: " << e.what(); \
+        err_stream << "Thread #" << ThreadNumber << " caught exception: " << e.what(); \
     } catch(std::exception& e) { \
         KRATOS_CRITICAL_SECTION \
-        err_stream << "Thread #" << i << " caught exception: " << e.what(); \
+        err_stream << "Thread #" << ThreadNumber << " caught exception: " << e.what(); \
     } catch(...) { \
         KRATOS_CRITICAL_SECTION \
-        err_stream << "Thread #" << i << " caught unknown exception:"; \
+        err_stream << "Thread #" << ThreadNumber << " caught unknown exception:"; \
     }
 #else
     #define KRATOS_CATCH_THREAD_EXCEPTION {}
@@ -189,7 +189,7 @@ public:
             for (auto it = mBlockPartition[i]; it != mBlockPartition[i+1]; ++it) {
                 f(*it); //note that we pass the value to the function, not the iterator
             }
-            KRATOS_CATCH_THREAD_EXCEPTION
+            KRATOS_CATCH_THREAD_EXCEPTION(i)
         }
 
         KRATOS_CHECK_AND_THROW_THREAD_EXCEPTION
@@ -214,7 +214,7 @@ public:
                 local_reducer.LocalReduce(f(*it));
             }
             global_reducer.ThreadSafeReduce(local_reducer);
-            KRATOS_CATCH_THREAD_EXCEPTION
+            KRATOS_CATCH_THREAD_EXCEPTION(i)
         }
 
         KRATOS_CHECK_AND_THROW_THREAD_EXCEPTION
@@ -244,7 +244,7 @@ public:
                 for (auto it = mBlockPartition[i]; it != mBlockPartition[i+1]; ++it){
                     f(*it, thread_local_storage); // note that we pass the value to the function, not the iterator
                 }
-                KRATOS_CATCH_THREAD_EXCEPTION
+                KRATOS_CATCH_THREAD_EXCEPTION(i)
             }
         }
         KRATOS_CHECK_AND_THROW_THREAD_EXCEPTION
@@ -278,7 +278,7 @@ public:
                     local_reducer.LocalReduce(f(*it, thread_local_storage));
                 }
                 global_reducer.ThreadSafeReduce(local_reducer);
-                KRATOS_CATCH_THREAD_EXCEPTION
+                KRATOS_CATCH_THREAD_EXCEPTION(i)
             }
         }
         KRATOS_CHECK_AND_THROW_THREAD_EXCEPTION
@@ -525,7 +525,7 @@ public:
             for (auto k = mBlockPartition[i]; k < mBlockPartition[i+1]; ++k) {
                 f(k); //note that we pass a reference to the value, not the iterator
             }
-            KRATOS_CATCH_THREAD_EXCEPTION
+            KRATOS_CATCH_THREAD_EXCEPTION(i)
         }
         KRATOS_CHECK_AND_THROW_THREAD_EXCEPTION
     }
@@ -549,7 +549,7 @@ public:
                 local_reducer.LocalReduce(f(k));
             }
             global_reducer.ThreadSafeReduce(local_reducer);
-            KRATOS_CATCH_THREAD_EXCEPTION
+            KRATOS_CATCH_THREAD_EXCEPTION(i)
         }
         KRATOS_CHECK_AND_THROW_THREAD_EXCEPTION
         return global_reducer.GetValue();
@@ -578,7 +578,7 @@ public:
                 for (auto k = mBlockPartition[i]; k < mBlockPartition[i+1]; ++k) {
                     f(k, thread_local_storage); //note that we pass a reference to the value, not the iterator
                 }
-                KRATOS_CATCH_THREAD_EXCEPTION
+                KRATOS_CATCH_THREAD_EXCEPTION(i)
             }
         }
         KRATOS_CHECK_AND_THROW_THREAD_EXCEPTION
@@ -612,7 +612,7 @@ public:
                     local_reducer.LocalReduce(f(k, thread_local_storage));
                 }
                 global_reducer.ThreadSafeReduce(local_reducer);
-                KRATOS_CATCH_THREAD_EXCEPTION
+                KRATOS_CATCH_THREAD_EXCEPTION(i)
             }
         }
         KRATOS_CHECK_AND_THROW_THREAD_EXCEPTION


### PR DESCRIPTION
**📝 Description**
In a previous PR #14193, one of the raw omp loops was provided with error handling. We have found that the other raw OpenMP loops in the same class, the `ResidualBasedBlockBuilderAndSolver`, result in similar hard crashes on windows. 

In the aforementioned PR it was proven that adding these try-catch macros don't have a significant impact on runtime.

There is one small discussion point here about the loop index `i`, for which I'll add a clarifying comment close to the concerning code.


