### PR TITLE
[GeoMechanicsApplication] Serialization of SaturatedLaw and few others

### DIFF
--- a/applications/GeoMechanicsApplication/geo_mechanics_application.cpp
+++ b/applications/GeoMechanicsApplication/geo_mechanics_application.cpp
@@ -14,7 +14,11 @@
 
 // Application includes
 #include "geo_mechanics_application.h"
+
+#include "custom_constitutive/thermal_filter_law.h"
 #include "custom_retention/saturated_below_phreatic_level_law.h"
+#include "custom_retention/saturated_law.h"
+#include "custom_retention/van_genuchten_law.h"
 
 namespace Kratos
 {
@@ -603,7 +607,17 @@ void KratosGeoMechanicsApplication::Register()
     KRATOS_REGISTER_VARIABLE(GEO_PLASTICITY_STATUS)
 
     Serializer::Register("PlaneStrain", PlaneStrain{});
-    Serializer::Register("PlaneStrainStressState", PlaneStrainStressState{});
+    Serializer::Register("ThreeDimensional", ThreeDimensional{});
     Serializer::Register("SaturatedBelowPhreaticLevelLaw", SaturatedBelowPhreaticLevelLaw{});
+    Serializer::Register("SaturatedLaw", SaturatedLaw{});
+    Serializer::Register("VanGenuchtenLaw", VanGenuchtenLaw{});
+    Serializer::Register("PlaneStrainStressState", PlaneStrainStressState{});
+    Serializer::Register("ThreeDimensionalStressState", ThreeDimensionalStressState{});
+    Serializer::Register("AxisymmetricStressState", AxisymmetricStressState{});
+    Serializer::Register("Line2DInterfaceStressState", Line2DInterfaceStressState{});
+    Serializer::Register("SurfaceInterfaceStressState", SurfaceInterfaceStressState{});
+    Serializer::Register("InterfacePlaneStrain", InterfacePlaneStrain{});
+    Serializer::Register("InterfaceThreeDimensionalSurface", InterfaceThreeDimensionalSurface{});
+    Serializer::Register("GeoThermalFilterLaw", GeoThermalFilterLaw{});
 }
 } // namespace Kratos.

--- a/applications/GeoMechanicsApplication/geo_mechanics_application.cpp
+++ b/applications/GeoMechanicsApplication/geo_mechanics_application.cpp
@@ -15,6 +15,8 @@
 // Application includes
 #include "geo_mechanics_application.h"
 
+#include "custom_constitutive/coulomb_yield_surface.h"
+#include "custom_constitutive/tension_cutoff.h"
 #include "custom_constitutive/thermal_filter_law.h"
 #include "custom_retention/saturated_below_phreatic_level_law.h"
 #include "custom_retention/saturated_law.h"
@@ -618,6 +620,8 @@ void KratosGeoMechanicsApplication::Register()
     Serializer::Register("SurfaceInterfaceStressState", SurfaceInterfaceStressState{});
     Serializer::Register("InterfacePlaneStrain", InterfacePlaneStrain{});
     Serializer::Register("InterfaceThreeDimensionalSurface", InterfaceThreeDimensionalSurface{});
