### PR TITLE
[IGA] Add NURBS Curve Refinement Support to RefinementModeler and Curves Embedded in Brep Curve

### DIFF
--- a/applications/IgaApplication/custom_modelers/refinement_modeler.cpp
+++ b/applications/IgaApplication/custom_modelers/refinement_modeler.cpp
@@ -275,6 +275,154 @@ namespace Kratos
                     }
                 }
             }
+        } else if (rParameters["geometry_type"].GetString() == "NurbsCurve") {
+            for (IndexType n = 0; n < geometry_list.size(); ++n) {
+                auto p_nurbs_curve =
+                    std::dynamic_pointer_cast<NurbsCurveGeometry<3, PointerVector<Node>>>(
+                        geometry_list(n)
+                    );
+
+                if (!p_nurbs_curve) {
+                    p_nurbs_curve =
+                        std::dynamic_pointer_cast<NurbsCurveGeometry<3, PointerVector<Node>>>(
+                            geometry_list(n)->pGetGeometryPart(
+                                GeometryType::BACKGROUND_GEOMETRY_INDEX
+                            )
+                        );
+                }
+
+                KRATOS_ERROR_IF_NOT(p_nurbs_curve)
+                    << "Selected geometry is not a NurbsCurveGeometry and does not contain "
+                    << "a NurbsCurveGeometry as BACKGROUND_GEOMETRY.\nSelected geometry:\n"
+                    << *geometry_list(n) << std::endl;
+
+                if (rParameters["parameters"].Has("increase_degree")) {
+                    const SizeType increase_degree =
+                        rParameters["parameters"]["increase_degree"].GetInt();
+
+                    if (increase_degree > 0) {
+                        KRATOS_INFO_IF("::[RefinementModeler]::ApplyRefinement", mEchoLevel > 1)
+                            << "Refining nurbs curve #" << p_nurbs_curve->Id()
+                            << " by elevating degree: " << increase_degree << std::endl;
+
+                        PointerVector<NodeType> PointsRefined;
+                        Vector KnotsRefined;
+                        Vector WeightsRefined;
+
+                        NurbsCurveRefinementUtilities::DegreeElevation(
+                            *p_nurbs_curve,
+                            increase_degree,
+                            PointsRefined,
+                            KnotsRefined,
+                            WeightsRefined
+                        );
+
+                        for (auto& r_point : p_nurbs_curve->Points()) {
+                            r_point.Set(TO_ERASE, true);
+                        }
+
+                        r_model_part.RemoveNodesFromAllLevels(TO_ERASE);
+
+                        IndexType node_id = r_model_part.Nodes().empty()
+                            ? 1
+                            : (r_model_part.NodesEnd() - 1)->Id() + 1;
+
+                        for (IndexType i = 0; i < PointsRefined.size(); ++i) {
+                            if (PointsRefined(i)->Id() == 0) {
+                                PointsRefined(i) = r_model_part.CreateNewNode(
+                                    node_id,
+                                    PointsRefined[i][0],
+                                    PointsRefined[i][1],
+                                    PointsRefined[i][2]
+                                );
+                                node_id++;
+                            }
+                        }
+
+                        KRATOS_INFO_IF("::[RefinementModeler]::ApplyRefinement", mEchoLevel > 1)
+                            << "New knot vector: " << KnotsRefined
+                            << ", new weights vector: " << WeightsRefined << std::endl;
+
+                        p_nurbs_curve->SetInternals(
+                            PointsRefined,
+                            p_nurbs_curve->PolynomialDegree(0) + increase_degree,
+                            KnotsRefined,
+                            WeightsRefined
+                        );
+                    }
+                }
+
+                if (rParameters["parameters"].Has("insert_nb_per_span")) {
+                    const IndexType nb_per_span =
+                        rParameters["parameters"]["insert_nb_per_span"].GetInt();
+
+                    if (nb_per_span > 0) {
+                        std::vector<double> spans_local_space;
+                        p_nurbs_curve->SpansLocalSpace(spans_local_space);
+
+                        std::vector<double> knots_to_insert;
+
+                        for (IndexType i = 0; i < spans_local_space.size() - 1; ++i) {
+                            const double delta =
+                                (spans_local_space[i + 1] - spans_local_space[i]) /
+                                static_cast<double>(nb_per_span + 1);
+
+                            for (IndexType j = 1; j < nb_per_span + 1; ++j) {
+                                knots_to_insert.push_back(spans_local_space[i] + delta * j);
+                            }
+                        }
+
+                        KRATOS_INFO_IF("::[RefinementModeler]::ApplyRefinement", mEchoLevel > 1)
+                            << "Refining nurbs curve #" << p_nurbs_curve->Id()
+                            << " by inserting knots: " << knots_to_insert << std::endl;
+
+                        PointerVector<NodeType> PointsRefined;
+                        Vector KnotsRefined;
+                        Vector WeightsRefined;
+
+                        NurbsCurveRefinementUtilities::KnotRefinement(
+                            *p_nurbs_curve,
+                            knots_to_insert,
+                            PointsRefined,
+                            KnotsRefined,
+                            WeightsRefined
+                        );
+
+                        for (auto& r_point : p_nurbs_curve->Points()) {
+                            r_point.Set(TO_ERASE, true);
+                        }
+
+                        r_model_part.RemoveNodesFromAllLevels(TO_ERASE);
+
+                        IndexType node_id = r_model_part.Nodes().empty()
+                            ? 1
+                            : (r_model_part.NodesEnd() - 1)->Id() + 1;
+
+                        for (IndexType i = 0; i < PointsRefined.size(); ++i) {
+                            if (PointsRefined(i)->Id() == 0) {
+                                PointsRefined(i) = r_model_part.CreateNewNode(
+                                    node_id,
+                                    PointsRefined[i][0],
+                                    PointsRefined[i][1],
+                                    PointsRefined[i][2]
+                                );
+                                node_id++;
+                            }
+                        }
+
+                        KRATOS_INFO_IF("::[RefinementModeler]::ApplyRefinement", mEchoLevel > 1)
+                            << "New knot vector: " << KnotsRefined
+                            << ", new weights vector: " << WeightsRefined << std::endl;
+
+                        p_nurbs_curve->SetInternals(
+                            PointsRefined,
+                            p_nurbs_curve->PolynomialDegree(0),
+                            KnotsRefined,
+                            WeightsRefined
+                        );
+                    }
+                }
+            }
         }
 
         // Reassign node ids from 1 to n after refinement

