### PR TITLE
[Core] `IsNull` missing in `UblasSpace`

### DIFF
--- a/kratos/solving_strategies/strategies/residualbased_linear_strategy.h
+++ b/kratos/solving_strategies/strategies/residualbased_linear_strategy.h
@@ -485,11 +485,11 @@ public:
         }
 
         // Clearing the system of equations
-        if (mpA != nullptr)
+        if (!SparseSpaceType::IsNull(mpA))
             SparseSpaceType::Clear(mpA);
-        if (mpDx != nullptr)
+        if (!SparseSpaceType::IsNull(mpDx))
             SparseSpaceType::Clear(mpDx);
-        if (mpb != nullptr)
+        if (!SparseSpaceType::IsNull(mpb))
             SparseSpaceType::Clear(mpb);
 
         // Clearing scheme

--- a/kratos/solving_strategies/strategies/residualbased_newton_raphson_strategy.h
+++ b/kratos/solving_strategies/strategies/residualbased_newton_raphson_strategy.h
@@ -716,11 +716,11 @@ class ResidualBasedNewtonRaphsonStrategy
         }
 
         // Clearing the system of equations
-        if (mpA != nullptr)
+        if (!SparseSpaceType::IsNull(mpA))
             SparseSpaceType::Clear(mpA);
-        if (mpDx != nullptr)
+        if (!SparseSpaceType::IsNull(mpDx))
             SparseSpaceType::Clear(mpDx);
-        if (mpb != nullptr)
+        if (!SparseSpaceType::IsNull(mpb))
             SparseSpaceType::Clear(mpb);
 
         // Clearing scheme

--- a/kratos/spaces/ublas_space.h
+++ b/kratos/spaces/ublas_space.h
@@ -185,6 +185,17 @@ public:
         return VectorPointerType(new TVectorType(0));
     }
 
+    /**
+     * @brief This method returns true if the pointer is null
+     * @param pPointer The pointer considered
+     * @return True if the pointer is null
+     */
+    template<class TPointerType>
+    inline static bool IsNull(const TPointerType& pPointer)
+    {
+        return !static_cast<bool>(pPointer);
+    }
+
     /// return size of vector rV
 
     static IndexType Size(VectorType const& rV)


### PR DESCRIPTION
---
name: ✨ Feature
about: `IsNull` missing in `UblasSpace`.

---

## **📝 Description**

`IsNull` missing in `UblasSpace`, for compatibility with `TrilinosSpace`.

## **🆕 Changelog**

- [Add `IsNull` method to `UblasSpace` for pointer nullity check](https://github.com/KratosMultiphysics/Kratos/commit/1d0ac49c529e3cc7737158d77470fcbb21429236)
- [Refactor clearing logic in residual-based strategies to use `IsNull` for pointer checks](https://github.com/KratosMultiphysics/Kratos/commit/d9a34df2399d1df078bc922765d46321554a7af8)
