### PR TITLE
[Iga] Clean compute traction utility for shell 3p.

### DIFF
--- a/applications/IgaApplication/custom_utilities/compute_interface_traction_shell_3p.cpp
+++ b/applications/IgaApplication/custom_utilities/compute_interface_traction_shell_3p.cpp
@@ -129,7 +129,6 @@ void ComputeInterfaceTractionShell3pUtility::ComputeAndSetInterfaceTraction(
 
             traction_values[point_number] = traction;
             
-            KRATOS_WATCH(traction)
             r_condition.SetValue(rTractionVariable, traction);
         }
     }


### PR DESCRIPTION
This PR erases a forgotten `KRATOS_WATCH()` inside the created utility.