### PR TITLE
[MeshMovingApplication] Improve robustness of structural mesh moving element against inverted elements

### DIFF
--- a/applications/MeshMovingApplication/custom_elements/structural_meshmoving_element.cpp
+++ b/applications/MeshMovingApplication/custom_elements/structural_meshmoving_element.cpp
@@ -104,7 +104,7 @@ StructuralMeshMovingElement::SetAndModifyConstitutiveLaw(
 
   MoveMeshUtilities::CheckJacobianDimension(invJ0, detJ0, rgeom);
 
-  if (detJ0[PointNumber] < 0.0) {
+  if (detJ0[PointNumber] < std::numeric_limits<double>::epsilon()) {
     KRATOS_ERROR << "Invalid negative Jacobian determinant detected!, Element ID: " << this->Id()
     << "\n Element is inverted. Check mesh quality, node ordering, or surface normals." << std::endl;
   }

--- a/applications/MeshMovingApplication/custom_elements/structural_meshmoving_element.cpp
+++ b/applications/MeshMovingApplication/custom_elements/structural_meshmoving_element.cpp
@@ -104,6 +104,11 @@ StructuralMeshMovingElement::SetAndModifyConstitutiveLaw(
 
   MoveMeshUtilities::CheckJacobianDimension(invJ0, detJ0, rgeom);
 
+  if (detJ0[PointNumber] < 0.0) {
+    KRATOS_ERROR << "Invalid negative Jacobian determinant detected!, Element ID: " << this->Id()
+    << "\n Element is inverted. Check mesh quality, node ordering, or surface normals." << std::endl;
+  }
+
   J0 = GetGeometry().Jacobian(J0, this_integration_method);
 
   MathUtils<double>::InvertMatrix(J0[PointNumber], invJ0[PointNumber],


### PR DESCRIPTION
## 🚀 Description
This PR adds checks for negative Jacobians in the structural mesh moving element to detect inverted elements early.  
It also improves error reporting, preventing silent NaNs and facilitating debugging of mesh quality issues.

## ⚠️ Motivation
Inverted elements can lead to invalid Jacobians and NaNs during assembly.

## 🔧 Changelog
- Modified `structural_meshmoving_element.cpp`