### PR TITLE
[ExternalLibraries] Update AMGCL to last master branch

### DIFF
--- a/external_libraries/amgcl/adapter/eigen.hpp
+++ b/external_libraries/amgcl/adapter/eigen.hpp
@@ -65,7 +65,7 @@ template <class T>
 struct is_eigen_type<
     T,
     typename std::enable_if<
-        std::is_arithmetic<typename T::Scalar>::value &&
+        std::is_arithmetic<typename T::RealScalar>::value &&
         std::is_base_of<Eigen::EigenBase<T>, T>::value
         >::type
     > : std::true_type

--- a/external_libraries/amgcl/backend/cuda.hpp
+++ b/external_libraries/amgcl/backend/cuda.hpp
@@ -110,25 +110,104 @@ struct cuda_deleter {
         AMGCL_CALL_CUDA( cusparseDestroyMatDescr(handle) );
     }
 
-#if CUDART_VERSION < 11000
-    void operator()(cusparseHybMat_t handle) {
-        AMGCL_CALL_CUDA( cusparseDestroyHybMat(handle) );
-    }
-#endif
-
-    void operator()(csrilu02Info_t handle) {
-        AMGCL_CALL_CUDA( cusparseDestroyCsrilu02Info(handle) );
+    void operator()(cusparseSpMatDescr_t handle) {
+        AMGCL_CALL_CUDA( cusparseDestroySpMat(handle) );
     }
 
-    void operator()(csrsv2Info_t handle) {
-        AMGCL_CALL_CUDA( cusparseDestroyCsrsv2Info(handle) );
+    void operator()(cusparseDnVecDescr_t handle) {
+        AMGCL_CALL_CUDA( cusparseDestroyDnVec(handle) );
     }
 
     void operator()(cudaEvent_t handle) {
         AMGCL_CALL_CUDA( cudaEventDestroy(handle) );
     }
+
+    void operator()(csrilu02Info_t handle) {
+        AMGCL_CALL_CUDA( cusparseDestroyCsrilu02Info(handle) );
+    }
+
+#if CUDART_VERSION >= 11000
+    void operator()(cusparseSpSVDescr_t handle) {
+        AMGCL_CALL_CUDA( cusparseSpSV_destroyDescr(handle) );
+    }
+#else
+    void operator()(cusparseHybMat_t handle) {
+        AMGCL_CALL_CUDA( cusparseDestroyHybMat(handle) );
+    }
+
+    void operator()(csrsv2Info_t handle) {
+        AMGCL_CALL_CUDA( cusparseDestroyCsrsv2Info(handle) );
+    }
+#endif
 };
 
+
+template <typename real>
+cudaDataType cuda_datatype() {
+    if (sizeof(real) == sizeof(float))
+        return CUDA_R_32F;
+    else
+        return CUDA_R_64F;
+}
+
+#if CUDART_VERSION >= 11000
+template <typename real>
+cusparseDnVecDescr_t cuda_vector_description(thrust::device_vector<real> &x) {
+    cusparseDnVecDescr_t desc;
+    AMGCL_CALL_CUDA(
+            cusparseCreateDnVec(
+                &desc,
+                x.size(),
+                thrust::raw_pointer_cast(&x[0]),
+                cuda_datatype<real>()
+                )
+            );
+    return desc;
+}
+
+template <typename real>
+cusparseDnVecDescr_t cuda_vector_description(const thrust::device_vector<real> &&x) {
+    cusparseDnVecDescr_t desc;
+    AMGCL_CALL_CUDA(
+            cusparseCreateDnVec(
+                &desc,
+                x.size(),
+                thrust::raw_pointer_cast(&x[0]),
+                cuda_datatype<real>()
+                )
+            );
+    return desc;
+}
+
+template <typename real>
+cusparseSpMatDescr_t cuda_matrix_description(
+        size_t nrows,
+        size_t ncols,
+        size_t nnz,
+        thrust::device_vector<int> &ptr,
+        thrust::device_vector<int> &col,
+        thrust::device_vector<real> &val
+        )
+{
+    cusparseSpMatDescr_t desc;
+    AMGCL_CALL_CUDA(
+            cusparseCreateCsr(
+                &desc,
+                nrows,
+                ncols,
+                nnz,
+                thrust::raw_pointer_cast(&ptr[0]),
+                thrust::raw_pointer_cast(&col[0]),
+                thrust::raw_pointer_cast(&val[0]),
+                CUSPARSE_INDEX_32I,
+                CUSPARSE_INDEX_32I,
+                CUSPARSE_INDEX_BASE_ZERO,
+                detail::cuda_datatype<real>()
+                )
+            );
+    return desc;
+}
+#endif // CUDART_VERSION >= 11000
 
 } // namespace detail
 
