### PR TITLE
[Core] Fix Intel LLVM structured-bindings workaround and alignment macro in P-multigrid scaling

### DIFF
--- a/kratos/solving_strategies/builder_and_solvers/p_multigrid/diagonal_scaling.hpp
+++ b/kratos/solving_strategies/builder_and_solvers/p_multigrid/diagonal_scaling.hpp
@@ -134,11 +134,16 @@ void Scaling::Cache(const typename TSparse::MatrixType& rMatrix)
         ? std::pow(static_cast<Value>(1) / static_cast<Value>(rMatrix.size1()), static_cast<Value>(2))
         : static_cast<Value>(1);
 
-    const auto [abs_max, square_norm] = IndexPartition<typename TSparse::IndexType>(rMatrix.size1()).template for_each<Reduction>([&rMatrix, norm_coefficient](auto i_row){
+    // Note: structured bindings on the result of for_each<CombinedReduction> crash
+    // Intel LLVM (icx-cl) with an ICE in LLVM IR generation.
+    // Use std::get<> explicitly to work around the bug.
+    const auto result = IndexPartition<typename TSparse::IndexType>(rMatrix.size1()).template for_each<Reduction>([&rMatrix, norm_coefficient](auto i_row){
         const auto maybe_diagonal_entry = detail::FindDiagonal<TSparse>(rMatrix, i_row);
         const Value diagonal_entry = maybe_diagonal_entry.has_value() ? *maybe_diagonal_entry : static_cast<Value>(0);
         return std::make_tuple(std::abs(diagonal_entry), norm_coefficient * diagonal_entry * diagonal_entry);
     });
+    const Value abs_max = std::get<0>(result);
+    const Value square_norm = std::get<1>(result);
 
     this->Cache(abs_max, std::sqrt(square_norm));
 

--- a/kratos/solving_strategies/builder_and_solvers/p_multigrid/sparse_utilities.hpp
+++ b/kratos/solving_strategies/builder_and_solvers/p_multigrid/sparse_utilities.hpp
@@ -56,11 +56,13 @@ namespace Kratos {
 
 
 // "Hey compiler trust me, my arrays are aligned so try vectorizing my loops over them."
-#if defined(__GNUC__) || defined(__clang__)
+// Note: Intel LLVM (icx-cl) defines __clang__ but __builtin_assume_aligned triggers an ICE
+// in its clang frontend, so we exclude it via __INTEL_LLVM_COMPILER.
+#if (defined(__GNUC__) || defined(__clang__)) && !defined(__INTEL_LLVM_COMPILER)
 #define KRATOS_GET_ALIGNED_INDEX_ARRAY(POINTER_TYPE, POINTER_NAME, POINTER_VALUE)                                                   \
     POINTER_TYPE __restrict POINTER_NAME = (POINTER_TYPE) __builtin_assume_aligned(POINTER_VALUE, CHAR_BIT * sizeof(POINTER_TYPE));
 #else
-// Someone can figure out how to encourage AVX on MSVC, I won't.
+// Someone can figure out how to encourage AVX on MSVC/Intel LLVM, I won't.
 #define KRATOS_GET_ALIGNED_INDEX_ARRAY(POINTER_TYPE, POINTER_NAME, POINTER_VALUE)   \
     POINTER_TYPE POINTER_NAME = POINTER_VALUE;
 #endif


### PR DESCRIPTION
---
name: 🔧 Bugfix / Portability
about: Fix compiler-specific issues for Intel/oneAPI LLVM in p-multigrid scaling
---

## **📝 Description**

Two small, non-breaking fixes to improve compiler portability in the p-multigrid scaling code:

- Apply a structured-bindings workaround in `Scaling::Cache` to avoid compilation errors with Intel/oneAPI LLVM.
- Adjust the alignment macro to exclude Intel/oneAPI LLVM where it misbehaves and clarify AVX support conditions.

### **What / Why**

Intel's LLVM frontend shows issues with structured bindings and the current alignment macro usage in the p-multigrid scaling utilities. These edits apply a safe workaround and restrict the alignment macro where it causes problems. The intent is to preserve semantics while making the code compile correctly with Intel/oneAPI LLVM.

### **Impact**

- Implementation-only, no public API or algorithmic behavior changes.
- Intended to improve cross-compiler portability (Intel/oneAPI LLVM), while remaining compatible with MSVC/GCC/Clang.

## **🆕 Changelog**

### **Files changed**

- `kratos/solving_strategies/builder_and_solvers/p_multigrid/diagonal_scaling.hpp`
- `kratos/solving_strategies/builder_and_solvers/p_multigrid/sparse_utilities.hpp`

### **Commits**

- [Fix alignment macro to exclude Intel LLVM compiler and clarify AVX support](https://github.com/KratosMultiphysics/Kratos/commit/6256dd088aa8e6336f21d2cde07b213f0877c2f2)
- [Fix structured bindings workaround for Intel LLVM compiler in Scaling::Cache](https://github.com/KratosMultiphysics/Kratos/commit/33d8b0cdc0a13ce9eeac8a828f2f5be191281928)