--- a/applications/IgaApplication/custom_modelers/refinement_modeler.h
+++ b/applications/IgaApplication/custom_modelers/refinement_modeler.h
@@ -22,6 +22,7 @@
 #include "modeler/modeler.h"
 
 #include "geometries/nurbs_shape_function_utilities/nurbs_surface_refinement_utilities.h"
+#include "geometries/nurbs_shape_function_utilities/nurbs_curve_refinement_utilities.h"
 #include "geometries/nurbs_surface_geometry.h"
 #include "utilities/variable_utils.h"
 

--- a/applications/IgaApplication/tests/modeler_tests/curve_geometry.cad.json
+++ b/applications/IgaApplication/tests/modeler_tests/curve_geometry.cad.json
@@ -1,0 +1,43 @@
+{
+  "tolerances": {
+    "model_tolerance": 0.001
+  },
+  "version_number": 1,
+  "breps": [
+    {
+      "brep_id": 1,
+      "faces": [],
+      "edges": [
+        {
+          "brep_id": 2,
+          "3d_curve": {
+            "degree": 2,
+            "knot_vector": [0, 0, 0, 5, 10, 10, 10],
+            "active_range": [0, 10],
+            "control_points": [
+              [
+                1,
+                [0.0, 0.0, 0.0, 1.0]
+              ],
+              [
+                2,
+                [2.5, 2.0, 0.0, 1.0]
+              ],
+              [
+                3,
+                [7.5, 2.0, 0.0, 1.0]
+              ],
+              [
+                4,
+                [10.0, 0.0, 0.0, 1.0]
+              ]
+            ]
+          },
+          "topology": [],
+          "embedded_points": []
+        }
+      ],
+      "vertices": []
+    }
+  ]
+}

--- a/applications/IgaApplication/tests/modeler_tests/curve_h_refinements.iga.json
+++ b/applications/IgaApplication/tests/modeler_tests/curve_h_refinements.iga.json
@@ -1,0 +1,13 @@
+{
+    "refinements": [
+        {
+            "brep_ids": [ 2 ],
+            "geometry_type": "NurbsCurve",
+            "model_part_name": "IgaModelPart",
+            "parameters": {
+                "insert_nb_per_span": 2,
+                "increase_degree": 0
+            }
+        }
+    ]
+}

--- a/applications/IgaApplication/tests/modeler_tests/curve_p_refinements.iga.json
+++ b/applications/IgaApplication/tests/modeler_tests/curve_p_refinements.iga.json
@@ -1,0 +1,13 @@
+{
+    "refinements": [
+        {
+            "brep_ids": [ 2 ],
+            "geometry_type": "NurbsCurve",
+            "model_part_name": "IgaModelPart",
+            "parameters": {
+                "insert_nb_per_span": 0,
+                "increase_degree": 1
+            }
+        }
+    ]
+}

--- a/applications/IgaApplication/tests/test_modelers.py
+++ b/applications/IgaApplication/tests/test_modelers.py
@@ -643,8 +643,161 @@ class TestModelers(KratosUnittest.TestCase):
             param[0] += 0.1
             param[1] = 0.0
 
+    def get_brep_curve(self, model_part, geometry_id=2):
+        return model_part.GetGeometry(geometry_id)
 
+    def get_curve_degree(self, curve):
+        return curve.PolynomialDegree(0)
 
