### PR TITLE
[Doc] Renaming contributor from Altair to Siemens DISW

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,8 +104,8 @@ Organizations contributing to Kratos:
 
 <br><br>
 
-<img align="left" src="https://github.com/KratosMultiphysics/Documentation/raw/master/Wiki_files/Logos/altair-sponsor-logo.png" width="128">
-<br><p>Altair Engineering</p>
+<img align="left" src="https://github.com/KratosMultiphysics/Documentation/raw/master/Wiki_files/Logos/siemens_logo.png" width="128">
+<br><p>Siemens Industry Software Inc</p>
 
 <img align="left" src="https://github.com/KratosMultiphysics/Documentation/raw/master/Wiki_files/Logos/Deltares_logo.png" width="128">
 <br><p>Deltares</p>


### PR DESCRIPTION
---
name: ✨ Feature
about: Renaming contributor from Altair to Siemens DISWRenaming contributor from Altair to Siemens DISW

---

## **📝 Description**

Renaming contributor from Altair to Siemens DISW

Context: https://press.siemens.com/global/en/pressrelease/siemens-acquires-altair-create-most-complete-ai-powered-portfolio-industrial-software

## **🆕 Changelog**

- [Renaming contributor from Altair to Siemens DISW](https://github.com/KratosMultiphysics/Kratos/commit/8456e67faab254d8bd56c6978aace253c159c9a2)