+    Serializer::Register("CoulombYieldSurface", CoulombYieldSurface{});
+    Serializer::Register("TensionCutoff", TensionCutoff{});
     Serializer::Register("GeoThermalFilterLaw", GeoThermalFilterLaw{});
 }
 } // namespace Kratos.

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/serialization/test_check_serialization_registration.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/serialization/test_check_serialization_registration.cpp
@@ -1,0 +1,79 @@
+// KRATOS___
+//     //   ) )
+//    //         ___      ___
+//   //  ____  //___) ) //   ) )
+//  //    / / //       //   / /
+// ((____/ / ((____   ((___/ /  MECHANICS
+//
+//  License:         geo_mechanics_application/license.txt
+//
+//  Main authors:    Automated test
+//
+
+#include "custom_elements/axisymmetric_stress_state.h"
+#include "custom_elements/interface_stress_state.h"
+#include "custom_elements/plane_strain_stress_state.h"
+#include "custom_elements/three_dimensional_stress_state.h"
+
+#include "custom_constitutive/interface_plane_strain.h"
+#include "custom_constitutive/interface_three_dimensional_surface.h"
+#include "custom_constitutive/plane_strain.h"
+#include "custom_constitutive/thermal_filter_law.h"
+#include "custom_constitutive/three_dimensional.h"
+#include "custom_retention/saturated_below_phreatic_level_law.h"
+#include "custom_retention/saturated_law.h"
+#include "custom_retention/van_genuchten_law.h"
+
+#include "custom_utilities/registration_utilities.hpp"
+#include "includes/serializer.h"
+#include "tests/cpp_tests/geo_mechanics_fast_suite.h"
+
+namespace Kratos::Testing
+{
+template <typename TConcrete, typename TBase>
+void CheckSerializable(const std::string& rName)
+{
+    const auto scoped_registration = ScopedSerializerRegistration{std::make_pair(rName, TConcrete{})};
+
+    const auto p_obj      = std::unique_ptr<TBase>{std::make_unique<TConcrete>()};
+    auto       serializer = StreamSerializer{};
+
+    serializer.save("test_tag", p_obj);
+    auto p_loaded = std::unique_ptr<TBase>{};
+    serializer.load("test_tag", p_loaded);
+
+    KRATOS_EXPECT_NE(p_loaded, nullptr);
+    KRATOS_EXPECT_NE(dynamic_cast<TConcrete*>(p_loaded.get()), nullptr);
+}
+
+KRATOS_TEST_CASE_IN_SUITE(GeoMechanics_CheckSerializationRegistration, KratosGeoMechanicsFastSuite)
+{
+    // Stress state policies
+    CheckSerializable<PlaneStrainStressState, StressStatePolicy>("PlaneStrainStressState");
+    CheckSerializable<ThreeDimensionalStressState, StressStatePolicy>(
+        "ThreeDimensionalStressState");
+    CheckSerializable<AxisymmetricStressState, StressStatePolicy>("AxisymmetricStressState");
+    CheckSerializable<Line2DInterfaceStressState, StressStatePolicy>("Line2DInterfaceStressState");
+    CheckSerializable<SurfaceInterfaceStressState, StressStatePolicy>(
+        "SurfaceInterfaceStressState");
+
+    // Constitutive law dimensions already covered elsewhere but include smoke checks
+    CheckSerializable<PlaneStrain, ConstitutiveLawDimension>("PlaneStrain");
+    CheckSerializable<ThreeDimensional, ConstitutiveLawDimension>("ThreeDimensional");
+
+    // Retention laws
+    CheckSerializable<SaturatedBelowPhreaticLevelLaw, RetentionLaw>(
+        "SaturatedBelowPhreaticLevelLaw");
+    CheckSerializable<SaturatedLaw, RetentionLaw>("SaturatedLaw");
+    CheckSerializable<VanGenuchtenLaw, RetentionLaw>("VanGenuchtenLaw");
+
+    // Constitutive law dimensions
+    CheckSerializable<InterfacePlaneStrain, ConstitutiveLawDimension>("InterfacePlaneStrain");
+    CheckSerializable<InterfaceThreeDimensionalSurface, ConstitutiveLawDimension>(
+        "InterfaceThreeDimensionalSurface");
+
+    // Thermal law
+    CheckSerializable<GeoThermalFilterLaw, GeoThermalLaw>("GeoThermalFilterLaw");
+}
+
+} // namespace Kratos::Testing

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/serialization/test_check_serialization_registration.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/serialization/test_check_serialization_registration.cpp
@@ -15,9 +15,11 @@
 #include "custom_elements/plane_strain_stress_state.h"
 #include "custom_elements/three_dimensional_stress_state.h"
 
+#include "custom_constitutive/coulomb_yield_surface.h"
 #include "custom_constitutive/interface_plane_strain.h"
 #include "custom_constitutive/interface_three_dimensional_surface.h"
 #include "custom_constitutive/plane_strain.h"
+#include "custom_constitutive/tension_cutoff.h"
 #include "custom_constitutive/thermal_filter_law.h"
 #include "custom_constitutive/three_dimensional.h"
 #include "custom_retention/saturated_below_phreatic_level_law.h"
@@ -33,8 +35,6 @@ namespace Kratos::Testing
 template <typename TConcrete, typename TBase>
 void CheckSerializable(const std::string& rName)
 {
-    const auto scoped_registration = ScopedSerializerRegistration{std::make_pair(rName, TConcrete{})};
-
     const auto p_obj      = std::unique_ptr<TBase>{std::make_unique<TConcrete>()};
     auto       serializer = StreamSerializer{};
 
@@ -74,6 +74,10 @@ KRATOS_TEST_CASE_IN_SUITE(GeoMechanics_CheckSerializationRegistration, KratosGeo
 
     // Thermal law
     CheckSerializable<GeoThermalFilterLaw, GeoThermalLaw>("GeoThermalFilterLaw");
+
+    // Yield surfaces
+    CheckSerializable<CoulombYieldSurface, CoulombYieldSurface>("CoulombYieldSurface");
+    CheckSerializable<TensionCutoff, TensionCutoff>("TensionCutoff");
 }
 
 } // namespace Kratos::Testing

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/serialization/test_check_serialization_registration.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/serialization/test_check_serialization_registration.cpp
@@ -7,7 +7,7 @@
 //
 //  License:         geo_mechanics_application/license.txt
 //