+    def get_curve_spans(self, curve):
+        return curve.SpansLocalSpace()
+
+    def get_curve_number_of_control_points(self, curve):
+        return curve.GetGeometryPart(
+            KratosMultiphysics.Geometry.BACKGROUND_GEOMETRY_INDEX
+        ).PointsNumber()
+
+    def count_nonzero_spans(self, spans):
+        return len(spans) - 1
+
+    def run_curve_refinement_test(self, refinement_file_name):
+        current_model = KratosMultiphysics.Model()
+
+        modelers_list = KratosMultiphysics.Parameters(
+        """ [{
+            "modeler_name": "CadIoModeler",
+            "Parameters": {
+                "echo_level": 0,
+                "cad_model_part_name": "IgaModelPart",
+                "geometry_file_name": "modeler_tests/curve_geometry.cad.json"
+            } }, {
+            "modeler_name": "RefinementModeler",
+            "Parameters": {
+                "echo_level":  0,
+                "refinements_file_name": "%s"
+            } }] """ % refinement_file_name)
+
+        run_modelers(current_model, modelers_list)
+
+        model_part = current_model.GetModelPart("IgaModelPart")
+        curve = self.get_brep_curve(model_part, 2)
+
+        return model_part, curve
+
+    def run_curve_reference_test(self):
+        current_model = KratosMultiphysics.Model()
+
+        modelers_list = KratosMultiphysics.Parameters(
+        """ [{
+            "modeler_name": "CadIoModeler",
+            "Parameters": {
+                "echo_level": 0,
+                "cad_model_part_name": "IgaModelPart",
+                "geometry_file_name": "modeler_tests/curve_geometry.cad.json"
+            } }] """)
+
+        run_modelers(current_model, modelers_list)
+
+        model_part = current_model.GetModelPart("IgaModelPart")
+        curve = self.get_brep_curve(model_part, 2)
+
+        return model_part, curve
+
+    def test_RefinementModeler_nurbs_curve_mesh(self):
+        reference_model_part, reference_curve = self.run_curve_reference_test()
+
+        model_part, curve = self.run_curve_refinement_test(
+            "modeler_tests/curve_h_refinements.iga.json"
+        )
+
+        reference_spans = self.get_curve_spans(reference_curve)
+        refined_spans = self.get_curve_spans(curve)
+
+        reference_number_of_spans = self.count_nonzero_spans(reference_spans)
+        insert_nb_per_span = 2
+
+        expected_number_of_points = (
+            self.get_curve_number_of_control_points(reference_curve)
+            + reference_number_of_spans * insert_nb_per_span
+        )
+
+        expected_number_of_spans = (
+            reference_number_of_spans * (insert_nb_per_span + 1)
+        )
+
+        self.assertEqual(model_part.NumberOfNodes(), expected_number_of_points)
+        self.assertEqual(
+            self.get_curve_number_of_control_points(curve),
+            expected_number_of_points
+        )
+
+        self.assertEqual(
+            self.get_curve_degree(curve),
+            self.get_curve_degree(reference_curve)
+        )
+
+        self.assertEqual(len(refined_spans), expected_number_of_spans + 1)
+
+        param = KratosMultiphysics.Vector(3)
+        param[1] = 0.0
+        param[2] = 0.0
+
+        u_min = reference_spans[0]
+        u_max = reference_spans[-1]
+
+        for i in range(101):
+            param[0] = u_min + (u_max - u_min) * i / 100.0
+
+            reference_coord = reference_curve.GlobalCoordinates(param)
+            refined_coord = curve.GlobalCoordinates(param)
+
+            self.assertVectorAlmostEqual(reference_coord, refined_coord)
+
+    def test_RefinementModeler_nurbs_curve_polynomial(self):
+        reference_model_part, reference_curve = self.run_curve_reference_test()
+
+        model_part, curve = self.run_curve_refinement_test(
+            "modeler_tests/curve_p_refinements.iga.json"
+        )
+
+        reference_spans = self.get_curve_spans(reference_curve)
+        refined_spans = self.get_curve_spans(curve)
+
+        reference_degree = self.get_curve_degree(reference_curve)
+        increase_degree = 1
+        expected_degree = reference_degree + increase_degree
+
+        reference_number_of_spans = self.count_nonzero_spans(reference_spans)
+
+        expected_number_of_points = (
+            self.get_curve_number_of_control_points(reference_curve)
+            + reference_number_of_spans * increase_degree
+        )
+
+        self.assertEqual(self.get_curve_degree(curve), expected_degree)
+        self.assertEqual(
+            self.get_curve_number_of_control_points(curve),
+            expected_number_of_points
+        )
+        self.assertEqual(model_part.NumberOfNodes(), expected_number_of_points)
+
+        # p-refinement changes the degree but should not split the knot spans.
+        self.assertVectorAlmostEqual(refined_spans, reference_spans)
+
+        param = KratosMultiphysics.Vector(3)
+        param[1] = 0.0
+        param[2] = 0.0
+
+        u_min = reference_spans[0]
+        u_max = reference_spans[-1]
+
+        for i in range(101):
+            param[0] = u_min + (u_max - u_min) * i / 100.0
+
+            reference_coord = reference_curve.GlobalCoordinates(param)
+            refined_coord = curve.GlobalCoordinates(param)
+
+            self.assertVectorAlmostEqual(reference_coord, refined_coord)
 
 if __name__ == '__main__':
     KratosUnittest.main()

--- a/kratos/geometries/brep_curve.h
+++ b/kratos/geometries/brep_curve.h
@@ -207,6 +207,19 @@ public:
         return mpNurbsCurve->PolynomialDegree(LocalDirectionIndex);
     }
 
+    /// Return knot spans in direction
+    Vector Knots() const
+    {
+        return mpNurbsCurve->Knots();
+    }
+
+    void SpansLocalSpace(
+        std::vector<double>& rSpans,
+        IndexType LocalDirectionIndex = 0) const override
+    {
+        mpNurbsCurve->SpansLocalSpace(rSpans, LocalDirectionIndex);
+    }
+
     ///@}
     ///@name Information
     ///@{

--- a/kratos/geometries/nurbs_curve_geometry.h
+++ b/kratos/geometries/nurbs_curve_geometry.h
@@ -707,6 +707,18 @@ public:
         return rResult;
     }
 
+    void SetInternals(
+        const PointsArrayType& rThisPoints,
+        const SizeType PolynomialDegree,
+        const Vector& rKnots,
+        const Vector& rWeights)
+    {
+        this->Points() = rThisPoints;
+        mPolynomialDegree = PolynomialDegree;
+        mKnots = rKnots;
+        mWeights = rWeights;
+    }
+
     ///@}
     ///@name Geometry Family
     ///@{

