### PR TITLE
[Core / OptApp] Add Step and Time customization for VtuOutput

### DIFF
--- a/applications/OptimizationApplication/python_scripts/processes/optimization_problem_vtu_output_process.py
+++ b/applications/OptimizationApplication/python_scripts/processes/optimization_problem_vtu_output_process.py
@@ -63,7 +63,7 @@ class TensorAdaptorVtuOutput(TensorAdaptorOutput):
         output_file_name = self.output_file_name_prefix
         output_file_name = output_file_name.replace("<model_part_full_name>", self.model_part.FullName())
         output_file_name = output_file_name.replace("<model_part_name>", self.model_part.Name)
-        self.vtu_output.PrintOutput(str(self.output_path / output_file_name))
+        self.vtu_output.PrintOutput(str(self.output_path / output_file_name), self.optimization_problem.GetStep(), self.optimization_problem.GetStep())
 
     def __str__(self) -> str:
         return f"TensorAdaptorVtuOutput with \"{self.vtu_output.GetModelPart().FullName()}\""

--- a/kratos/input_output/vtu_output.cpp
+++ b/kratos/input_output/vtu_output.cpp
@@ -1488,18 +1488,26 @@ void VtuOutput::WriteData(
     KRATOS_CATCH("");
 }
 
-void VtuOutput::PrintOutput(const std::string& rOutputFileNamePrefix)
+void VtuOutput::PrintOutput(
+    const std::string& rOutputFileNamePrefix,
+    const int Step,
+    const double Time)
 {
     KRATOS_TRY
 
-    const auto& r_process_info = mrModelPart.GetProcessInfo();
-
-    // here we do not check whether the r_process_info has the time variable specified
-    // because, in a const DataValueContainer, if the variable is not there, it returns the
-    // zero value of the variable.
-    const double time = r_process_info[TIME];
-
-    const IndexType step = r_process_info[STEP];
+    double time;
+    IndexType step;
+    if (Step != std::numeric_limits<int>::lowest()) {
+        step = Step;
+        time = Time;
+    } else {
+        const auto& r_process_info = mrModelPart.GetProcessInfo();
+        // here we do not check whether the r_process_info has the time variable specified
+        // because, in a const DataValueContainer, if the variable is not there, it returns the
+        // zero value of the variable.
+        step = r_process_info[STEP];
+        time = r_process_info[TIME];
+    }
 
     std::filesystem::create_directories(rOutputFileNamePrefix);
 

--- a/kratos/input_output/vtu_output.h
+++ b/kratos/input_output/vtu_output.h
@@ -16,6 +16,7 @@
 #include <map>
 #include <string>
 #include <variant>
+#include <limits>
 
 // External includes
 
@@ -308,7 +309,10 @@ public:
      *
      * @param rOutputFilenamePrefix The prefix to use for the output filename.
      */
-    void PrintOutput(const std::string& rOutputFilenamePrefix);
+    void PrintOutput(
+        const std::string& rOutputFilenamePrefix,
+        const int Step = std::numeric_limits<int>::lowest(),
+        const double Time = std::numeric_limits<double>::lowest());
 
     ///@}
     ///@name Input and output

--- a/kratos/python/add_io_to_python.cpp
+++ b/kratos/python/add_io_to_python.cpp
@@ -251,7 +251,8 @@ void  AddIOToPython(pybind11::module& m)
         .def("EmplaceTensorAdaptor", &VtuOutput::EmplaceTensorAdaptor<TensorAdaptor<double>::Pointer>, py::arg("tensor_adaptor_name"), py::arg("tensor_adaptor"))
         .def("GetModelPart", &VtuOutput::GetModelPart, py::return_value_policy::reference)
         .def("GetOutputContainerList", &VtuOutput::GetOutputContainerList)
-        .def("PrintOutput", &VtuOutput::PrintOutput, py::arg("output_file_name_prefix"))
+        .def("PrintOutput", [](VtuOutput& rSelf, const std::string& rOutputFilenamePrefix) { rSelf.PrintOutput(rOutputFilenamePrefix); }, py::arg("output_file_name_prefix"))
+        .def("PrintOutput", [](VtuOutput& rSelf, const std::string& rOutputFilenamePrefix, const int Step, const double Time) { rSelf.PrintOutput(rOutputFilenamePrefix, Step, Time); }, py::arg("output_file_name_prefix"), py::arg("step"), py::arg("time"))
         .def("__str__", PrintObject<VtuOutput>)
         ;
 }

--- a/kratos/python_scripts/vtu_output_process.py
+++ b/kratos/python_scripts/vtu_output_process.py
@@ -2,7 +2,7 @@ from pathlib import Path
 import KratosMultiphysics as Kratos
 import KratosMultiphysics.kratos_utilities as kratos_utils
 
