### PR TITLE
Geo/clang tidy remarks

### DIFF
--- a/applications/GeoMechanicsApplication/custom_constitutive/tension_cutoff.cpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/tension_cutoff.cpp
@@ -34,7 +34,9 @@ double TensionCutoff::YieldFunctionValue(const Geo::PrincipalStresses& rPrincipa
     return rPrincipalStresses.Values()[0] - mTensileStrength;
 }
 
-Vector TensionCutoff::DerivativeOfFlowFunction(const Geo::SigmaTau&, Geo::PrincipalStresses::AveragingType AveragingType)
+// NOLINTBEGIN(readability-convert-member-functions-to-static)
+Vector TensionCutoff::DerivativeOfFlowFunction(const Geo::SigmaTau&,
+                                               Geo::PrincipalStresses::AveragingType AveragingType) const
 {
     switch (AveragingType) {
         using enum Geo::PrincipalStresses::AveragingType;
@@ -48,8 +50,11 @@ Vector TensionCutoff::DerivativeOfFlowFunction(const Geo::SigmaTau&, Geo::Princi
     }
 }
 
+// NOLINTEND(readability-convert-member-functions-to-static)
+
+// NOLINTBEGIN(readability-convert-member-functions-to-static)
 Vector TensionCutoff::DerivativeOfFlowFunction(const Geo::PrincipalStresses&,
-                                               Geo::PrincipalStresses::AveragingType AveragingType)
+                                               Geo::PrincipalStresses::AveragingType AveragingType) const
 {
     switch (AveragingType) {
         using enum Geo::PrincipalStresses::AveragingType;
@@ -62,6 +67,7 @@ Vector TensionCutoff::DerivativeOfFlowFunction(const Geo::PrincipalStresses&,
         KRATOS_ERROR << "Unsupported Averaging Type: " << static_cast<std::size_t>(AveragingType) << "\n";
     }
 }
+// NOLINTEND(readability-convert-member-functions-to-static)
 
 double TensionCutoff::CalculatePlasticMultiplier(const Geo::SigmaTau& rTrialSigmaTau,
                                                  const Vector&        rDerivativeOfFlowFunction,

--- a/applications/GeoMechanicsApplication/custom_constitutive/tension_cutoff.cpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/tension_cutoff.cpp
@@ -34,15 +34,13 @@ double TensionCutoff::YieldFunctionValue(const Geo::PrincipalStresses& rPrincipa
     return rPrincipalStresses.Values()[0] - mTensileStrength;
 }
 
-Vector TensionCutoff::DerivativeOfFlowFunction(const Geo::SigmaTau&,
-                                               Geo::PrincipalStresses::AveragingType AveragingType) const
+Vector TensionCutoff::DerivativeOfFlowFunction(const Geo::SigmaTau&, Geo::PrincipalStresses::AveragingType AveragingType)
 {
     switch (AveragingType) {
         using enum Geo::PrincipalStresses::AveragingType;
     case LOWEST_PRINCIPAL_STRESSES:
         return UblasUtilities::CreateVector({0.5, 0.5});
     case NO_AVERAGING:
-        return UblasUtilities::CreateVector({1.0, 1.0});
     case HIGHEST_PRINCIPAL_STRESSES:
         return UblasUtilities::CreateVector({1.0, 1.0});
     default:
@@ -51,14 +49,13 @@ Vector TensionCutoff::DerivativeOfFlowFunction(const Geo::SigmaTau&,
 }
 
 Vector TensionCutoff::DerivativeOfFlowFunction(const Geo::PrincipalStresses&,
-                                               Geo::PrincipalStresses::AveragingType AveragingType) const
+                                               Geo::PrincipalStresses::AveragingType AveragingType)
 {
     switch (AveragingType) {
         using enum Geo::PrincipalStresses::AveragingType;
     case LOWEST_PRINCIPAL_STRESSES:
         return UblasUtilities::CreateVector({0.5, 0.5, 0.0});
     case NO_AVERAGING:
-        return UblasUtilities::CreateVector({1.0, 0.0, 0.0});
     case HIGHEST_PRINCIPAL_STRESSES:
         return UblasUtilities::CreateVector({1.0, 0.0, 0.0});
     default:

--- a/applications/GeoMechanicsApplication/custom_constitutive/tension_cutoff.cpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/tension_cutoff.cpp
@@ -67,6 +67,7 @@ Vector TensionCutoff::DerivativeOfFlowFunction(const Geo::PrincipalStresses&,
         KRATOS_ERROR << "Unsupported Averaging Type: " << static_cast<std::size_t>(AveragingType) << "\n";
     }
 }
+
 // NOLINTEND(readability-convert-member-functions-to-static)
 
 double TensionCutoff::CalculatePlasticMultiplier(const Geo::SigmaTau& rTrialSigmaTau,

--- a/applications/GeoMechanicsApplication/custom_constitutive/tension_cutoff.h
+++ b/applications/GeoMechanicsApplication/custom_constitutive/tension_cutoff.h
@@ -43,12 +43,12 @@ public:
 
     [[nodiscard]] double YieldFunctionValue(const Geo::SigmaTau& rSigmaTau) const;
     [[nodiscard]] double YieldFunctionValue(const Geo::PrincipalStresses& rPrincipalStresses) const;
-    [[nodiscard]] static Vector DerivativeOfFlowFunction(
-        const Geo::SigmaTau&,
-        Geo::PrincipalStresses::AveragingType AveragingType = Geo::PrincipalStresses::AveragingType::NO_AVERAGING);
-    [[nodiscard]] static Vector DerivativeOfFlowFunction(
-        const Geo::PrincipalStresses&,
-        Geo::PrincipalStresses::AveragingType AveragingType = Geo::PrincipalStresses::AveragingType::NO_AVERAGING);
+    [[nodiscard]] Vector DerivativeOfFlowFunction(const Geo::SigmaTau&,
+                                                  Geo::PrincipalStresses::AveragingType AveragingType =
+                                                      Geo::PrincipalStresses::AveragingType::NO_AVERAGING) const;
+    [[nodiscard]] Vector DerivativeOfFlowFunction(const Geo::PrincipalStresses&,
+                                                  Geo::PrincipalStresses::AveragingType AveragingType =
+                                                      Geo::PrincipalStresses::AveragingType::NO_AVERAGING) const;
 
     [[nodiscard]] double CalculatePlasticMultiplier(const Geo::SigmaTau& rTrialSigmaTau,
                                                     const Vector&        rDerivativeOfFlowFunction,

--- a/applications/GeoMechanicsApplication/custom_constitutive/tension_cutoff.h
+++ b/applications/GeoMechanicsApplication/custom_constitutive/tension_cutoff.h
@@ -43,12 +43,12 @@ public:
 
     [[nodiscard]] double YieldFunctionValue(const Geo::SigmaTau& rSigmaTau) const;
     [[nodiscard]] double YieldFunctionValue(const Geo::PrincipalStresses& rPrincipalStresses) const;
-    [[nodiscard]] Vector DerivativeOfFlowFunction(const Geo::SigmaTau&,
-                                                  Geo::PrincipalStresses::AveragingType AveragingType =
-                                                      Geo::PrincipalStresses::AveragingType::NO_AVERAGING) const;
-    [[nodiscard]] Vector DerivativeOfFlowFunction(const Geo::PrincipalStresses&,
-                                                  Geo::PrincipalStresses::AveragingType AveragingType =
-                                                      Geo::PrincipalStresses::AveragingType::NO_AVERAGING) const;
+    [[nodiscard]] static Vector DerivativeOfFlowFunction(
+        const Geo::SigmaTau&,
+        Geo::PrincipalStresses::AveragingType AveragingType = Geo::PrincipalStresses::AveragingType::NO_AVERAGING);
+    [[nodiscard]] static Vector DerivativeOfFlowFunction(
+        const Geo::PrincipalStresses&,
+        Geo::PrincipalStresses::AveragingType AveragingType = Geo::PrincipalStresses::AveragingType::NO_AVERAGING);
 
     [[nodiscard]] double CalculatePlasticMultiplier(const Geo::SigmaTau& rTrialSigmaTau,
                                                     const Vector&        rDerivativeOfFlowFunction,

--- a/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_FIC_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_FIC_element.cpp
@@ -447,8 +447,6 @@ void UPwSmallStrainFICElement<TDim, TNumNodes>::CalculateAll(MatrixType& rLeftHa
     FICElementVariables FICVariables;
     this->InitializeFICElementVariables(FICVariables, Variables.DN_DXContainer, Geom, Prop, CurrentProcessInfo);
 
-    RetentionLaw::Parameters RetentionParameters(this->GetProperties());
-
     const auto b_matrices = this->CalculateBMatrices(Variables.DN_DXContainer, Variables.NContainer);
     const auto integration_coefficients =
         this->CalculateIntegrationCoefficients(IntegrationPoints, Variables.detJContainer);

--- a/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_element.cpp
@@ -258,7 +258,7 @@ void UPwSmallStrainElement<TDim, TNumNodes>::SetValuesOnIntegrationPoints(const 
                "UPwSmallStrainElement::SetValuesOnIntegrationPoints"
             << std::endl;
         mStressVector.resize(rValues.size());
-        std::copy(rValues.begin(), rValues.end(), mStressVector.begin());
+        std::ranges::copy(rValues, mStressVector.begin());
     } else {
         KRATOS_ERROR_IF(rValues.size() < mConstitutiveLawVector.size())
             << "Insufficient number of values for "
@@ -1363,19 +1363,16 @@ void UPwSmallStrainElement<TDim, TNumNodes>::CalculateAnyOfMaterialResponse(
 {
     if (rStrainVectors.size() != rDeformationGradients.size()) {
         rStrainVectors.resize(rDeformationGradients.size());
-        std::fill(rStrainVectors.begin(), rStrainVectors.end(),
-                  ZeroVector(this->GetStressStatePolicy().GetVoigtSize()));
+        std::ranges::fill(rStrainVectors, ZeroVector(this->GetStressStatePolicy().GetVoigtSize()));
     }
     if (rStressVectors.size() != rDeformationGradients.size()) {
         rStressVectors.resize(rDeformationGradients.size());
-        std::fill(rStressVectors.begin(), rStressVectors.end(),
-                  ZeroVector(this->GetStressStatePolicy().GetVoigtSize()));
+        std::ranges::fill(rStressVectors, ZeroVector(this->GetStressStatePolicy().GetVoigtSize()));
     }
     if (rConstitutiveMatrices.size() != rDeformationGradients.size()) {
         rConstitutiveMatrices.resize(rDeformationGradients.size());
-        std::fill(rConstitutiveMatrices.begin(), rConstitutiveMatrices.end(),
-                  ZeroMatrix(this->GetStressStatePolicy().GetVoigtSize(),
-                             this->GetStressStatePolicy().GetVoigtSize()));
+        std::ranges::fill(rConstitutiveMatrices, ZeroMatrix(this->GetStressStatePolicy().GetVoigtSize(),
+                                                            this->GetStressStatePolicy().GetVoigtSize()));
     }
 
     const auto determinants_of_deformation_gradients =

--- a/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_interface_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_interface_element.cpp
@@ -603,8 +603,6 @@ void UPwSmallStrainInterfaceElement<TDim, TNumNodes>::CalculateOnLobattoIntegrat
         InterfaceElementVariables Variables;
         this->InitializeElementVariables(Variables, r_geometry, r_properties, rCurrentProcessInfo);
 
-        RetentionLaw::Parameters RetentionParameters(r_properties);
-
         // Loop over integration points
         for (unsigned int GPoint = 0; GPoint < NumGPoints; ++GPoint) {
             InterfaceElementUtilities::CalculateNuMatrix(Variables.Nu, NContainer, GPoint);

--- a/applications/GeoMechanicsApplication/custom_elements/U_Pw_updated_lagrangian_FIC_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/U_Pw_updated_lagrangian_FIC_element.cpp
@@ -112,8 +112,6 @@ void UPwUpdatedLagrangianFICElement<TDim, TNumNodes>::CalculateAll(MatrixType& r
     FICElementVariables FICVariables;
     this->InitializeFICElementVariables(FICVariables, Variables.DN_DXContainer, Geom, Prop, rCurrentProcessInfo);
 
-    RetentionLaw::Parameters RetentionParameters(this->GetProperties());
-
     const auto b_matrices = this->CalculateBMatrices(Variables.DN_DXContainer, Variables.NContainer);
     const auto integration_coefficients =
         this->CalculateIntegrationCoefficients(IntegrationPoints, Variables.detJContainer);

--- a/applications/GeoMechanicsApplication/custom_elements/small_strain_U_Pw_diff_order_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/small_strain_U_Pw_diff_order_element.cpp
@@ -391,7 +391,7 @@ void SmallStrainUPwDiffOrderElement::SetValuesOnIntegrationPoints(const Variable
                "SmallStrainUPwDiffOrderElement::SetValuesOnIntegrationPoints"
             << std::endl;
         mStressVector.resize(rValues.size());
-        std::copy(rValues.begin(), rValues.end(), mStressVector.begin());
+        std::ranges::copy(rValues, mStressVector.begin());
     } else {
         KRATOS_ERROR_IF(rValues.size() < mConstitutiveLawVector.size())
             << "Insufficient number of values for "
@@ -564,8 +564,8 @@ void SmallStrainUPwDiffOrderElement::CalculateOnIntegrationPoints(const Variable
                                              Variables.NuContainer, Variables.DNu_DXContainer,
                                              strain_vectors, mStressVector, constitutive_matrices);
 
-        std::transform(constitutive_matrices.begin(), constitutive_matrices.end(), rOutput.begin(),
-                       [variable_index](const Matrix& constitutive_matrix) {
+        std::ranges::transform(constitutive_matrices, rOutput.begin(),
+                               [variable_index](const Matrix& constitutive_matrix) {
             return constitutive_matrix(variable_index, variable_index);
         });
     } else if (r_properties.Has(rVariable)) {
@@ -1652,15 +1652,15 @@ void SmallStrainUPwDiffOrderElement::CalculateAnyOfMaterialResponse(
 
     if (rStrainVectors.size() != rDeformationGradients.size()) {
         rStrainVectors.resize(rDeformationGradients.size());
-        std::fill(rStrainVectors.begin(), rStrainVectors.end(), ZeroVector(voigt_size));
+        std::ranges::fill(rStrainVectors, ZeroVector(voigt_size));
     }
     if (rStressVectors.size() != rDeformationGradients.size()) {
         rStressVectors.resize(rDeformationGradients.size());
-        std::fill(rStressVectors.begin(), rStressVectors.end(), ZeroVector(voigt_size));
+        std::ranges::fill(rStressVectors, ZeroVector(voigt_size));
     }
     if (rConstitutiveMatrices.size() != rDeformationGradients.size()) {
         rConstitutiveMatrices.resize(rDeformationGradients.size());
-        std::fill(rConstitutiveMatrices.begin(), rConstitutiveMatrices.end(), ZeroMatrix(voigt_size, voigt_size));
+        std::ranges::fill(rConstitutiveMatrices, ZeroMatrix(voigt_size, voigt_size));
     }
 
     const auto determinants_of_deformation_gradients =

--- a/applications/GeoMechanicsApplication/custom_elements/small_strain_U_Pw_diff_order_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/small_strain_U_Pw_diff_order_element.cpp
@@ -192,7 +192,7 @@ Vector SmallStrainUPwDiffOrderElement::GetPressures(const size_t n_nodes) const
 {
     const auto& r_geom = GetGeometry();
     Vector      pressure(n_nodes);
-    std::transform(r_geom.begin(), r_geom.begin() + n_nodes, pressure.begin(),
+    std::transform(r_geom.begin(), r_geom.begin() + static_cast<std::ptrdiff_t>(n_nodes), pressure.begin(),
                    [](const auto& node) { return node.FastGetSolutionStepValue(WATER_PRESSURE); });
     return pressure;
 }

--- a/applications/GeoMechanicsApplication/custom_elements/transient_Pw_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/transient_Pw_element.cpp
@@ -254,7 +254,7 @@ void TransientPwElement<TDim, TNumNodes>::CalculateOnIntegrationPoints(const Var
         if (rOutput.size() != mRetentionLawVector.size())
             rOutput.resize(mRetentionLawVector.size());
 
-        std::fill(rOutput.begin(), rOutput.end(), 0.0);
+        std::ranges::fill(rOutput, 0.0);
     }
 
     KRATOS_CATCH("")
@@ -334,8 +334,6 @@ void TransientPwElement<TDim, TNumNodes>::CalculateAll(MatrixType&        rLeftH
     // Element variables
     ElementVariables Variables;
     this->InitializeElementVariables(Variables, rCurrentProcessInfo);
-
-    RetentionLaw::Parameters RetentionParameters(this->GetProperties());
 
     const auto fluid_pressures = GeoTransportEquationUtilities::CalculateFluidPressures(
         Variables.NContainer, Variables.PressureVector);

--- a/applications/GeoMechanicsApplication/custom_processes/apply_constant_interpolate_line_pressure_process.cpp
+++ b/applications/GeoMechanicsApplication/custom_processes/apply_constant_interpolate_line_pressure_process.cpp
@@ -265,7 +265,7 @@ void ApplyConstantInterpolateLinePressureProcess::FindTwoClosestNodeOnBoundaryNo
 }
 
 Node* ApplyConstantInterpolateLinePressureProcess::FindClosestNodeOnBoundaryNodes(
-    const Node& rNode, const std::vector<Node*>& BoundaryNodes, const bool isBottom) const
+    const Node& rNode, const std::vector<Node*>& BoundaryNodes, bool isBottom) const
 {
     const double       HorizontalCoordinate = rNode.Coordinates()[mHorizontalDirection];
     std::vector<Node*> FoundNodes;

--- a/applications/GeoMechanicsApplication/custom_processes/apply_constant_interpolate_line_pressure_process.cpp
+++ b/applications/GeoMechanicsApplication/custom_processes/apply_constant_interpolate_line_pressure_process.cpp
@@ -21,9 +21,9 @@ namespace Kratos
 {
 using namespace std::string_literals;
 
-ApplyConstantInterpolateLinePressureProcess::ApplyConstantInterpolateLinePressureProcess(ModelPart& model_part,
+ApplyConstantInterpolateLinePressureProcess::ApplyConstantInterpolateLinePressureProcess(ModelPart& rModelPart,
                                                                                          Parameters rParameters)
-    : Process(Flags()), mrModelPart(model_part)
+    : Process(Flags()), mrModelPart(rModelPart)
 {
     KRATOS_TRY
 
@@ -102,7 +102,7 @@ std::string ApplyConstantInterpolateLinePressureProcess::Info() const
     return "ApplyConstantInterpolateLinePressureProcess"s;
 }
 
-double ApplyConstantInterpolateLinePressureProcess::CalculatePressure(const Node& rNode)
+double ApplyConstantInterpolateLinePressureProcess::CalculatePressure(const Node& rNode) const
 {
     // find top boundary
     std::vector<Node*> TopBoundaryNodes;
@@ -343,7 +343,7 @@ void ApplyConstantInterpolateLinePressureProcess::FindRightBoundaryNodes(const N
     }
 }
 
-int ApplyConstantInterpolateLinePressureProcess::GetMaxNodeID()
+int ApplyConstantInterpolateLinePressureProcess::GetMaxNodeID() const
 {
     KRATOS_TRY
 
@@ -381,23 +381,23 @@ void ApplyConstantInterpolateLinePressureProcess::FindBoundaryNodes()
     KRATOS_CATCH("")
 }
 
-void ApplyConstantInterpolateLinePressureProcess::FillListOfBoundaryNodesFast(std::vector<int>& BoundaryNodes)
+void ApplyConstantInterpolateLinePressureProcess::FillListOfBoundaryNodesFast(std::vector<int>& BoundaryNodes) const
 {
-    const int ID_UNDEFINED = -1;
-    const int N_ELEMENT    = 10;
+    constexpr int ID_UNDEFINED = -1;
+    constexpr int N_ELEMENT    = 10;
 
-    std::vector<std::vector<int>> ELementsOfNodes;
-    std::vector<int>              ELementsOfNodesSize;
+    std::vector<std::vector<int>> elements_of_nodes;
+    std::vector<int>              elements_of_nodes_size;
 
     int MaxNodeID = GetMaxNodeID();
 
-    ELementsOfNodes.resize(MaxNodeID);
-    ELementsOfNodesSize.resize(MaxNodeID);
+    elements_of_nodes.resize(MaxNodeID);
+    elements_of_nodes_size.resize(MaxNodeID);
 
-    for (unsigned int i = 0; i < ELementsOfNodes.size(); ++i) {
-        ELementsOfNodes[i].resize(N_ELEMENT);
-        ELementsOfNodesSize[i] = 0;
-        std::fill(ELementsOfNodes[i].begin(), ELementsOfNodes[i].end(), ID_UNDEFINED);
+    for (unsigned int i = 0; i < elements_of_nodes.size(); ++i) {
+        elements_of_nodes[i].resize(N_ELEMENT);
+        elements_of_nodes_size[i] = 0;
+        std::ranges::fill(elements_of_nodes[i], ID_UNDEFINED);
     }
 
     const auto nElements = static_cast<unsigned int>(mrModelPart.NumberOfElements());
@@ -410,11 +410,11 @@ void ApplyConstantInterpolateLinePressureProcess::FillListOfBoundaryNodesFast(st
             auto ElementId = static_cast<int>(pElemIt->Id());
 
             int index = NodeID - 1;
-            ELementsOfNodesSize[index]++;
-            if (ELementsOfNodesSize[index] > N_ELEMENT - 1) {
-                ELementsOfNodes[index].push_back(ElementId);
+            elements_of_nodes_size[index]++;
+            if (elements_of_nodes_size[index] > N_ELEMENT - 1) {
+                elements_of_nodes[index].push_back(ElementId);
             } else {
-                ELementsOfNodes[index][ELementsOfNodesSize[index] - 1] = ElementId;
+                elements_of_nodes[index][elements_of_nodes_size[index] - 1] = ElementId;
             }
         }
     }
@@ -432,7 +432,7 @@ void ApplyConstantInterpolateLinePressureProcess::FillListOfBoundaryNodesFast(st
                     static_cast<int>(pElemIt->GetGeometry().GenerateEdges()[iEdge].GetPoint(iPoint).Id());
             }
 
-            if (IsMoreThanOneElementWithThisEdgeFast(FaceID, ELementsOfNodes, ELementsOfNodesSize))
+            if (IsMoreThanOneElementWithThisEdgeFast(FaceID, elements_of_nodes, elements_of_nodes_size))
                 continue;
             auto add_boundary_node_if_missing = [&BoundaryNodes](int node_id) {
                 if (std::ranges::find(BoundaryNodes, node_id) == BoundaryNodes.end()) {
@@ -451,15 +451,15 @@ void ApplyConstantInterpolateLinePressureProcess::FillListOfBoundaryNodesFast(st
 
 bool ApplyConstantInterpolateLinePressureProcess::IsMoreThanOneElementWithThisEdgeFast(
     const std::vector<int>&              rFaceIDs,
-    const std::vector<std::vector<int>>& rELementsOfNodes,
-    const std::vector<int>&              rELementsOfNodesSize) const
+    const std::vector<std::vector<int>>& rElementsOfNodes,
+    const std::vector<int>&              rElementsOfNodesSize)
 
 {
-    const auto ContainsElementInRange = [](std::vector<vector<int>>& ElementIDs, int element_id,
-                                           unsigned int begin, unsigned int end) {
+    const auto ContainsElementInRange = [](const std::vector<vector<int>>& ElementIDs,
+                                           int element_id, unsigned int begin, unsigned int end) {
         for (unsigned int iPointInner = begin; iPointInner < end; ++iPointInner) {
             const auto& rElementIds = ElementIDs[iPointInner];
-            if (std::find(rElementIds.begin(), rElementIds.end(), element_id) != rElementIds.end()) {
+            if (std::ranges::find(rElementIds, element_id) != rElementIds.end()) {
                 return true;
             }
         }
@@ -468,7 +468,7 @@ bool ApplyConstantInterpolateLinePressureProcess::IsMoreThanOneElementWithThisEd
 
     int nMaxElements = 0;
     for (auto node_id : rFaceIDs) {
-        nMaxElements += rELementsOfNodesSize[node_id - 1];
+        nMaxElements += rElementsOfNodesSize[node_id - 1];
     }
 
     if (nMaxElements == 0) return false;
@@ -485,8 +485,8 @@ bool ApplyConstantInterpolateLinePressureProcess::IsMoreThanOneElementWithThisEd
     for (unsigned int iPoint = 0; iPoint < rFaceIDs.size(); ++iPoint) {
         int NodeID = rFaceIDs[iPoint];
         int index  = NodeID - 1;
-        for (int i = 0; i < rELementsOfNodesSize[index]; ++i) {
-            int iElementID        = rELementsOfNodes[index][i];
+        for (int i = 0; i < rElementsOfNodesSize[index]; ++i) {
+            int iElementID        = rElementsOfNodes[index][i];
             ElementIDs[iPoint][i] = iElementID;
         }
     }
@@ -500,8 +500,7 @@ bool ApplyConstantInterpolateLinePressureProcess::IsMoreThanOneElementWithThisEd
                   ContainsElementInRange(ElementIDs, element_id, iPoint + 1,
                                          static_cast<int>(ElementIDs.size()))))
                 continue;
-            if (std::find(SharedElementIDs.begin(), SharedElementIDs.end(), element_id) ==
-                SharedElementIDs.end()) {
+            if (std::ranges::find(SharedElementIDs, element_id) == SharedElementIDs.end()) {
                 SharedElementIDs.push_back(element_id);
             }
         }

--- a/applications/GeoMechanicsApplication/custom_processes/apply_constant_interpolate_line_pressure_process.h
+++ b/applications/GeoMechanicsApplication/custom_processes/apply_constant_interpolate_line_pressure_process.h
@@ -28,7 +28,7 @@ class KRATOS_API(GEO_MECHANICS_APPLICATION) ApplyConstantInterpolateLinePressure
 public:
     KRATOS_CLASS_POINTER_DEFINITION(ApplyConstantInterpolateLinePressureProcess);
 
-    ApplyConstantInterpolateLinePressureProcess(ModelPart& model_part, Parameters rParameters);
+    ApplyConstantInterpolateLinePressureProcess(ModelPart& rModelPart, Parameters rParameters);
     ~ApplyConstantInterpolateLinePressureProcess() override = default;
     ApplyConstantInterpolateLinePressureProcess(const ApplyConstantInterpolateLinePressureProcess&) = delete;
     ApplyConstantInterpolateLinePressureProcess& operator=(const ApplyConstantInterpolateLinePressureProcess&) = delete;
@@ -40,7 +40,7 @@ public:
     void ExecuteInitializeSolutionStep() override;
 
     /// Turn back information as a string.
-    std::string Info() const override;
+    [[nodiscard]] std::string Info() const override;
 
 private:
     /// Member Variables
@@ -56,7 +56,7 @@ private:
     std::vector<Node*> mBoundaryNodes;
     double             mPressureTensionCutOff;
 
-    double CalculatePressure(const Node& rNode);
+    [[nodiscard]] double CalculatePressure(const Node& rNode) const;
 
     void CalculateBoundaryPressure(const Node&               rNode,
                                    const std::vector<Node*>& BoundaryNodes,
@@ -78,9 +78,9 @@ private:
                                            const std::vector<Node*>& rBoundaryNodes,
                                            std::vector<Node*>&       rFoundNodes) const;
 
-    Node* FindClosestNodeOnBoundaryNodes(const Node&               rNode,
-                                         const std::vector<Node*>& BoundaryNodes,
-                                         const bool                isBottom) const;
+    [[nodiscard]] Node* FindClosestNodeOnBoundaryNodes(const Node&               rNode,
+                                                       const std::vector<Node*>& BoundaryNodes,
+                                                       bool                      isBottom) const;
 
     void FindTopBoundaryNodes(const Node& rNode, std::vector<Node*>& TopBoundaryNodes) const;
 
@@ -94,15 +94,15 @@ private:
                                 const std::vector<Node*>& rBoundaryNodes,
                                 std::vector<Node*>&       rRightBoundaryNodes) const;
 
-    int GetMaxNodeID();
+    [[nodiscard]] int GetMaxNodeID() const;
 
     void FindBoundaryNodes();
 
-    void FillListOfBoundaryNodesFast(std::vector<int>& BoundaryNodes);
+    void FillListOfBoundaryNodesFast(std::vector<int>& BoundaryNodes) const;
 
-    bool IsMoreThanOneElementWithThisEdgeFast(const std::vector<int>&              rFaceIDs,
-                                              const std::vector<std::vector<int>>& rELementsOfNodes,
-                                              const std::vector<int>& rELementsOfNodesSize) const;
+    static bool IsMoreThanOneElementWithThisEdgeFast(const std::vector<int>& rFaceIDs,
+                                                     const std::vector<std::vector<int>>& rElementsOfNodes,
+                                                     const std::vector<int>& rElementsOfNodesSize);
 
 }; // Class ApplyConstantInterpolateLinePressureProcess
 

--- a/applications/GeoMechanicsApplication/custom_processes/apply_vector_constraint_table_process.cpp
+++ b/applications/GeoMechanicsApplication/custom_processes/apply_vector_constraint_table_process.cpp
@@ -92,7 +92,7 @@ std::size_t ApplyVectorConstraintTableProcess::ComponentToIndex(char component)
 }
 
 ApplyVectorConstraintTableProcess::ProcessUniquePointer ApplyVectorConstraintTableProcess::MakeProcessFor(
-    ModelPart& rModelPart, const Parameters& rParameters) const
+    ModelPart& rModelPart, const Parameters& rParameters)
 {
     if (rParameters.Has("table")) {
         return std::make_unique<ApplyComponentTableProcess>(rModelPart, rParameters);

--- a/applications/GeoMechanicsApplication/custom_processes/apply_vector_constraint_table_process.h
+++ b/applications/GeoMechanicsApplication/custom_processes/apply_vector_constraint_table_process.h
@@ -40,7 +40,7 @@ public:
     void ExecuteInitializeSolutionStep() override;
     void ExecuteFinalize() override;
 
-    std::string Info() const override;
+    [[nodiscard]] std::string Info() const override;
 
 private:
     static std::vector<Parameters> CreateParametersForActiveComponents(const ModelPart&  rModelPart,
@@ -50,7 +50,7 @@ private:
                                                                 const Parameters& rSettings,
                                                                 char              Component);
     static std::size_t             ComponentToIndex(char component);
-    ProcessUniquePointer MakeProcessFor(ModelPart& rModelPart, const Parameters& rParameters) const;
+    static ProcessUniquePointer MakeProcessFor(ModelPart& rModelPart, const Parameters& rParameters);
 
     std::vector<std::reference_wrapper<ModelPart>> mrModelParts;
     std::vector<ProcessUniquePointer>              mProcesses;

--- a/applications/GeoMechanicsApplication/custom_processes/apply_write_result_scalar_process.cpp
+++ b/applications/GeoMechanicsApplication/custom_processes/apply_write_result_scalar_process.cpp
@@ -63,7 +63,7 @@ void ApplyWriteScalarProcess::ExecuteInitialize()
         mOutFile.resize(nNodes);
 
         for (IndexType i = 0; i < nNodes; ++i) {
-            ModelPart::NodesContainerType::iterator it = it_begin + i;
+            ModelPart::NodesContainerType::iterator it = it_begin + static_cast<std::ptrdiff_t>(i);
 
             const IndexType    nodeId = it->Id();
             std::ostringstream oss;
@@ -99,7 +99,7 @@ void ApplyWriteScalarProcess::ExecuteFinalizeSolutionStep()
         ModelPart::NodesContainerType::iterator it_begin = mrModelPart.NodesBegin();
 
         for (IndexType i = 0; i < nNodes; ++i) {
-            ModelPart::NodesContainerType::iterator it = it_begin + i;
+            ModelPart::NodesContainerType::iterator it = it_begin + static_cast<std::ptrdiff_t>(i);
 
             const double value = it->FastGetSolutionStepValue(var);
             mOutFile[i] << Time << "   " << value << "\n";

--- a/applications/GeoMechanicsApplication/custom_processes/deactivate_conditions_on_inactive_elements_process.cpp
+++ b/applications/GeoMechanicsApplication/custom_processes/deactivate_conditions_on_inactive_elements_process.cpp
@@ -26,26 +26,19 @@ DeactivateConditionsOnInactiveElements::DeactivateConditionsOnInactiveElements(M
 
 void DeactivateConditionsOnInactiveElements::Execute()
 {
-    KRATOS_TRY
+    auto is_active = [](const auto& rpNeighbourElement) {
+        return rpNeighbourElement->IsDefined(ACTIVE) ? rpNeighbourElement->Is(ACTIVE) : true;
+    };
 
-    block_for_each(mrModelPart.Conditions(), [&](Condition& rCondition) {
-        const auto& VectorOfNeighbours = rCondition.GetValue(NEIGHBOUR_ELEMENTS);
-        KRATOS_ERROR_IF(VectorOfNeighbours.size() == 0)
+    block_for_each(mrModelPart.Conditions(), [&is_active](Condition& rCondition) {
+        const auto& vector_of_neighbours = rCondition.GetValue(NEIGHBOUR_ELEMENTS);
+        KRATOS_ERROR_IF(vector_of_neighbours.size() == 0)
             << "Condition without any corresponding element, ID " << rCondition.Id() << "\n"
             << "Call a process to find neighbour elements before calling this function." << std::endl;
 
-        bool IsElementActive = false;
-        for (unsigned int i = 0; i < VectorOfNeighbours.size(); ++i) {
-            if (VectorOfNeighbours[i].IsDefined(ACTIVE)) {
-                if (VectorOfNeighbours[i].Is(ACTIVE)) IsElementActive = true;
-            } else {
-                IsElementActive = true;
-            }
-        }
-        rCondition.Set(ACTIVE, IsElementActive);
+        rCondition.Set(ACTIVE, std::any_of(vector_of_neighbours.ptr_begin(),
+                                           vector_of_neighbours.ptr_end(), is_active));
     });
-
-    KRATOS_CATCH("")
 }
 
 std::string DeactivateConditionsOnInactiveElements::Info() const

--- a/applications/GeoMechanicsApplication/custom_utilities/element_utilities.cpp
+++ b/applications/GeoMechanicsApplication/custom_utilities/element_utilities.cpp
@@ -209,7 +209,7 @@ Vector GeoElementUtilities::GetNodalVariableVector(const Element::GeometryType& 
     auto        result   = Vector(NumberOfDofs);
     std::size_t position = 0;
     for (const auto& values : nodal_values) {
-        std::copy(values.begin(), values.begin() + Dimension, result.begin() + position);
+        std::copy_n(values.begin(), Dimension, result.begin() + static_cast<std::ptrdiff_t>(position));
         position += Dimension;
     }
     return result;

--- a/applications/GeoMechanicsApplication/custom_utilities/geometry_utilities.cpp
+++ b/applications/GeoMechanicsApplication/custom_utilities/geometry_utilities.cpp
@@ -56,8 +56,8 @@ std::size_t GetNumberOfEdgePoints(GeometryData::KratosGeometryFamily    Geometry
 }
 
 template <std::random_access_iterator InputIt>
-void ReverseNodes(InputIt                               Begin,
-                  InputIt                               End,
+void ReverseNodes(const InputIt&                        Begin,
+                  const InputIt&                        End,
                   GeometryData::KratosGeometryFamily    GeometryFamily,
                   GeometryData::KratosGeometryOrderType GeometryOrderType)
 {

--- a/applications/GeoMechanicsApplication/custom_utilities/neighbouring_element_finder.cpp
+++ b/applications/GeoMechanicsApplication/custom_utilities/neighbouring_element_finder.cpp
@@ -123,7 +123,7 @@ bool NeighbouringElementFinder::AreLinearRotatedEquivalents(std::vector<std::siz
                                                             const std::vector<std::size_t>& rSecond)
 {
     const auto amount_of_needed_rotations = std::ranges::find(First, rSecond[0]) - First.begin();
-    std::rotate(First.begin(), First.begin() + amount_of_needed_rotations, First.end());
+    std::ranges::rotate(First.begin(), First.begin() + amount_of_needed_rotations, First.end());
     return First == rSecond;
 }
 
@@ -131,10 +131,11 @@ bool NeighbouringElementFinder::AreQuadraticRotatedEquivalents(std::vector<std::
                                                                const std::vector<std::size_t>& rSecond)
 {
     const auto amount_of_needed_rotations = std::ranges::find(First, rSecond[0]) - First.begin();
-    const auto first_mid_side_node_id     = First.begin() + First.size() / 2;
+    const auto first_mid_side_node_id = First.begin() + static_cast<std::ptrdiff_t>(First.size() / 2);
     std::rotate(First.begin(), First.begin() + amount_of_needed_rotations, first_mid_side_node_id);
 
-    std::rotate(first_mid_side_node_id, first_mid_side_node_id + amount_of_needed_rotations, First.end());
+    std::ranges::rotate(first_mid_side_node_id, first_mid_side_node_id + amount_of_needed_rotations,
+                        First.end());
 
     return First == rSecond;
 }

--- a/applications/GeoMechanicsApplication/custom_utilities/neighbouring_element_finder.cpp
+++ b/applications/GeoMechanicsApplication/custom_utilities/neighbouring_element_finder.cpp
@@ -123,7 +123,7 @@ bool NeighbouringElementFinder::AreLinearRotatedEquivalents(std::vector<std::siz
                                                             const std::vector<std::size_t>& rSecond)
 {
     const auto amount_of_needed_rotations = std::ranges::find(First, rSecond[0]) - First.begin();
-    std::ranges::rotate(First.begin(), First.begin() + amount_of_needed_rotations, First.end());
+    std::rotate(First.begin(), First.begin() + amount_of_needed_rotations, First.end());
     return First == rSecond;
 }
 
@@ -134,8 +134,7 @@ bool NeighbouringElementFinder::AreQuadraticRotatedEquivalents(std::vector<std::
     const auto first_mid_side_node_id = First.begin() + static_cast<std::ptrdiff_t>(First.size() / 2);
     std::rotate(First.begin(), First.begin() + amount_of_needed_rotations, first_mid_side_node_id);
 
-    std::ranges::rotate(first_mid_side_node_id, first_mid_side_node_id + amount_of_needed_rotations,
-                        First.end());
+    std::rotate(first_mid_side_node_id, first_mid_side_node_id + amount_of_needed_rotations, First.end());
 
     return First == rSecond;
 }

--- a/applications/GeoMechanicsApplication/exceptions_for_json_formatting.txt
+++ b/applications/GeoMechanicsApplication/exceptions_for_json_formatting.txt
@@ -67,7 +67,6 @@ tests/test_constant_strip_load_2d/MaterialParameters_stage_1.json
 tests/test_constant_strip_load_2d/ProjectParameters.json
 tests/test_darcy_law.gid/MaterialParameters.json
 tests/test_darcy_law.gid/ProjectParameters.json
-tests/test_element_lab/test_triaxial/MaterialParameters.json
 tests/test_inclinded_phreatic_line_smaller_line.gid/MaterialParameters.json
 tests/test_inclinded_phreatic_line_smaller_line.gid/ProjectParameters.json
 tests/test_inclinded_phreatic_surface.gid/MaterialParameters.json

--- a/applications/GeoMechanicsApplication/test_setup_utilities/model_setup_utilities.cpp
+++ b/applications/GeoMechanicsApplication/test_setup_utilities/model_setup_utilities.cpp
@@ -48,7 +48,7 @@ PointerVector<Node> CreateNewNodes(ModelPart& rModelPart, const std::vector<Poin
 }
 
 template <std::input_iterator InputIt>
-void AddDofsToNodes(InputIt NodeRangeBegin, InputIt NodeRangeEnd, const Geo::ConstVariableRefs& rNodalVariables)
+void AddDofsToNodes(const InputIt& NodeRangeBegin, const InputIt& NodeRangeEnd, const Geo::ConstVariableRefs& rNodalVariables)
 {
     for (const auto& r_variable : rNodalVariables) {
         for (auto it = NodeRangeBegin; it != NodeRangeEnd; ++it) {

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_conditions/test_U_Pw_normal_lysmer_absorbing_condition.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_conditions/test_U_Pw_normal_lysmer_absorbing_condition.cpp
@@ -43,9 +43,8 @@ public:
 
         if (geometry_family == GeometryData::KratosGeometryFamily::Kratos_Triangle) {
             number_of_integration_points = 3;
-        } else if (geometry_family == GeometryData::KratosGeometryFamily::Kratos_Quadrilateral) {
-            number_of_integration_points = 4;
-        } else if (geometry_family == GeometryData::KratosGeometryFamily::Kratos_Tetrahedra) {
+        } else if (geometry_family == GeometryData::KratosGeometryFamily::Kratos_Quadrilateral ||
+                   geometry_family == GeometryData::KratosGeometryFamily::Kratos_Tetrahedra) {
             number_of_integration_points = 4;
         } else if (geometry_family == GeometryData::KratosGeometryFamily::Kratos_Hexahedra) {
             number_of_integration_points = 8;
@@ -472,8 +471,8 @@ KRATOS_TEST_CASE_IN_SUITE(CalculateLocalSystemUPwNormalLysmerAbsorbingCondition2
 
     // set expected_results
 
-    const double shear_stiffness_over_virt_thickness    = 5.0 / 100;
-    const double confined_stiffness_over_virt_thickness = 4.0 / 100;
+    constexpr auto shear_stiffness_over_virt_thickness    = 5.0 / 100;
+    constexpr auto confined_stiffness_over_virt_thickness = 4.0 / 100;
 
     Matrix expected_matrix = ZeroMatrix(condition_size, condition_size);
     expected_matrix(0, 0)  = shear_stiffness_over_virt_thickness / 9;
@@ -619,8 +618,8 @@ KRATOS_TEST_CASE_IN_SUITE(CalculateLocalSystemUPwNormalLysmerAbsorbingCondition3
 
     // set expected_results
 
-    const double shear_stiffness_over_virt_thickness    = 5.0 / 100;
-    const double confined_stiffness_over_virt_thickness = 4.0 / 100;
+    constexpr auto shear_stiffness_over_virt_thickness    = 5.0 / 100;
+    constexpr auto confined_stiffness_over_virt_thickness = 4.0 / 100;
 
     Matrix expected_matrix = ZeroMatrix(condition_size, condition_size);
     expected_matrix(0, 0)  = shear_stiffness_over_virt_thickness / 81;
@@ -938,8 +937,8 @@ KRATOS_TEST_CASE_IN_SUITE(CalculateLocalSystemUPwNormalLysmerAbsorbingCondition3
     p_cond->CalculateLocalSystem(rLeftHandSideMatrix, right_hand_side_vector, r_process_info);
 
     // set expected_results
-    const double shear_stiffness_over_virt_thickness    = 5.0 / 100;
-    const double confined_stiffness_over_virt_thickness = 4.0 / 100;
+    constexpr auto shear_stiffness_over_virt_thickness    = 5.0 / 100;
+    constexpr auto confined_stiffness_over_virt_thickness = 4.0 / 100;
 
     Matrix expected_matrix = ZeroMatrix(condition_size, condition_size);
     expected_matrix(0, 0)  = shear_stiffness_over_virt_thickness / 30;


### PR DESCRIPTION
## **📝 Description**
Resolve some of the clang tidy remarks on GeoMechanicsApplication that are indicated by clang tidy on Team City and in our IDE's

### **Key changes**
use of
- static
- const and const &
- constexpr
- std::ranges
- naming conventions for arguments and local variables from the Kratos style guide.
