### PR TITLE
[MAPPING] Fix typo in KratosBeamMapping default parameters retrieval

### DIFF
--- a/applications/CoSimulationApplication/python_scripts/data_transfer_operators/kratos_beam_mapping.py
+++ b/applications/CoSimulationApplication/python_scripts/data_transfer_operators/kratos_beam_mapping.py
@@ -114,7 +114,7 @@ class KratosBeamMapping(CoSimulationDataTransferOperator):
             "type": "kratos_beam_mapping",
             "echo_level": 0
         }""")
-        this_defaults.AddMissingParameters(super(KratosBeamMapping, cls)._GetDefaultParameterss())
+        this_defaults.AddMissingParameters(super(KratosBeamMapping, cls)._GetDefaultParameters())
         return this_defaults
 
     @classmethod


### PR DESCRIPTION
**Description**
This PR fixes a typo in `KratosBeamMapping._GetDefaultParameters(),` where the base class method was incorrectly called as `super()._GetDefaultParameterss()` instead of `super()._GetDefaultParameters()`.