### PR TITLE
[GeoMechanicsApplication] Fix total stress vector calculation breaking plasticity status output

### DIFF
--- a/applications/GeoMechanicsApplication/custom_constitutive/interface_coulomb_with_tension_cut_off.cpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/interface_coulomb_with_tension_cut_off.cpp
@@ -145,6 +145,10 @@ void InterfaceCoulombWithTensionCutOff::InitializeMaterialResponseCauchy(Paramet
 
 void InterfaceCoulombWithTensionCutOff::CalculateMaterialResponseCauchy(Parameters& rConstitutiveLawParameters)
 {
+    if (!rConstitutiveLawParameters.GetOptions().Is(ConstitutiveLaw::COMPUTE_STRESS)) {
+        return;
+    }
+
     const auto& r_properties = rConstitutiveLawParameters.GetMaterialProperties();
 
     auto trial_sigma_tau = CalculateTrialTractionVector(rConstitutiveLawParameters.GetStrainVector(),

--- a/applications/GeoMechanicsApplication/custom_constitutive/mohr_coulomb_with_tension_cutoff.cpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/mohr_coulomb_with_tension_cutoff.cpp
@@ -202,6 +202,9 @@ void MohrCoulombWithTensionCutOff::CalculateMaterialResponseCauchy(ConstitutiveL
     if (rParameters.GetOptions().Is(ConstitutiveLaw::COMPUTE_CONSTITUTIVE_TENSOR)) {
         rParameters.GetConstitutiveMatrix() = mpConstitutiveDimension->CalculateElasticMatrix(r_properties);
     }
+    if (!rParameters.GetOptions().Is(ConstitutiveLaw::COMPUTE_STRESS)) {
+        return;
+    }
 
     const auto trial_stress_vector = CalculateTrialStressVector(rParameters.GetStrainVector(), r_properties);
     const auto& [trial_principal_stresses, rotation_matrix] =

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_constitutive/test_interface_coulomb_with_tension_cut_off.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_constitutive/test_interface_coulomb_with_tension_cut_off.cpp
@@ -66,6 +66,7 @@ KRATOS_TEST_CASE_IN_SUITE(InterfaceCoulombWithTensionCutOff_CalculateMaterialRes
 
     auto parameters = ConstitutiveLaw::Parameters{};
     parameters.SetMaterialProperties(properties);
+    parameters.Set(ConstitutiveLaw::COMPUTE_STRESS);
     auto traction_vector = Vector{ZeroVector{2}};
     parameters.SetStressVector(traction_vector);
     auto relative_displacement_vector = Vector{ZeroVector{2}};
@@ -131,6 +132,7 @@ KRATOS_TEST_CASE_IN_SUITE(InterfaceCoulombWithTensionCutOff_CalculateMaterialRes
 
     auto parameters = ConstitutiveLaw::Parameters{};
     parameters.SetMaterialProperties(properties);
+    parameters.Set(ConstitutiveLaw::COMPUTE_STRESS);
     auto traction_vector = Vector{ZeroVector{2}};
     parameters.SetStressVector(traction_vector);
     auto relative_displacement_vector = Vector{ZeroVector{2}};
@@ -171,6 +173,7 @@ KRATOS_TEST_CASE_IN_SUITE(InterfaceCoulombWithTensionCutOff_CalculateMaterialRes
 
     auto parameters = ConstitutiveLaw::Parameters{};
     parameters.SetMaterialProperties(properties);
+    parameters.Set(ConstitutiveLaw::COMPUTE_STRESS);
     auto traction_vector = Vector{ZeroVector{2}};
     parameters.SetStressVector(traction_vector);
     auto relative_displacement_vector = Vector{ZeroVector{2}};
@@ -209,6 +212,7 @@ KRATOS_TEST_CASE_IN_SUITE(InterfaceCoulombWithTensionCutOff_CalculateMaterialRes
 
     auto parameters = ConstitutiveLaw::Parameters{};
     parameters.SetMaterialProperties(properties);
+    parameters.Set(ConstitutiveLaw::COMPUTE_STRESS);
     auto traction_vector = Vector{ZeroVector{2}};
     parameters.SetStressVector(traction_vector);
     auto relative_displacement_vector = Vector{ZeroVector{2}};
@@ -249,6 +253,7 @@ KRATOS_TEST_CASE_IN_SUITE(InterfaceCoulombWithTensionCutOff_CalculateMaterialRes
 
     auto parameters = ConstitutiveLaw::Parameters{};
     parameters.SetMaterialProperties(properties);
+    parameters.Set(ConstitutiveLaw::COMPUTE_STRESS);
     auto traction_vector = Vector{ZeroVector{2}};
     parameters.SetStressVector(traction_vector);
     auto relative_displacement_vector = Vector{ZeroVector{2}};
@@ -275,6 +280,39 @@ KRATOS_TEST_CASE_IN_SUITE(InterfaceCoulombWithTensionCutOff_CalculateMaterialRes
     KRATOS_EXPECT_EQ(plasticity_status, static_cast<int>(PlasticityStatus::MOHR_COULOMB_FAILURE));
 }
 
+KRATOS_TEST_CASE_IN_SUITE(InterfaceCoulombWithTensionCutOff_DoesNotCalculateStressDependingOnOption,
+                          KratosGeoMechanicsFastSuiteWithoutKernel)
+{
+    // Arrange
+    auto properties = Properties{};
+    properties.SetValue(GEO_FRICTION_ANGLE, 35.0);
+    properties.SetValue(GEO_COHESION, 10.0);
+    properties.SetValue(GEO_DILATANCY_ANGLE, 0.0);
+    properties.SetValue(GEO_TENSILE_STRENGTH, 10.0);
+    properties.SetValue(INTERFACE_NORMAL_STIFFNESS, 25.0);
+    properties.SetValue(INTERFACE_SHEAR_STIFFNESS, 12.5);
+
+    auto parameters = ConstitutiveLaw::Parameters{};
+    parameters.SetMaterialProperties(properties);
+    auto traction_vector = Vector{ZeroVector{2}};
+    parameters.SetStressVector(traction_vector);
+    auto relative_displacement_vector = Vector{ZeroVector{2}};
+    parameters.SetStrainVector(relative_displacement_vector);
+
+    auto law = InterfaceCoulombWithTensionCutOff{std::make_unique<InterfacePlaneStrain>()};
+    InitializeLawMaterial(law, properties);
+
+    // Act
+    law.CalculateMaterialResponseCauchy(parameters);
+    const auto& r_resulting_traction = parameters.GetStressVector();
+    int         plasticity_status;
+    law.GetValue(GEO_PLASTICITY_STATUS, plasticity_status);
+
+    // Assert
+    const auto expected_traction = UblasUtilities::CreateVector({0.0, 0.0});
+    KRATOS_EXPECT_VECTOR_NEAR(r_resulting_traction, expected_traction, Defaults::absolute_tolerance);
+}
+
 KRATOS_TEST_CASE_IN_SUITE(InterfaceCoulombWithTensionCutOff_Serialization, KratosGeoMechanicsFastSuiteWithoutKernel)
 {
     // Arrange
@@ -288,6 +326,7 @@ KRATOS_TEST_CASE_IN_SUITE(InterfaceCoulombWithTensionCutOff_Serialization, Krato
 
     auto parameters = ConstitutiveLaw::Parameters{};
     parameters.SetMaterialProperties(properties);
+    parameters.Set(ConstitutiveLaw::COMPUTE_STRESS);
     auto traction_vector = Vector{ZeroVector{2}};
     parameters.SetStressVector(traction_vector);
     auto relative_displacement_vector = Vector{ZeroVector{2}};

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_constitutive/test_interface_coulomb_with_tension_cut_off.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_constitutive/test_interface_coulomb_with_tension_cut_off.cpp
@@ -305,8 +305,6 @@ KRATOS_TEST_CASE_IN_SUITE(InterfaceCoulombWithTensionCutOff_DoesNotCalculateStre
     // Act
     law.CalculateMaterialResponseCauchy(parameters);
     const auto& r_resulting_traction = parameters.GetStressVector();
-    int         plasticity_status;
-    law.GetValue(GEO_PLASTICITY_STATUS, plasticity_status);
 
     // Assert
     const auto expected_traction = UblasUtilities::CreateVector({0.0, 0.0});

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_constitutive/test_interface_coulomb_with_tension_cut_off.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_constitutive/test_interface_coulomb_with_tension_cut_off.cpp
@@ -296,7 +296,7 @@ KRATOS_TEST_CASE_IN_SUITE(InterfaceCoulombWithTensionCutOff_DoesNotCalculateStre
     parameters.SetMaterialProperties(properties);
     auto traction_vector = Vector{ZeroVector{2}};
     parameters.SetStressVector(traction_vector);
-    auto relative_displacement_vector = Vector{ZeroVector{2}};
+    auto relative_displacement_vector = Vector{2, 1.0};
     parameters.SetStrainVector(relative_displacement_vector);
 
     auto law = InterfaceCoulombWithTensionCutOff{std::make_unique<InterfacePlaneStrain>()};
@@ -305,10 +305,13 @@ KRATOS_TEST_CASE_IN_SUITE(InterfaceCoulombWithTensionCutOff_DoesNotCalculateStre
     // Act
     law.CalculateMaterialResponseCauchy(parameters);
     const auto& r_resulting_traction = parameters.GetStressVector();
+    int         plasticity_status;
+    law.GetValue(GEO_PLASTICITY_STATUS, plasticity_status);
 
     // Assert
     const auto expected_traction = UblasUtilities::CreateVector({0.0, 0.0});
     KRATOS_EXPECT_VECTOR_NEAR(r_resulting_traction, expected_traction, Defaults::absolute_tolerance);
+    KRATOS_EXPECT_EQ(plasticity_status, static_cast<int>(PlasticityStatus::ELASTIC));
 }
 
 KRATOS_TEST_CASE_IN_SUITE(InterfaceCoulombWithTensionCutOff_Serialization, KratosGeoMechanicsFastSuiteWithoutKernel)

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_constitutive/test_interface_coulomb_with_tension_cut_off.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_constitutive/test_interface_coulomb_with_tension_cut_off.cpp
@@ -280,7 +280,7 @@ KRATOS_TEST_CASE_IN_SUITE(InterfaceCoulombWithTensionCutOff_CalculateMaterialRes
     KRATOS_EXPECT_EQ(plasticity_status, static_cast<int>(PlasticityStatus::MOHR_COULOMB_FAILURE));
 }
 
-KRATOS_TEST_CASE_IN_SUITE(InterfaceCoulombWithTensionCutOff_DoesNotCalculateStressDependingOnOption,
+KRATOS_TEST_CASE_IN_SUITE(InterfaceCoulombWithTensionCutOff_DoesNotCalculateStressWhenComputeStressOptionIsNotSet,
                           KratosGeoMechanicsFastSuiteWithoutKernel)
 {
     // Arrange

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_constitutive/test_mohr_coulomb_with_tension_cutoff.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_constitutive/test_mohr_coulomb_with_tension_cutoff.cpp
@@ -716,22 +716,21 @@ KRATOS_TEST_CASE_IN_SUITE(MohrCoulombWithTensionCutOff_DoesNotCalculateStressWhe
     const auto dummy_shape_function_values = Vector{};
     law.InitializeMaterial(properties, dummy_element_geometry, dummy_shape_function_values);
 
-    auto   cauchy_stress_vector = UblasUtilities::CreateVector({18.0, 0.0, 0.0, -8.0});
-    Vector strain_vector        = ZeroVector(4);
+    auto cauchy_stress_vector = Vector{4, 0.0};
+    auto strain_vector        = Vector{4, 1.0};
     parameters.SetStrainVector(strain_vector);
     parameters.SetStressVector(cauchy_stress_vector);
 
-    const auto dummy_process_info = ProcessInfo{};
-    law.SetValue(CAUCHY_STRESS_VECTOR, cauchy_stress_vector, dummy_process_info);
-    law.FinalizeMaterialResponseCauchy(parameters);
-
     // Act
     law.CalculateMaterialResponseCauchy(parameters);
+    int plasticity_status;
+    law.GetValue(GEO_PLASTICITY_STATUS, plasticity_status);
 
     // Assert
-    const auto expected_cauchy_stress_vector = UblasUtilities::CreateVector({18.0, 0.0, 0.0, -8.0});
+    const auto expected_cauchy_stress_vector = Vector{4, 0.0};
     KRATOS_EXPECT_VECTOR_NEAR(parameters.GetStressVector(), expected_cauchy_stress_vector,
                               Defaults::absolute_tolerance);
+    KRATOS_EXPECT_EQ(plasticity_status, static_cast<int>(PlasticityStatus::ELASTIC));
 }
 
 KRATOS_TEST_CASE_IN_SUITE(MohrCoulombWithTensionCutOff_CalculateMaterialResponseCauchyAtTensionApexReturnZoneInterface,

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_constitutive/test_mohr_coulomb_with_tension_cutoff.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_constitutive/test_mohr_coulomb_with_tension_cutoff.cpp
@@ -32,6 +32,8 @@ Vector CalculateMappedStressVector(Vector&                       rCauchyStressVe
     Vector strain_vector = ZeroVector(4);
     rParameters.SetStrainVector(strain_vector);
     rParameters.SetStressVector(rCauchyStressVector);
+    rParameters.Set(ConstitutiveLaw::COMPUTE_STRESS);
+
     const auto dummy_process_info = ProcessInfo{};
     rLaw.SetValue(CAUCHY_STRESS_VECTOR, rCauchyStressVector, dummy_process_info);
     rLaw.FinalizeMaterialResponseCauchy(rParameters);
@@ -696,6 +698,42 @@ KRATOS_TEST_CASE_IN_SUITE(MohrCoulombWithTensionCutOff_CalculateMaterialResponse
     KRATOS_EXPECT_EQ(plasticity_status, static_cast<int>(PlasticityStatus::TENSION_MOHR_COULOMB_CORNER));
 }
 
+KRATOS_TEST_CASE_IN_SUITE(MohrCoulombWithTensionCutOff_CalculateMaterialResponseCauchyDoesNotChangeStressVectorDependingOnOptions,
+                          KratosGeoMechanicsFastSuiteWithoutKernel)
+{
+    // Arrange
+    auto       law = MohrCoulombWithTensionCutOff(std::make_unique<PlaneStrain>());
+    Properties properties;
+    properties.SetValue(YOUNG_MODULUS, 1.0e6);
+    properties.SetValue(POISSON_RATIO, 0.25);
+    properties.SetValue(GEO_FRICTION_ANGLE, 35.0);
+    properties.SetValue(GEO_COHESION, 10.0);
+    properties.SetValue(GEO_DILATANCY_ANGLE, 20.0);
+    properties.SetValue(GEO_TENSILE_STRENGTH, 10.0);
+    ConstitutiveLaw::Parameters parameters;
+    parameters.SetMaterialProperties(properties);
+    const auto dummy_element_geometry      = Geometry<Node>{};
+    const auto dummy_shape_function_values = Vector{};
+    law.InitializeMaterial(properties, dummy_element_geometry, dummy_shape_function_values);
+
+    auto   cauchy_stress_vector = UblasUtilities::CreateVector({18.0, 0.0, 0.0, -8.0});
+    Vector strain_vector        = ZeroVector(4);
+    parameters.SetStrainVector(strain_vector);
+    parameters.SetStressVector(cauchy_stress_vector);
+
+    const auto dummy_process_info = ProcessInfo{};
+    law.SetValue(CAUCHY_STRESS_VECTOR, cauchy_stress_vector, dummy_process_info);
+    law.FinalizeMaterialResponseCauchy(parameters);
+
+    // Act
+    law.CalculateMaterialResponseCauchy(parameters);
+
+    // Assert
+    const auto expected_cauchy_stress_vector = UblasUtilities::CreateVector({18.0, 0.0, 0.0, -8.0});
+    KRATOS_EXPECT_VECTOR_NEAR(parameters.GetStressVector(), expected_cauchy_stress_vector,
+                              Defaults::absolute_tolerance);
+}
+
 KRATOS_TEST_CASE_IN_SUITE(MohrCoulombWithTensionCutOff_CalculateMaterialResponseCauchyAtTensionApexReturnZoneInterface,
                           KratosGeoMechanicsFastSuiteWithoutKernel)
 {
@@ -800,6 +838,7 @@ Vector ComputeStressVectorUsingCPhiReductionTestData(double  Cohesion,
     law.InitializeMaterial(properties, dummy_element_geometry, dummy_shape_function_values);
 
     ConstitutiveLaw::Parameters parameters;
+    parameters.Set(ConstitutiveLaw::COMPUTE_STRESS);
     parameters.SetMaterialProperties(properties);
     parameters.SetStrainVector(rStrainVectorFinalized);
     parameters.SetStressVector(rStressVectorFinalized);

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_constitutive/test_mohr_coulomb_with_tension_cutoff.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_constitutive/test_mohr_coulomb_with_tension_cutoff.cpp
@@ -698,7 +698,7 @@ KRATOS_TEST_CASE_IN_SUITE(MohrCoulombWithTensionCutOff_CalculateMaterialResponse
     KRATOS_EXPECT_EQ(plasticity_status, static_cast<int>(PlasticityStatus::TENSION_MOHR_COULOMB_CORNER));
 }
 
-KRATOS_TEST_CASE_IN_SUITE(MohrCoulombWithTensionCutOff_CalculateMaterialResponseCauchyDoesNotChangeStressVectorDependingOnOptions,
+KRATOS_TEST_CASE_IN_SUITE(MohrCoulombWithTensionCutOff_DoesNotCalculateStressWhenComputeStressOptionIsNotSet,
                           KratosGeoMechanicsFastSuiteWithoutKernel)
 {
     // Arrange

--- a/applications/GeoMechanicsApplication/tests/test_mohr_coulomb_with_tension_cutoff/test_dirichlet_regular_failure_zone_2d/ProjectParameters.json
+++ b/applications/GeoMechanicsApplication/tests/test_mohr_coulomb_with_tension_cutoff/test_dirichlet_regular_failure_zone_2d/ProjectParameters.json
@@ -67,7 +67,7 @@
                         "node_output":         true,
                         "skin_output":         false,
                         "nodal_results":       ["DISPLACEMENT","REACTION"],
-                        "gauss_point_results": ["CAUCHY_STRESS_TENSOR", "ENGINEERING_STRAIN_TENSOR","GEO_PLASTICITY_STATUS"]
+                        "gauss_point_results": ["CAUCHY_STRESS_TENSOR", "ENGINEERING_STRAIN_TENSOR","TOTAL_STRESS_TENSOR","GEO_PLASTICITY_STATUS"]
                     }
                 }
             }


### PR DESCRIPTION
**📝 Description**
This PR fixes the issue that `TOTAL_STRESS_VECTOR` calculation has an influence on the `GEO_PLASTICITY_STATUS`. When calculating the total stress vector, the `CalculateMaterialResponseCauchy` is called without the `ConstitutiveLaw::COMPUTE_STRESS` option. When this option is off, the stress shouldn't be calculated (and re-calculating the stress multiple times per iteration is what causes the issue).

Our new laws didn't take these options into account properly. This is fixed in this PR. Also for one of the integration tests, the total stress vector is added as an output, such that it fails without this fix.