### PR TITLE
[IGA] Add Python bindings and tests for the construction of BrepSurface and BrepCurveOnSurface

### DIFF
--- a/applications/IgaApplication/tests/test_IgaApplication.py
+++ b/applications/IgaApplication/tests/test_IgaApplication.py
@@ -61,6 +61,8 @@ from test_map_nurbs_volume_results_to_embedded_geometry_process import TestMapNu
 # Fluid Element and Conditions tests
 from test_stokes_elements_and_conditions import FluidTests as TTestFluid
 from test_stokes_sbm_conditions_3d import SbmStokes3DTests as TTestSbmStokes
+# Iga geometries python bindings tests
+from test_python_bindings_iga_geometries import TestPythonBindingsIGAGeometries
 
 has_linear_solvers_application = kratos_utilities.CheckIfApplicationsAvailable("LinearSolversApplication")
 
@@ -119,7 +121,9 @@ def AssembleTestSuites():
         TTestMapNurbsVolumeResultsToEmbeddedGeometryProcess,
         # Fluids
         TTestFluid,
-        TTestSbmStokes
+        TTestSbmStokes,
+        # Iga geometries python bindings
+        TestPythonBindingsIGAGeometries
     ]))
 
     if has_linear_solvers_application:

--- a/applications/IgaApplication/tests/test_python_bindings_iga_geometries.py
+++ b/applications/IgaApplication/tests/test_python_bindings_iga_geometries.py
@@ -3,7 +3,8 @@ import KratosMultiphysics.IgaApplication
 from KratosMultiphysics import KratosUnittest
 
 
-class TestPythonBindingsBrepSurface(KratosUnittest.TestCase):
+class TestPythonBindingsIGAGeometries(KratosUnittest.TestCase):
+
     def setUp(self):
         self.model = KM.Model()
         self.model_part = self.model.CreateModelPart("ModelPart")
@@ -56,6 +57,43 @@ class TestPythonBindingsBrepSurface(KratosUnittest.TestCase):
         self.assertEqual(CountGeometries(self.model_part), 1)
         self.assertEqual(brep_surface.Id, 1002)
 
+    def test_create_brep_curve_on_surface_from_python_bindings(self):
+        nurbs_surface = CreateNurbsSurfaceFromPythonIGABindings(
+            self.model_part,
+            self.degree_u,
+            self.degree_v,
+            self.knot_vector_u,
+            self.knot_vector_v
+        )
+
+        curve_2d = CreateLinearParametricCurveOnUnitSquare((0.0, 0.0), (1.0, 0.0))
+
+        brep_curve_on_surface = KM.BrepCurveOnSurface(
+            nurbs_surface,
+            curve_2d,
+            True
+        )
+
+        self.assertIsNotNone(brep_curve_on_surface)
+
+    def test_create_brep_curve_on_surface_from_python_bindings_with_default_direction(self):
+        nurbs_surface = CreateNurbsSurfaceFromPythonIGABindings(
+            self.model_part,
+            self.degree_u,
+            self.degree_v,
+            self.knot_vector_u,
+            self.knot_vector_v
+        )
+
+        curve_2d = CreateLinearParametricCurveOnUnitSquare((0.0, 0.0), (0.0, 1.0))
+
+        brep_curve_on_surface = KM.BrepCurveOnSurface(
+            nurbs_surface,
+            curve_2d
+        )
+
+        self.assertIsNotNone(brep_curve_on_surface)
+
 
 def MakeVector(values):
     v = KM.Vector(len(values))
@@ -71,7 +109,7 @@ def MakePointsList2D(p0, p1):
     ]
 
 
-def MakeBoundaryBrepCurve(surface, p0, p1, same_curve_direction=True):
+def CreateLinearParametricCurveOnUnitSquare(p0, p1):
     knot_vector_curve = KM.Vector(4)
     knot_vector_curve[0] = 0.0
     knot_vector_curve[1] = 0.0