-//  Main authors:    Automated test
+//  Main authors:    Gennady Markelov
 //
 
 #include "custom_elements/axisymmetric_stress_state.h"

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/serialization/test_check_serialization_registration.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/serialization/test_check_serialization_registration.cpp
@@ -33,7 +33,7 @@
 namespace Kratos::Testing
 {
 template <typename TConcrete, typename TBase>
-void CheckSerializable(const std::string& rName)
+void CheckSerializable()
 {
     const auto p_obj      = std::unique_ptr<TBase>{std::make_unique<TConcrete>()};
     auto       serializer = StreamSerializer{};
@@ -49,35 +49,31 @@ void CheckSerializable(const std::string& rName)
 KRATOS_TEST_CASE_IN_SUITE(GeoMechanics_CheckSerializationRegistration, KratosGeoMechanicsFastSuite)
 {
     // Stress state policies
-    CheckSerializable<PlaneStrainStressState, StressStatePolicy>("PlaneStrainStressState");
-    CheckSerializable<ThreeDimensionalStressState, StressStatePolicy>(
-        "ThreeDimensionalStressState");
-    CheckSerializable<AxisymmetricStressState, StressStatePolicy>("AxisymmetricStressState");
-    CheckSerializable<Line2DInterfaceStressState, StressStatePolicy>("Line2DInterfaceStressState");
-    CheckSerializable<SurfaceInterfaceStressState, StressStatePolicy>(
-        "SurfaceInterfaceStressState");
+    CheckSerializable<PlaneStrainStressState, StressStatePolicy>();
+    CheckSerializable<ThreeDimensionalStressState, StressStatePolicy>();
+    CheckSerializable<AxisymmetricStressState, StressStatePolicy>();
+    CheckSerializable<Line2DInterfaceStressState, StressStatePolicy>();
+    CheckSerializable<SurfaceInterfaceStressState, StressStatePolicy>();
 
     // Constitutive law dimensions already covered elsewhere but include smoke checks
-    CheckSerializable<PlaneStrain, ConstitutiveLawDimension>("PlaneStrain");
-    CheckSerializable<ThreeDimensional, ConstitutiveLawDimension>("ThreeDimensional");
+    CheckSerializable<PlaneStrain, ConstitutiveLawDimension>();
+    CheckSerializable<ThreeDimensional, ConstitutiveLawDimension>();
 
     // Retention laws
-    CheckSerializable<SaturatedBelowPhreaticLevelLaw, RetentionLaw>(
-        "SaturatedBelowPhreaticLevelLaw");
-    CheckSerializable<SaturatedLaw, RetentionLaw>("SaturatedLaw");
-    CheckSerializable<VanGenuchtenLaw, RetentionLaw>("VanGenuchtenLaw");
+    CheckSerializable<SaturatedBelowPhreaticLevelLaw, RetentionLaw>();
+    CheckSerializable<SaturatedLaw, RetentionLaw>();
+    CheckSerializable<VanGenuchtenLaw, RetentionLaw>();
 
     // Constitutive law dimensions
-    CheckSerializable<InterfacePlaneStrain, ConstitutiveLawDimension>("InterfacePlaneStrain");
-    CheckSerializable<InterfaceThreeDimensionalSurface, ConstitutiveLawDimension>(
-        "InterfaceThreeDimensionalSurface");
+    CheckSerializable<InterfacePlaneStrain, ConstitutiveLawDimension>();
+    CheckSerializable<InterfaceThreeDimensionalSurface, ConstitutiveLawDimension>();
 
     // Thermal law
-    CheckSerializable<GeoThermalFilterLaw, GeoThermalLaw>("GeoThermalFilterLaw");
+    CheckSerializable<GeoThermalFilterLaw, GeoThermalLaw>();
 
     // Yield surfaces
-    CheckSerializable<CoulombYieldSurface, CoulombYieldSurface>("CoulombYieldSurface");
-    CheckSerializable<TensionCutoff, TensionCutoff>("TensionCutoff");
+    CheckSerializable<CoulombYieldSurface, CoulombYieldSurface>();
+    CheckSerializable<TensionCutoff, TensionCutoff>();
 }
 
 } // namespace Kratos::Testing


### PR DESCRIPTION
## **📝 Description**
A brief description of the PR.

- registered the following classes: ThreeDimensional,  SaturatedLaw, VanGenuchtenLaw, ThreeDimensionalStressState, AxisymmetricStressState, Line2DInterfaceStressState, SurfaceInterfaceStressState, InterfacePlaneStrain, InterfaceThreeDimensionalSurface and GeoThermalFilterLaw.
- added a simple unit test that calls save/load for all classes registered with Serializer::Register.