@@ -141,15 +220,18 @@ class cuda_matrix {
 
         cuda_matrix(
                 size_t n, size_t m,
-                const ptrdiff_t *ptr,
-                const ptrdiff_t *col,
-                const real      *val,
+                const ptrdiff_t *p_ptr,
+                const ptrdiff_t *p_col,
+                const real      *p_val,
                 cusparseHandle_t handle
                 )
-            : nrows(n), ncols(m), nnz(ptr[n]), handle(handle),
-              ptr(ptr, ptr + n + 1), col(col, col + nnz), val(val, val + nnz),
-              desc(create_description(), backend::detail::cuda_deleter())
+            : nrows(n), ncols(m), nnz(p_ptr[n]), handle(handle),
+              ptr(p_ptr, p_ptr + n + 1), col(p_col, p_col + nnz), val(p_val, p_val + nnz)
         {
+              desc.reset(
+                      detail::cuda_matrix_description(nrows, ncols, nnz, ptr, col, val),
+                      backend::detail::cuda_deleter()
+                      );
         }
 
         void spmv(
@@ -157,47 +239,45 @@ class cuda_matrix {
                 real beta,  thrust::device_vector<real>       &y
             ) const
         {
+            std::shared_ptr<std::remove_pointer<cusparseDnVecDescr_t>::type> xdesc(
+                    detail::cuda_vector_description(const_cast<thrust::device_vector<real>&>(x)),
+                    backend::detail::cuda_deleter()
+                    );
+            std::shared_ptr<std::remove_pointer<cusparseDnVecDescr_t>::type> ydesc(
+                    detail::cuda_vector_description(y),
+                    backend::detail::cuda_deleter()
+                    );
+
             size_t buf_size;
             AMGCL_CALL_CUDA(
-                    cusparseCsrmvEx_bufferSize(
+                    cusparseSpMV_bufferSize(
                         handle,
-                        CUSPARSE_ALG_MERGE_PATH,
                         CUSPARSE_OPERATION_NON_TRANSPOSE,
-                        nrows,
-                        ncols,
-                        nnz,
-                        &alpha, datatype(),
+                        &alpha,
                         desc.get(),
-                        thrust::raw_pointer_cast(&val[0]), datatype(),
-                        thrust::raw_pointer_cast(&ptr[0]),
-                        thrust::raw_pointer_cast(&col[0]),
-                        thrust::raw_pointer_cast(&x[0]), datatype(),
-                        &beta, datatype(),
-                        thrust::raw_pointer_cast(&y[0]), datatype(),
-                        datatype(),
-                        &buf_size)
+                        xdesc.get(),
+                        &beta,
+                        ydesc.get(),
+                        detail::cuda_datatype<real>(),
+                        CUSPARSE_SPMV_CSR_ALG1,
+                        &buf_size
+                        )
                     );
 
             if (buf.size() < buf_size)
                 buf.resize(buf_size);
 
             AMGCL_CALL_CUDA(
-                    cusparseCsrmvEx(
+                    cusparseSpMV(
                         handle,
-                        CUSPARSE_ALG_MERGE_PATH,
                         CUSPARSE_OPERATION_NON_TRANSPOSE,
-                        nrows,
-                        ncols,
-                        nnz,
-                        &alpha, datatype(),
+                        &alpha,
                         desc.get(),
-                        thrust::raw_pointer_cast(&val[0]), datatype(),
-                        thrust::raw_pointer_cast(&ptr[0]),
-                        thrust::raw_pointer_cast(&col[0]),
-                        thrust::raw_pointer_cast(&x[0]), datatype(),
-                        &beta, datatype(),
-                        thrust::raw_pointer_cast(&y[0]), datatype(),
-                        datatype(),
+                        xdesc.get(),
+                        &beta,
+                        ydesc.get(),
+                        detail::cuda_datatype<real>(),
+                        CUSPARSE_SPMV_CSR_ALG1,
                         thrust::raw_pointer_cast(&buf[0])
                         )
                     );
@@ -217,7 +297,7 @@ class cuda_matrix {
 
         cusparseHandle_t handle;
 
-        std::shared_ptr<std::remove_pointer<cusparseMatDescr_t>::type> desc;
+        std::shared_ptr<std::remove_pointer<cusparseSpMatDescr_t>::type> desc;
 
         thrust::device_vector<int>  ptr;
         thrust::device_vector<int>  col;
@@ -225,20 +305,6 @@ class cuda_matrix {
 
         mutable thrust::device_vector<char> buf;
 
-        static cusparseMatDescr_t create_description() {
-            cusparseMatDescr_t desc;
-            AMGCL_CALL_CUDA( cusparseCreateMatDescr(&desc) );
-            AMGCL_CALL_CUDA( cusparseSetMatType(desc, CUSPARSE_MATRIX_TYPE_GENERAL) );
-            AMGCL_CALL_CUDA( cusparseSetMatIndexBase(desc, CUSPARSE_INDEX_BASE_ZERO) );
-            return desc;
-        }
-
-        static cudaDataType datatype() {
-            if (sizeof(real) == sizeof(float))
-                return CUDA_R_32F;
-            else
-                return CUDA_R_64F;
-        }
 };
 
 #else  // CUDART_VERSION >= 11000
@@ -370,7 +436,6 @@ class cuda_matrix {
 };
 
 #endif // CUDART_VERSION >= 11000
-
 /// CUDA backend.
 /**
  * Uses CUSPARSE for matrix operations and Thrust for vector operations.

--- a/external_libraries/amgcl/backend/eigen.hpp
+++ b/external_libraries/amgcl/backend/eigen.hpp
@@ -190,7 +190,7 @@ struct inner_product_impl<
     typedef typename value_type<V1>::type real;
     static real get(const V1 &x, const V2 &y)
     {
-        return x.dot(y);
+        return y.dot(x);
     }
 };
 

--- a/external_libraries/amgcl/backend/vexcl.hpp
+++ b/external_libraries/amgcl/backend/vexcl.hpp
@@ -267,7 +267,7 @@ template <
 struct vexcl_hybrid : public vexcl<typename math::scalar_of<BlockType>::type, ColumnType, PointerType, DirectSolver>
 {
     typedef typename math::scalar_of<BlockType>::type ScalarType;
-    typedef vexcl<ScalarType, DirectSolver> Base;
+    typedef vexcl<ScalarType, ColumnType, PointerType, DirectSolver> Base;
     typedef vex::sparse::distributed<
                 vex::sparse::matrix<
                     BlockType,

--- a/external_libraries/amgcl/coarsening/smoothed_aggregation.hpp
+++ b/external_libraries/amgcl/coarsening/smoothed_aggregation.hpp
@@ -199,7 +199,7 @@ struct smoothed_aggregation {
                     if (A.col[j] == i || !aggr.strong_connection[j])
                         dia += A.val[j];
                 }
-                dia = -omega * math::inverse(dia);
+                if (!math::is_zero(dia)) dia = -omega * math::inverse(dia);
 
                 ptrdiff_t row_beg = P->ptr[i];
                 ptrdiff_t row_end = row_beg;

--- a/external_libraries/amgcl/make_solver.hpp
+++ b/external_libraries/amgcl/make_solver.hpp
@@ -189,6 +189,11 @@ class make_solver : public amgcl::detail::non_copyable {
             return S;
         }
 
+        /// Returns reference to the constructed iterative solver.
+        IterativeSolver& solver() {
+            return S;
+        }
+
         /// Returns the system matrix in the backend format.
         std::shared_ptr<typename Precond::matrix> system_matrix_ptr() const {
             return P.system_matrix_ptr();

--- a/external_libraries/amgcl/mpi/amg.hpp
+++ b/external_libraries/amgcl/mpi/amg.hpp
@@ -196,6 +196,16 @@ class amg {
             rebuild(std::make_shared<matrix>(comm, M, backend::rows(M)), bprm);
         }
 
+        template <class OtherBackend>
+        typename std::enable_if<!std::is_same<Backend, OtherBackend>::value, void>::type
+        rebuild(
+                std::shared_ptr<distributed_matrix<OtherBackend>> A,
+                const backend_params &bprm = backend_params()
+        )
+        {
+            return rebuild(std::make_shared<matrix>(*A), bprm);
+        }
+
         void rebuild(
                 std::shared_ptr<matrix> A,
                 const backend_params &bprm = backend_params()
@@ -210,10 +220,12 @@ class amg {
                     );
 
             AMGCL_TIC("rebuild");
+            this->A = A;
             Coarsening C(prm.coarsening);
             for(auto &level : levels) {
                 A = level.rebuild(A, C, prm, bprm);
             }
+            this->A->move_to_backend(bprm);
             AMGCL_TOC("rebuild");
         }
 
@@ -410,7 +422,7 @@ class amg {
             }
 
             AMGCL_TIC("move to backend");
-            this->A->move_to_backend(bprm);
+            this->A->move_to_backend(bprm, prm.allow_rebuild);
             AMGCL_TOC("move to backend");
         }
 

--- a/external_libraries/amgcl/mpi/direct_solver/solver_base.hpp
+++ b/external_libraries/amgcl/mpi/direct_solver/solver_base.hpp
@@ -128,7 +128,7 @@ class solver_base {
                     shift += counts[j];
                 }
 
-                MPI_Waitall(cnt_req.size(), &cnt_req[0], MPI_STATUSES_IGNORE);
+                MPI_Waitall(cnt_req.size(), cnt_req.data(), MPI_STATUSES_IGNORE);
 
                 A.set_nonzeros(A.scan_row_sizes());
 
@@ -150,8 +150,8 @@ class solver_base {
                     shift += nnz;
                 }
 
-                MPI_Waitall(col_req.size(), &col_req[0], MPI_STATUSES_IGNORE);
-                MPI_Waitall(val_req.size(), &val_req[0], MPI_STATUSES_IGNORE);
+                MPI_Waitall(col_req.size(), col_req.data(), MPI_STATUSES_IGNORE);
+                MPI_Waitall(val_req.size(), val_req.data(), MPI_STATUSES_IGNORE);
 
                 solver().init(masters_comm, A);
             } else {
@@ -227,7 +227,7 @@ class solver_base {
                     shift += counts[j++];
                 }
 
-                MPI_Waitall(solve_req.size(), &solve_req[0], MPI_STATUSES_IGNORE);
+                MPI_Waitall(solve_req.size(), solve_req.data(), MPI_STATUSES_IGNORE);
 
                 solver().solve(cons_f, cons_x);
 
@@ -240,10 +240,10 @@ class solver_base {
                     shift += counts[j++];
                 }
 
-                MPI_Waitall(solve_req.size(), &solve_req[0], MPI_STATUSES_IGNORE);
+                MPI_Waitall(solve_req.size(), solve_req.data(), MPI_STATUSES_IGNORE);
             } else {
-                MPI_Send(&host_v[0], n, T, group_master, rhs_tag, comm);
-                MPI_Recv(&host_v[0], n, T, group_master, sol_tag, comm, MPI_STATUS_IGNORE);
+                MPI_Send(host_v.data(), n, T, group_master, rhs_tag, comm);
+                MPI_Recv(host_v.data(), n, T, group_master, sol_tag, comm, MPI_STATUS_IGNORE);
             }
 
             backend::copy(host_v, x);

--- a/external_libraries/amgcl/mpi/distributed_matrix.hpp
+++ b/external_libraries/amgcl/mpi/distributed_matrix.hpp
@@ -498,16 +498,13 @@ class distributed_matrix {
             }
 
             if (!A_rem && a_rem && a_rem->nnz > 0) {
-                std::vector<ptrdiff_t> backup;
                 if (keep_src) {
-                    backup.assign(a_rem->col, a_rem->col + a_rem->nnz);
-                }
-
-                C->renumber(a_rem->nnz, a_rem->col);
-                A_rem = Backend::copy_matrix(a_rem, bprm);
-
-                if (keep_src) {
-                    std::copy(backup.begin(), backup.end(), a_rem->col);
+                    auto rem_copy = std::make_shared<build_matrix>(*a_rem);
+                    C->renumber(rem_copy->nnz, rem_copy->col);
+                    A_rem = Backend::copy_matrix(rem_copy, bprm);
+                } else {
+                    C->renumber(a_rem->nnz, a_rem->col);
+                    A_rem = Backend::copy_matrix(a_rem, bprm);
                 }
             }
 

--- a/external_libraries/amgcl/mpi/make_solver.hpp
+++ b/external_libraries/amgcl/mpi/make_solver.hpp
@@ -32,11 +32,15 @@ THE SOFTWARE.
  */
 
 #include <iostream>
-
-#include <boost/property_tree/ptree.hpp>
 #include <memory>
 
 #include <mpi.h>
+
+// If asked explicitly, or if boost is available, enable
+// using boost::propert_tree::ptree as amgcl parameters:
+#ifndef AMGCL_NO_BOOST
+#  include <boost/property_tree/ptree.hpp>
+#endif
 
 #include <amgcl/util.hpp>
 #include <amgcl/mpi/inner_product.hpp>

--- a/external_libraries/amgcl/mpi/relaxation/as_preconditioner.hpp
+++ b/external_libraries/amgcl/mpi/relaxation/as_preconditioner.hpp
@@ -56,7 +56,7 @@ struct as_preconditioner {
             const Matrix &A,
             const params &prm = params(),
             const backend_params &bprm = backend_params()
-       ) : A(std::make_shared>(comm, A, backend::rows(A))),
+       ) : A(std::make_shared<matrix>(comm, A, backend::rows(A))),
            S(A, prm, bprm)
     {
         this->A->move_to_backend(bprm);

--- a/external_libraries/amgcl/mpi/util.hpp
+++ b/external_libraries/amgcl/mpi/util.hpp
@@ -97,6 +97,7 @@ struct datatype_impl<unsigned long long> {
     static MPI_Datatype get() { return MPI_UNSIGNED_LONG_LONG; }
 };
 
+#if (MPI_VERSION > 2) || (MPI_VERSION == 2 && MPI_SUBVERSION >= 2)
 template <>
 struct datatype_impl< std::complex<double> > {
     static MPI_Datatype get() { return MPI_CXX_DOUBLE_COMPLEX; }
@@ -106,6 +107,7 @@ template <>
 struct datatype_impl< std::complex<float> > {
     static MPI_Datatype get() { return MPI_CXX_FLOAT_COMPLEX; }
 };
+#endif
 
 template <typename T>
 struct datatype_impl<T,

--- a/external_libraries/amgcl/preconditioner/schur_pressure_correction.hpp
+++ b/external_libraries/amgcl/preconditioner/schur_pressure_correction.hpp
@@ -73,12 +73,14 @@ class schur_pressure_correction {
             backend_type;
 
         typedef typename backend_type::value_type value_type;
+        typedef typename backend_type::col_type col_type;
+        typedef typename backend_type::ptr_type ptr_type;
         typedef typename math::scalar_of<value_type>::type scalar_type;
         typedef typename backend_type::matrix     matrix;
         typedef typename backend_type::vector     vector;
         typedef typename backend_type::params     backend_params;
 
-        typedef typename backend::builtin<value_type>::matrix build_matrix;
+        typedef typename backend::builtin<value_type, col_type, ptr_type>::matrix build_matrix;
 
         struct params {
             typedef typename USolver::params usolver_params;

--- a/external_libraries/amgcl/relaxation/as_block.hpp
+++ b/external_libraries/amgcl/relaxation/as_block.hpp
@@ -69,7 +69,7 @@ struct as_block {
                     const params &prm = params(),
                     const backend_params &bprm = backend_params()
                     )
-            : base(*std::make_shared<typename BlockBackend::matrix>(adapter::block_matrix<BlockType>(A)), prm, bprm),
+            : base(*std::make_shared<typename backend::crs<BlockType, col_type, ptr_type>>(adapter::block_matrix<BlockType>(A)), prm, bprm),
               nrows(backend::rows(A) / math::static_rows<BlockType>::value)
             { }
 

--- a/external_libraries/amgcl/relaxation/cusparse_ilu0.hpp
+++ b/external_libraries/amgcl/relaxation/cusparse_ilu0.hpp
@@ -46,7 +46,7 @@ template <class Backend> struct ilu0;
 template <typename real>
 struct ilu0< backend::cuda<real> > {
     typedef real value_type;
-    typedef backend::cuda<double> Backend;
+    typedef backend::cuda<real> Backend;
 
     struct params {
         /// Damping factor.
@@ -77,16 +77,232 @@ struct ilu0< backend::cuda<real> > {
           val(A.val, A.val + nnz),
           y(n)
     {
-        // Create matrix descriptors.
+        // LU decomposition
+        std::shared_ptr<std::remove_pointer<cusparseMatDescr_t>::type> descr_M;
+        std::shared_ptr<std::remove_pointer<csrilu02Info_t>::type> info_M;
+
         {
             cusparseMatDescr_t descr;
+            csrilu02Info_t info;
 
             AMGCL_CALL_CUDA( cusparseCreateMatDescr(&descr) );
             AMGCL_CALL_CUDA( cusparseSetMatIndexBase(descr, CUSPARSE_INDEX_BASE_ZERO) );
             AMGCL_CALL_CUDA( cusparseSetMatType(descr, CUSPARSE_MATRIX_TYPE_GENERAL) );
 
+            AMGCL_CALL_CUDA( cusparseCreateCsrilu02Info(&info) );
+
             descr_M.reset(descr, backend::detail::cuda_deleter());
+            info_M.reset(info, backend::detail::cuda_deleter());
+
+            int buf_size;
+
+            AMGCL_CALL_CUDA(
+                    cusparseXcsrilu02_bufferSize(
+                        handle, n, nnz, descr_M.get(),
+                        thrust::raw_pointer_cast(&val[0]),
+                        thrust::raw_pointer_cast(&ptr[0]),
+                        thrust::raw_pointer_cast(&col[0]),
+                        info_M.get(), &buf_size
+                        )
+                    );
+
+            thrust::device_vector<char> bufLU(buf_size);
+
+            // Analysis and incomplete factorization of the system matrix.
+            int structural_zero;
+            int numerical_zero;
+
+            AMGCL_CALL_CUDA(
+                    cusparseXcsrilu02_analysis(
+                        handle,
+                        n,
+                        nnz,
+                        descr_M.get(),
+                        thrust::raw_pointer_cast(&val[0]),
+                        thrust::raw_pointer_cast(&ptr[0]),
+                        thrust::raw_pointer_cast(&col[0]),
+                        info_M.get(),
+                        CUSPARSE_SOLVE_POLICY_USE_LEVEL,
+                        thrust::raw_pointer_cast(&bufLU[0])
+                        )
+                    );
+
+            precondition(
+                    CUSPARSE_STATUS_ZERO_PIVOT != cusparseXcsrilu02_zeroPivot(handle, info_M.get(), &structural_zero),
+                    "Zero pivot in cuSPARSE ILU0"
+                    );
+
+            AMGCL_CALL_CUDA(
+                    cusparseXcsrilu02(
+                        handle,
+                        n,
+                        nnz,
+                        descr_M.get(),
+                        thrust::raw_pointer_cast(&val[0]),
+                        thrust::raw_pointer_cast(&ptr[0]),
+                        thrust::raw_pointer_cast(&col[0]),
+                        info_M.get(),
+                        CUSPARSE_SOLVE_POLICY_USE_LEVEL,
+                        thrust::raw_pointer_cast(&bufLU[0])
+                        )
+                    );
+            precondition(
+                    CUSPARSE_STATUS_ZERO_PIVOT != cusparseXcsrilu02_zeroPivot(handle, info_M.get(), &numerical_zero),
+                    "Zero pivot in cuSPARSE ILU0"
+                    );
+
         }
+
+        // Triangular solvers
+#if CUDART_VERSION >= 11000
+        const real alpha = 1;
+        thrust::device_vector<value_type> t(n);
+
+        descr_y.reset(
+                backend::detail::cuda_vector_description(y),
+                backend::detail::cuda_deleter()
+                );
+
+        std::shared_ptr<std::remove_pointer<cusparseDnVecDescr_t>::type> descr_t(
+                backend::detail::cuda_vector_description(t),
+                backend::detail::cuda_deleter()
+                );
+
+        cusparseFillMode_t fill_lower    = CUSPARSE_FILL_MODE_LOWER;
+        cusparseFillMode_t fill_upper    = CUSPARSE_FILL_MODE_UPPER;
+        cusparseDiagType_t diag_unit     = CUSPARSE_DIAG_TYPE_UNIT;
+        cusparseDiagType_t diag_non_unit = CUSPARSE_DIAG_TYPE_NON_UNIT;
+
+        // Triangular solver for L
+        {
+            descr_L.reset(
+                    backend::detail::cuda_matrix_description(n, n, nnz, ptr, col, val),
+                    backend::detail::cuda_deleter()
+                    );
+
+            AMGCL_CALL_CUDA(
+                    cusparseSpMatSetAttribute(
+                        descr_L.get(),
+                        CUSPARSE_SPMAT_FILL_MODE,
+                        &fill_lower,
+                        sizeof(fill_lower)
+                        )
+                    );
+
+            AMGCL_CALL_CUDA(
+                    cusparseSpMatSetAttribute(
+                        descr_L.get(),
+                        CUSPARSE_SPMAT_DIAG_TYPE,
+                        &diag_unit,
+                        sizeof(diag_unit)
+                        )
+                    );
+
+
+            size_t buf_size;
+
+            cusparseSpSVDescr_t desc;
+            AMGCL_CALL_CUDA( cusparseSpSV_createDescr(&desc) );
+            descr_SL.reset(desc, backend::detail::cuda_deleter());
+
+            AMGCL_CALL_CUDA(
+                    cusparseSpSV_bufferSize(
+                        handle,
+                        CUSPARSE_OPERATION_NON_TRANSPOSE,
+                        &alpha,
+                        descr_L.get(),
+                        descr_t.get(),
+                        descr_y.get(),
+                        backend::detail::cuda_datatype<real>(),
+                        CUSPARSE_SPSV_ALG_DEFAULT,
+                        descr_SL.get(),
+                        &buf_size
+                        )
+                    );
+
+            bufL.resize(buf_size);
+
+            AMGCL_CALL_CUDA(
+                    cusparseSpSV_analysis(
+                        handle,
+                        CUSPARSE_OPERATION_NON_TRANSPOSE,
+                        &alpha,
+                        descr_L.get(),
+                        descr_t.get(),
+                        descr_y.get(),
+                        backend::detail::cuda_datatype<real>(),
+                        CUSPARSE_SPSV_ALG_DEFAULT,
+                        descr_SL.get(),
+                        thrust::raw_pointer_cast(&bufL[0])
+                        )
+                    );
+        }
+
+        // Triangular solver for U
+        {
+            descr_U.reset(
+                    backend::detail::cuda_matrix_description(n, n, nnz, ptr, col, val),
+                    backend::detail::cuda_deleter()
+                    );
+
+            AMGCL_CALL_CUDA(
+                    cusparseSpMatSetAttribute(
+                        descr_U.get(),
+                        CUSPARSE_SPMAT_FILL_MODE,
+                        &fill_upper,
+                        sizeof(fill_upper)
+                        )
+                    );
+
+            AMGCL_CALL_CUDA(
+                    cusparseSpMatSetAttribute(
+                        descr_U.get(),
+                        CUSPARSE_SPMAT_DIAG_TYPE,
+                        &diag_non_unit,
+                        sizeof(diag_non_unit)
+                        )
+                    );
+
+
+            size_t buf_size;
+
+            cusparseSpSVDescr_t desc;
+            AMGCL_CALL_CUDA( cusparseSpSV_createDescr(&desc) );
+            descr_SU.reset(desc, backend::detail::cuda_deleter());
+
+            AMGCL_CALL_CUDA(
+                    cusparseSpSV_bufferSize(
+                        handle,
+                        CUSPARSE_OPERATION_NON_TRANSPOSE,
+                        &alpha,
+                        descr_U.get(),
+                        descr_y.get(),
+                        descr_t.get(),
+                        backend::detail::cuda_datatype<real>(),
+                        CUSPARSE_SPSV_ALG_DEFAULT,
+                        descr_SU.get(),
+                        &buf_size
+                        )
+                    );
+
+            bufU.resize(buf_size);
+
+            AMGCL_CALL_CUDA(
+                    cusparseSpSV_analysis(
+                        handle,
+                        CUSPARSE_OPERATION_NON_TRANSPOSE,
+                        &alpha,
+                        descr_U.get(),
+                        descr_y.get(),
+                        descr_t.get(),
+                        backend::detail::cuda_datatype<real>(),
+                        CUSPARSE_SPSV_ALG_DEFAULT,
+                        descr_SU.get(),
+                        thrust::raw_pointer_cast(&bufU[0])
+                        )
+                    );
+        }
+#else  // CUDART_VERSION >= 11000
         {
             cusparseMatDescr_t descr;
 
@@ -112,11 +328,6 @@ struct ilu0< backend::cuda<real> > {
 
         // Create info structures.
         {
-            csrilu02Info_t info;
-            AMGCL_CALL_CUDA( cusparseCreateCsrilu02Info(&info) );
-            info_M.reset(info, backend::detail::cuda_deleter());
-        }
-        {
             csrsv2Info_t info;
             AMGCL_CALL_CUDA( cusparseCreateCsrsv2Info(&info) );
             info_L.reset(info, backend::detail::cuda_deleter());
@@ -129,25 +340,16 @@ struct ilu0< backend::cuda<real> > {
 
         // Allocate scratch buffer.
         {
-            const cusparseOperation_t trans_L  = CUSPARSE_OPERATION_NON_TRANSPOSE;
-            const cusparseOperation_t trans_U  = CUSPARSE_OPERATION_NON_TRANSPOSE;
-
-            int buf_size_M;
             int buf_size_L;
             int buf_size_U;
 
             AMGCL_CALL_CUDA(
-                    cusparseXcsrilu02_bufferSize(
-                        handle, n, nnz, descr_M.get(),
-                        thrust::raw_pointer_cast(&val[0]),
-                        thrust::raw_pointer_cast(&ptr[0]),
-                        thrust::raw_pointer_cast(&col[0]),
-                        info_M.get(), &buf_size_M
-                        )
-                    );
-            AMGCL_CALL_CUDA(
                     cusparseXcsrsv2_bufferSize(
-                        handle, trans_L, n, nnz, descr_L.get(),
+                        handle,
+                        CUSPARSE_OPERATION_NON_TRANSPOSE,
+                        n,
+                        nnz,
+                        descr_L.get(),
                         thrust::raw_pointer_cast(&val[0]),
                         thrust::raw_pointer_cast(&ptr[0]),
                         thrust::raw_pointer_cast(&col[0]),
@@ -156,7 +358,11 @@ struct ilu0< backend::cuda<real> > {
                     );
             AMGCL_CALL_CUDA(
                     cusparseXcsrsv2_bufferSize(
-                        handle, trans_U, n, nnz, descr_U.get(),
+                        handle,
+                        CUSPARSE_OPERATION_NON_TRANSPOSE,
+                        n,
+                        nnz,
+                        descr_U.get(),
                         thrust::raw_pointer_cast(&val[0]),
                         thrust::raw_pointer_cast(&ptr[0]),
                         thrust::raw_pointer_cast(&col[0]),
@@ -164,64 +370,39 @@ struct ilu0< backend::cuda<real> > {
                         )
                     );
 
-            buf.resize( std::max(buf_size_M, std::max(buf_size_L, buf_size_U)) );
+            buf.resize( std::max(buf_size_L, buf_size_U) );
         }
 
-        // Analysis and incomplete factorization of the system matrix.
-        int structural_zero;
-        int numerical_zero;
-
-        AMGCL_CALL_CUDA(
-                cusparseXcsrilu02_analysis(handle, n, nnz, descr_M.get(),
-                    thrust::raw_pointer_cast(&val[0]),
-                    thrust::raw_pointer_cast(&ptr[0]),
-                    thrust::raw_pointer_cast(&col[0]),
-                    info_M.get(), policy_M,
-                    thrust::raw_pointer_cast(&buf[0])
-                    )
-                );
-
-        precondition(
-                CUSPARSE_STATUS_ZERO_PIVOT != cusparseXcsrilu02_zeroPivot(handle, info_M.get(), &structural_zero),
-                "Zero pivot in cuSPARSE ILU0"
-                );
-
         AMGCL_CALL_CUDA(
                 cusparseXcsrsv2_analysis(
-                    handle, trans_L, n, nnz, descr_L.get(),
+                    handle,
+                    CUSPARSE_OPERATION_NON_TRANSPOSE,
+                    n,
+                    nnz,
+                    descr_L.get(),
                     thrust::raw_pointer_cast(&val[0]),
                     thrust::raw_pointer_cast(&ptr[0]),
                     thrust::raw_pointer_cast(&col[0]),
-                    info_L.get(), policy_L,
+                    info_L.get(), CUSPARSE_SOLVE_POLICY_USE_LEVEL,
                     thrust::raw_pointer_cast(&buf[0])
                     )
                 );
 
         AMGCL_CALL_CUDA(
                 cusparseXcsrsv2_analysis(
-                    handle, trans_U, n, nnz, descr_U.get(),
+                    handle,
+                    CUSPARSE_OPERATION_NON_TRANSPOSE,
+                    n,
+                    nnz,
+                    descr_U.get(),
                     thrust::raw_pointer_cast(&val[0]),
                     thrust::raw_pointer_cast(&ptr[0]),
                     thrust::raw_pointer_cast(&col[0]),
-                    info_U.get(), policy_U,
+                    info_U.get(), CUSPARSE_SOLVE_POLICY_USE_LEVEL,
                     thrust::raw_pointer_cast(&buf[0])
                     )
                 );
-
-        AMGCL_CALL_CUDA(
-                cusparseXcsrilu02(
-                    handle, n, nnz, descr_M.get(),
-                    thrust::raw_pointer_cast(&val[0]),
-                    thrust::raw_pointer_cast(&ptr[0]),
-                    thrust::raw_pointer_cast(&col[0]),
-                    info_M.get(), policy_M,
-                    thrust::raw_pointer_cast(&buf[0])
-                    )
-                );
-        precondition(
-              CUSPARSE_STATUS_ZERO_PIVOT != cusparseXcsrilu02_zeroPivot(handle, info_M.get(), &numerical_zero),
-              "Zero pivot in cuSPARSE ILU0"
-              );
+#endif // CUDART_VERSION >= 11000
     }
 
     /// \copydoc amgcl::relaxation::damped_jacobi::apply_pre
@@ -260,44 +441,90 @@ struct ilu0< backend::cuda<real> > {
             backend::bytes(col) +
             backend::bytes(val) +
             backend::bytes(y) +
-            backend::bytes(buf);
+#if CUDART_VERSION >= 11000
+            backend::bytes(bufL) +
+            backend::bytes(bufU)
+#else
+            backend::bytes(buf)
+#endif
+            ;
     }
 
     private:
-        static const cusparseSolvePolicy_t policy_M = CUSPARSE_SOLVE_POLICY_NO_LEVEL;
-        static const cusparseSolvePolicy_t policy_L = CUSPARSE_SOLVE_POLICY_USE_LEVEL;
-        static const cusparseSolvePolicy_t policy_U = CUSPARSE_SOLVE_POLICY_USE_LEVEL;
-        static const cusparseOperation_t   trans_L  = CUSPARSE_OPERATION_NON_TRANSPOSE;
-        static const cusparseOperation_t   trans_U  = CUSPARSE_OPERATION_NON_TRANSPOSE;
-
         cusparseHandle_t handle;
         int n, nnz;
-
-        std::shared_ptr<std::remove_pointer<cusparseMatDescr_t>::type> descr_M, descr_L, descr_U;
-        std::shared_ptr<std::remove_pointer<csrilu02Info_t>::type> info_M;
-        std::shared_ptr<std::remove_pointer<csrsv2Info_t>::type>  info_L, info_U;
 
         thrust::device_vector<int> ptr, col;
         thrust::device_vector<value_type> val;
         mutable thrust::device_vector<value_type> y;
-        mutable thrust::device_vector<char> buf;
 
+#if CUDART_VERSION >= 11000
+        std::shared_ptr<std::remove_pointer<cusparseSpMatDescr_t>::type> descr_L, descr_U;
+        std::shared_ptr<std::remove_pointer<cusparseSpSVDescr_t>::type>  descr_SL, descr_SU;
+        std::shared_ptr<std::remove_pointer<cusparseDnVecDescr_t>::type> descr_y;
+        mutable thrust::device_vector<char> bufL, bufU;
+#else
+        std::shared_ptr<std::remove_pointer<cusparseMatDescr_t>::type> descr_L, descr_U;
+        std::shared_ptr<std::remove_pointer<csrsv2Info_t>::type>  info_L, info_U;
+        mutable thrust::device_vector<char> buf;
+#endif
 
         template <class VectorX>
         void solve(VectorX &x) const {
             value_type alpha = 1;
 
+#if CUDART_VERSION >= 11000
+            std::shared_ptr<std::remove_pointer<cusparseDnVecDescr_t>::type> descr_x(
+                    backend::detail::cuda_vector_description(x),
+                    backend::detail::cuda_deleter()
+                    );
+
+            // Solve L * y = x
+            AMGCL_CALL_CUDA(
+                    cusparseSpSV_solve(
+                        handle,
+                        CUSPARSE_OPERATION_NON_TRANSPOSE,
+                        &alpha,
+                        descr_L.get(),
+                        descr_x.get(),
+                        descr_y.get(),
+                        backend::detail::cuda_datatype<real>(),
+                        CUSPARSE_SPSV_ALG_DEFAULT,
+                        descr_SL.get()
+                        )
+                    );
+
+            // Solve U * x = y
+            AMGCL_CALL_CUDA(
+                    cusparseSpSV_solve(
+                        handle,
+                        CUSPARSE_OPERATION_NON_TRANSPOSE,
+                        &alpha,
+                        descr_U.get(),
+                        descr_y.get(),
+                        descr_x.get(),
+                        backend::detail::cuda_datatype<real>(),
+                        CUSPARSE_SPSV_ALG_DEFAULT,
+                        descr_SU.get()
+                        )
+                    );
+#else  // CUDART_VERSION >= 11000
             // Solve L * y = x
             AMGCL_CALL_CUDA(
                     cusparseXcsrsv2_solve(
-                        handle, trans_L, n, nnz, &alpha, descr_L.get(),
+                        handle,
+                        CUSPARSE_OPERATION_NON_TRANSPOSE,
+                        n,
+                        nnz,
+                        &alpha,
+                        descr_L.get(),
                         thrust::raw_pointer_cast(&val[0]),
                         thrust::raw_pointer_cast(&ptr[0]),
                         thrust::raw_pointer_cast(&col[0]),
                         info_L.get(),
                         thrust::raw_pointer_cast(&x[0]),
                         thrust::raw_pointer_cast(&y[0]),
-                        policy_L,
+                        CUSPARSE_SOLVE_POLICY_USE_LEVEL,
                         thrust::raw_pointer_cast(&buf[0])
                         )
                     );
@@ -305,19 +532,24 @@ struct ilu0< backend::cuda<real> > {
             // Solve U * x = y
             AMGCL_CALL_CUDA(
                     cusparseXcsrsv2_solve(
-                        handle, trans_U, n, nnz, &alpha, descr_U.get(),
+                        handle,
+                        CUSPARSE_OPERATION_NON_TRANSPOSE,
+                        n,
+                        nnz,
+                        &alpha,
+                        descr_U.get(),
                         thrust::raw_pointer_cast(&val[0]),
                         thrust::raw_pointer_cast(&ptr[0]),
                         thrust::raw_pointer_cast(&col[0]),
                         info_U.get(),
                         thrust::raw_pointer_cast(&y[0]),
                         thrust::raw_pointer_cast(&x[0]),
-                        policy_U,
+                        CUSPARSE_SOLVE_POLICY_USE_LEVEL,
                         thrust::raw_pointer_cast(&buf[0])
                         )
                     );
+#endif // CUDART_VERSION >= 11000
         }
-
 
         static cusparseStatus_t cusparseXcsrilu02_bufferSize(
                 cusparseHandle_t handle,
@@ -349,42 +581,6 @@ struct ilu0< backend::cuda<real> > {
             return cusparseScsrilu02_bufferSize(
                 handle, m, nnz, descrA, csrSortedValA, csrSortedRowPtrA,
                 csrSortedColIndA, info, pBufferSizeInBytes);
-        }
-
-        static cusparseStatus_t cusparseXcsrsv2_bufferSize(
-                cusparseHandle_t handle,
-                cusparseOperation_t transA,
-                int m,
-                int nnz,
-                const cusparseMatDescr_t descrA,
-                double *csrSortedValA,
-                const int *csrSortedRowPtrA,
-                const int *csrSortedColIndA,
-                csrsv2Info_t info,
-                int *pBufferSizeInBytes
-                )
-        {
-            return cusparseDcsrsv2_bufferSize(
-                handle, transA, m, nnz, descrA, csrSortedValA,
-                csrSortedRowPtrA, csrSortedColIndA, info, pBufferSizeInBytes);
-        }
-
-        static cusparseStatus_t cusparseXcsrsv2_bufferSize(
-                cusparseHandle_t handle,
-                cusparseOperation_t transA,
-                int m,
-                int nnz,
-                const cusparseMatDescr_t descrA,
-                float *csrSortedValA,
-                const int *csrSortedRowPtrA,
-                const int *csrSortedColIndA,
-                csrsv2Info_t info,
-                int *pBufferSizeInBytes
-                )
-        {
-            return cusparseScsrsv2_bufferSize(
-                handle, transA, m, nnz, descrA, csrSortedValA,
-                csrSortedRowPtrA, csrSortedColIndA, info, pBufferSizeInBytes);
         }
 
         static cusparseStatus_t cusparseXcsrilu02_analysis(
@@ -423,6 +619,78 @@ struct ilu0< backend::cuda<real> > {
                 csrSortedRowPtrA, csrSortedColIndA, info, policy, pBuffer);
         }
 
+
+        static cusparseStatus_t cusparseXcsrilu02(cusparseHandle_t handle,
+                int m,
+                int nnz,
+                const cusparseMatDescr_t descrA,
+                double *csrSortedValA_valM,
+                const int *csrSortedRowPtrA,
+                const int *csrSortedColIndA,
+                csrilu02Info_t info,
+                cusparseSolvePolicy_t policy,
+                void *pBuffer
+                )
+        {
+            return cusparseDcsrilu02(handle, m, nnz, descrA,
+                    csrSortedValA_valM, csrSortedRowPtrA, csrSortedColIndA,
+                    info, policy, pBuffer);
+        }
+
+        static cusparseStatus_t cusparseXcsrilu02(cusparseHandle_t handle,
+                int m,
+                int nnz,
+                const cusparseMatDescr_t descrA,
+                float *csrSortedValA_valM,
+                const int *csrSortedRowPtrA,
+                const int *csrSortedColIndA,
+                csrilu02Info_t info,
+                cusparseSolvePolicy_t policy,
+                void *pBuffer
+                )
+        {
+            return cusparseScsrilu02(handle, m, nnz, descrA,
+                    csrSortedValA_valM, csrSortedRowPtrA, csrSortedColIndA,
+                    info, policy, pBuffer);
+        }
+
+#if CUDART_VERSION < 11000
+        static cusparseStatus_t cusparseXcsrsv2_bufferSize(
+                cusparseHandle_t handle,
+                cusparseOperation_t transA,
+                int m,
+                int nnz,
+                const cusparseMatDescr_t descrA,
+                double *csrSortedValA,
+                const int *csrSortedRowPtrA,
+                const int *csrSortedColIndA,
+                csrsv2Info_t info,
+                int *pBufferSizeInBytes
+                )
+        {
+            return cusparseDcsrsv2_bufferSize(
+                handle, transA, m, nnz, descrA, csrSortedValA,
+                csrSortedRowPtrA, csrSortedColIndA, info, pBufferSizeInBytes);
+        }
+
+        static cusparseStatus_t cusparseXcsrsv2_bufferSize(
+                cusparseHandle_t handle,
+                cusparseOperation_t transA,
+                int m,
+                int nnz,
+                const cusparseMatDescr_t descrA,
+                float *csrSortedValA,
+                const int *csrSortedRowPtrA,
+                const int *csrSortedColIndA,
+                csrsv2Info_t info,
+                int *pBufferSizeInBytes
+                )
+        {
+            return cusparseScsrsv2_bufferSize(
+                handle, transA, m, nnz, descrA, csrSortedValA,
+                csrSortedRowPtrA, csrSortedColIndA, info, pBufferSizeInBytes);
+        }
+
         static cusparseStatus_t cusparseXcsrsv2_analysis(
                 cusparseHandle_t handle,
                 cusparseOperation_t transA,
@@ -459,40 +727,6 @@ struct ilu0< backend::cuda<real> > {
             return cusparseScsrsv2_analysis(
                     handle, transA, m, nnz, descrA, csrSortedValA,
                     csrSortedRowPtrA, csrSortedColIndA, info, policy, pBuffer);
-        }
-
-        static cusparseStatus_t cusparseXcsrilu02(cusparseHandle_t handle,
-                int m,
-                int nnz,
-                const cusparseMatDescr_t descrA,
-                double *csrSortedValA_valM,
-                const int *csrSortedRowPtrA,
-                const int *csrSortedColIndA,
-                csrilu02Info_t info,
-                cusparseSolvePolicy_t policy,
-                void *pBuffer
-                )
-        {
-            return cusparseDcsrilu02(handle, m, nnz, descrA,
-                    csrSortedValA_valM, csrSortedRowPtrA, csrSortedColIndA,
-                    info, policy, pBuffer);
-        }
-
-        static cusparseStatus_t cusparseXcsrilu02(cusparseHandle_t handle,
-                int m,
-                int nnz,
-                const cusparseMatDescr_t descrA,
-                float *csrSortedValA_valM,
-                const int *csrSortedRowPtrA,
-                const int *csrSortedColIndA,
-                csrilu02Info_t info,
-                cusparseSolvePolicy_t policy,
-                void *pBuffer
-                )
-        {
-            return cusparseScsrilu02(handle, m, nnz, descrA,
-                    csrSortedValA_valM, csrSortedRowPtrA, csrSortedColIndA,
-                    info, policy, pBuffer);
         }
 
         static cusparseStatus_t cusparseXcsrsv2_solve(
@@ -540,6 +774,7 @@ struct ilu0< backend::cuda<real> > {
                     nnz, alpha, descrA, csrSortedValA, csrSortedRowPtrA,
                     csrSortedColIndA, info, f, x, policy, pBuffer);
         }
+#endif // CUDART_VERSION < 11000
 };
 
 } // namespace relaxation

--- a/external_libraries/amgcl/relaxation/detail/ilu_solve.hpp
+++ b/external_libraries/amgcl/relaxation/detail/ilu_solve.hpp
@@ -458,7 +458,7 @@ template <class Block, class Col, class Ptr>
 class ilu_solve< backend::builtin_hybrid<Block, Col, Ptr> >
     : public ilu_solve< backend::builtin<typename math::scalar_of<Block>::type, Col, Ptr> >
 {
-    typedef ilu_solve< backend::builtin<typename math::scalar_of<Block>::type> > Base;
+    typedef ilu_solve< backend::builtin<typename math::scalar_of<Block>::type, Col, Ptr> > Base;
 
     public:
         using Base::Base;


### PR DESCRIPTION
---
name: ✨ Feature
about: New applications, new features or wider changes

---

## **📝 Description**

Update AMGCL to last [master branch](https://github.com/ddemidov/amgcl). Development has slow down recently, but some updating anyway to the last version.

### **Key changes**

- Added a check for zero diagonal in smoothed aggregation to prevent division by zero.
- Introduced a method to retrieve the constructed iterative solver in make_solver.
- Enhanced the rebuild function in the MPI AMG class to support different backends.
- Updated MPI direct solver to use data() for request arrays in MPI_Waitall calls.
- Improved distributed_matrix handling by using shared pointers for matrix copies.
- Modified make_solver to conditionally include Boost property tree support.
- Fixed a typo in as_preconditioner constructor for shared_ptr creation.
- Added missing includes in schur_pressure_correction for mixing backend.
- Updated relaxation methods to support new backend types and improved parameter handling.
- Enhanced cusparse_ilu0 to support CUDART_VERSION checks and improved buffer management.
- Refactored ilu_solve to correctly handle block types in hybrid backends.

### **Validation**

CI passes.

## **🆕 Changelog**

- [Update AMGCL to last master branch](https://github.com/KratosMultiphysics/Kratos/commit/e9806024399147872fcd3f59245ea4e69013462e)