-def Factory(parameters: Kratos.Parameters, model: Kratos.Model):
+def Factory(parameters: Kratos.Parameters, model: Kratos.Model) -> Kratos.OutputProcess:
     if not isinstance(parameters, Kratos.Parameters):
         raise Exception("expected input shall be a Parameters object, encapsulating a json string")
     if not isinstance(model, Kratos.Model):
@@ -17,6 +17,7 @@ class VtuOutputProcess(Kratos.OutputProcess):
         {
             "model_part_name"                   : "PLEASE_SPECIFY_MODEL_PART_NAME",
             "file_format"                       : "binary",
+            "echo_level"                        : 0,
             "output_precision"                  : 7,
             "output_control_type"               : "step",
             "output_interval"                   : 1.0,
@@ -24,6 +25,7 @@ class VtuOutputProcess(Kratos.OutputProcess):
             "output_path"                       : "VTU_Output",
             "save_output_files_in_folder"       : true,
             "write_deformed_configuration"      : false,
+            "write_ids"                         : false,
             "nodal_solution_step_data_variables": [],
             "nodal_data_value_variables"        : [],
             "nodal_flags"                       : [],
@@ -40,7 +42,9 @@ class VtuOutputProcess(Kratos.OutputProcess):
         parameters.ValidateAndAssignDefaults(self.GetDefaultParameters())
 
         self.model_part = model[parameters["model_part_name"].GetString()]
+        self.echo_level = parameters["echo_level"].GetInt()
         self.write_deformed_configuration = parameters["write_deformed_configuration"].GetBool()
+        self.write_ids = parameters["write_ids"].GetBool()
         self.output_precision = parameters["output_precision"].GetInt()
         self.output_sub_model_parts = parameters["output_sub_model_parts"].GetBool()
 
@@ -57,8 +61,12 @@ class VtuOutputProcess(Kratos.OutputProcess):
             self.writer_format = Kratos.VtuOutput.ASCII
         elif file_format == "binary":
             self.writer_format = Kratos.VtuOutput.BINARY
+        elif file_format == "raw":
+            self.writer_format = Kratos.VtuOutput.RAW
+        elif file_format == "compressed_raw":
+            self.writer_format = Kratos.VtuOutput.COMPRESSED_RAW
         else:
-            raise RuntimeError(f"Unsupported file format requested [ requested format = {file_format} ]. Supported file formats:\n\tascii\n\tbinary")
+            raise RuntimeError(f"Unsupported file format requested [ requested format = {file_format} ]. Supported file formats:\n\tascii\n\tbinary\n\traw\n\tcompressed_raw")
 
         if parameters["save_output_files_in_folder"].GetBool():
             self.output_path = Path(parameters["output_path"].GetString())
@@ -70,46 +78,30 @@ class VtuOutputProcess(Kratos.OutputProcess):
         else:
             self.output_path = Path(".")
 
-        self.vtu_output_ios: 'list[Kratos.VtuOutput]' = []
-
         self.__controller = Kratos.OutputController(model, parameters)
 
     def ExecuteInitialize(self) -> None:
-        # check and create all the vtu outputs
-        self.vtu_output_ios.append(Kratos.VtuOutput(self.model_part, not self.write_deformed_configuration, self.writer_format, self.output_precision))
+        self.vtu_output = Kratos.VtuOutput(self.model_part, not self.write_deformed_configuration, self.writer_format, self.output_precision, self.output_sub_model_parts, self.write_ids, self.echo_level)
 
-        if self.output_sub_model_parts:
-            for sub_model_part in self.model_part.SubModelParts:
-                self.vtu_output_ios.append(Kratos.VtuOutput(sub_model_part, not self.write_deformed_configuration, self.writer_format, self.output_precision))
+        for variable in self.nodal_solution_step_data_variables:
+            self.vtu_output.AddVariable(Kratos.KratosGlobals.GetVariable(variable), Kratos.Globals.DataLocation.NodeHistorical)
+        for variable in self.nodal_data_value_variables:
+            self.vtu_output.AddVariable(Kratos.KratosGlobals.GetVariable(variable), Kratos.Globals.DataLocation.NodeNonHistorical)
+        for variable in self.condition_data_value_variables:
+            self.vtu_output.AddVariable(Kratos.KratosGlobals.GetVariable(variable), Kratos.Globals.DataLocation.Condition)
+        for variable in self.element_data_value_variables:
+            self.vtu_output.AddVariable(Kratos.KratosGlobals.GetVariable(variable), Kratos.Globals.DataLocation.Element)
 
-        for vtu_output_io in self.vtu_output_ios:
-            self.__AddData(vtu_output_io)
+        for flag in self.nodal_flags:
+            self.vtu_output.AddFlag(flag, Kratos.KratosGlobals.GetFlag(flag), Kratos.Globals.DataLocation.NodeNonHistorical)
+        for flag in self.condition_flags:
+            self.vtu_output.AddFlag(flag, Kratos.KratosGlobals.GetFlag(flag), Kratos.Globals.DataLocation.Condition)
+        for flag in self.element_flags:
+            self.vtu_output.AddFlag(flag, Kratos.KratosGlobals.GetFlag(flag), Kratos.Globals.DataLocation.Element)
 
     def PrintOutput(self) -> None:
-        current_suffix = self.__controller.GetCurrentControlValue()
-
-        for vtu_output in self.vtu_output_ios:
-            vtu_output.PrintOutput(f"{self.output_path / vtu_output.GetModelPart().FullName()}_{current_suffix}")
-
+        self.vtu_output.PrintOutput(f"{self.output_path / self.model_part.FullName()}")
         self.__controller.Update()
 
     def IsOutputStep(self) -> bool:
         return self.__controller.Evaluate()
-
-    def __AddData(self, vtu_output_io: Kratos.VtuOutput) -> None:
-        for variable in self.nodal_solution_step_data_variables:
-            vtu_output_io.AddHistoricalVariable(Kratos.KratosGlobals.GetVariable(variable))
-        for variable in self.nodal_data_value_variables:
-            vtu_output_io.AddNonHistoricalVariable(Kratos.KratosGlobals.GetVariable(variable), Kratos.VtuOutput.NODES)
-        for variable in self.condition_data_value_variables:
-            vtu_output_io.AddNonHistoricalVariable(Kratos.KratosGlobals.GetVariable(variable), Kratos.VtuOutput.CONDITIONS)
-        for variable in self.element_data_value_variables:
-            vtu_output_io.AddNonHistoricalVariable(Kratos.KratosGlobals.GetVariable(variable), Kratos.VtuOutput.ELEMENTS)
-
-        for flag in self.nodal_flags:
-            vtu_output_io.AddFlagVariable(flag, Kratos.KratosGlobals.GetFlag(flag), Kratos.VtuOutput.NODES)
-        for flag in self.condition_flags:
-            vtu_output_io.AddFlagVariable(flag, Kratos.KratosGlobals.GetFlag(flag), Kratos.VtuOutput.CONDITIONS)
-        for flag in self.element_flags:
-            vtu_output_io.AddFlagVariable(flag, Kratos.KratosGlobals.GetFlag(flag), Kratos.VtuOutput.ELEMENTS)
-


### PR DESCRIPTION
This pull request introduces several enhancements and refactoring to the VTU output process in Kratos, focusing on improving flexibility, supporting new output formats, and simplifying the Python interface. The main themes are improved output file handling, extended file format support, and interface simplification.

**Enhancements to VTU Output Process:**

*Support for Output File Handling and Customization:*
- The `PrintOutput` method in `VtuOutput` now accepts optional `Step` and `Time` parameters, allowing explicit control over output metadata from Python or C++ [[1]](diffhunk://#diff-78e6a12def4495c2d1e5637c57b1a82654f113e1eddfb36202c83cf56c0b771aL1491-R1510) [[2]](diffhunk://#diff-e24346a79b849837fdcbcc1fdadce502e6b23a2ee392b937d1604dad808bcdf1L311-R315) [[3]](diffhunk://#diff-b9942cf8385ca4154b51d00caf5ad2ff21d91dc5890af9fb6f376ade3a5f4f6bL66-R66) [[4]](diffhunk://#diff-811d3be5b8ff9c55b66e86f15e5ebccccf2f891152f06836c84915ac0801f3ecL254-R255).
- Added `echo_level` and `write_ids` options to the VTU output process for finer control over output verbosity and inclusion of node/element IDs [[1]](diffhunk://#diff-87fe00ec9e489571fc7bf40ff701e40466caf602bc5b8bcb888414fa42dfbd4aR20-R28) [[2]](diffhunk://#diff-87fe00ec9e489571fc7bf40ff701e40466caf602bc5b8bcb888414fa42dfbd4aR45-R47).

*Extended File Format Support:*
- The VTU output process now supports additional file formats: `raw` and `compressed_raw`, in addition to the existing `ascii` and `binary` formats.

*Python Interface Refactoring and Simplification:*
- Refactored the Python `vtu_output_process` to use a single `VtuOutput` instance instead of managing multiple outputs for submodel parts, simplifying the code and reducing maintenance overhead.
- Updated the process to use the new variable and flag addition methods, aligning with Kratos' latest data location conventions.

FYI @PhilippLeoJakobs 

---

## **🆕 Changelog**
- Added optional `Step` and `Time` specification when writing out Vtu files.
- Added `write_ids` and `echo_level` option to `vtu_output_process.py`
- Fixed `optimization_problem_vtu_output_process.py` to use the optimization iteration as `Step` and `Time`.