@@ -81,7 +119,15 @@ def MakeBoundaryBrepCurve(surface, p0, p1, same_curve_direction=True):
     degree_curve = 1
     points_curve = MakePointsList2D(p0, p1)
 
-    curve_2d = KM.NurbsCurveGeometry2DPoint(points_curve, degree_curve, knot_vector_curve)
+    return KM.NurbsCurveGeometry2DPoint(
+        points_curve,
+        degree_curve,
+        knot_vector_curve
+    )
+
+
+def MakeBoundaryBrepCurve(surface, p0, p1, same_curve_direction=True):
+    curve_2d = CreateLinearParametricCurveOnUnitSquare(p0, p1)
     return KM.BrepCurveOnSurface(surface, curve_2d, same_curve_direction)
 
 
@@ -101,7 +147,7 @@ def MakeNodesVectorFromCtrlPts(model_part, control_points):
     return points
 
 
-def CreateBrepSurfaceFromPythonIGABindings(
+def CreateNurbsSurfaceFromPythonIGABindings(
     model_part,
     degree_u,
     degree_v,
@@ -131,6 +177,26 @@ def CreateBrepSurfaceFromPythonIGABindings(
     )
     nurbs_surface.SetId(1001)
 
+    return nurbs_surface
+
+
+def CreateBrepSurfaceFromPythonIGABindings(
+    model_part,
+    degree_u,
+    degree_v,
+    knot_vector_u,
+    knot_vector_v,
+    weights=None
+):
+    nurbs_surface = CreateNurbsSurfaceFromPythonIGABindings(
+        model_part,
+        degree_u,
+        degree_v,
+        knot_vector_u,
+        knot_vector_v,
+        weights
+    )
+
     u_min, u_max, v_min, v_max = GetParametricBounds(
         knot_vector_u, knot_vector_v, degree_u, degree_v
     )
@@ -152,6 +218,7 @@ def CreateBrepSurfaceFromPythonIGABindings(
 
 def CountGeometries(model_part):
     return sum(1 for _ in model_part.Geometries)
+
 
 if __name__ == "__main__":
     KratosUnittest.main()

--- a/applications/IgaApplication/tests/test_python_bindings_iga_geometries.py
+++ b/applications/IgaApplication/tests/test_python_bindings_iga_geometries.py
@@ -1,0 +1,157 @@
+import KratosMultiphysics as KM
+import KratosMultiphysics.IgaApplication
+from KratosMultiphysics import KratosUnittest
+
+
+class TestPythonBindingsBrepSurface(KratosUnittest.TestCase):
+    def setUp(self):
+        self.model = KM.Model()
+        self.model_part = self.model.CreateModelPart("ModelPart")
+
+        self.degree_u = 1
+        self.degree_v = 1
+
+        self.knot_vector_u = [0.0, 0.0, 1.0, 1.0]
+        self.knot_vector_v = [0.0, 0.0, 1.0, 1.0]
+
+        # 2x2 bilinear patch
+        self.control_points = [
+            [0.0, 0.0, 0.0],
+            [1.0, 0.0, 0.0],
+            [0.0, 1.0, 0.0],
+            [1.0, 1.0, 0.0]
+        ]
+
+        MakeNodesVectorFromCtrlPts(self.model_part, self.control_points)
+
+    def test_create_brep_surface_from_python_bindings(self):
+        weights = MakeVector([1.0, 1.0, 1.0, 1.0])
+
+        brep_surface = CreateBrepSurfaceFromPythonIGABindings(
+            self.model_part,
+            self.degree_u,
+            self.degree_v,
+            self.knot_vector_u,
+            self.knot_vector_v,
+            weights
+        )
+
+        self.assertEqual(self.model_part.NumberOfNodes(), 4)
+        self.assertEqual(CountGeometries(self.model_part), 1)
+
+        self.assertEqual(brep_surface.Id, 1002)
+        self.assertEqual(brep_surface.PolynomialDegree(0), self.degree_u)
+        self.assertEqual(brep_surface.PolynomialDegree(1), self.degree_v)
+
+    def test_create_brep_surface_from_python_bindings_with_default_weights(self):
+        brep_surface = CreateBrepSurfaceFromPythonIGABindings(
+            self.model_part,
+            self.degree_u,
+            self.degree_v,
+            self.knot_vector_u,
+            self.knot_vector_v
+        )
+
+        self.assertEqual(self.model_part.NumberOfNodes(), 4)
+        self.assertEqual(CountGeometries(self.model_part), 1)
+        self.assertEqual(brep_surface.Id, 1002)
+
+
+def MakeVector(values):
+    v = KM.Vector(len(values))
+    for i, val in enumerate(values):
+        v[i] = float(val)
+    return v
+
+
+def MakePointsList2D(p0, p1):
+    return [
+        KM.Point(float(p0[0]), float(p0[1]), 0.0),
+        KM.Point(float(p1[0]), float(p1[1]), 0.0)
+    ]
+
+
+def MakeBoundaryBrepCurve(surface, p0, p1, same_curve_direction=True):
+    knot_vector_curve = KM.Vector(4)
+    knot_vector_curve[0] = 0.0
+    knot_vector_curve[1] = 0.0
+    knot_vector_curve[2] = 1.0
+    knot_vector_curve[3] = 1.0
+
+    degree_curve = 1
+    points_curve = MakePointsList2D(p0, p1)
+
+    curve_2d = KM.NurbsCurveGeometry2DPoint(points_curve, degree_curve, knot_vector_curve)
+    return KM.BrepCurveOnSurface(surface, curve_2d, same_curve_direction)
+
+
+def GetParametricBounds(knot_vector_u, knot_vector_v, degree_u, degree_v):
+    u_min = float(knot_vector_u[degree_u])
+    u_max = float(knot_vector_u[-degree_u - 1])
+    v_min = float(knot_vector_v[degree_v])
+    v_max = float(knot_vector_v[-degree_v - 1])
+    return u_min, u_max, v_min, v_max
+
+
+def MakeNodesVectorFromCtrlPts(model_part, control_points):
+    points = KM.NodesVector()
+    for i, cp in enumerate(control_points, start=1):
+        node = model_part.CreateNewNode(i, float(cp[0]), float(cp[1]), float(cp[2]))
+        points.append(node)
+    return points
+
+
+def CreateBrepSurfaceFromPythonIGABindings(
+    model_part,
+    degree_u,
+    degree_v,
+    knot_vector_u,
+    knot_vector_v,
+    weights=None
+):
+    surface_points = KM.NodesVector()
+    for node_id in sorted(node.Id for node in model_part.Nodes):
+        surface_points.append(model_part.GetNode(node_id))
+
+    knots_u = MakeVector(knot_vector_u)
+    knots_v = MakeVector(knot_vector_v)
+
+    if weights is None:
+        weights = KM.Vector(model_part.NumberOfNodes())
+        for i in range(model_part.NumberOfNodes()):
+            weights[i] = 1.0
+
+    nurbs_surface = KM.NurbsSurfaceGeometry3D(
+        surface_points,
+        degree_u,
+        degree_v,
+        knots_u,
+        knots_v,
+        weights
+    )
+    nurbs_surface.SetId(1001)
+
+    u_min, u_max, v_min, v_max = GetParametricBounds(
+        knot_vector_u, knot_vector_v, degree_u, degree_v
+    )
+
+    curve_bottom = MakeBoundaryBrepCurve(nurbs_surface, (u_min, v_min), (u_max, v_min), True)
+    curve_right  = MakeBoundaryBrepCurve(nurbs_surface, (u_max, v_min), (u_max, v_max), True)
+    curve_top    = MakeBoundaryBrepCurve(nurbs_surface, (u_max, v_max), (u_min, v_max), True)
+    curve_left   = MakeBoundaryBrepCurve(nurbs_surface, (u_min, v_max), (u_min, v_min), True)
+
+    outer_loops = [[curve_bottom, curve_right, curve_top, curve_left]]
+    inner_loops = []
+
+    brep_surface = KM.BrepSurface(nurbs_surface, outer_loops, inner_loops)
+    brep_surface.SetId(1002)
+
+    model_part.AddGeometry(brep_surface)
+    return brep_surface
+
+
+def CountGeometries(model_part):
+    return sum(1 for _ in model_part.Geometries)
+
+if __name__ == "__main__":
+    KratosUnittest.main()

--- a/kratos/python/add_geometries_to_python.cpp
+++ b/kratos/python/add_geometries_to_python.cpp
@@ -63,6 +63,7 @@ namespace Kratos::Python
     using IntegrationPointsArrayType = typename GeometryType::IntegrationPointsArrayType;
     using GeometriesArrayType = typename GeometryType::GeometriesArrayType;
     using CoordinatesArrayType = typename Point::CoordinatesArrayType;
+    using PointVectorType = Kratos::PointerVector<Kratos::Point>;
 
     const PointerVector< Node >& ConstGetPoints( GeometryType& geom ) { return geom.Points(); }
     PointerVector< Node >& GetPoints( GeometryType& geom ) { return geom.Points(); }
@@ -349,7 +350,7 @@ void  AddGeometriesToPython(pybind11::module& m)
         .def("Weights", &NurbsCurveGeometry<3, NodeContainerType>::Weights)
         ;
 
-    // NurbsCurveGeometry2D
+    // NurbsCurveGeometry2D (constructed with nodes)
     py::class_<NurbsCurveGeometry<2, NodeContainerType>, NurbsCurveGeometry<2, NodeContainerType>::Pointer, GeometryType >(m, "NurbsCurveGeometry2D")
         .def(py::init<const PointsArrayType&, const SizeType, const Vector>())
         .def(py::init<const PointsArrayType&, const SizeType, const Vector, const Vector>())
@@ -360,6 +361,39 @@ void  AddGeometriesToPython(pybind11::module& m)
         .def("IsRational", &NurbsCurveGeometry<2, NodeContainerType>::IsRational)
         .def("Weights", &NurbsCurveGeometry<2, NodeContainerType>::Weights)
         ;
+    
+    // NurbsCurveGeometry2D (constructed with points)
+    using NurbsCurveGeometry2DPointType = Kratos::NurbsCurveGeometry<2, PointVectorType>;
+    py::class_<NurbsCurveGeometry2DPointType,
+            NurbsCurveGeometry2DPointType::Pointer>(m, "NurbsCurveGeometry2DPoint")
+        .def(py::init([](const py::list& py_points, const SizeType degree, const Vector& knot_vector)
+        {
+            typename NurbsCurveGeometry2DPointType::PointsArrayType points;
+
+            for (std::size_t i = 0; i < py_points.size(); ++i) {
+                auto p_point = py::cast<std::shared_ptr<Kratos::Point>>(py_points[i]);
+                points.push_back(p_point);
+            }
+
+            return Kratos::make_shared<NurbsCurveGeometry2DPointType>(points, degree, knot_vector);
+        }))
+        .def(py::init([](const py::list& py_points, const SizeType degree, const Vector& knot_vector, const Vector& weights)
+        {
+            typename NurbsCurveGeometry2DPointType::PointsArrayType points;
+
+            for (std::size_t i = 0; i < py_points.size(); ++i) {
+                auto p_point = py::cast<std::shared_ptr<Kratos::Point>>(py_points[i]);
+                points.push_back(p_point);
+            }
+
+            return Kratos::make_shared<NurbsCurveGeometry2DPointType>(points, degree, knot_vector, weights);
+        }))
+        .def("PolynomialDegree", &NurbsCurveGeometry2DPointType::PolynomialDegree)
+        .def("Knots", &NurbsCurveGeometry2DPointType::Knots)
+        .def("NumberOfKnots", &NurbsCurveGeometry2DPointType::NumberOfKnots)
+        .def("NumberOfControlPoints", &NurbsCurveGeometry2DPointType::NumberOfNonzeroControlPoints)
+        .def("IsRational", &NurbsCurveGeometry2DPointType::IsRational)
+        .def("Weights", &NurbsCurveGeometry2DPointType::Weights);
 
     // NurbsCurveOnSurface3D
     using NurbsCurveOnSurfaceGeometry3DType = Kratos::NurbsCurveOnSurfaceGeometry<3, NodeContainerType, NodeContainerType>;
@@ -369,10 +403,57 @@ void  AddGeometriesToPython(pybind11::module& m)
             NurbsCurveOnSurfaceGeometry3DType::NurbsCurveType::Pointer>())
         ;
 
+    // BrepCurveOnSurface
+    using BrepSurfaceType = Kratos::BrepSurface<NodeContainerType, false, PointVectorType>;
+    using BrepCurveOnSurfaceType = typename BrepSurfaceType::BrepCurveOnSurfaceType;
+    py::class_<BrepCurveOnSurfaceType, typename BrepCurveOnSurfaceType::Pointer, GeometryType>(m, "BrepCurveOnSurface")
+        .def(py::init<
+            typename BrepCurveOnSurfaceType::NurbsSurfaceType::Pointer,
+            typename BrepCurveOnSurfaceType::NurbsCurveType::Pointer,
+            bool>(),
+            py::arg("surface"),
+            py::arg("curve"),
+            py::arg("same_curve_direction") = true
+        );
+
     // BrepSurface
-    using PointContainerType = Kratos::PointerVector<Kratos::Point>;
-    using BrepSurfaceType = Kratos::BrepSurface<NodeContainerType, false, PointContainerType>;
     py::class_<BrepSurfaceType, typename BrepSurfaceType::Pointer, GeometryType>(m, "BrepSurface")
+        .def(py::init([](
+            typename BrepSurfaceType::NurbsSurfaceType::Pointer pSurface,
+            const py::list& py_outer_loops,
+            const py::list& py_inner_loops)
+        {
+            using CurvePointerType = typename BrepSurfaceType::BrepCurveOnSurfaceType::Pointer;
+            using LoopType = typename BrepSurfaceType::BrepCurveOnSurfaceLoopType;
+            using LoopArrayType = typename BrepSurfaceType::BrepCurveOnSurfaceLoopArrayType;
+
+            LoopArrayType outer_loops(py_outer_loops.size());
+            LoopArrayType inner_loops(py_inner_loops.size());
+
+            for (std::size_t k = 0; k < py_outer_loops.size(); ++k) {
+                py::list py_loop = py::cast<py::list>(py_outer_loops[k]);
+                LoopType loop(py_loop.size());
+
+                for (std::size_t i = 0; i < py_loop.size(); ++i) {
+                    loop[i] = py::cast<CurvePointerType>(py_loop[i]);
+                }
+
+                outer_loops[k] = loop;
+            }
+
+            for (std::size_t k = 0; k < py_inner_loops.size(); ++k) {
+                py::list py_loop = py::cast<py::list>(py_inner_loops[k]);
+                LoopType loop(py_loop.size());
+
+                for (std::size_t i = 0; i < py_loop.size(); ++i) {
+                    loop[i] = py::cast<CurvePointerType>(py_loop[i]);
+                }
+
+                inner_loops[k] = loop;
+            }
+
+            return Kratos::make_shared<BrepSurfaceType>(pSurface, outer_loops, inner_loops);
+        }))
         .def("EvaluateShapeFunctionsAtLocalCoordinates",
             [](const BrepSurfaceType& self, const CoordinatesArrayType& rLocal, const IndexType derivative_order)
             {


### PR DESCRIPTION
## Summary

Adds Python bindings for `BrepSurface` and `BrepCurveOnSurface`, together with dedicated tests for the exposed IGA geometry bindings.

## What is included

- adds Python bindings for `BrepSurface`
- adds Python bindings for `BrepCurveOnSurface`
- adds Python tests covering the construction of IGA geometries from Python
- tests the creation of `BrepSurface`
- tests the construction of `BrepCurveOnSurface`, including the default `same_curve_direction` argument
- registers the new tests in the IGA test suites

FYI @rickyaristio 