### PR TITLE
[GeoMechanicsApplication] Fix Zero-Diagonal error in the a thermal case

### DIFF
--- a/applications/GeoMechanicsApplication/custom_elements/transient_thermal_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/transient_thermal_element.cpp
@@ -109,8 +109,9 @@ void TransientThermalElement<TDim, TNumNodes>::CalculateLocalSystem(MatrixType& 
     const auto integration_coefficients = mIntegrationCoefficientsCalculator.Run<Vector>(
         GetGeometry().IntegrationPoints(GetIntegrationMethod()), det_J_container, this);
     const auto conductivity_matrix = CalculateConductivityMatrix(dN_dX_container, integration_coefficients);
+    std::cout << "conductivity_matrix" << conductivity_matrix << std::endl;
     const auto capacity_matrix = CalculateCapacityMatrix(integration_coefficients);
-
+    std::cout << "capacity_matrix" << capacity_matrix << std::endl;
     AddContributionsToLhsMatrix(rLeftHandSideMatrix, conductivity_matrix, capacity_matrix,
                                 rCurrentProcessInfo[DT_TEMPERATURE_COEFFICIENT]);
     AddContributionsToRhsVector(rRightHandSideVector, conductivity_matrix, capacity_matrix);
@@ -155,13 +156,13 @@ int TransientThermalElement<TDim, TNumNodes>::Check(const ProcessInfo& rCurrentP
     check_properties.Check(DENSITY_SOLID);
     check_properties.Check(SPECIFIC_HEAT_CAPACITY_WATER);
     check_properties.Check(SPECIFIC_HEAT_CAPACITY_SOLID);
-    check_properties.Check(THERMAL_CONDUCTIVITY_WATER);
-    check_properties.Check(THERMAL_CONDUCTIVITY_SOLID_XX);
-    check_properties.Check(THERMAL_CONDUCTIVITY_SOLID_YY);
+    check_properties.SingleUseBounds(CheckProperties::Bounds::AllExclusive).Check(THERMAL_CONDUCTIVITY_WATER);
+    check_properties.SingleUseBounds(CheckProperties::Bounds::AllExclusive).Check(THERMAL_CONDUCTIVITY_SOLID_XX);
+    check_properties.SingleUseBounds(CheckProperties::Bounds::AllExclusive).Check(THERMAL_CONDUCTIVITY_SOLID_YY);
     check_properties.Check(THERMAL_CONDUCTIVITY_SOLID_XY);
 
     if constexpr (TDim == 3) {
-        check_properties.Check(THERMAL_CONDUCTIVITY_SOLID_ZZ);
+        check_properties.SingleUseBounds(CheckProperties::Bounds::AllExclusive).Check(THERMAL_CONDUCTIVITY_SOLID_ZZ);
         check_properties.Check(THERMAL_CONDUCTIVITY_SOLID_YZ);
         check_properties.Check(THERMAL_CONDUCTIVITY_SOLID_XZ);
     }
@@ -169,24 +170,6 @@ int TransientThermalElement<TDim, TNumNodes>::Check(const ProcessInfo& rCurrentP
     if constexpr (TDim == 2) CheckUtilities::CheckForNonZeroZCoordinateIn2D(GetGeometry());
 
     check_properties.CheckAvailabilityAndEquality(RETENTION_LAW, "SaturatedLaw");
-
-    std::vector<const Variable<double>*> properties_list{
-        &SPECIFIC_HEAT_CAPACITY_WATER,  &SPECIFIC_HEAT_CAPACITY_SOLID,
-        &THERMAL_CONDUCTIVITY_WATER,    &THERMAL_CONDUCTIVITY_SOLID_XX,
-        &THERMAL_CONDUCTIVITY_SOLID_YY, &THERMAL_CONDUCTIVITY_SOLID_XY};
-    if constexpr (TDim == 3) {
-        properties_list.insert(properties_list.end(), {&THERMAL_CONDUCTIVITY_SOLID_ZZ, &THERMAL_CONDUCTIVITY_SOLID_YZ,
-                                                       &THERMAL_CONDUCTIVITY_SOLID_XZ});
-    }
-    const auto areAllValuesZero =
-        std::ranges::all_of(properties_list, [&r_properties](const Variable<double>* pVariable) {
-        return std::abs(r_properties[*pVariable]) <= 1.0e-12;
-    });
-    if (areAllValuesZero) {
-        KRATOS_ERROR << "The input is invalid: capacity and thermal conductivity parameters "
-                        "cannot all be zero."
-                     << std::endl;
-    }
 
     return RetentionLawFactory::Clone(r_properties)->Check(r_properties, rCurrentProcessInfo);
     KRATOS_CATCH("")

--- a/applications/GeoMechanicsApplication/custom_elements/transient_thermal_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/transient_thermal_element.cpp
@@ -130,6 +130,16 @@ GeometryData::IntegrationMethod TransientThermalElement<TDim, TNumNodes>::GetInt
     }
 }
 
+inline bool AllZeroValues(std::vector<double>& rValues, double rel_tol = 1e-12)
+{
+    const auto max_abs =
+        std::max(1.0, *std::max_element(rValues.begin(), rValues.end(),
+                                        [](double a, double b) { return std::abs(a) < std::abs(b); }));
+    return std::all_of(rValues.begin(), rValues.end(), [&](double value) {
+        return std::abs(value) <= rel_tol || std::abs(value) <= std::numeric_limits<double>::epsilon();
+    });
+}
+
 template <unsigned int TDim, unsigned int TNumNodes>
 int TransientThermalElement<TDim, TNumNodes>::Check(const ProcessInfo& rCurrentProcessInfo) const
 {
@@ -165,8 +175,23 @@ int TransientThermalElement<TDim, TNumNodes>::Check(const ProcessInfo& rCurrentP
     if constexpr (TDim == 2) CheckUtilities::CheckForNonZeroZCoordinateIn2D(GetGeometry());
 
     check_properties.CheckAvailabilityAndEquality(RETENTION_LAW, "SaturatedLaw");
-    return RetentionLawFactory::Clone(r_properties)->Check(r_properties, rCurrentProcessInfo);
 
+    std::vector<double> vals{
+        r_properties[SPECIFIC_HEAT_CAPACITY_WATER],  r_properties[SPECIFIC_HEAT_CAPACITY_SOLID],
+        r_properties[THERMAL_CONDUCTIVITY_WATER],    r_properties[THERMAL_CONDUCTIVITY_SOLID_XX],
+        r_properties[THERMAL_CONDUCTIVITY_SOLID_YY], r_properties[THERMAL_CONDUCTIVITY_SOLID_XY]};
+    if constexpr (TDim == 3) {
+        vals.insert(vals.end(), {r_properties[THERMAL_CONDUCTIVITY_SOLID_ZZ],
+                                 r_properties[THERMAL_CONDUCTIVITY_SOLID_YZ],
+                                 r_properties[THERMAL_CONDUCTIVITY_SOLID_XZ]});
+    }
+    if (AllZeroValues(vals)) {
+        KRATOS_ERROR << "The input is invalid: capacity and thermal conductivity parameters "
+                        "cannot all be zero."
+                     << std::endl;
+    }
+
+    return RetentionLawFactory::Clone(r_properties)->Check(r_properties, rCurrentProcessInfo);
     KRATOS_CATCH("")
 }
 

--- a/applications/GeoMechanicsApplication/custom_elements/transient_thermal_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/transient_thermal_element.cpp
@@ -22,6 +22,10 @@
 #include "geo_mechanics_application_variables.h"
 #include "includes/serializer.h"
 
+#include <algorithm>
+#include <cmath>
+#include <limits>
+
 namespace Kratos
 {
 
@@ -130,16 +134,6 @@ GeometryData::IntegrationMethod TransientThermalElement<TDim, TNumNodes>::GetInt
     }
 }
 
-inline bool AllZeroValues(std::vector<double>& rValues, double rel_tol = 1e-12)
-{
-    const auto max_abs =
-        std::max(1.0, *std::max_element(rValues.begin(), rValues.end(),
-                                        [](double a, double b) { return std::abs(a) < std::abs(b); }));
-    return std::all_of(rValues.begin(), rValues.end(), [&](double value) {
-        return std::abs(value) <= rel_tol || std::abs(value) <= std::numeric_limits<double>::epsilon();
-    });
-}
-
 template <unsigned int TDim, unsigned int TNumNodes>
 int TransientThermalElement<TDim, TNumNodes>::Check(const ProcessInfo& rCurrentProcessInfo) const
 {
@@ -176,16 +170,19 @@ int TransientThermalElement<TDim, TNumNodes>::Check(const ProcessInfo& rCurrentP
 
     check_properties.CheckAvailabilityAndEquality(RETENTION_LAW, "SaturatedLaw");
 
-    std::vector<double> vals{
+    std::vector<double> values{
         r_properties[SPECIFIC_HEAT_CAPACITY_WATER],  r_properties[SPECIFIC_HEAT_CAPACITY_SOLID],
         r_properties[THERMAL_CONDUCTIVITY_WATER],    r_properties[THERMAL_CONDUCTIVITY_SOLID_XX],
         r_properties[THERMAL_CONDUCTIVITY_SOLID_YY], r_properties[THERMAL_CONDUCTIVITY_SOLID_XY]};
     if constexpr (TDim == 3) {
-        vals.insert(vals.end(), {r_properties[THERMAL_CONDUCTIVITY_SOLID_ZZ],
-                                 r_properties[THERMAL_CONDUCTIVITY_SOLID_YZ],
-                                 r_properties[THERMAL_CONDUCTIVITY_SOLID_XZ]});
+        values.insert(values.end(), {r_properties[THERMAL_CONDUCTIVITY_SOLID_ZZ],
+                                     r_properties[THERMAL_CONDUCTIVITY_SOLID_YZ],
+                                     r_properties[THERMAL_CONDUCTIVITY_SOLID_XZ]});
     }
-    if (AllZeroValues(vals)) {
+    const auto areAllValuesZero = std::all_of(values.begin(), values.end(), [&](double value) {
+        return std::abs(value) <= 1.0e-12 || std::abs(value) <= std::numeric_limits<double>::epsilon();
+    });
+    if (areAllValuesZero) {
         KRATOS_ERROR << "The input is invalid: capacity and thermal conductivity parameters "
                         "cannot all be zero."
                      << std::endl;

--- a/applications/GeoMechanicsApplication/custom_elements/transient_thermal_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/transient_thermal_element.cpp
@@ -109,9 +109,7 @@ void TransientThermalElement<TDim, TNumNodes>::CalculateLocalSystem(MatrixType& 
     const auto integration_coefficients = mIntegrationCoefficientsCalculator.Run<Vector>(
         GetGeometry().IntegrationPoints(GetIntegrationMethod()), det_J_container, this);
     const auto conductivity_matrix = CalculateConductivityMatrix(dN_dX_container, integration_coefficients);
-    std::cout << "conductivity_matrix" << conductivity_matrix << std::endl;
     const auto capacity_matrix = CalculateCapacityMatrix(integration_coefficients);
-    std::cout << "capacity_matrix" << capacity_matrix << std::endl;
     AddContributionsToLhsMatrix(rLeftHandSideMatrix, conductivity_matrix, capacity_matrix,
                                 rCurrentProcessInfo[DT_TEMPERATURE_COEFFICIENT]);
     AddContributionsToRhsVector(rRightHandSideVector, conductivity_matrix, capacity_matrix);
@@ -158,10 +156,12 @@ int TransientThermalElement<TDim, TNumNodes>::Check(const ProcessInfo& rCurrentP
     check_properties.Check(SPECIFIC_HEAT_CAPACITY_SOLID);
     check_properties.SingleUseBounds(CheckProperties::Bounds::AllExclusive).Check(THERMAL_CONDUCTIVITY_WATER);
     check_properties.SingleUseBounds(CheckProperties::Bounds::AllExclusive).Check(THERMAL_CONDUCTIVITY_SOLID_XX);
-    check_properties.SingleUseBounds(CheckProperties::Bounds::AllExclusive).Check(THERMAL_CONDUCTIVITY_SOLID_YY);
-    check_properties.Check(THERMAL_CONDUCTIVITY_SOLID_XY);
-
-    if constexpr (TDim == 3) {
+    const auto local_space_dimension = this->GetGeometry().LocalSpaceDimension();
+    if (local_space_dimension > 1) {
+        check_properties.SingleUseBounds(CheckProperties::Bounds::AllExclusive).Check(THERMAL_CONDUCTIVITY_SOLID_YY);
+        check_properties.Check(THERMAL_CONDUCTIVITY_SOLID_XY);
+    }
+    if (local_space_dimension > 2) {
         check_properties.SingleUseBounds(CheckProperties::Bounds::AllExclusive).Check(THERMAL_CONDUCTIVITY_SOLID_ZZ);
         check_properties.Check(THERMAL_CONDUCTIVITY_SOLID_YZ);
         check_properties.Check(THERMAL_CONDUCTIVITY_SOLID_XZ);

--- a/applications/GeoMechanicsApplication/custom_elements/transient_thermal_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/transient_thermal_element.cpp
@@ -170,17 +170,17 @@ int TransientThermalElement<TDim, TNumNodes>::Check(const ProcessInfo& rCurrentP
 
     check_properties.CheckAvailabilityAndEquality(RETENTION_LAW, "SaturatedLaw");
 
-    std::vector<double> values{
-        r_properties[SPECIFIC_HEAT_CAPACITY_WATER],  r_properties[SPECIFIC_HEAT_CAPACITY_SOLID],
-        r_properties[THERMAL_CONDUCTIVITY_WATER],    r_properties[THERMAL_CONDUCTIVITY_SOLID_XX],
-        r_properties[THERMAL_CONDUCTIVITY_SOLID_YY], r_properties[THERMAL_CONDUCTIVITY_SOLID_XY]};
+    std::vector<const Variable<double>*> properties_list{
+        &SPECIFIC_HEAT_CAPACITY_WATER,  &SPECIFIC_HEAT_CAPACITY_SOLID,
+        &THERMAL_CONDUCTIVITY_WATER,    &THERMAL_CONDUCTIVITY_SOLID_XX,
+        &THERMAL_CONDUCTIVITY_SOLID_YY, &THERMAL_CONDUCTIVITY_SOLID_XY};
     if constexpr (TDim == 3) {
-        values.insert(values.end(), {r_properties[THERMAL_CONDUCTIVITY_SOLID_ZZ],
-                                     r_properties[THERMAL_CONDUCTIVITY_SOLID_YZ],
-                                     r_properties[THERMAL_CONDUCTIVITY_SOLID_XZ]});
+        properties_list.insert(properties_list.end(), {&THERMAL_CONDUCTIVITY_SOLID_ZZ, &THERMAL_CONDUCTIVITY_SOLID_YZ,
+                                                       &THERMAL_CONDUCTIVITY_SOLID_XZ});
     }
-    const auto areAllValuesZero = std::all_of(values.begin(), values.end(), [&](double value) {
-        return std::abs(value) <= 1.0e-12 || std::abs(value) <= std::numeric_limits<double>::epsilon();
+    const auto areAllValuesZero =
+        std::ranges::all_of(properties_list, [&r_properties](const Variable<double>* pVariable) {
+        return std::abs(r_properties[*pVariable]) <= 1.0e-12;
     });
     if (areAllValuesZero) {
         KRATOS_ERROR << "The input is invalid: capacity and thermal conductivity parameters "

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_elements/test_transient_thermal_element.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_elements/test_transient_thermal_element.cpp
@@ -796,4 +796,31 @@ KRATOS_TEST_CASE_IN_SUITE(TransientThermalElement_GetIntegrationMethodForAllRegi
                      GeometryData::IntegrationMethod::GI_GAUSS_2);
 }
 
+KRATOS_TEST_CASE_IN_SUITE(CheckElement_Throws_WhenThermalCapacityAndConductivityAreAllZero,
+                          KratosGeoMechanicsFastSuiteWithoutKernel)
+{
+    Model      this_model;
+    ModelPart& model_part = this_model.CreateModelPart("Main", 2);
+    model_part.AddNodalSolutionStepVariable(TEMPERATURE);
+    model_part.AddNodalSolutionStepVariable(DT_TEMPERATURE);
+    GenerateTransientThermalElement3D4N(model_part);
+    SetupElement(model_part);
+
+    Element::Pointer p_element = model_part.pGetElement(1);
+    p_element->GetProperties().SetValue(SPECIFIC_HEAT_CAPACITY_WATER, 0.0);
+    p_element->GetProperties().SetValue(SPECIFIC_HEAT_CAPACITY_SOLID, 0.0);
+    p_element->GetProperties().SetValue(THERMAL_CONDUCTIVITY_WATER, 0.0);
+    p_element->GetProperties().SetValue(THERMAL_CONDUCTIVITY_SOLID_XX, 0.0);
+    p_element->GetProperties().SetValue(THERMAL_CONDUCTIVITY_SOLID_YY, 0.0);
+    p_element->GetProperties().SetValue(THERMAL_CONDUCTIVITY_SOLID_XY, 0.0);
+
+    const ProcessInfo& r_current_process_info = model_part.GetProcessInfo();
+    KRATOS_EXPECT_EXCEPTION_IS_THROWN(p_element->Check(r_current_process_info),
+                                      "Error: The input is invalid: capacity and thermal "
+                                      "conductivity parameters cannot all be zero.")
+
+    p_element->GetProperties().SetValue(SPECIFIC_HEAT_CAPACITY_WATER, 1.0);
+    EXPECT_NO_THROW(p_element->Check(r_current_process_info));
+}
+
 } // namespace Kratos::Testing

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_elements/test_transient_thermal_element.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_elements/test_transient_thermal_element.cpp
@@ -495,7 +495,7 @@ KRATOS_TEST_CASE_IN_SUITE(CheckElement_Throws_When3DPropertyHasInvalidValue, Kra
     KRATOS_EXPECT_EXCEPTION_IS_THROWN(
         p_element->Check(r_current_process_info),
         "THERMAL_CONDUCTIVITY_SOLID_ZZ in the properties with Id 0 at element with Id 1 has an "
-        "invalid value: -5 is out of the range [0, -).")
+        "invalid value: -5 is out of the range (0, -).")
 }
 
 KRATOS_TEST_CASE_IN_SUITE(EquationIdVectorTransientThermalElement3D4N, KratosGeoMechanicsFastSuiteWithoutKernel)
@@ -796,8 +796,7 @@ KRATOS_TEST_CASE_IN_SUITE(TransientThermalElement_GetIntegrationMethodForAllRegi
                      GeometryData::IntegrationMethod::GI_GAUSS_2);
 }
 
-KRATOS_TEST_CASE_IN_SUITE(CheckElement_Throws_WhenThermalCapacityAndConductivityAreAllZero,
-                          KratosGeoMechanicsFastSuiteWithoutKernel)
+KRATOS_TEST_CASE_IN_SUITE(CheckElement_Throws_WhenThermalConductivityAtDiagonalIsZero, KratosGeoMechanicsFastSuiteWithoutKernel)
 {
     Model      this_model;
     ModelPart& model_part = this_model.CreateModelPart("Main", 2);
@@ -807,20 +806,26 @@ KRATOS_TEST_CASE_IN_SUITE(CheckElement_Throws_WhenThermalCapacityAndConductivity
     SetupElement(model_part);
 
     Element::Pointer p_element = model_part.pGetElement(1);
-    p_element->GetProperties().SetValue(SPECIFIC_HEAT_CAPACITY_WATER, 0.0);
-    p_element->GetProperties().SetValue(SPECIFIC_HEAT_CAPACITY_SOLID, 0.0);
     p_element->GetProperties().SetValue(THERMAL_CONDUCTIVITY_WATER, 0.0);
-    p_element->GetProperties().SetValue(THERMAL_CONDUCTIVITY_SOLID_XX, 0.0);
-    p_element->GetProperties().SetValue(THERMAL_CONDUCTIVITY_SOLID_YY, 0.0);
-    p_element->GetProperties().SetValue(THERMAL_CONDUCTIVITY_SOLID_XY, 0.0);
-
     const ProcessInfo& r_current_process_info = model_part.GetProcessInfo();
-    KRATOS_EXPECT_EXCEPTION_IS_THROWN(p_element->Check(r_current_process_info),
-                                      "Error: The input is invalid: capacity and thermal "
-                                      "conductivity parameters cannot all be zero.")
+    KRATOS_EXPECT_EXCEPTION_IS_THROWN(
+        p_element->Check(r_current_process_info),
+        "Error: THERMAL_CONDUCTIVITY_WATER in the properties with Id 0 at element with Id 1 has an "
+        "invalid value: 0 is out of the range (0, -).")
 
-    p_element->GetProperties().SetValue(SPECIFIC_HEAT_CAPACITY_WATER, 1.0);
-    EXPECT_NO_THROW(p_element->Check(r_current_process_info));
+    p_element->GetProperties().SetValue(THERMAL_CONDUCTIVITY_WATER, 1.0);
+    p_element->GetProperties().SetValue(THERMAL_CONDUCTIVITY_SOLID_XX, 0.0);
+    KRATOS_EXPECT_EXCEPTION_IS_THROWN(
+        p_element->Check(r_current_process_info),
+        "Error: THERMAL_CONDUCTIVITY_SOLID_XX in the properties with Id 0 at element with Id 1 has "
+        "an invalid value: 0 is out of the range (0, -).")
+
+    p_element->GetProperties().SetValue(THERMAL_CONDUCTIVITY_SOLID_XX, 1.0);
+    p_element->GetProperties().SetValue(THERMAL_CONDUCTIVITY_SOLID_YY, 0.0);
+    KRATOS_EXPECT_EXCEPTION_IS_THROWN(
+        p_element->Check(r_current_process_info),
+        "Error: THERMAL_CONDUCTIVITY_SOLID_YY in the properties with Id 0 at element with Id 1 has "
+        "an invalid value: 0 is out of the range (0, -).")
 }
 
 } // namespace Kratos::Testing


### PR DESCRIPTION
## **📝 Description**
An error handeling is needed if the input material properties (heat capacity, and thermal conductivities) are all set to zer. It leads to zero-diagonal matrix.

## **🆕 Changelog**
1. Error handeling is added
2. Unit test is added
