### PR TITLE
[MPM] Cleanup UP element

### DIFF
--- a/applications/MPMApplication/custom_elements/mpm_updated_lagrangian_UP.cpp
+++ b/applications/MPMApplication/custom_elements/mpm_updated_lagrangian_UP.cpp
@@ -377,10 +377,6 @@ void MPMUpdatedLagrangianUP::CalculateAndAddRHS(
     const double& rIntegrationWeight,
     const ProcessInfo& rCurrentProcessInfo)
 {
-    //rVariables.detF0   *= rVariables.detF;
-    //double determinant_F = rVariables.detF;
-    //rVariables.detF = 1; //in order to simplify updated and spatial lagrangian
-
     // Operation performed: rRightHandSideVector += ExtForce*IntegrationWeight
     CalculateAndAddExternalForces( rRightHandSideVector, rVariables, rVolumeForce, rIntegrationWeight );
 
@@ -393,9 +389,6 @@ void MPMUpdatedLagrangianUP::CalculateAndAddRHS(
     if (rCurrentProcessInfo.GetValue(STABILIZATION_TYPE)==1)
         // Operation performed: rRightHandSideVector -= Stabilized Pressure Forces
         CalculateAndAddStabilizedPressure( rRightHandSideVector, rVariables, rIntegrationWeight);
-
-    //rVariables.detF     = determinant_F;
-    //rVariables.detF0   /= rVariables.detF;
 
 }
 //************************************************************************************
@@ -457,11 +450,10 @@ void MPMUpdatedLagrangianUP::CalculateAndAddInternalForces(VectorType& rRightHan
 
 
 double& MPMUpdatedLagrangianUP::CalculateVolumetricStrainFunction(double& rVolumetricStrainFunction, GeneralVariables & rVariables)
-
 {
     KRATOS_TRY
 
-    rVolumetricStrainFunction = (1- (1/rVariables.detFT));
+    rVolumetricStrainFunction = 1.0 - (1.0 / rVariables.detFT);
     return rVolumetricStrainFunction;
 
     KRATOS_CATCH( "" )
@@ -472,12 +464,10 @@ double& MPMUpdatedLagrangianUP::CalculateVolumetricStrainFunction(double& rVolum
 
 
 double& MPMUpdatedLagrangianUP::CalculateFunctionFromLinearizationOfVolumetricStrain(double &rFunction, GeneralVariables & rVariables)
-
 {
-
     KRATOS_TRY
 
-    rFunction= 1.0;
+    rFunction = 1.0;
 
     return rFunction;
 
@@ -508,7 +498,8 @@ void MPMUpdatedLagrangianUP::CalculateAndAddPressureForces(VectorType& rRightHan
     if (bulk_modulus != bulk_modulus)
         bulk_modulus = 1.e16;
 
-    double VolumetricStrainFunction = this->CalculateVolumetricStrainFunction( VolumetricStrainFunction, rVariables );
+    double volumetric_strain_function = 0.0;
+    volumetric_strain_function = this->CalculateVolumetricStrainFunction( volumetric_strain_function, rVariables );
 
     for ( unsigned int i = 0; i < number_of_nodes; i++ )
     {
@@ -519,8 +510,8 @@ void MPMUpdatedLagrangianUP::CalculateAndAddPressureForces(VectorType& rRightHan
             rRightHandSideVector[index_p] += (1.0 / bulk_modulus) * r_N(0, i) * r_N(0, j) * pressure * rIntegrationWeight / rVariables.detFT;  //2D-3D
         }
 
-         rRightHandSideVector[index_p] -=  VolumetricStrainFunction * r_N(0, i) * rIntegrationWeight; //FLUID-UP
-	     //rRightHandSideVector[index_p] -= (1.0 - 1.0 / rVariables.detFT) * r_N(0, i) * rIntegrationWeight;
+        rRightHandSideVector[index_p] -= volumetric_strain_function * r_N(0, i) * rIntegrationWeight;
+
         index_p += (dimension + 1);
     }
 
@@ -552,7 +543,7 @@ void MPMUpdatedLagrangianUP::CalculateAndAddStabilizedPressure(VectorType& rRigh
         if (dimension == 3)
             factor_value = 10.0; //JMC default value
 
-    	alpha_stabilization = alpha_stabilization * factor_value / shear_modulus;
+        alpha_stabilization = alpha_stabilization * factor_value / shear_modulus;
     }
     else
     {
@@ -598,10 +589,6 @@ void MPMUpdatedLagrangianUP::CalculateAndAddLHS(
     const double& rIntegrationWeight,
     const ProcessInfo& rCurrentProcessInfo)
 {
-    //rVariables.detF0   *= rVariables.detF;
-    //double determinant_F = rVariables.detF;
-    //rVariables.detF = 1; //in order to simplify updated and spatial lagrangian
-
     // Operation performed: add Km to the rLefsHandSideMatrix
     CalculateAndAddKuum( rLeftHandSideMatrix, rVariables, rIntegrationWeight );
 
@@ -623,9 +610,6 @@ void MPMUpdatedLagrangianUP::CalculateAndAddLHS(
     if (rCurrentProcessInfo.GetValue(STABILIZATION_TYPE)==1)
         // Operation performed: add Kpp_Stab to the rLefsHandSideMatrix
         CalculateAndAddKppStab( rLeftHandSideMatrix, rVariables, rIntegrationWeight );
-
-    //rVariables.detF     = determinant_F;
-    //rVariables.detF0   /= rVariables.detF;
 
 }
 //************************************************************************************
@@ -799,7 +783,7 @@ void MPMUpdatedLagrangianUP::CalculateAndAddKpp (MatrixType& rLeftHandSideMatrix
         unsigned int indexpj = dimension;
         for (unsigned int j = 0; j < number_of_nodes; j++)
         {
-             rLeftHandSideMatrix(indexpi,indexpj)  -= ((1.0)/(bulk_modulus)) * r_N(0, i) * r_N(0, j) * rIntegrationWeight / rVariables.detFT;
+            rLeftHandSideMatrix(indexpi,indexpj) -= ((1.0)/(bulk_modulus)) * r_N(0, i) * r_N(0, j) * rIntegrationWeight / rVariables.detFT;
 
             indexpj += (dimension + 1);
         }

--- a/applications/MPMApplication/custom_elements/mpm_updated_lagrangian_UP.cpp
+++ b/applications/MPMApplication/custom_elements/mpm_updated_lagrangian_UP.cpp
@@ -461,7 +461,7 @@ double& MPMUpdatedLagrangianUP::CalculateVolumetricStrainFunction(double& rVolum
 {
     KRATOS_TRY
 
-    rVolumetricStrainFunction = (1- (1/rVariables.detFT)); //rVariables.detFT - 1; // rVariables.detF0*rVariables.detF - 1;
+    rVolumetricStrainFunction = (1- (1/rVariables.detFT));
     return rVolumetricStrainFunction;
 
     KRATOS_CATCH( "" )

--- a/applications/MPMApplication/custom_elements/mpm_updated_lagrangian_UP.cpp
+++ b/applications/MPMApplication/custom_elements/mpm_updated_lagrangian_UP.cpp
@@ -471,7 +471,7 @@ double& MPMUpdatedLagrangianUP::CalculateVolumetricStrainFunction(double& rVolum
 //************************************************************************************
 
 
-double& MPMUpdatedLagrangianUP::CalculateFunctionFromLinearizarionOfVolumetricStrain(double &rFunction, GeneralVariables & rVariables)
+double& MPMUpdatedLagrangianUP::CalculateFunctionFromLinearizationOfVolumetricStrain(double &rFunction, GeneralVariables & rVariables)
 
 {
 
@@ -516,7 +516,7 @@ void MPMUpdatedLagrangianUP::CalculateAndAddPressureForces(VectorType& rRightHan
         {
             const double& pressure = r_geometry[j].FastGetSolutionStepValue(PRESSURE);
 
-            rRightHandSideVector[index_p] += (1.0 / bulk_modulus) * r_N(0, i) * r_N(0, j) * pressure * rIntegrationWeight;  //2D-3D
+            rRightHandSideVector[index_p] += (1.0 / bulk_modulus) * r_N(0, i) * r_N(0, j) * pressure * rIntegrationWeight / rVariables.detFT;  //2D-3D
         }
 
          rRightHandSideVector[index_p] -=  VolumetricStrainFunction * r_N(0, i) * rIntegrationWeight; //FLUID-UP
@@ -573,7 +573,7 @@ void MPMUpdatedLagrangianUP::CalculateAndAddStabilizedPressure(VectorType& rRigh
                 if (i == j)
                     consistent = 2 * alpha_stabilization / 36.0;
 
-                rRightHandSideVector[index_p] += consistent * pressure * rIntegrationWeight; //2D
+                rRightHandSideVector[index_p] += consistent * pressure * rIntegrationWeight / rVariables.detFT; //2D
             }
             else
             {
@@ -581,7 +581,7 @@ void MPMUpdatedLagrangianUP::CalculateAndAddStabilizedPressure(VectorType& rRigh
                 if (i == j)
                     consistent = 3 * alpha_stabilization / 80.0;
 
-                rRightHandSideVector[index_p] += consistent * pressure * rIntegrationWeight; //3D
+                rRightHandSideVector[index_p] += consistent * pressure * rIntegrationWeight / rVariables.detFT; //3D
             }
         }
         index_p += (dimension + 1);
@@ -799,7 +799,7 @@ void MPMUpdatedLagrangianUP::CalculateAndAddKpp (MatrixType& rLeftHandSideMatrix
         unsigned int indexpj = dimension;
         for (unsigned int j = 0; j < number_of_nodes; j++)
         {
-             rLeftHandSideMatrix(indexpi,indexpj)  -= ((1.0)/(bulk_modulus)) * r_N(0, i) * r_N(0, j) * rIntegrationWeight;
+             rLeftHandSideMatrix(indexpi,indexpj)  -= ((1.0)/(bulk_modulus)) * r_N(0, i) * r_N(0, j) * rIntegrationWeight / rVariables.detFT;
 
             indexpj += (dimension + 1);
         }
@@ -860,7 +860,7 @@ void MPMUpdatedLagrangianUP::CalculateAndAddKppStab (MatrixType& rLeftHandSideMa
                 if (indexpi == indexpj)
                     consistent = 2 * alpha_stabilization / 36.0;
 
-                rLeftHandSideMatrix(indexpi, indexpj) -= consistent * rIntegrationWeight;  //2D
+                rLeftHandSideMatrix(indexpi, indexpj) -= consistent * rIntegrationWeight / rVariables.detFT;  //2D
             }
             else
             {
@@ -868,7 +868,7 @@ void MPMUpdatedLagrangianUP::CalculateAndAddKppStab (MatrixType& rLeftHandSideMa
                 if (indexpi == indexpj)
                     consistent = 3 * alpha_stabilization / 80.0;
 
-                rLeftHandSideMatrix(indexpi, indexpj) -= consistent * rIntegrationWeight;  //3D
+                rLeftHandSideMatrix(indexpi, indexpj) -= consistent * rIntegrationWeight / rVariables.detFT;  //3D
             }
             indexpj += (dimension + 1);
         }
@@ -1210,4 +1210,3 @@ void MPMUpdatedLagrangianUP::load( Serializer& rSerializer )
 }
 
 } // Namespace Kratos
-

--- a/applications/MPMApplication/custom_elements/mpm_updated_lagrangian_UP.cpp
+++ b/applications/MPMApplication/custom_elements/mpm_updated_lagrangian_UP.cpp
@@ -449,12 +449,11 @@ void MPMUpdatedLagrangianUP::CalculateAndAddInternalForces(VectorType& rRightHan
 //******************************************************************************************************************
 
 
-double& MPMUpdatedLagrangianUP::CalculateVolumetricStrainFunction(double& rVolumetricStrainFunction, GeneralVariables & rVariables)
+double MPMUpdatedLagrangianUP::CalculateVolumetricStrainFunction(GeneralVariables & rVariables)
 {
     KRATOS_TRY
 
-    rVolumetricStrainFunction = 1.0 - (1.0 / rVariables.detFT);
-    return rVolumetricStrainFunction;
+    return 1.0 - (1.0 / rVariables.detFT);
 
     KRATOS_CATCH( "" )
 }
@@ -498,8 +497,7 @@ void MPMUpdatedLagrangianUP::CalculateAndAddPressureForces(VectorType& rRightHan
     if (bulk_modulus != bulk_modulus)
         bulk_modulus = 1.e16;
 
-    double volumetric_strain_function = 0.0;
-    volumetric_strain_function = this->CalculateVolumetricStrainFunction( volumetric_strain_function, rVariables );
+    const double volumetric_strain_function = this->CalculateVolumetricStrainFunction(rVariables);
 
     for ( unsigned int i = 0; i < number_of_nodes; i++ )
     {

--- a/applications/MPMApplication/custom_elements/mpm_updated_lagrangian_UP.cpp
+++ b/applications/MPMApplication/custom_elements/mpm_updated_lagrangian_UP.cpp
@@ -377,9 +377,9 @@ void MPMUpdatedLagrangianUP::CalculateAndAddRHS(
     const double& rIntegrationWeight,
     const ProcessInfo& rCurrentProcessInfo)
 {
-    rVariables.detF0   *= rVariables.detF;
-    double determinant_F = rVariables.detF;
-    rVariables.detF = 1; //in order to simplify updated and spatial lagrangian
+    //rVariables.detF0   *= rVariables.detF;
+    //double determinant_F = rVariables.detF;
+    //rVariables.detF = 1; //in order to simplify updated and spatial lagrangian
 
     // Operation performed: rRightHandSideVector += ExtForce*IntegrationWeight
     CalculateAndAddExternalForces( rRightHandSideVector, rVariables, rVolumeForce, rIntegrationWeight );
@@ -394,8 +394,8 @@ void MPMUpdatedLagrangianUP::CalculateAndAddRHS(
         // Operation performed: rRightHandSideVector -= Stabilized Pressure Forces
         CalculateAndAddStabilizedPressure( rRightHandSideVector, rVariables, rIntegrationWeight);
 
-    rVariables.detF     = determinant_F;
-    rVariables.detF0   /= rVariables.detF;
+    //rVariables.detF     = determinant_F;
+    //rVariables.detF0   /= rVariables.detF;
 
 }
 //************************************************************************************
@@ -454,31 +454,32 @@ void MPMUpdatedLagrangianUP::CalculateAndAddInternalForces(VectorType& rRightHan
 
 //******************************************************************************************************************
 //******************************************************************************************************************
-double& MPMUpdatedLagrangianUP::CalculatePUCoefficient(double& rCoefficient, GeneralVariables & rVariables)
+
+
+double& MPMUpdatedLagrangianUP::CalculateVolumetricStrainFunction(double& rVolumetricStrainFunction, GeneralVariables & rVariables)
+
 {
     KRATOS_TRY
 
-    // TODO: Check what is the meaning of this function
-    rCoefficient = rVariables.detF0 - 1;
-
-    return rCoefficient;
+    rVolumetricStrainFunction = (1- (1/rVariables.detFT)); //rVariables.detFT - 1; // rVariables.detF0*rVariables.detF - 1;
+    return rVolumetricStrainFunction;
 
     KRATOS_CATCH( "" )
 }
 
-
 //************************************************************************************
 //************************************************************************************
 
-double& MPMUpdatedLagrangianUP::CalculatePUDeltaCoefficient(double &rDeltaCoefficient, GeneralVariables & rVariables)
+
+double& MPMUpdatedLagrangianUP::CalculateFunctionFromLinearizarionOfVolumetricStrain(double &rFunction, GeneralVariables & rVariables)
+
 {
 
     KRATOS_TRY
 
-    // TODO: Check what is the meaning of this function
-    rDeltaCoefficient = 1.0;
+    rFunction= 1.0;
 
-    return rDeltaCoefficient;
+    return rFunction;
 
     KRATOS_CATCH( "" )
 
@@ -507,11 +508,7 @@ void MPMUpdatedLagrangianUP::CalculateAndAddPressureForces(VectorType& rRightHan
     if (bulk_modulus != bulk_modulus)
         bulk_modulus = 1.e16;
 
-    double delta_coefficient = 0;
-    delta_coefficient = this->CalculatePUDeltaCoefficient( delta_coefficient, rVariables );
-
-    double coefficient = 0;
-    coefficient = this->CalculatePUCoefficient( coefficient, rVariables );
+    double VolumetricStrainFunction = this->CalculateVolumetricStrainFunction( VolumetricStrainFunction, rVariables );
 
     for ( unsigned int i = 0; i < number_of_nodes; i++ )
     {
@@ -519,11 +516,11 @@ void MPMUpdatedLagrangianUP::CalculateAndAddPressureForces(VectorType& rRightHan
         {
             const double& pressure = r_geometry[j].FastGetSolutionStepValue(PRESSURE);
 
-            rRightHandSideVector[index_p] += (1.0/(delta_coefficient * bulk_modulus)) * r_N(0, i) * r_N(0, j) * pressure * rIntegrationWeight / (rVariables.detF0/rVariables.detF) ; //2D-3D
+            rRightHandSideVector[index_p] += (1.0 / bulk_modulus) * r_N(0, i) * r_N(0, j) * pressure * rIntegrationWeight;  //2D-3D
         }
 
-        rRightHandSideVector[index_p] -=  coefficient/delta_coefficient * r_N(0, i) * rIntegrationWeight / (rVariables.detF0/rVariables.detF);
-
+         rRightHandSideVector[index_p] -=  VolumetricStrainFunction * r_N(0, i) * rIntegrationWeight; //FLUID-UP
+	     //rRightHandSideVector[index_p] -= (1.0 - 1.0 / rVariables.detFT) * r_N(0, i) * rIntegrationWeight;
         index_p += (dimension + 1);
     }
 
@@ -576,7 +573,7 @@ void MPMUpdatedLagrangianUP::CalculateAndAddStabilizedPressure(VectorType& rRigh
                 if (i == j)
                     consistent = 2 * alpha_stabilization / 36.0;
 
-                rRightHandSideVector[index_p] += consistent * pressure * rIntegrationWeight / (rVariables.detF0/rVariables.detF); //2D
+                rRightHandSideVector[index_p] += consistent * pressure * rIntegrationWeight; //2D
             }
             else
             {
@@ -584,7 +581,7 @@ void MPMUpdatedLagrangianUP::CalculateAndAddStabilizedPressure(VectorType& rRigh
                 if (i == j)
                     consistent = 3 * alpha_stabilization / 80.0;
 
-                rRightHandSideVector[index_p] += consistent * pressure * rIntegrationWeight / (rVariables.detF0/rVariables.detF) ; //3D
+                rRightHandSideVector[index_p] += consistent * pressure * rIntegrationWeight; //3D
             }
         }
         index_p += (dimension + 1);
@@ -601,9 +598,9 @@ void MPMUpdatedLagrangianUP::CalculateAndAddLHS(
     const double& rIntegrationWeight,
     const ProcessInfo& rCurrentProcessInfo)
 {
-    rVariables.detF0   *= rVariables.detF;
-    double determinant_F = rVariables.detF;
-    rVariables.detF = 1; //in order to simplify updated and spatial lagrangian
+    //rVariables.detF0   *= rVariables.detF;
+    //double determinant_F = rVariables.detF;
+    //rVariables.detF = 1; //in order to simplify updated and spatial lagrangian
 
     // Operation performed: add Km to the rLefsHandSideMatrix
     CalculateAndAddKuum( rLeftHandSideMatrix, rVariables, rIntegrationWeight );
@@ -627,8 +624,8 @@ void MPMUpdatedLagrangianUP::CalculateAndAddLHS(
         // Operation performed: add Kpp_Stab to the rLefsHandSideMatrix
         CalculateAndAddKppStab( rLeftHandSideMatrix, rVariables, rIntegrationWeight );
 
-    rVariables.detF     = determinant_F;
-    rVariables.detF0   /= rVariables.detF;
+    //rVariables.detF     = determinant_F;
+    //rVariables.detF0   /= rVariables.detF;
 
 }
 //************************************************************************************
@@ -766,7 +763,7 @@ void MPMUpdatedLagrangianUP::CalculateAndAddKpu (MatrixType& rLeftHandSideMatrix
             unsigned int index_up = dimension*j + j;
             for ( unsigned int k = 0; k < dimension; k++ )
             {
-                rLeftHandSideMatrix(index_p,index_up+k) += r_N(0, i) * rVariables.DN_DX ( j, k ) * rIntegrationWeight * rVariables.detF;
+                rLeftHandSideMatrix(index_p,index_up+k) += r_N(0, i) * rVariables.DN_DX ( j, k ) * rIntegrationWeight;
             }
         }
         index_p += (dimension + 1);
@@ -802,7 +799,7 @@ void MPMUpdatedLagrangianUP::CalculateAndAddKpp (MatrixType& rLeftHandSideMatrix
         unsigned int indexpj = dimension;
         for (unsigned int j = 0; j < number_of_nodes; j++)
         {
-            rLeftHandSideMatrix(indexpi,indexpj)  -= ((1.0)/(bulk_modulus)) * r_N(0, i) * r_N(0, j) * rIntegrationWeight /((rVariables.detF0/rVariables.detF));
+             rLeftHandSideMatrix(indexpi,indexpj)  -= ((1.0)/(bulk_modulus)) * r_N(0, i) * r_N(0, j) * rIntegrationWeight;
 
             indexpj += (dimension + 1);
         }
@@ -863,7 +860,7 @@ void MPMUpdatedLagrangianUP::CalculateAndAddKppStab (MatrixType& rLeftHandSideMa
                 if (indexpi == indexpj)
                     consistent = 2 * alpha_stabilization / 36.0;
 
-                rLeftHandSideMatrix(indexpi, indexpj) -= consistent * rIntegrationWeight / (rVariables.detF0/rVariables.detF) ; //2D
+                rLeftHandSideMatrix(indexpi, indexpj) -= consistent * rIntegrationWeight;  //2D
             }
             else
             {
@@ -871,7 +868,7 @@ void MPMUpdatedLagrangianUP::CalculateAndAddKppStab (MatrixType& rLeftHandSideMa
                 if (indexpi == indexpj)
                     consistent = 3 * alpha_stabilization / 80.0;
 
-                rLeftHandSideMatrix(indexpi, indexpj) -= consistent * rIntegrationWeight / (rVariables.detF0/rVariables.detF); //3D
+                rLeftHandSideMatrix(indexpi, indexpj) -= consistent * rIntegrationWeight;  //3D
             }
             indexpj += (dimension + 1);
         }

--- a/applications/MPMApplication/custom_elements/mpm_updated_lagrangian_UP.cpp
+++ b/applications/MPMApplication/custom_elements/mpm_updated_lagrangian_UP.cpp
@@ -731,7 +731,7 @@ void MPMUpdatedLagrangianUP::CalculateAndAddKup (MatrixType& rLeftHandSideMatrix
         {
             for ( unsigned int k = 0; k < dimension; k++ )
             {
-                rLeftHandSideMatrix(index_up+k,index_p) +=  rVariables.DN_DX ( i, k ) * r_N(0, j) * rIntegrationWeight * rVariables.detF;
+                rLeftHandSideMatrix(index_up+k,index_p) +=  rVariables.DN_DX ( i, k ) * r_N(0, j) * rIntegrationWeight;
             }
             index_p += (dimension + 1);
         }

--- a/applications/MPMApplication/custom_elements/mpm_updated_lagrangian_UP.cpp
+++ b/applications/MPMApplication/custom_elements/mpm_updated_lagrangian_UP.cpp
@@ -462,13 +462,11 @@ double MPMUpdatedLagrangianUP::CalculateVolumetricStrainFunction(GeneralVariable
 //************************************************************************************
 
 
-double& MPMUpdatedLagrangianUP::CalculateFunctionFromLinearizationOfVolumetricStrain(double &rFunction, GeneralVariables & rVariables)
+double MPMUpdatedLagrangianUP::CalculateFunctionFromLinearizationOfVolumetricStrain(GeneralVariables & rVariables)
 {
     KRATOS_TRY
 
-    rFunction = 1.0;
-
-    return rFunction;
+    return 1.0;
 
     KRATOS_CATCH( "" )
 
@@ -735,6 +733,8 @@ void MPMUpdatedLagrangianUP::CalculateAndAddKpu (MatrixType& rLeftHandSideMatrix
     const unsigned int number_of_nodes = GetGeometry().size();
     const unsigned int dimension = GetGeometry().WorkingSpaceDimension();
     const Matrix& r_N = GetGeometry().ShapeFunctionsValues();
+    const double volumetric_strain_linearization_factor =
+        this->CalculateFunctionFromLinearizationOfVolumetricStrain(rVariables);
 
     // Assemble components considering added DOF matrix system
     unsigned int index_p = dimension;
@@ -745,7 +745,8 @@ void MPMUpdatedLagrangianUP::CalculateAndAddKpu (MatrixType& rLeftHandSideMatrix
             unsigned int index_up = dimension*j + j;
             for ( unsigned int k = 0; k < dimension; k++ )
             {
-                rLeftHandSideMatrix(index_p,index_up+k) += r_N(0, i) * rVariables.DN_DX ( j, k ) * rIntegrationWeight;
+                rLeftHandSideMatrix(index_p,index_up+k) +=
+                    volumetric_strain_linearization_factor * r_N(0, i) * rVariables.DN_DX(j, k) * rIntegrationWeight;
             }
         }
         index_p += (dimension + 1);

--- a/applications/MPMApplication/custom_elements/mpm_updated_lagrangian_UP.hpp
+++ b/applications/MPMApplication/custom_elements/mpm_updated_lagrangian_UP.hpp
@@ -371,7 +371,7 @@ protected:
     /**
      * Calculation of the volumetric strain function for the pressure equation
      */
-    virtual double& CalculateVolumetricStrainFunction(double& rCoefficient, GeneralVariables & rVariables);
+    virtual double CalculateVolumetricStrainFunction(GeneralVariables & rVariables);
 
     /**
      * Calculation of the linearization factor of the volumetric strain function

--- a/applications/MPMApplication/custom_elements/mpm_updated_lagrangian_UP.hpp
+++ b/applications/MPMApplication/custom_elements/mpm_updated_lagrangian_UP.hpp
@@ -371,12 +371,13 @@ protected:
     /**
      * Calculation of the constitutive coefficient for pressure of the Element
      */
-    virtual double& CalculatePUCoefficient(double& rCoefficient, GeneralVariables & rVariables);
+    virtual double& CalculateVolumetricStrainFunction(double& rCoefficient, GeneralVariables & rVariables);
 
     /**
      * Calculation of the constitutive coefficient derivative for pressure  of the Element
      */
-    virtual double& CalculatePUDeltaCoefficient(double& rCoefficient, GeneralVariables & rVariables);
+    virtual double& CalculateFunctionFromLinearizarionOfVolumetricStrain(double& rCoefficient, GeneralVariables & rVariables);
+
 
     /**
      * Get the Historical Deformation Gradient to calculate after finalize the step

--- a/applications/MPMApplication/custom_elements/mpm_updated_lagrangian_UP.hpp
+++ b/applications/MPMApplication/custom_elements/mpm_updated_lagrangian_UP.hpp
@@ -369,12 +369,12 @@ protected:
 
 
     /**
-     * Calculation of the constitutive coefficient for pressure of the Element
+     * Calculation of the volumetric strain function for the pressure equation
      */
     virtual double& CalculateVolumetricStrainFunction(double& rCoefficient, GeneralVariables & rVariables);
 
     /**
-     * Calculation of the constitutive coefficient derivative for pressure  of the Element
+     * Calculation of the linearization factor of the volumetric strain function
      */
     virtual double& CalculateFunctionFromLinearizationOfVolumetricStrain(double& rCoefficient, GeneralVariables & rVariables);
 

--- a/applications/MPMApplication/custom_elements/mpm_updated_lagrangian_UP.hpp
+++ b/applications/MPMApplication/custom_elements/mpm_updated_lagrangian_UP.hpp
@@ -376,7 +376,7 @@ protected:
     /**
      * Calculation of the linearization factor of the volumetric strain function
      */
-    virtual double& CalculateFunctionFromLinearizationOfVolumetricStrain(double& rCoefficient, GeneralVariables & rVariables);
+    virtual double CalculateFunctionFromLinearizationOfVolumetricStrain(GeneralVariables & rVariables);
 
 
     /**

--- a/applications/MPMApplication/custom_elements/mpm_updated_lagrangian_UP.hpp
+++ b/applications/MPMApplication/custom_elements/mpm_updated_lagrangian_UP.hpp
@@ -376,7 +376,7 @@ protected:
     /**
      * Calculation of the constitutive coefficient derivative for pressure  of the Element
      */
-    virtual double& CalculateFunctionFromLinearizarionOfVolumetricStrain(double& rCoefficient, GeneralVariables & rVariables);
+    virtual double& CalculateFunctionFromLinearizationOfVolumetricStrain(double& rCoefficient, GeneralVariables & rVariables);
 
 
     /**


### PR DESCRIPTION

- Clean up and clarification of pressure-displacement coupling terms in `UpdatedLagrangianUP`.
- Use `detFT` directly in pressure RHS/LHS contributions instead of temporarily modifying `detF` and `detF0`.
- Rename pressure helper functions to better reflect their role in the volumetric strain contributions.

### **Validation**
- All UP test pass
