### PR TITLE
[Core] Add `KRATOS_DEPRECATED_ERROR` macro for compile-time deprecation enforcement

### DIFF
--- a/kratos/includes/define.h
+++ b/kratos/includes/define.h
@@ -524,6 +524,16 @@ catch(...) { Block KRATOS_THROW_ERROR(std::runtime_error, "Unknown error", MoreI
 #define KRATOS_DEPRECATED [[deprecated]]
 #define KRATOS_DEPRECATED_MESSAGE(deprecated_message) [[deprecated(deprecated_message)]]
 
+// Triggers a compile-time error once the given deadline date (year, month, day) is reached.
+// Intended for use inside function/method bodies, at class scope, or at namespace scope to
+// enforce hard removal deadlines on deprecated code.
+// Example: KRATOS_DEPRECATED_ERROR(2026, 12, 31, "Remove OldFunction and update all callers.")
+#define KRATOS_DEPRECATED_ERROR(year, month, day, message)                                         \
+    static_assert(                                                                                  \
+        ::Kratos::Internals::CompileDateAsInt(__DATE__) <                                           \
+        ::Kratos::Internals::DeadlineDateAsInt(year, month, day),                                  \
+        "DEPRECATED [deadline: " #year "-" #month "-" #day "]: " message)
+
 // The following block defines the macro KRATOS_START_IGNORING_DEPRECATED_FUNCTION_WARNING
 // If written in a file, for the following lines of code the compiler will not print warnings of type 'deprecated function'.
 // The scope ends where KRATOS_STOP_IGNORING_DEPRECATED_FUNCTION_WARNING is called.
@@ -592,6 +602,42 @@ namespace Kratos
 #define KRATOS_WATCH(variable) std::cout << #variable << " : " << variable << std::endl;
 #define KRATOS_WATCH_CERR(variable) std::cerr << #variable << " : " << variable << std::endl;
 #define KRATOS_WATCH_MPI(variable, mpi_data_comm) std::cout << "RANK " << mpi_data_comm.Rank() << "/" << mpi_data_comm.Size()  << "    "; KRATOS_WATCH(variable);
+
+namespace Internals {
+
+// Compile-time helpers for KRATOS_DEPRECATED_ERROR.
+constexpr int DeprecationMonthToInt(const char* m) noexcept
+{
+    if (m[0]=='J' && m[1]=='a') return 1;               // Jan
+    if (m[0]=='F') return 2;                             // Feb
+    if (m[0]=='M' && m[1]=='a' && m[2]=='r') return 3;  // Mar
+    if (m[0]=='A' && m[1]=='p') return 4;               // Apr
+    if (m[0]=='M' && m[1]=='a' && m[2]=='y') return 5;  // May
+    if (m[0]=='J' && m[1]=='u' && m[2]=='n') return 6;  // Jun
+    if (m[0]=='J' && m[1]=='u' && m[2]=='l') return 7;  // Jul
+    if (m[0]=='A' && m[1]=='u') return 8;               // Aug
+    if (m[0]=='S') return 9;                            // Sep
+    if (m[0]=='O') return 10;                           // Oct
+    if (m[0]=='N') return 11;                           // Nov
+    if (m[0]=='D') return 12;                           // Dec
+    return 0;
+}
+
+// Converts the __DATE__ predefined macro string ("Mon DD YYYY") to a YYYYMMDD integer.
+constexpr int CompileDateAsInt(const char* date) noexcept
+{
+    const int month = DeprecationMonthToInt(date);
+    const int day   = (date[4] == ' ' ? 0 : (date[4] - '0')) * 10 + (date[5] - '0');
+    const int year  = (date[7]-'0')*1000 + (date[8]-'0')*100 + (date[9]-'0')*10 + (date[10]-'0');
+    return year * 10000 + month * 100 + day;
+}
+
+constexpr int DeadlineDateAsInt(int year, int month, int day) noexcept
+{
+    return year * 10000 + month * 100 + day;
+}
+
+} // namespace Internals
 
 }  /* namespace Kratos.*/
 


### PR DESCRIPTION
---
name: ✨ Feature
about: Add `KRATOS_DEPRECATED_ERROR` macro for compile-time deprecation enforcement.

---

## **📝 Description**

Adds a new macro `KRATOS_DEPRECATED_ERROR` to `kratos/includes/define.h` that causes a **compile-time error** once a specified deadline date is reached. This complements the existing `KRATOS_DEPRECATED_MESSAGE` (which emits a deprecation warning) by providing a hard enforcement mechanism: code marked with this macro will simply refuse to compile past its deadline, ensuring deprecated APIs are actually removed.

Fixes #14461 ?

### **Typical usage** 

Inside a function body, at class scope, or at namespace scope:

```cpp
// Warn users at call sites (existing mechanism)
KRATOS_DEPRECATED_MESSAGE("Use NewFunction instead")
void OldFunction() {
      // Fail compilation once the deadline is reached (new mechanism)
      KRATOS_DEPRECATED_ERROR(2026, 12, 31, "Remove OldFunction and update all callers.");
      // ... old implementation
}
```

When the deadline passes, the compiler emits a clear error pointing to the macro call site, including the deadline date and the developer-supplied message:

```
error: static assertion failed: DEPRECATED [deadline: 2026-12-31]: Remove OldFunction and update all callers.
note: the comparison reduces to '(20270103 < 20261231)'
```

### **Key changes**

- **New macro `KRATOS_DEPRECATED_ERROR(year, month, day, message)`** added alongside `KRATOS_DEPRECATED` and `KRATOS_DEPRECATED_MESSAGE` in `kratos/includes/define.h`. Expands to a `static_assert` that compares the compile date against the given deadline. The assert fires on the dead line day itself (strictly `<`).
 - **Three `constexpr` helpers** added in a new `namespace Kratos::Internals` block inside the existing `namespace Kratos` section of `define.h`:
      - `DeprecationMonthToInt(const char*)` — maps the 3-letter month string from `__DATE__` to an integer 1–12.
      - `CompileDateAsInt(const char*)` — parses the `__DATE__` predefined macro (`"Mon DD YYYY"`) into a YYYYMMDD integer for comparison.
      - `DeadlineDateAsInt(int, int, int)` — packs the (year, month, day) macro arguments into the same YYYYMMDD format.
 
No changes to CMake, Python bindings, or application code are needed — the macro is purely a header-level addition and the constexpr helpers are zero-overhead (evaluated entirely at compile time).

### **Validation**

1. **Future deadline** (`2099-12-31`) — compiles without error.
2. **Past deadline** (`2020-01-01`) — produces the expected `static_assert` error with the correct message and comparison values printed by the compiler.

## **🆕 Changelog**

- [Added `KRATOS_DEPRECATED_ERROR(year, month, day, message)` macro to `kratos/includes/define.h` to enforce hard compile-time removal deadlines on deprecated code.](https://github.com/KratosMultiphysics/Kratos/commit/1b476e4f799ff9a35affa63ccef8b6f83e81c570)

