### PR TITLE
[Core] Correcting a BIG performance bug of `model_part_io`

### DIFF
--- a/kratos/includes/model_part.h
+++ b/kratos/includes/model_part.h
@@ -1990,64 +1990,62 @@ private:
     };
 
     template<class TContainerType>
-    struct EntityChecker
-    {
-        void operator()(const TContainerType& r_entities, const typename TContainerType::value_type * r_entity, std::string_view rModelPartName, std::string_view rRootModelPartName) {
-            KRATOS_TRY
+    static bool IsValidEntity(const TContainerType& r_entities, const typename TContainerType::value_type * r_entity, std::string_view rModelPartName, std::string_view rRootModelPartName) {
+        KRATOS_TRY
 
-            auto it_found = r_entities.find(r_entity->Id());
+        auto it_found = r_entities.find(r_entity->Id());
 
-            if (it_found != r_entities.end()) {
-                auto ref_ptr_entity = &*it_found;
-                if constexpr(std::is_same_v<TContainerType, GeometryContainerType>) {
-                    // For Geometries we need to check the connectivities as well in case of id match, for other entities just checking the pointer is enough.
-                    // Check if the geometry being added is the same as the existing one in case of id match.
-                    // 1 - First check for the geometry type
-                    KRATOS_ERROR_IF_NOT(GeometryType::HasSameGeometryType(r_entity, ref_ptr_entity)) 
+        if (it_found != r_entities.end()) {
+            auto ref_ptr_entity = &*it_found;
+            if constexpr(std::is_same_v<TContainerType, GeometryContainerType>) {
+                // For Geometries we need to check the connectivities as well in case of id match, for other entities just checking the pointer is enough.
+                // Check if the geometry being added is the same as the existing one in case of id match.
+                // 1 - First check for the geometry type
+                KRATOS_ERROR_IF_NOT(GeometryType::HasSameGeometryType(r_entity, ref_ptr_entity)) 
+                    << "attempting to add a new " << Container<TContainerType>::GetEntityName() << " with Id :"
+                    << r_entity->Id() << " to root model part " << rRootModelPartName
+                    << ", unfortunately a (different) " << Container<TContainerType>::GetEntityName()
+                    << " with the same Id already exists. [ Occurred while adding " << Container<TContainerType>::GetEntityName()
+                    << " to " << rModelPartName << " ]."
+                    << std::endl;
+                
+                // 1.5 - Double check that the number of nodes is the same, as this is a common error that can happen when creating geometries.
+                KRATOS_ERROR_IF(r_entity->PointsNumber() != ref_ptr_entity->PointsNumber())
+                    << "attempting to add a new " << Container<TContainerType>::GetEntityName() << " with Id :"
+                    << r_entity->Id() << " to root model part " << rRootModelPartName
+                    << ", unfortunately a (different) " << Container<TContainerType>::GetEntityName()
+                    << " with the same Id already exists but with different number of nodes. [ Occurred while adding " << Container<TContainerType>::GetEntityName()
+                    << " to " << rModelPartName << " ]."
+                    << std::endl;
+
+                // 2 - Check if the geometry connectivities are the same. 
+                // Note: We deliberately check the node ids and not the pointer adresses as there might be very rare situations
+                // (e.g., creating nodes bypassing the model part interface) with same connectivities but different pointer addresses
+                for (IndexType i_node = 0; i_node < r_entity->PointsNumber(); ++i_node) {
+                    KRATOS_ERROR_IF((*r_entity)[i_node].Id() != (*ref_ptr_entity)[i_node].Id())
                         << "attempting to add a new " << Container<TContainerType>::GetEntityName() << " with Id :"
                         << r_entity->Id() << " to root model part " << rRootModelPartName
                         << ", unfortunately a (different) " << Container<TContainerType>::GetEntityName()
-                        << " with the same Id already exists. [ Occurred while adding " << Container<TContainerType>::GetEntityName()
-                        << " to " << rModelPartName << " ]."
-                        << std::endl;
-                    
-                    // 1.5 - Double check that the number of nodes is the same, as this is a common error that can happen when creating geometries.
-                    KRATOS_ERROR_IF(r_entity->PointsNumber() != ref_ptr_entity->PointsNumber())
-                        << "attempting to add a new " << Container<TContainerType>::GetEntityName() << " with Id :"
-                        << r_entity->Id() << " to root model part " << rRootModelPartName
-                        << ", unfortunately a (different) " << Container<TContainerType>::GetEntityName()
-                        << " with the same Id already exists but with different number of nodes. [ Occurred while adding " << Container<TContainerType>::GetEntityName()
-                        << " to " << rModelPartName << " ]."
-                        << std::endl;
-
-                    // 2 - Check if the geometry connectivities are the same. 
-                    // Note: We deliberately check the node ids and not the pointer adresses as there might be very rare situations
-                    // (e.g., creating nodes bypassing the model part interface) with same connectivities but different pointer addresses
-                    for (IndexType i_node = 0; i_node < r_entity->PointsNumber(); ++i_node) {
-                        KRATOS_ERROR_IF((*r_entity)[i_node].Id() != (*ref_ptr_entity)[i_node].Id())
-                            << "attempting to add a new " << Container<TContainerType>::GetEntityName() << " with Id :"
-                            << r_entity->Id() << " to root model part " << rRootModelPartName
-                            << ", unfortunately a (different) " << Container<TContainerType>::GetEntityName()
-                            << " with the same Id already and different connectivities alreadyexists. [ Occurred while adding " << Container<TContainerType>::GetEntityName()
-                            << " to " << rModelPartName << " ]."
-                            << std::endl;
-                    }
-                } else {
-                    // For the other entities just check if the pointer is the same in case of id match.
-                    KRATOS_ERROR_IF_NOT(ref_ptr_entity == r_entity)
-                        << "attempting to add a new " << Container<TContainerType>::GetEntityName() << " with Id :"
-                        << r_entity->Id() << " to root model part " << rRootModelPartName
-                        << ", unfortunately a (different) " << Container<TContainerType>::GetEntityName()
-                        << " with the same Id already exists. [ Occurred while adding " << Container<TContainerType>::GetEntityName()
+                        << " with the same Id already and different connectivities alreadyexists. [ Occurred while adding " << Container<TContainerType>::GetEntityName()
                         << " to " << rModelPartName << " ]."
                         << std::endl;
                 }
+            } else {
+                // For the other entities just check if the pointer is the same in case of id match.
+                KRATOS_ERROR_IF_NOT(ref_ptr_entity == r_entity)
+                    << "attempting to add a new " << Container<TContainerType>::GetEntityName() << " with Id :"
+                    << r_entity->Id() << " to root model part " << rRootModelPartName
+                    << ", unfortunately a (different) " << Container<TContainerType>::GetEntityName()
+                    << " with the same Id already exists. [ Occurred while adding " << Container<TContainerType>::GetEntityName()
+                    << " to " << rModelPartName << " ]."
+                    << std::endl;
             }
-
-            // 3 - If types and nodes are the same, its ok.
-
-            KRATOS_CATCH("");
         }
+
+        // 3 - If types and nodes are the same, its ok.
+        return true;
+
+        KRATOS_CATCH("");
     };
 
     /**
@@ -2067,7 +2065,7 @@ private:
                 const auto& r_entity = ReferenceGetter<typename TContainerType::value_type>::Get(prEntity);
                 const auto& r_entities = Container<TContainerType>::GetContainer(p_root_model_part->GetMesh()); // TODO: This is only required to only trigger a find, not a sort. Once the find is fixed, then we can simplify this.
                 
-                EntityChecker<TContainerType>()(r_entities, &r_entity, pModelPart->FullName(), p_root_model_part->FullName());
+                IsValidEntity(r_entities, &r_entity, pModelPart->FullName(), p_root_model_part->FullName());
             });
             KRATOS_CATCH("");
         }

--- a/kratos/includes/model_part.h
+++ b/kratos/includes/model_part.h
@@ -1989,6 +1989,58 @@ private:
         }
     };
 
+    template<class TContainerType>
+    struct EntityChecker
+    {
+        void operator()(const TContainerType& r_entities, const typename TContainerType::value_type * r_entity, std::string_view rModelPartName, std::string_view rRootModelPartName) {
+            KRATOS_TRY
+
+            auto it_found = r_entities.find(r_entity->Id());
+
+            if (it_found != r_entities.end()) {
+                auto ref_ptr_entity = &*it_found;
+                if constexpr(std::is_same_v<TContainerType, GeometryContainerType>) {
+                    // For Geometries we need to check the connectivities as well in case of id match, for other entities just checking the pointer is enough.
+                    // Check if the geometry being added is the same as the existing one in case of id match.
+                    // 1 - First check for the geometry type
+                    KRATOS_ERROR_IF_NOT(GeometryType::HasSameGeometryType(r_entity, ref_ptr_entity)) 
+                        << "attempting to add a new " << Container<TContainerType>::GetEntityName() << " with Id :"
+                        << r_entity->Id() << " to root model part " << rRootModelPartName
+                        << ", unfortunately a (different) " << Container<TContainerType>::GetEntityName()
+                        << " with the same Id already exists. [ Occurred while adding " << Container<TContainerType>::GetEntityName()
+                        << " to " << rModelPartName << " ]."
+                        << std::endl;
+                    
+                    // 2 - Check if the geometry connectivities are the same. 
+                    // Note: We deliberately check the node ids and not the pointer adresses as there might be very rare situations
+                    // (e.g., creating nodes bypassing the model part interface) with same connectivities but different pointer addresses
+                    for (IndexType i_node = 0; i_node < r_entity->PointsNumber(); ++i_node) {
+                        KRATOS_ERROR_IF((*r_entity)[i_node].Id() != (*ref_ptr_entity)[i_node].Id())
+                            << "attempting to add a new " << Container<TContainerType>::GetEntityName() << " with Id :"
+                            << r_entity->Id() << " to root model part " << rRootModelPartName
+                            << ", unfortunately a (different) " << Container<TContainerType>::GetEntityName()
+                            << " with the same Id already and different connectivities alreadyexists. [ Occurred while adding " << Container<TContainerType>::GetEntityName()
+                            << " to " << rModelPartName << " ]."
+                            << std::endl;
+                    }
+                } else {
+                    // For the other entities just check if the pointer is the same in case of id match.
+                    KRATOS_ERROR_IF_NOT(ref_ptr_entity == r_entity)
+                        << "attempting to add a new " << Container<TContainerType>::GetEntityName() << " with Id :"
+                        << r_entity->Id() << " to root model part " << rRootModelPartName
+                        << ", unfortunately a different " << Container<TContainerType>::GetEntityName()
+                        << " with the same Id already exists. [ Occurred while adding " << Container<TContainerType>::GetEntityName()
+                        << " to " << rModelPartName << " ]."
+                        << std::endl;
+                }
+            }
+
+            // 3 - If types and nodes are the same, its ok.
+
+            KRATOS_CATCH("");
+        }
+    };
+
     /**
      * @brief Generalized checker to check whether if an item being inserted is already there, if so whether the item is the same.
      *
@@ -2005,14 +2057,8 @@ private:
             block_for_each(begin, end, [&](const auto& prEntity) {
                 const auto& r_entity = ReferenceGetter<typename TContainerType::value_type>::Get(prEntity);
                 const auto& r_entities = Container<TContainerType>::GetContainer(p_root_model_part->GetMesh()); // TODO: This is only required to only trigger a find, not a sort. Once the find is fixed, then we can simplify this.
-                auto it_found = r_entities.find(r_entity.Id());
-                KRATOS_ERROR_IF(it_found != r_entities.end() && &r_entity != &*it_found)
-                    << "attempting to add a new " << Container<TContainerType>::GetEntityName() << " with Id :"
-                    << r_entity.Id() << " to root model part " << p_root_model_part->FullName()
-                    << ", unfortunately a (different) " << Container<TContainerType>::GetEntityName()
-                    << " with the same Id already exists. [ Occurred while adding " << Container<TContainerType>::GetEntityName()
-                    << " to " << pModelPart->FullName() << " ]."
-                    << std::endl;
+                
+                EntityChecker<TContainerType>()(r_entities, &r_entity, pModelPart->FullName(), p_root_model_part->FullName());
             });
             KRATOS_CATCH("");
         }

--- a/kratos/includes/model_part.h
+++ b/kratos/includes/model_part.h
@@ -2011,6 +2011,15 @@ private:
                         << " to " << rModelPartName << " ]."
                         << std::endl;
                     
+                    // 1.5 - Double check that the number of nodes is the same, as this is a common error that can happen when creating geometries.
+                    KRATOS_ERROR_IF(r_entity->PointsNumber() != ref_ptr_entity->PointsNumber())
+                        << "attempting to add a new " << Container<TContainerType>::GetEntityName() << " with Id :"
+                        << r_entity->Id() << " to root model part " << rRootModelPartName
+                        << ", unfortunately a (different) " << Container<TContainerType>::GetEntityName()
+                        << " with the same Id already exists but with different number of nodes. [ Occurred while adding " << Container<TContainerType>::GetEntityName()
+                        << " to " << rModelPartName << " ]."
+                        << std::endl;
+
                     // 2 - Check if the geometry connectivities are the same. 
                     // Note: We deliberately check the node ids and not the pointer adresses as there might be very rare situations
                     // (e.g., creating nodes bypassing the model part interface) with same connectivities but different pointer addresses
@@ -2028,7 +2037,7 @@ private:
                     KRATOS_ERROR_IF_NOT(ref_ptr_entity == r_entity)
                         << "attempting to add a new " << Container<TContainerType>::GetEntityName() << " with Id :"
                         << r_entity->Id() << " to root model part " << rRootModelPartName
-                        << ", unfortunately a different " << Container<TContainerType>::GetEntityName()
+                        << ", unfortunately a (different) " << Container<TContainerType>::GetEntityName()
                         << " with the same Id already exists. [ Occurred while adding " << Container<TContainerType>::GetEntityName()
                         << " to " << rModelPartName << " ]."
                         << std::endl;

--- a/kratos/sources/model_part.cpp
+++ b/kratos/sources/model_part.cpp
@@ -1602,7 +1602,7 @@ void ModelPart::AddGeometry(ModelPart::GeometryType::Pointer pNewGeometry)
         const auto& r_entity = ReferenceGetter<typename ModelPart::GeometryType>::Get(pNewGeometry);
         const auto& r_entities = Container<ModelPart::GeometryContainerType>::GetContainer(this->GetMesh());
                 
-        EntityChecker<ModelPart::GeometryContainerType>()(r_entities, &r_entity, this->FullName(), this->GetRootModelPart().FullName());
+        ModelPart::IsValidEntity(r_entities, &r_entity, this->FullName(), this->GetRootModelPart().FullName());
     }
 
     GetMesh(0).AddGeometry(pNewGeometry);

--- a/kratos/sources/model_part.cpp
+++ b/kratos/sources/model_part.cpp
@@ -1597,29 +1597,15 @@ void ModelPart::AddGeometry(ModelPart::GeometryType::Pointer pNewGeometry)
 {
     if (IsSubModelPart()) {
         mpParentModelPart->AddGeometry(pNewGeometry);
-        GetMesh(0).AddGeometry(pNewGeometry);
     }
-    else
-    {
-        auto existing_geometry_it = this->GetMesh(0).Geometries().find(pNewGeometry->Id());
-        if( existing_geometry_it == GetMesh(0).Geometries().end()) //geometry did not exist
-        {
-            GetMesh(0).AddGeometry(pNewGeometry);
-        }
-        else  //geometry did exist already
-        {
-            // Check if the connectivities coincide
-            // First check for the geometry type
-            KRATOS_ERROR_IF_NOT(GeometryType::HasSameGeometryType(*existing_geometry_it, *pNewGeometry)) << "Attempting to add geometry with Id: " << pNewGeometry->Id() << ". A different geometry with the same Id already exists." << std::endl;
-            // Check that the connectivities are the same
-            // note that we deliberately check the node ids and not the pointer adresses as there might be very rare situations
+    else {
+        const auto& r_entity = ReferenceGetter<typename ModelPart::GeometryType>::Get(pNewGeometry);
+        const auto& r_entities = Container<ModelPart::GeometryContainerType>::GetContainer(this->GetMesh());
+                
+        EntityChecker<ModelPart::GeometryContainerType>()(r_entities, &r_entity, this->FullName(), this->GetRootModelPart().FullName());
+    }
 
-            // (e.g., creating nodes bypassing the model part interface) with same connectivities but different pointer addresses
-            for (IndexType i_node = 0; i_node < existing_geometry_it->PointsNumber(); ++i_node) {
-                KRATOS_ERROR_IF((*existing_geometry_it)[i_node].Id() != (*pNewGeometry)[i_node].Id()) << "Attempting to add a new geometry with Id: " << pNewGeometry->Id() << ". A same type geometry with same Id but different connectivities already exists." << std::endl;
-            }
-        }
-    }
+    GetMesh(0).AddGeometry(pNewGeometry);
 }
 
 /** Inserts a list of geometries to a submodelpart provided their Id. Does nothing if applied to the top model part

--- a/kratos/sources/model_part_io.cpp
+++ b/kratos/sources/model_part_io.cpp
@@ -2213,12 +2213,6 @@ void ModelPartIO::ReadGeometriesBlock(ModelPart& rModelPart)
         ++number_of_read_geometries;
     }
     
-    // Sort by geometry ID to maintain deterministic ordering (equivalent to std::map behavior)
-    std::sort(aux_geometries.begin(), aux_geometries.end(),
-        [](const GeometryType::Pointer& a, const GeometryType::Pointer& b) {
-            return a->Id() < b->Id();
-        });
-    
     rModelPart.AddGeometries(aux_geometries.begin(), aux_geometries.end());
     KRATOS_INFO("") << number_of_read_geometries << " geometries read] [Type: " <<geometry_name << "]" << std::endl;
 

--- a/kratos/sources/model_part_io.cpp
+++ b/kratos/sources/model_part_io.cpp
@@ -2190,11 +2190,11 @@ void ModelPartIO::ReadGeometriesBlock(ModelPart& rModelPart)
         KRATOS_ERROR << buffer.str() << std::endl;
         return;
     }
-
     GeometryType const& r_clone_geometry = KratosComponents<GeometryType>::Get(geometry_name);
     SizeType number_of_nodes = r_clone_geometry.size();
     Element::NodesArrayType temp_geometry_nodes;
-    ModelPart::GeometryContainerType aux_geometries;
+    std::vector<GeometryType::Pointer> aux_geometries;
+    aux_geometries.reserve(1024);
 
     while(!mpStream->eof()) {
         ReadWord(word); // Reading the geometry id or End
@@ -2203,16 +2203,23 @@ void ModelPartIO::ReadGeometriesBlock(ModelPart& rModelPart)
 
         ExtractValue(word,id);
         temp_geometry_nodes.clear();
-        for(SizeType i = 0 ; i < number_of_nodes ; i++) {
+        for(SizeType i = 0; i < number_of_nodes; ++i) {
             ReadWord(word); // Reading the node id;
             ExtractValue(word, node_id);
-            temp_geometry_nodes.push_back( *(FindKey(rModelPart.Nodes(), ReorderedNodeId(node_id), "Node").base()));
+            temp_geometry_nodes.push_back(*(FindKey(rModelPart.Nodes(), ReorderedNodeId(node_id), "Node").base()));
         }
 
-        rModelPart.AddGeometry(r_clone_geometry.Create(ReorderedGeometryId(id), temp_geometry_nodes));
-        number_of_read_geometries++;
-
+        aux_geometries.push_back(r_clone_geometry.Create(ReorderedGeometryId(id), temp_geometry_nodes));
+        ++number_of_read_geometries;
     }
+    
+    // Sort by geometry ID to maintain deterministic ordering (equivalent to std::map behavior)
+    std::sort(aux_geometries.begin(), aux_geometries.end(),
+        [](const GeometryType::Pointer& a, const GeometryType::Pointer& b) {
+            return a->Id() < b->Id();
+        });
+    
+    rModelPart.AddGeometries(aux_geometries.begin(), aux_geometries.end());
     KRATOS_INFO("") << number_of_read_geometries << " geometries read] [Type: " <<geometry_name << "]" << std::endl;
 
     KRATOS_CATCH("")


### PR DESCRIPTION
---
name: ✨ Feature
about: Correcting a BIG performance bug of `model_part_io`

---

## **📝 Description**

At some point a BIG performance bug was introduced in the `ReadGeometriesBlock` function of `ModelPartIO`.

### **Key changes**

Essentially an insert was triggered for every new geomety which was triggering quadratic times in the reading phase when geometries were to be read in non-cosecutive order (has happens when multiple parts are written)

### **Validation**

CI passes.

## **🆕 Changelog**

- [Correcting a BIG performance bug of `model_part_io`](https://github.com/KratosMultiphysics/Kratos/pull/14433/commits/5804596710a3c51b7f6f372eb4a2aa4ba38ffbf7)