--- a/kratos/geometries/nurbs_shape_function_utilities/nurbs_curve_refinement_utilities.cpp
+++ b/kratos/geometries/nurbs_shape_function_utilities/nurbs_curve_refinement_utilities.cpp
@@ -630,9 +630,6 @@ Vector NurbsCurveRefinementUtilities::CreateReducedKnotVector(
     const Vector& rFullKnots,
     const SizeType Degree)
 {
-    const double first = rFullKnots[0];
-    const double last = rFullKnots[rFullKnots.size() - 1];
-
     const SizeType remove_each_side = 1;
 
     Vector reduced_knots(rFullKnots.size() - 2 * remove_each_side);

--- a/kratos/geometries/nurbs_shape_function_utilities/nurbs_curve_refinement_utilities.cpp
+++ b/kratos/geometries/nurbs_shape_function_utilities/nurbs_curve_refinement_utilities.cpp
@@ -1,0 +1,649 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
+//
+//  Main authors:    Juan I. Camarotti
+//
+
+#include "nurbs_curve_refinement_utilities.h"
+
+namespace Kratos {
+
+void NurbsCurveRefinementUtilities::KnotRefinement(
+    NurbsCurveGeometryType& rGeometry,
+    std::vector<double>& rKnotsToInsert,
+    PointerVector<NodeType>& rPointsRefined,
+    Vector& rKnotsRefined,
+    Vector& rWeightsRefined)
+{
+    const SizeType degree = rGeometry.PolynomialDegree(0);
+
+    const Vector knots_old = CreateFullKnotVector(rGeometry.Knots(), degree);
+
+    SortAndFilter(rKnotsToInsert, knots_old);
+
+    if (rKnotsToInsert.empty()) {
+        KRATOS_WARNING("::NurbsCurveRefinementUtilities::KnotRefinement")
+            << "No refinement applied as knot vector is empty." << std::endl;
+        return;
+    }
+
+    const SizeType nb_cp_old = rGeometry.size();
+    const SizeType nb_knots_old = knots_old.size();
+    const SizeType nb_knots_to_insert = rKnotsToInsert.size();
+
+    KRATOS_ERROR_IF_NOT(nb_knots_old == nb_cp_old + degree + 1)
+        << "Invalid full knot vector. knots.size() = " << nb_knots_old
+        << ", points.size() = " << nb_cp_old
+        << ", degree = " << degree
+        << ", expected = " << nb_cp_old + degree + 1
+        << std::endl;
+
+    Vector weights_old = rGeometry.Weights();
+    if (weights_old.size() != nb_cp_old) {
+        weights_old.resize(nb_cp_old);
+        std::fill(weights_old.begin(), weights_old.end(), 1.0);
+    }
+
+    const SizeType n = nb_cp_old - 1;
+    const SizeType m = nb_knots_old - 1;
+    const SizeType r = nb_knots_to_insert - 1;
+
+    const SizeType a = NurbsUtilities::GetUpperSpan(
+        degree,
+        knots_old,
+        rKnotsToInsert.front()
+    );
+
+    SizeType b = NurbsUtilities::GetUpperSpan(
+        degree,
+        knots_old,
+        rKnotsToInsert.back()
+    );
+
+    b += 1;
+
+    const SizeType nb_cp_refined = nb_cp_old + nb_knots_to_insert;
+    const SizeType nb_knots_refined = nb_knots_old + nb_knots_to_insert;
+
+    rPointsRefined.resize(nb_cp_refined);
+    rWeightsRefined.resize(nb_cp_refined, false);
+    rKnotsRefined.resize(nb_knots_refined, false);
+
+    rWeightsRefined = ZeroVector(nb_cp_refined);
+    rKnotsRefined = ZeroVector(nb_knots_refined);
+
+    for (IndexType i = 0; i <= a - degree; ++i) {
+        const array_1d<double, 3> cp_coordinates =
+            rGeometry[i] * weights_old[i];
+
+        rPointsRefined(i) =
+            Kratos::make_intrusive<NodeType>(0, cp_coordinates);
+
+        rWeightsRefined[i] = weights_old[i];
+    }
+
+    for (IndexType i = b - 1; i <= n; ++i) {
+        const IndexType refined_index = i + nb_knots_to_insert;
+
+        KRATOS_ERROR_IF(refined_index >= nb_cp_refined)
+            << "Out-of-bounds refined_index = " << refined_index
+            << ", nb_cp_refined = " << nb_cp_refined << std::endl;
+
+        const array_1d<double, 3> cp_coordinates =
+            rGeometry[i] * weights_old[i];
+
+        rPointsRefined(refined_index) =
+            Kratos::make_intrusive<NodeType>(0, cp_coordinates);
+
+        rWeightsRefined[refined_index] = weights_old[i];
+    }
+
+    for (IndexType i = 0; i <= a; ++i) {
+        rKnotsRefined[i] = knots_old[i];
+    }
+
+    for (IndexType i = b + degree; i <= m; ++i) {
+        const IndexType refined_index = i + nb_knots_to_insert;
+
+        KRATOS_ERROR_IF(refined_index >= nb_knots_refined)
+            << "Out-of-bounds refined knot index = " << refined_index
+            << ", nb_knots_refined = " << nb_knots_refined << std::endl;
+
+        rKnotsRefined[refined_index] = knots_old[i];
+    }
+
+    IndexType i = b + degree - 1;
+    IndexType k = b + degree + r;
+
+    for (int j = static_cast<int>(r); j >= 0; --j) {
+        while (i > a && rKnotsToInsert[j] <= knots_old[i]) {
+            const IndexType old_index = i - degree - 1;
+            const IndexType refined_index = k - degree - 1;
+
+            const array_1d<double, 3> cp_coordinates =
+                rGeometry[old_index] * weights_old[old_index];
+
+            rPointsRefined(refined_index) =
+                Kratos::make_intrusive<NodeType>(0, cp_coordinates);
+
+            rWeightsRefined[refined_index] = weights_old[old_index];
+            rKnotsRefined[k] = knots_old[i];
+
+            --k;
+            --i;
+        }
+
+        rPointsRefined(k - degree - 1) =
+            rPointsRefined(k - degree);
+
+        rWeightsRefined[k - degree - 1] =
+            rWeightsRefined[k - degree];
+
+        for (IndexType l = 1; l <= degree; ++l) {
+            const IndexType index = k - degree + l;
+            const IndexType old_knot_index = i - degree + l;
+
+            double alpha =
+                rKnotsRefined[k + l] - rKnotsToInsert[j];
+
+            if (std::abs(alpha) < 1.0e-7) {
+                rPointsRefined(index - 1) =
+                    rPointsRefined(index);
+
+                rWeightsRefined[index - 1] =
+                    rWeightsRefined[index];
+            } else {
+                const double denominator =
+                    rKnotsRefined[k + l] - knots_old[old_knot_index];
+
+                KRATOS_ERROR_IF(std::abs(denominator) < 1.0e-14)
+                    << "Zero denominator in alpha computation." << std::endl;
+
+                alpha /= denominator;
+
+                const array_1d<double, 3> cp_coordinates =
+                    alpha * rPointsRefined[index - 1]
+                    + (1.0 - alpha) * rPointsRefined[index];
+
+                rPointsRefined(index - 1) =
+                    Kratos::make_intrusive<NodeType>(0, cp_coordinates);
+
+                rWeightsRefined[index - 1] =
+                    alpha * rWeightsRefined[index - 1]
+                    + (1.0 - alpha) * rWeightsRefined[index];
+            }
+        }
+
+        rKnotsRefined[k] = rKnotsToInsert[j];
+
+        --k;
+    }
+
+    for (IndexType i_cp = 0; i_cp < nb_cp_refined; ++i_cp) {
+        rPointsRefined(i_cp)->Coordinates() =
+            rPointsRefined(i_cp)->Coordinates()
+            / rWeightsRefined[i_cp];
+    }
+
+    rKnotsRefined = CreateReducedKnotVector(rKnotsRefined, degree);
+}
+
+void NurbsCurveRefinementUtilities::DegreeElevation(
+    NurbsCurveGeometryType& rGeometry,
+    SizeType rDegreeToElevate,
+    PointerVector<NodeType>& rPointsRefined,
+    Vector& rKnotsRefined,
+    Vector& rWeightsRefined)
+{
+    const Vector& knots_old = rGeometry.Knots();
+
+    if (rDegreeToElevate == 0) {
+        KRATOS_WARNING("::NurbsCurveRefinementUtilities::DegreeElevation")
+            << "No elevation applied as degree is zero." << std::endl;
+        return;
+    }
+
+    const SizeType degree_old = rGeometry.PolynomialDegree(0);
+    const SizeType degree = degree_old + rDegreeToElevate;
+
+    const SizeType nb_cp_old = rGeometry.size();
+    const SizeType nb_knots_old = knots_old.size();
+
+    Vector weights_old = rGeometry.Weights();
+    if (weights_old.size() != nb_cp_old) {
+        weights_old.resize(nb_cp_old);
+        std::fill(weights_old.begin(), weights_old.end(), 1.0);
+    }
+
+    SizeType number_of_non_zero_spans = 0;
+    for (IndexType i = 0; i < nb_knots_old - 1; ++i) {
+        if (knots_old[i] != knots_old[i + 1]) {
+            ++number_of_non_zero_spans;
+        }
+    }
+
+    const SizeType nb_knots_refined =
+        nb_knots_old + rDegreeToElevate * (number_of_non_zero_spans + 1);
+
+    const SizeType nb_cp_refined =
+        nb_knots_refined - degree + 1;
+
+    rKnotsRefined.resize(nb_knots_refined, false);
+    rWeightsRefined.resize(nb_cp_refined, false);
+    rPointsRefined.resize(nb_cp_refined);
+
+    rKnotsRefined = ZeroVector(nb_knots_refined);
+    rWeightsRefined = ZeroVector(nb_cp_refined);
+
+    Matrix bezier_alphas = ZeroMatrix(degree + 1, degree_old + 1);
+
+    PointerVector<NodeType> bezier_points;
+    bezier_points.resize(degree_old + 1);
+
+    Vector bezier_points_weights = ZeroVector(degree_old + 1);
+
+    PointerVector<NodeType> elevate_bezier_points;
+    elevate_bezier_points.resize(degree + 1);
+
+    Vector elevate_bezier_points_weights = ZeroVector(degree + 1);
+
+    PointerVector<NodeType> next_bezier_points;
+    if (degree_old > 1) {
+        next_bezier_points.resize(degree_old - 1);
+    }
+
+    Vector next_bezier_points_weights =
+        degree_old > 1 ? ZeroVector(degree_old - 1) : ZeroVector(0);
+
+    bezier_alphas(0, 0) = 1.0;
+    bezier_alphas(degree, degree_old) = 1.0;
+
+    for (IndexType i = 1; i < degree / 2 + 1; ++i) {
+        const double inv =
+            1.0 / NurbsUtilities::GetBinomCoefficient(degree, i);
+
+        const SizeType min_degree = std::min(degree_old, i);
+        const int index = std::max(
+            0,
+            static_cast<int>(i - rDegreeToElevate)
+        );
+
+        for (IndexType j = index; j < min_degree + 1; ++j) {
+            bezier_alphas(i, j) =
+                inv
+                * NurbsUtilities::GetBinomCoefficient(degree_old, j)
+                * NurbsUtilities::GetBinomCoefficient(rDegreeToElevate, i - j);
+
+            bezier_alphas(degree - i, degree_old - j) =
+                bezier_alphas(i, j);
+        }
+    }
+
+    SizeType a = degree_old - 1;
+    SizeType b = degree_old;
+
+    int r = -1;
+
+    IndexType knot_index = degree + 1;
+    IndexType control_point_index = 1;
+
+    double knot_old_a = knots_old[a];
+
+    for (IndexType i = 0; i < degree; ++i) {
+        rKnotsRefined[i] = knot_old_a;
+    }
+
+    {
+        const array_1d<double, 3> cp_coordinates =
+            rGeometry[0] * weights_old[0];
+
+        rPointsRefined(0) =
+            Kratos::make_intrusive<NodeType>(0, cp_coordinates);
+
+        rWeightsRefined[0] = weights_old[0];
+    }
+
+    for (IndexType i = 0; i < degree_old + 1; ++i) {
+        const array_1d<double, 3> cp_coordinates =
+            rGeometry[i] * weights_old[i];
+
+        bezier_points(i) =
+            Kratos::make_intrusive<NodeType>(0, cp_coordinates);
+
+        bezier_points_weights[i] = weights_old[i];
+    }
+
+    while (b < nb_knots_old) {
+        IndexType i = b;
+
+        while (b < nb_knots_old - 1 && knots_old[b] == knots_old[b + 1]) {
+            ++b;
+        }
+
+        if (b + 1 == nb_knots_old) {
+            ++b;
+        }
+
+        const IndexType mult = b - i + 1;
+        const double knot_old_b = knots_old[i];
+
+        const int r_old = r;
+        r = static_cast<int>(degree_old - mult);
+
+        IndexType left_bezier;
+        IndexType right_bezier;
+
+        if (r_old > 0) {
+            left_bezier = (r_old + 2) / 2;
+        } else {
+            left_bezier = 1;
+        }
+
+        if (r > 0) {
+            right_bezier = degree - ((r + 1) / 2);
+        } else {
+            right_bezier = degree;
+        }
+
+        if (r > 0) {
+            Vector alphas = ZeroVector(degree_old - 1);
+
+            for (IndexType k = degree_old; k > mult; --k) {
+                alphas[k - mult - 1] =
+                    (knot_old_b - knot_old_a)
+                    / (knots_old[a + k] - knot_old_a);
+            }
+
+            for (IndexType j = 1; j < static_cast<IndexType>(r + 1); ++j) {
+                const int save = r - static_cast<int>(j);
+                const IndexType s = mult + j;
+
+                for (IndexType k = degree_old; k >= s; --k) {
+                    const array_1d<double, 3> cp_coordinates =
+                        alphas[k - s] * bezier_points[k]
+                        + (1.0 - alphas[k - s]) * bezier_points[k - 1];
+
+                    bezier_points(k) =
+                        Kratos::make_intrusive<NodeType>(0, cp_coordinates);
+
+                    bezier_points_weights[k] =
+                        alphas[k - s] * bezier_points_weights[k]
+                        + (1.0 - alphas[k - s]) * bezier_points_weights[k - 1];
+
+                    if (k == s) {
+                        break;
+                    }
+                }
+
+                if (degree_old > 1) {
+                    next_bezier_points(save) = bezier_points(degree_old);
+                    next_bezier_points_weights[save] =
+                        bezier_points_weights[degree_old];
+                }
+            }
+        }
+
+        for (IndexType i_elev = left_bezier; i_elev < degree + 1; ++i_elev) {
+            const array_1d<double, 3> zero_coordinates = ZeroVector(3);
+
+            elevate_bezier_points(i_elev) =
+                Kratos::make_intrusive<NodeType>(0, zero_coordinates);
+
+            elevate_bezier_points_weights[i_elev] = 0.0;
+
+            const SizeType min_degree = std::min(degree_old, i_elev);
+            const int index = std::max(
+                0,
+                static_cast<int>(i_elev - rDegreeToElevate)
+            );
+
+            for (IndexType j = index; j < min_degree + 1; ++j) {
+                const array_1d<double, 3> cp_coordinates =
+                    elevate_bezier_points[i_elev]
+                    + bezier_alphas(i_elev, j) * bezier_points[j];
+
+                elevate_bezier_points(i_elev) =
+                    Kratos::make_intrusive<NodeType>(0, cp_coordinates);
+
+                elevate_bezier_points_weights[i_elev] +=
+                    bezier_alphas(i_elev, j) * bezier_points_weights[j];
+            }
+        }
+
+        if (r_old > 1) {
+            IndexType first = knot_index - 2;
+            IndexType last = knot_index;
+
+            const double beta =
+                (knot_old_b - rKnotsRefined[knot_index - 2])
+                / (knot_old_b - knot_old_a);
+
+            for (IndexType t = 1; t < static_cast<IndexType>(r_old); ++t) {
+                IndexType i_remove = first;
+                IndexType j_remove = last;
+                IndexType k_remove = j_remove - knot_index + 1;
+
+                while (j_remove - i_remove > t) {
+                    if (i_remove < control_point_index) {
+                        const double alpha =
+                            (knot_old_b - rKnotsRefined[i_remove - 1])
+                            / (knot_old_a - rKnotsRefined[i_remove - 1]);
+
+                        const array_1d<double, 3> cp_coordinates =
+                            alpha * rPointsRefined[i_remove]
+                            + (1.0 - alpha) * rPointsRefined[i_remove - 1];
+
+                        rPointsRefined(i_remove) =
+                            Kratos::make_intrusive<NodeType>(0, cp_coordinates);
+
+                        rWeightsRefined[i_remove] =
+                            alpha * rWeightsRefined[i_remove]
+                            + (1.0 - alpha) * rWeightsRefined[i_remove - 1];
+                    }
+
+                    if (j_remove >= left_bezier) {
+                        if ((j_remove - t) <= (knot_index - degree + r_old)) {
+                            const double gamma =
+                                (knot_old_b - rKnotsRefined[j_remove - t - 1])
+                                / (knot_old_b - knot_old_a);
+
+                            const array_1d<double, 3> cp_coordinates =
+                                gamma * elevate_bezier_points[k_remove]
+                                + (1.0 - gamma) * elevate_bezier_points[k_remove + 1];
+
+                            elevate_bezier_points(k_remove) =
+                                Kratos::make_intrusive<NodeType>(0, cp_coordinates);
+
+                            elevate_bezier_points_weights[k_remove] =
+                                gamma * elevate_bezier_points_weights[k_remove]
+                                + (1.0 - gamma)
+                                * elevate_bezier_points_weights[k_remove + 1];
+                        } else {
+                            const array_1d<double, 3> cp_coordinates =
+                                beta * elevate_bezier_points[k_remove]
+                                + (1.0 - beta) * elevate_bezier_points[k_remove + 1];
+
+                            elevate_bezier_points(k_remove) =
+                                Kratos::make_intrusive<NodeType>(0, cp_coordinates);
+
+                            elevate_bezier_points_weights[k_remove] =
+                                beta * elevate_bezier_points_weights[k_remove]
+                                + (1.0 - beta)
+                                * elevate_bezier_points_weights[k_remove + 1];
+                        }
+                    }
+
+                    ++i_remove;
+                    --j_remove;
+                    --k_remove;
+                }
+
+                --first;
+                ++last;
+            }
+        }
+
+        if ((a + 1) != degree_old) {
+            for (IndexType i_knot = 0; i_knot < degree - r_old; ++i_knot) {
+                rKnotsRefined[knot_index - 1] = knot_old_a;
+                ++knot_index;
+            }
+        }
+
+        for (IndexType j = left_bezier; j < right_bezier + 1; ++j) {
+            rPointsRefined(control_point_index) =
+                elevate_bezier_points(j);
+
+            rWeightsRefined[control_point_index] =
+                elevate_bezier_points_weights[j];
+
+            ++control_point_index;
+        }
+
+        if (b < nb_knots_old) {
+            for (IndexType j = 0; j < static_cast<IndexType>(r); ++j) {
+                bezier_points(j) = next_bezier_points(j);
+                bezier_points_weights[j] = next_bezier_points_weights[j];
+            }
+
+            for (IndexType j = r; j < degree_old + 1; ++j) {
+                const IndexType old_index =
+                    b - degree_old + j + 1;
+
+                const array_1d<double, 3> cp_coordinates =
+                    rGeometry[old_index] * weights_old[old_index];
+
+                bezier_points(j) =
+                    Kratos::make_intrusive<NodeType>(0, cp_coordinates);
+
+                bezier_points_weights[j] =
+                    weights_old[old_index];
+            }
+
+            a = b;
+            ++b;
+            knot_old_a = knot_old_b;
+        } else {
+            for (IndexType i_knot = 0; i_knot < degree; ++i_knot) {
+                rKnotsRefined[knot_index - 1 + i_knot] = knot_old_b;
+            }
+        }
+    }
+
+    for (IndexType i = 0; i < nb_cp_refined; ++i) {
+        rPointsRefined(i)->Coordinates() =
+            rPointsRefined(i)->Coordinates() / rWeightsRefined[i];
+    }
+}
+
+void NurbsCurveRefinementUtilities::SortAndFilter(
+    std::vector<double>& rKnotsToInsert,
+    const Vector& rKnotsOld)
+{
+    std::sort(rKnotsToInsert.begin(), rKnotsToInsert.end());
+
+    const double lower_bound =
+        std::min(rKnotsOld[0], rKnotsOld[rKnotsOld.size() - 1]);
+
+    const double upper_bound =
+        std::max(rKnotsOld[0], rKnotsOld[rKnotsOld.size() - 1]);
+
+    auto start =
+        std::lower_bound(
+            rKnotsToInsert.begin(),
+            rKnotsToInsert.end(),
+            lower_bound);
+
+    auto end =
+        std::upper_bound(
+            rKnotsToInsert.begin(),
+            rKnotsToInsert.end(),
+            upper_bound);
+
+    rKnotsToInsert =
+        std::vector<double>(start, end);
+}
+
+Vector NurbsCurveRefinementUtilities::CreateFullKnotVector(
+    const Vector& rReducedKnots,
+    const SizeType Degree)
+{
+    const double first = rReducedKnots[0];
+    const double last = rReducedKnots[rReducedKnots.size() - 1];
+
+    SizeType first_multiplicity = 0;
+    for (IndexType i = 0; i < rReducedKnots.size(); ++i) {
+        if (std::abs(rReducedKnots[i] - first) < 1.0e-12) {
+            ++first_multiplicity;
+        } else {
+            break;
+        }
+    }
+
+    SizeType last_multiplicity = 0;
+    for (int i = static_cast<int>(rReducedKnots.size()) - 1; i >= 0; --i) {
+        if (std::abs(rReducedKnots[i] - last) < 1.0e-12) {
+            ++last_multiplicity;
+        } else {
+            break;
+        }
+    }
+
+    const SizeType required_multiplicity = Degree + 1;
+
+    const SizeType add_first =
+        required_multiplicity > first_multiplicity
+        ? required_multiplicity - first_multiplicity
+        : 0;
+
+    const SizeType add_last =
+        required_multiplicity > last_multiplicity
+        ? required_multiplicity - last_multiplicity
+        : 0;
+
+    Vector full_knots(rReducedKnots.size() + add_first + add_last);
+
+    IndexType index = 0;
+
+    for (IndexType i = 0; i < add_first; ++i) {
+        full_knots[index++] = first;
+    }
+
+    for (IndexType i = 0; i < rReducedKnots.size(); ++i) {
+        full_knots[index++] = rReducedKnots[i];
+    }
+
+    for (IndexType i = 0; i < add_last; ++i) {
+        full_knots[index++] = last;
+    }
+
+    return full_knots;
+}
+
+Vector NurbsCurveRefinementUtilities::CreateReducedKnotVector(
+    const Vector& rFullKnots,
+    const SizeType Degree)
+{
+    const double first = rFullKnots[0];
+    const double last = rFullKnots[rFullKnots.size() - 1];
+
+    const SizeType remove_each_side = 1;
+
+    Vector reduced_knots(rFullKnots.size() - 2 * remove_each_side);
+
+    IndexType index = 0;
+
+    for (IndexType i = remove_each_side; i < rFullKnots.size() - remove_each_side; ++i) {
+        reduced_knots[index++] = rFullKnots[i];
+    }
+
+    return reduced_knots;
+}
+
+} // namespace Kratos

--- a/kratos/geometries/nurbs_shape_function_utilities/nurbs_curve_refinement_utilities.h
+++ b/kratos/geometries/nurbs_shape_function_utilities/nurbs_curve_refinement_utilities.h
@@ -1,0 +1,62 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
+//
+//  Main authors:    Juan I. Camarotti
+//
+
+#pragma once
+
+// System includes
+
+// External includes
+
+// Project includes
+#include "geometries/nurbs_curve_geometry.h"
+#include "nurbs_utilities.h"
+#include "includes/node.h"
+
+namespace Kratos {
+
+class KRATOS_API(KRATOS_CORE) NurbsCurveRefinementUtilities{
+    public:
+        using IndexType = std::size_t;
+        using SizeType = std::size_t;
+        using NodeType = Node;
+
+        using NurbsCurveGeometryType = NurbsCurveGeometry<3, PointerVector<NodeType>>;
+        using NurbsCurveGeometryPointerType = typename NurbsCurveGeometryType::Pointer;
+
+        static void KnotRefinement(
+            NurbsCurveGeometryType& rGeometry,
+            std::vector<double>& rKnotsToInsert,
+            PointerVector<NodeType>& rPointsRefined,
+            Vector& rKnotsRefined,
+            Vector& rWeightsRefined);
+
+        static void DegreeElevation(
+            NurbsCurveGeometryType& rGeometry,
+            const SizeType rDegreeToElevate,
+            PointerVector<NodeType>& rPointsRefined,
+            Vector& rKnotsRefined,
+            Vector& rWeightsRefined);
+
+        static void SortAndFilter(
+            std::vector<double>& rKnotsToInsert,
+            const Vector& rKnotsOld);
+
+        static Vector CreateFullKnotVector(
+            const Vector& rKnots,
+            const SizeType Degree);
+
+        static Vector CreateReducedKnotVector(
+            const Vector& rFullKnots,
+            const SizeType Degree);
+};
+
+} // namespace Kratos

--- a/kratos/python/add_geometries_to_python.cpp
+++ b/kratos/python/add_geometries_to_python.cpp
@@ -144,6 +144,12 @@ void  AddGeometriesToPython(pybind11::module& m)
     .def("PointsNumber", &GeometryType::PointsNumber)
     .def("PointsNumberInDirection", &GeometryType::PointsNumberInDirection)
     .def("PolynomialDegree", &GeometryType::PolynomialDegree)
+    .def("SpansLocalSpace", [](GeometryType& self, IndexType LocalDirectionIndex)
+    {
+        std::vector<double> spans;
+        self.SpansLocalSpace(spans, LocalDirectionIndex);
+        return spans;
+    }, py::arg("local_direction_index") = 0)
     // Geometry data
     .def("GetDefaultIntegrationMethod", &GeometryType::GetDefaultIntegrationMethod)
     .def("GetGeometryFamily", &GeometryType::GetGeometryFamily)


### PR DESCRIPTION
# Add NURBS Curve Refinement Support to `RefinementModeler`

## Description

This PR extends the `RefinementModeler` to support refinement of `NurbsCurveGeometry` objects in the IgaApplication.

The implementation includes:

- h-refinement (knot insertion)
- p-refinement (degree elevation)
- support for curves embedded in `BrepCurve`
- Python exposure of curve spans
- unit tests for  NURBS curves

The implementation follows the same workflow already used for NURBS surfaces.

---

## Input Format

Example:

```json
{
    "refinements": [
        {
            "brep_ids": [ 2 ],
            "geometry_type": "NurbsCurve",
            "model_part_name": "IgaModelPart",
            "parameters": {
                "insert_nb_per_span": 1,
                "increase_degree": 0
            }
        }
    ]
}
```

The implementation can be tested running the following bernoulli beam example:
[test_1_euler_bernoulli_line_load.zip](https://github.com/user-attachments/files/27594867/test_1_euler_bernoulli_line_load.zip)

