### PR TITLE
[SMApp] Rename shell corotational element for naming consistency

### DIFF
--- a/applications/StructuralMechanicsApplication/structural_mechanics_application.cpp
+++ b/applications/StructuralMechanicsApplication/structural_mechanics_application.cpp
@@ -598,7 +598,7 @@ void KratosStructuralMechanicsApplication::Register() {
 
     // deprecated names
     KRATOS_REGISTER_ELEMENT("ShellThickElement3D4N", mShellThickElement3D4N) // It uses MITC
-    KRATOS_REGISTER_ELEMENT("ShellThickCorotationalElement3D4N", mShellThickCorotationalElement3D4N) // It uses MITC
+    KRATOS_REGISTER_ELEMENT("ShellThickElementCorotational3D4N", mShellThickCorotationalElement3D4N) // It uses MITC
 
     KRATOS_REGISTER_ELEMENT("ShellThinElementCorotational3D4N", mShellThinCorotationalElement3D4N)
     KRATOS_REGISTER_ELEMENT("ShellThinElement3D3N", mShellThinElement3D3N)


### PR DESCRIPTION
This quick PR fixes issue #14454, which concerns the inconsistency in the shell corotational names.

Noted that this PR does not affect the new shell elements (#14284 and #13921).