### PR TITLE
[Core][TrilinosApplication] Add gather/scatter and COO extraction utilities to spaces

### DIFF
--- a/applications/TrilinosApplication/tests/cpp_tests/test_trilinos_space.cpp
+++ b/applications/TrilinosApplication/tests/cpp_tests/test_trilinos_space.cpp
@@ -11,8 +11,12 @@
 //
 
 // System includes
+#include <algorithm>
+#include <numeric>
+#include <vector>
 
 // External includes
+#include <mpi.h>
 #include <Teuchos_RCP.hpp>
 
 // Project includes
@@ -1389,6 +1393,133 @@ KRATOS_TEST_CASE_IN_SUITE(TrilinosGetAveragevalueDiagonal, KratosTrilinosApplica
     auto matrix = TrilinosCPPTestUtilities::GenerateDummySparseMatrix(r_comm, size, 1.0);
     const double expected_avg = 0.5 * (1.0 + 12.0);
     KRATOS_EXPECT_DOUBLE_EQ(expected_avg, TrilinosSparseSpaceType::GetAveragevalueDiagonal(matrix));
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// New space-method tests (GetMpiComm, CreateSerialMap, GatherToBuffer,
+// ScatterFromBuffer, GetRawValuesPtr, GetNumLocalRows, GetLocalCOO)
+// ─────────────────────────────────────────────────────────────────────────────
+
+KRATOS_DISTRIBUTED_TEST_CASE_IN_SUITE(TrilinosGetMpiComm, KratosTrilinosApplicationMPITestSuite)
+{
+    const auto& r_comm = Testing::GetDefaultDataCommunicator();
+    const int size = 4 * r_comm.Size();
+    auto A = TrilinosCPPTestUtilities::GenerateDummySparseMatrix(r_comm, size, 1.0);
+
+    const auto& epetra_comm = TrilinosSparseSpaceType::GetCommunicator(A);
+    MPI_Comm mpi_comm = TrilinosSparseSpaceType::GetMpiComm(epetra_comm);
+
+    int mpi_rank;
+    MPI_Comm_rank(mpi_comm, &mpi_rank);
+    KRATOS_EXPECT_EQ(mpi_rank, TrilinosSparseSpaceType::GetRank(epetra_comm));
+}
+
+KRATOS_DISTRIBUTED_TEST_CASE_IN_SUITE(TrilinosCreateSerialMap, KratosTrilinosApplicationMPITestSuite)
+{
+    const auto& r_comm = Testing::GetDefaultDataCommunicator();
+    auto b = TrilinosCPPTestUtilities::GenerateDummySparseVector(r_comm, 8);
+    const auto& epetra_comm = TrilinosSparseSpaceType::GetCommunicator(b);
+
+    auto p_serial_map = TrilinosSparseSpaceType::CreateSerialMap(epetra_comm, 8);
+
+    // Rank 0 owns all 8 elements; others own none
+    const bool is_root = (TrilinosSparseSpaceType::GetRank(epetra_comm) == 0);
+    KRATOS_EXPECT_EQ(p_serial_map->NumMyElements(), is_root ? 8 : 0);
+    KRATOS_EXPECT_EQ(p_serial_map->NumGlobalElements(), 8);
+}
+
+KRATOS_DISTRIBUTED_TEST_CASE_IN_SUITE(TrilinosGatherToBufferScatterFromBuffer,
+                                       KratosTrilinosApplicationMPITestSuite)
+{
+    // Build a vector b[i] = i+1 (global 0-based) and gather/scatter it
+    const auto& r_comm = Testing::GetDefaultDataCommunicator();
+    const int size = 4 * r_comm.Size();
+    auto b = TrilinosCPPTestUtilities::GenerateDummySparseVector(r_comm, size, 1.0);
+    auto x = TrilinosCPPTestUtilities::GenerateDummySparseVector(r_comm, size, 0.0);
+    const auto& epetra_comm = TrilinosSparseSpaceType::GetCommunicator(b);
+
+    std::vector<double> buf;
+    TrilinosSparseSpaceType::GatherToBuffer(b, epetra_comm, buf);
+
+    // Only rank 0 has data; scatter it to x
+    TrilinosSparseSpaceType::ScatterFromBuffer(epetra_comm, buf, x);
+
+    // x must equal b on every rank
+    const int n_local = x.Map().NumMyElements();
+    for (int i = 0; i < n_local; ++i) {
+        const double expected = 1.0 + static_cast<double>(x.Map().GID(i));
+        KRATOS_EXPECT_NEAR(x[0][i], expected, 1e-15);
+    }
+}
+
+KRATOS_DISTRIBUTED_TEST_CASE_IN_SUITE(TrilinosGetRawValuesPtr, KratosTrilinosApplicationMPITestSuite)
+{
+    const auto& r_comm = Testing::GetDefaultDataCommunicator();
+    const int size = 4 * r_comm.Size();
+    auto b = TrilinosCPPTestUtilities::GenerateDummySparseVector(r_comm, size, 1.0);
+
+    double* ptr = TrilinosSparseSpaceType::GetRawValuesPtr(b);
+    KRATOS_EXPECT_NE(ptr, nullptr);
+
+    // Value at local index 0 must equal b[0][0]
+    KRATOS_EXPECT_DOUBLE_EQ(*ptr, b[0][0]);
+}
+
+KRATOS_DISTRIBUTED_TEST_CASE_IN_SUITE(TrilinosGetNumLocalRows, KratosTrilinosApplicationMPITestSuite)
+{
+    const auto& r_comm = Testing::GetDefaultDataCommunicator();
+    const int size = 4 * r_comm.Size();
+    auto A = TrilinosCPPTestUtilities::GenerateDummySparseMatrix(r_comm, size, 1.0);
+
+    const auto n_local = TrilinosSparseSpaceType::GetNumLocalRows(A);
+    // With a balanced map each rank should own exactly 4 rows
+    KRATOS_EXPECT_EQ(n_local, static_cast<std::size_t>(4));
+
+    // Sum across ranks must equal global size
+    int n_local_int = static_cast<int>(n_local);
+    int n_global_sum = 0;
+    MPI_Allreduce(&n_local_int, &n_global_sum, 1, MPI_INT, MPI_SUM,
+                  TrilinosSparseSpaceType::GetMpiComm(TrilinosSparseSpaceType::GetCommunicator(A)));
+    KRATOS_EXPECT_EQ(n_global_sum, size);
+}
+
+KRATOS_DISTRIBUTED_TEST_CASE_IN_SUITE(TrilinosGetLocalCOODiagonal, KratosTrilinosApplicationMPITestSuite)
+{
+    // Diagonal matrix A(i,i) = i+1. COO should contain exactly one entry per local row.
+    const auto& r_comm = Testing::GetDefaultDataCommunicator();
+    const int size = 4 * r_comm.Size();
+    auto A = TrilinosCPPTestUtilities::GenerateDummySparseMatrix(r_comm, size, 1.0);
+
+    std::vector<std::size_t> rows, cols;
+    std::vector<double> vals;
+    TrilinosSparseSpaceType::GetLocalCOO(A, rows, cols, vals);
+
+    KRATOS_EXPECT_EQ(rows.size(), static_cast<std::size_t>(4)); // 4 local rows
+
+    // Every entry must be on the diagonal and equal to global_row + 1
+    for (std::size_t k = 0; k < rows.size(); ++k) {
+        KRATOS_EXPECT_EQ(rows[k], cols[k]);
+        KRATOS_EXPECT_NEAR(vals[k], static_cast<double>(rows[k]) + 1.0, 1e-15);
+    }
+}
+
+KRATOS_DISTRIBUTED_TEST_CASE_IN_SUITE(TrilinosGetLocalCOOLowerTriangular, KratosTrilinosApplicationMPITestSuite)
+{
+    // Diagonal matrix is symmetric; lower-triangular COO must equal full COO
+    const auto& r_comm = Testing::GetDefaultDataCommunicator();
+    const int size = 4 * r_comm.Size();
+    auto A = TrilinosCPPTestUtilities::GenerateDummySparseMatrix(r_comm, size, 1.0);
+
+    std::vector<std::size_t> rows_full, cols_full, rows_lt, cols_lt;
+    std::vector<double> vals_full, vals_lt;
+    TrilinosSparseSpaceType::GetLocalCOO(A, rows_full, cols_full, vals_full);
+    TrilinosSparseSpaceType::GetLocalCOO(A, rows_lt, cols_lt, vals_lt, /*LowerTriangularOnly=*/true);
+
+    // Diagonal-only matrix: full == lower-triangular
+    KRATOS_EXPECT_EQ(rows_full.size(), rows_lt.size());
+    for (std::size_t k = 0; k < rows_lt.size(); ++k) {
+        KRATOS_EXPECT_TRUE(rows_lt[k] >= cols_lt[k]);
+    }
 }
 
 } // namespace Kratos::Testing

--- a/applications/TrilinosApplication/tests/cpp_tests/test_trilinos_space_experimental.cpp
+++ b/applications/TrilinosApplication/tests/cpp_tests/test_trilinos_space_experimental.cpp
@@ -11,8 +11,10 @@
 //
 
 // System includes
+#include <vector>
 
 // External includes
+#include <mpi.h>
 
 // Project includes
 #include "trilinos_space_experimental.h"
@@ -1574,6 +1576,92 @@ KRATOS_TEST_CASE_IN_SUITE(TrilinosExperimentalGetOrCreateMap, KratosTrilinosAppl
     auto node_elements = p_map->getNodeElementList();
     KRATOS_EXPECT_EQ(static_cast<int>(node_elements[0]), first_my_id);
     KRATOS_EXPECT_EQ(static_cast<int>(node_elements[1]), first_my_id + 1);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Tests for new space methods (GetMpiComm, CreateSerialMap, GatherToBuffer,
+// ScatterFromBuffer, GetNumLocalRows, GetLocalCOO)
+// ─────────────────────────────────────────────────────────────────────────────
+
+KRATOS_TEST_CASE_IN_SUITE(TrilinosExperimentalGetMpiComm, KratosTrilinosApplicationMPITestSuite)
+{
+    const auto& r_comm = Testing::GetDefaultDataCommunicator();
+    auto raw_mpi_comm = MPIDataCommunicator::GetMPICommunicator(r_comm);
+    TrilinosSparseSpaceType::CommunicatorType tpetra_comm(raw_mpi_comm);
+
+    MPI_Comm extracted = TrilinosSparseSpaceType::GetMpiComm(tpetra_comm);
+
+    int mpi_rank;
+    MPI_Comm_rank(extracted, &mpi_rank);
+    KRATOS_EXPECT_EQ(mpi_rank, tpetra_comm.getRank());
+}
+
+KRATOS_TEST_CASE_IN_SUITE(TrilinosExperimentalCreateSerialMap, KratosTrilinosApplicationMPITestSuite)
+{
+    using GO = TrilinosSparseSpaceType::GO;
+    const auto& r_comm = Testing::GetDefaultDataCommunicator();
+    auto raw_mpi_comm = MPIDataCommunicator::GetMPICommunicator(r_comm);
+    TrilinosSparseSpaceType::CommunicatorType tpetra_comm(raw_mpi_comm);
+
+    auto p_map = TrilinosSparseSpaceType::CreateSerialMap(tpetra_comm, 8);
+
+    const bool is_root = (tpetra_comm.getRank() == 0);
+    KRATOS_EXPECT_EQ(static_cast<int>(p_map->getNodeNumElements()), is_root ? 8 : 0);
+    KRATOS_EXPECT_EQ(static_cast<GO>(p_map->getGlobalNumElements()), static_cast<GO>(8));
+}
+
+KRATOS_TEST_CASE_IN_SUITE(TrilinosExperimentalGatherToBufferScatterFromBuffer,
+                           KratosTrilinosApplicationMPITestSuite)
+{
+    using LO = TrilinosSparseSpaceType::LO;
+    const auto& r_comm = Testing::GetDefaultDataCommunicator();
+    auto raw_mpi_comm = MPIDataCommunicator::GetMPICommunicator(r_comm);
+    TrilinosSparseSpaceType::CommunicatorType tpetra_comm(raw_mpi_comm);
+
+    const int size = 4 * r_comm.Size();
+    auto p_b = TrilinosCPPTestExperimentalUtilities::GenerateDummySparseVector(r_comm, size, 1.0);
+    auto p_x = TrilinosCPPTestExperimentalUtilities::GenerateDummySparseVector(r_comm, size, 0.0);
+
+    std::vector<double> buf;
+    TrilinosSparseSpaceType::GatherToBuffer(*p_b, tpetra_comm, buf);
+    TrilinosSparseSpaceType::ScatterFromBuffer(tpetra_comm, buf, *p_x);
+
+    // x must equal b
+    const auto local_view_x = p_x->getLocalViewHost(Tpetra::Access::ReadOnly);
+    const auto local_view_b = p_b->getLocalViewHost(Tpetra::Access::ReadOnly);
+    const LO n_local = static_cast<LO>(p_x->getLocalLength());
+    for (LO i = 0; i < n_local; ++i) {
+        KRATOS_EXPECT_NEAR(static_cast<double>(local_view_x(i, 0)),
+                           static_cast<double>(local_view_b(i, 0)), 1e-15);
+    }
+}
+
+KRATOS_TEST_CASE_IN_SUITE(TrilinosExperimentalGetNumLocalRows, KratosTrilinosApplicationMPITestSuite)
+{
+    const auto& r_comm = Testing::GetDefaultDataCommunicator();
+    const int size = 4 * r_comm.Size();
+    auto p_A = TrilinosCPPTestExperimentalUtilities::GenerateDummySparseMatrix(r_comm, size, 1.0);
+
+    const auto n_local = TrilinosSparseSpaceType::GetNumLocalRows(*p_A);
+    KRATOS_EXPECT_EQ(n_local, static_cast<std::size_t>(4));
+}
+
+KRATOS_TEST_CASE_IN_SUITE(TrilinosExperimentalGetLocalCOO, KratosTrilinosApplicationMPITestSuite)
+{
+    const auto& r_comm = Testing::GetDefaultDataCommunicator();
+    const int size = 4 * r_comm.Size();
+    auto p_A = TrilinosCPPTestExperimentalUtilities::GenerateDummySparseMatrix(r_comm, size, 1.0);
+
+    std::vector<std::size_t> rows, cols;
+    std::vector<double> vals;
+    TrilinosSparseSpaceType::GetLocalCOO(*p_A, rows, cols, vals);
+
+    // Diagonal matrix: one entry per local row
+    KRATOS_EXPECT_EQ(rows.size(), static_cast<std::size_t>(4));
+    for (std::size_t k = 0; k < rows.size(); ++k) {
+        KRATOS_EXPECT_EQ(rows[k], cols[k]); // diagonal
+        KRATOS_EXPECT_NEAR(vals[k], static_cast<double>(rows[k]) + 1.0, 1e-15);
+    }
 }
 
 } // namespace Kratos::Testing

--- a/applications/TrilinosApplication/trilinos_space.h
+++ b/applications/TrilinosApplication/trilinos_space.h
@@ -14,6 +14,9 @@
 #pragma once
 
 // System includes
+#include <algorithm>
+#include <numeric>
+#include <vector>
 
 // External includes
 
@@ -1433,6 +1436,210 @@ public:
 
         rX.Comm().Barrier();
         KRATOS_CATCH("")
+    }
+
+    /**
+     * @brief Returns the raw MPI communicator handle from an Epetra communicator.
+     * @details Needed by solvers that call MPI or Fortran libraries (e.g. MUMPS)
+     *          directly and must pass the communicator as an MPI_Comm.
+     * @param rComm The Epetra MPI communicator.
+     * @return The underlying MPI_Comm handle.
+     */
+    static MPI_Comm GetMpiComm(const CommunicatorType& rComm)
+    {
+        return rComm.Comm();
+    }
+
+    /**
+     * @brief Creates a map that places all @p GlobalSize elements on rank 0 and
+     *        assigns zero elements to every other rank.
+     * @details This "serial" (root-only) map is the building block for gather/
+     *          scatter operations where a direct solver needs all data on one rank.
+     * @param rComm     The Epetra communicator.
+     * @param GlobalSize Total number of global elements.
+     * @return Shared pointer to the newly created serial map.
+     */
+    static MapPointerType CreateSerialMap(const CommunicatorType& rComm, IndexType GlobalSize)
+    {
+        const int n_local = (rComm.MyPID() == 0) ? static_cast<int>(GlobalSize) : 0;
+        return Kratos::make_shared<MapType>(static_cast<int>(GlobalSize), n_local, 0, rComm);
+    }
+
+    /**
+     * @brief Creates a new vector by importing @p rSource into the layout described
+     *        by @p pTargetMap.
+     * @details Uses an Epetra_Import to redistribute data between the two maps.
+     *          Entries in @p pTargetMap that are not present in @p rSource.Map()
+     *          are left at their initialized (zero) value.
+     * @param rSource    The source vector (arbitrary distributed map).
+     * @param pTargetMap The target map for the new vector.
+     * @return Shared pointer to the newly created vector.
+     */
+    static VectorPointerType ImportVector(const VectorType& rSource, const MapPointerType& pTargetMap)
+    {
+        auto p_result = Kratos::make_shared<VectorType>(*pTargetMap);
+        Epetra_Import importer(*pTargetMap, rSource.Map());
+        const int ierr = p_result->Import(rSource, importer, Insert);
+        KRATOS_ERROR_IF(ierr != 0) << "Epetra vector import failure " << ierr << std::endl;
+        return p_result;
+    }
+
+    /**
+     * @brief Gathers the full distributed vector @p rSource to rank 0.
+     * @details All global values of @p rSource are collected into a serial vector
+     *          owned entirely by rank 0.  Non-root ranks receive an empty (zero-row)
+     *          vector that is nonetheless a valid Epetra object.
+     * @param rSource The distributed source vector.
+     * @param rComm   The Epetra communicator shared by all participating ranks.
+     * @return Shared pointer to the gathered serial vector (non-empty only on rank 0).
+     */
+    static VectorPointerType GatherToRank0(const VectorType& rSource, const CommunicatorType& rComm)
+    {
+        return ImportVector(rSource, CreateSerialMap(rComm, Size(rSource)));
+    }
+
+    /**
+     * @brief Scatters values from the serial vector @p pSerial (on rank 0) back to
+     *        the distributed vector @p rDest.
+     * @details Each rank receives the subset of the solution that belongs to its
+     *          portion of @p rDest.Map().  The serial vector must have been created
+     *          with a map returned by CreateSerialMap() for the same global size.
+     * @param pSerial Pointer to the serial (root-only) source vector.
+     * @param rDest   The distributed destination vector (overwritten).
+     */
+    static void ScatterFromRank0(const VectorPointerType& pSerial, VectorType& rDest)
+    {
+        Epetra_Import importer(rDest.Map(), pSerial->Map());
+        const int ierr = rDest.Import(*pSerial, importer, Insert);
+        KRATOS_ERROR_IF(ierr != 0) << "Epetra vector scatter failure " << ierr << std::endl;
+    }
+
+    /**
+     * @brief Gathers all global values of the distributed vector @p rSource into a
+     *        flat @c std::vector<double> on rank 0.
+     * @details Non-root ranks receive an empty buffer.  The call is collective: all
+     *          ranks must participate even though only rank 0 stores the result.
+     *          This is the preferred interface for solvers (e.g. MUMPS) that require
+     *          a contiguous raw-pointer array on the host process, because the
+     *          returned buffer owns its storage independently of the Epetra object.
+     * @param rSource The distributed source vector.
+     * @param rComm   The Epetra communicator (must match rSource).
+     * @param rBuffer Output buffer filled on rank 0; cleared on other ranks.
+     */
+    static void GatherToBuffer(
+        const VectorType& rSource,
+        const CommunicatorType& rComm,
+        std::vector<double>& rBuffer)
+    {
+        auto p_serial = GatherToRank0(rSource, rComm); // collective
+        if (rComm.MyPID() == 0) {
+            const IndexType n_global = Size(rSource);
+            rBuffer.resize(n_global);
+            const double* values = p_serial->Values();
+            std::copy(values, values + static_cast<int>(n_global), rBuffer.begin());
+        } else {
+            rBuffer.clear();
+        }
+    }
+
+    /**
+     * @brief Scatters values from the rank-0 buffer @p rBuffer back to the
+     *        distributed vector @p rDest.
+     * @details The buffer must contain exactly @c Size(rDest) entries on rank 0 and
+     *          be empty on all other ranks.  After the call every rank owns its
+     *          share of the global solution.  The call is collective.
+     * @param rComm   The Epetra communicator.
+     * @param rBuffer Source buffer (non-empty only on rank 0).
+     * @param rDest   Destination distributed vector (overwritten).
+     */
+    static void ScatterFromBuffer(
+        const CommunicatorType& rComm,
+        const std::vector<double>& rBuffer,
+        VectorType& rDest)
+    {
+        const IndexType n_global = Size(rDest);
+        auto p_serial_map = CreateSerialMap(rComm, n_global);
+        auto p_serial = Kratos::make_shared<VectorType>(*p_serial_map);
+        if (rComm.MyPID() == 0) {
+            KRATOS_ERROR_IF(rBuffer.size() != n_global)
+                << "ScatterFromBuffer: buffer size " << rBuffer.size()
+                << " ≠ global vector size " << n_global << std::endl;
+            double* values = (*p_serial)[0]; // zeroth-column pointer
+            std::copy(rBuffer.begin(), rBuffer.end(), values);
+        }
+        ScatterFromRank0(p_serial, rDest);
+    }
+
+    /**
+     * @brief Returns a raw pointer to the contiguous local data of the vector.
+     * @details For Epetra_FEVector (a single-column Epetra_MultiVector) this is
+     *          equivalent to the zeroth-column pointer returned by
+     *          Epetra_MultiVector::Values().  The pointer is valid as long as @p rV
+     *          is alive and has not been reallocated.
+     * @param rV The vector whose local data pointer is requested.
+     * @return Pointer to the first local element of the vector.
+     */
+    static double* GetRawValuesPtr(VectorType& rV)
+    {
+        return rV.Values();
+    }
+
+    /**
+     * @brief Returns the number of locally owned rows of the matrix @p rA.
+     * @param rA The distributed sparse matrix.
+     * @return Number of rows owned by the calling rank.
+     */
+    static IndexType GetNumLocalRows(const MatrixType& rA)
+    {
+        return static_cast<IndexType>(rA.NumMyRows());
+    }
+
+    /**
+     * @brief Extracts the locally owned non-zeros of @p rA as COO triplets using
+     *        0-based global indices.
+     * @details Each MPI rank populates only its own rows.  The three output vectors
+     *          are resized and filled; any previous content is discarded.
+     *          When @p LowerTriangularOnly is set, only entries with
+     *          global_row ≥ global_col are emitted — this is the format expected
+     *          by MUMPS (and similar) for symmetric matrices.
+     * @param rA                The distributed sparse matrix.
+     * @param rIRowIndices      Output: 0-based global row indices.
+     * @param rIColIndices      Output: 0-based global column indices.
+     * @param rValues           Output: corresponding non-zero values.
+     * @param LowerTriangularOnly When @c true, restrict to the lower triangle.
+     */
+    static void GetLocalCOO(
+        const MatrixType& rA,
+        std::vector<IndexType>& rIRowIndices,
+        std::vector<IndexType>& rIColIndices,
+        std::vector<double>& rValues,
+        const bool LowerTriangularOnly = false)
+    {
+        const int n_local_rows    = rA.NumMyRows();
+        const Epetra_Map& row_map = rA.RowMap();
+        const Epetra_Map& col_map = rA.ColMap();
+
+        rIRowIndices.clear();
+        rIColIndices.clear();
+        rValues.clear();
+
+        for (int i_local = 0; i_local < n_local_rows; ++i_local) {
+            const IndexType global_row = static_cast<IndexType>(row_map.GID(i_local));
+            int     num_entries;
+            double* values;
+            int*    col_inds;
+            const int ierr = rA.ExtractMyRowView(i_local, num_entries, values, col_inds);
+            KRATOS_ERROR_IF(ierr != 0) << "Epetra failure extracting local row "
+                << i_local << " (code " << ierr << ")" << std::endl;
+            for (int k = 0; k < num_entries; ++k) {
+                const IndexType global_col = static_cast<IndexType>(col_map.GID(col_inds[k]));
+                if (!LowerTriangularOnly || global_row >= global_col) {
+                    rIRowIndices.push_back(global_row);
+                    rIColIndices.push_back(global_col);
+                    rValues.push_back(values[k]);
+                }
+            }
+        }
     }
 
     /**

--- a/applications/TrilinosApplication/trilinos_space_experimental.h
+++ b/applications/TrilinosApplication/trilinos_space_experimental.h
@@ -13,9 +13,12 @@
 #pragma once
 
 // System includes
+#include <algorithm>
 #include <mutex>
+#include <vector>
 
 // External includes
+#include <mpi.h>
 
 /* Trilinos includes */
 #include <Tpetra_Core.hpp>
@@ -2041,6 +2044,188 @@ public:
         pComm->barrier();
 
         KRATOS_CATCH("")
+    }
+
+    /**
+     * @brief Returns the raw MPI communicator handle from a Teuchos MPI communicator.
+     * @param rComm The Teuchos MpiComm wrapper.
+     * @return The underlying MPI_Comm handle.
+     */
+    static MPI_Comm GetMpiComm(const CommunicatorType& rComm)
+    {
+        return (*rComm.getRawMpiComm())();
+    }
+
+    /**
+     * @brief Creates a map that places all @p GlobalSize elements on rank 0 and
+     *        assigns zero elements to every other rank.
+     * @param rComm      The Teuchos communicator.
+     * @param GlobalSize Total number of global elements.
+     * @return RCP to the newly created serial map.
+     */
+    static MapPointerType CreateSerialMap(const CommunicatorType& rComm, IndexType GlobalSize)
+    {
+        const GO n_local = (rComm.getRank() == 0) ? static_cast<GO>(GlobalSize) : 0;
+        return Teuchos::rcp(new MapType(
+            static_cast<GO>(GlobalSize), n_local,
+            static_cast<GO>(0),
+            Teuchos::rcpFromRef(const_cast<CommunicatorType&>(rComm))));
+    }
+
+    /**
+     * @brief Creates a new vector by importing @p rSource into the layout
+     *        described by @p pTargetMap.
+     * @param rSource    The source vector (arbitrary distributed map).
+     * @param pTargetMap The target map for the new vector.
+     * @return RCP to the newly created vector.
+     */
+    static VectorPointerType ImportVector(const VectorType& rSource, const MapPointerType& pTargetMap)
+    {
+        auto p_result = CreateVector(pTargetMap);
+        Tpetra::Import<LO, GO, NT> importer(rSource.getMap(), pTargetMap);
+        p_result->doImport(rSource, importer, Tpetra::INSERT);
+        return p_result;
+    }
+
+    /**
+     * @brief Gathers the full distributed vector @p rSource to rank 0.
+     * @details Non-root ranks receive an empty (zero-row) but valid vector.
+     *          The call is collective on all participating ranks.
+     * @param rSource The distributed source vector.
+     * @param rComm   The Teuchos communicator.
+     * @return RCP to the gathered serial vector (non-empty only on rank 0).
+     */
+    static VectorPointerType GatherToRank0(const VectorType& rSource, const CommunicatorType& rComm)
+    {
+        return ImportVector(rSource, CreateSerialMap(rComm, Size(rSource)));
+    }
+
+    /**
+     * @brief Scatters values from the serial vector @p pSerial (on rank 0) back to
+     *        the distributed vector @p rDest.
+     * @param pSerial RCP to the serial (root-only) source vector.
+     * @param rDest   The distributed destination vector (overwritten).
+     */
+    static void ScatterFromRank0(const VectorPointerType& pSerial, VectorType& rDest)
+    {
+        Tpetra::Import<LO, GO, NT> importer(pSerial->getMap(), rDest.getMap());
+        rDest.doImport(*pSerial, importer, Tpetra::INSERT);
+    }
+
+    /**
+     * @brief Gathers all global values of @p rSource into a flat buffer on rank 0.
+     * @param rSource The distributed source vector.
+     * @param rComm   The Teuchos communicator.
+     * @param rBuffer Output buffer filled on rank 0; cleared on other ranks.
+     */
+    static void GatherToBuffer(
+        const VectorType& rSource,
+        const CommunicatorType& rComm,
+        std::vector<double>& rBuffer)
+    {
+        auto p_serial = GatherToRank0(rSource, rComm); // collective
+        if (rComm.getRank() == 0) {
+            const IndexType n_global = Size(rSource);
+            rBuffer.resize(n_global);
+            auto local_view = p_serial->getLocalViewHost(Tpetra::Access::ReadOnly);
+            for (std::size_t i = 0; i < n_global; ++i) {
+                rBuffer[i] = static_cast<double>(local_view(i, 0));
+            }
+        } else {
+            rBuffer.clear();
+        }
+    }
+
+    /**
+     * @brief Scatters values from the rank-0 buffer back to the distributed @p rDest.
+     * @param rComm   The Teuchos communicator.
+     * @param rBuffer Source buffer (non-empty only on rank 0).
+     * @param rDest   Distributed destination vector (overwritten).
+     */
+    static void ScatterFromBuffer(
+        const CommunicatorType& rComm,
+        const std::vector<double>& rBuffer,
+        VectorType& rDest)
+    {
+        const IndexType n_global = Size(rDest);
+        auto p_serial_map = CreateSerialMap(rComm, n_global);
+        auto p_serial = CreateVector(p_serial_map);
+        if (rComm.getRank() == 0) {
+            KRATOS_ERROR_IF(rBuffer.size() != n_global)
+                << "ScatterFromBuffer: buffer size " << rBuffer.size()
+                << " ≠ global vector size " << n_global << std::endl;
+            auto local_view = p_serial->getLocalViewHost(Tpetra::Access::ReadWrite);
+            for (std::size_t i = 0; i < n_global; ++i) {
+                local_view(i, 0) = static_cast<ST>(rBuffer[i]);
+            }
+        }
+        ScatterFromRank0(p_serial, rDest);
+    }
+
+    /**
+     * @brief Returns a raw pointer to the contiguous local data of the vector.
+     * @details For a Tpetra FEMultiVector the pointer is obtained from the
+     *          host-view column 0.  The pointer remains valid as long as @p rV is
+     *          alive and the view is not invalidated by a subsequent device sync.
+     * @param rV The vector whose local data pointer is requested.
+     * @return Pointer to the first local element of column 0.
+     */
+    static double* GetRawValuesPtr(VectorType& rV)
+    {
+        auto local_view = rV.getLocalViewHost(Tpetra::Access::ReadWrite);
+        return reinterpret_cast<double*>(local_view.data());
+    }
+
+    /**
+     * @brief Returns the number of locally owned rows of @p rA.
+     * @param rA The distributed sparse matrix.
+     * @return Number of rows owned by the calling rank.
+     */
+    static IndexType GetNumLocalRows(const MatrixType& rA)
+    {
+        return static_cast<IndexType>(rA.getNodeNumRows());
+    }
+
+    /**
+     * @brief Extracts locally owned non-zeros of @p rA as COO triplets using
+     *        0-based global indices.
+     * @details When @p LowerTriangularOnly is set, only entries with
+     *          global_row ≥ global_col are emitted (for symmetric matrices).
+     * @param rA                The distributed sparse matrix.
+     * @param rIRowIndices      Output: 0-based global row indices.
+     * @param rIColIndices      Output: 0-based global column indices.
+     * @param rValues           Output: corresponding non-zero values.
+     * @param LowerTriangularOnly When @c true, restrict to the lower triangle.
+     */
+    static void GetLocalCOO(
+        const MatrixType& rA,
+        std::vector<IndexType>& rIRowIndices,
+        std::vector<IndexType>& rIColIndices,
+        std::vector<double>& rValues,
+        const bool LowerTriangularOnly = false)
+    {
+        const LO n_local_rows = static_cast<LO>(rA.getNodeNumRows());
+        const auto& row_map = *(rA.getRowMap());
+        const auto& col_map = *(rA.getColMap());
+
+        rIRowIndices.clear();
+        rIColIndices.clear();
+        rValues.clear();
+
+        for (LO i_local = 0; i_local < n_local_rows; ++i_local) {
+            const IndexType global_row = static_cast<IndexType>(row_map.getGlobalElement(i_local));
+            Teuchos::ArrayView<const LO> local_col_inds;
+            Teuchos::ArrayView<const ST> local_vals;
+            rA.getLocalRowView(i_local, local_col_inds, local_vals);
+            for (LO k = 0; k < static_cast<LO>(local_col_inds.size()); ++k) {
+                const IndexType global_col = static_cast<IndexType>(col_map.getGlobalElement(local_col_inds[k]));
+                if (!LowerTriangularOnly || global_row >= global_col) {
+                    rIRowIndices.push_back(global_row);
+                    rIColIndices.push_back(global_col);
+                    rValues.push_back(static_cast<double>(local_vals[k]));
+                }
+            }
+        }
     }
 
     /**

--- a/kratos/spaces/ublas_space.h
+++ b/kratos/spaces/ublas_space.h
@@ -953,6 +953,71 @@ public:
         KRATOS_CATCH("")
     }
 
+    /**
+     * @brief Returns the number of locally owned rows of @p rA.
+     * @details For the sequential UblasSpace, local equals global (there is no
+     *          distribution), so this is equivalent to Size1(@p rA).
+     * @param rA The matrix.
+     * @return Number of rows.
+     */
+    static IndexType GetNumLocalRows(MatrixType const& rA)
+    {
+        return Size1(rA);
+    }
+
+    /**
+     * @brief Extracts the non-zeros of @p rA as COO triplets using 0-based indices.
+     * @details For the sequential UblasSpace all indices are local = global.
+     *          When @p LowerTriangularOnly is set, only entries with row ≥ col
+     *          are emitted (for symmetric matrices).
+     *          Uses ublas row/column iterators so the same code works for both
+     *          `compressed_matrix` (visits stored non-zeros only) and dense `Matrix`
+     *          (visits all entries, skipping structural zeros).
+     * @param rA                The matrix.
+     * @param rIRowIndices      Output: 0-based row indices.
+     * @param rIColIndices      Output: 0-based column indices.
+     * @param rValues           Output: corresponding non-zero values.
+     * @param LowerTriangularOnly When @c true, restrict to the lower triangle.
+     */
+    static void GetLocalCOO(
+        const MatrixType& rA,
+        std::vector<IndexType>& rIRowIndices,
+        std::vector<IndexType>& rIColIndices,
+        std::vector<TDataType>& rValues,
+        const bool LowerTriangularOnly = false)
+    {
+        rIRowIndices.clear();
+        rIColIndices.clear();
+        rValues.clear();
+
+        for (auto it1 = rA.begin1(); it1 != rA.end1(); ++it1) {
+            const std::size_t row = it1.index1();
+            for (auto it2 = it1.begin(); it2 != it1.end(); ++it2) {
+                const std::size_t col = it2.index2();
+                if (!LowerTriangularOnly || row >= col) {
+                    const TDataType val = *it2;
+                    if (val != TDataType{}) {
+                        rIRowIndices.push_back(row);
+                        rIColIndices.push_back(col);
+                        rValues.push_back(val);
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * @brief Returns a raw pointer to the contiguous storage of the vector.
+     * @details For a ublas vector the underlying storage is always contiguous on
+     *          the host, so @c &rV[0] is well-defined.
+     * @param rV The vector whose data pointer is requested.
+     * @return Pointer to the first element.
+     */
+    static TDataType* GetRawValuesPtr(VectorType& rV)
+    {
+        return rV.size() > 0 ? &rV[0] : nullptr;
+    }
+
     template< class TOtherMatrixType >
     static bool WriteMatrixMarketMatrix(const char* pFileName, const TOtherMatrixType& rM, const bool Symmetric)
     {

--- a/kratos/tests/cpp_tests/spaces/test_ublas_space.cpp
+++ b/kratos/tests/cpp_tests/spaces/test_ublas_space.cpp
@@ -116,5 +116,65 @@ KRATOS_TEST_CASE_IN_SUITE(GetScaleNorm, KratosCoreFastSuite)
     KRATOS_EXPECT_DOUBLE_EQ(norm, 1.0);
 }
 
+// ─────────────────────────────────────────────────────────────────────────────
+// Tests for new methods: GetNumLocalRows, GetLocalCOO, GetRawValuesPtr
+// ─────────────────────────────────────────────────────────────────────────────
+
+using LocalSparseSpaceType = UblasSpace<double, CompressedMatrix, Vector>;
+
+KRATOS_TEST_CASE_IN_SUITE(UblasGetNumLocalRows, KratosCoreFastSuite)
+{
+    CompressedMatrix A(4, 4);
+    A.push_back(0, 0, 1.0);
+    A.push_back(1, 1, 2.0);
+    A.push_back(2, 2, 3.0);
+    A.push_back(3, 3, 4.0);
+
+    KRATOS_EXPECT_EQ(LocalSparseSpaceType::GetNumLocalRows(A), std::size_t(4));
+}
+
+KRATOS_TEST_CASE_IN_SUITE(UblasGetLocalCOOSparse, KratosCoreFastSuite)
+{
+    // Symmetric tridiagonal: diag=[2,2], off-diag=[-1]
+    CompressedMatrix A(3, 3);
+    A.push_back(0, 0,  2.0);
+    A.push_back(0, 1, -1.0);
+    A.push_back(1, 0, -1.0);
+    A.push_back(1, 1,  2.0);
+    A.push_back(1, 2, -1.0);
+    A.push_back(2, 1, -1.0);
+    A.push_back(2, 2,  2.0);
+
+    std::vector<std::size_t> rows, cols;
+    std::vector<double> vals;
+    LocalSparseSpaceType::GetLocalCOO(A, rows, cols, vals);
+
+    // All 7 entries must be returned
+    KRATOS_EXPECT_EQ(rows.size(), std::size_t(7));
+
+    // Lower-triangular only: 5 entries (3 diag + 2 lower off-diag)
+    std::vector<std::size_t> rows_lt, cols_lt;
+    std::vector<double> vals_lt;
+    LocalSparseSpaceType::GetLocalCOO(A, rows_lt, cols_lt, vals_lt, /*LowerTriangularOnly=*/true);
+    KRATOS_EXPECT_EQ(rows_lt.size(), std::size_t(5));
+
+    for (std::size_t k = 0; k < rows_lt.size(); ++k) {
+        KRATOS_EXPECT_TRUE(rows_lt[k] >= cols_lt[k]);
+    }
+}
+
+KRATOS_TEST_CASE_IN_SUITE(UblasGetRawValuesPtr, KratosCoreFastSuite)
+{
+    Vector v(4);
+    v[0] = 1.0; v[1] = 2.0; v[2] = 3.0; v[3] = 4.0;
+
+    double* ptr = LocalSparseSpaceType::GetRawValuesPtr(v);
+    KRATOS_EXPECT_NE(ptr, nullptr);
+
+    // Modifying through the pointer must change the vector
+    ptr[0] = 42.0;
+    KRATOS_EXPECT_DOUBLE_EQ(v[0], 42.0);
+}
+
 } // namespace Testing
 } // namespace Kratos.


### PR DESCRIPTION
---
name: ✨ Feature
about: Add gather/scatter and COO extraction utilities to spaces

---

## **📝 Description**

This PR extends spaces with a set of low-level MPI gather/scatter utilities and a COO matrix extraction helper, primarily intended to support parallel-to-serial direct solvers (e.g. MUMPS) that require all data to reside on rank 0.

### **COO (vs CSR)**

> COO (Coordinate format) is a simple, intuitive way to store sparse matrices by listing all non-zero elements as (row, column, value) triplets. CSR (Compressed Sparse Row) optimizes this by compressing repeated row indices, making it highly efficient for memory storage and fast mathematical operations like matrix multiplication.

This can be used for a native support of MUMPS solver instead of using Trilinos wrapper directly. 

### **Motivation**

Direct solvers such as MUMPS, called via the Trilinos `Amesos`/`Amesos2` interfaces, typically need either:
- access to the raw `MPI_Comm` to configure their internal communicator, or  
- all matrix/vector data gathered on a single rank.

The new helpers provide a clean, reusable API for both patterns entirely within `TrilinosSpace`, without requiring solvers to reach into Epetra internals directly.

### **Key changes**

| Method | Purpose |
|---|---|
| `GetMpiComm(rComm)` | Returns the raw `MPI_Comm` handle from an `Epetra_MpiComm`, needed by Fortran-interfaced solvers such as MUMPS |
| `CreateSerialMap(rComm, GlobalSize)` | Creates an `Epetra_Map` that places all `GlobalSize` elements on rank 0 and zero elements on all other ranks |
| `ImportVector(rSource, pTargetMap)` | Creates a new vector by importing `rSource` into the layout described by `pTargetMap` using `Epetra_Import` |
| `GatherToRank0(rSource, rComm)` | Gathers a fully distributed vector onto rank 0; non-root ranks receive an empty (zero-row) but valid Epetra object |
| `ScatterFromRank0(pSerial, rDest)` | Scatters the serial vector on rank 0 back into the distributed vector `rDest` |
| `GatherToBuffer(rSource, rComm, rBuffer)` | Collective: gathers all global values into a contiguous `std::vector<double>` on rank 0 (non-root ranks get an empty buffer) |
| `ScatterFromBuffer(rComm, rBuffer, rDest)` | Collective: scatters a rank-0 `std::vector<double>` buffer back to the distributed destination vector |
| `GetRawValuesPtr(rV)` | Returns `rV.Values()` — a raw pointer to the contiguous local data of the vector |
| `GetNumLocalRows(rA)` | Returns the number of locally owned rows of a distributed sparse matrix |
| `GetLocalCOO(rA, rows, cols, vals, LowerTriangularOnly)` | Extracts locally owned non-zeros as 0-based global COO triplets; when `LowerTriangularOnly=true`, only lower-triangular entries are emitted (the format expected by MUMPS for symmetric problems) |

### **Validation**

Tests added.

## **🆕 Changelog**

- [Add new MPI-related methods and tests to `TrilinosSpace`](https://github.com/KratosMultiphysics/Kratos/commit/403827ee43451525e22cadcbf58c9882f0a7b79d)
- [Add new MPI-related methods and tests to `TrilinosExperimentalSpace`](https://github.com/KratosMultiphysics/Kratos/commit/ff5d76441b48613d2399e9e1cbaf03cd93f22bff)
- [Add new methods and tests for `UblasSpace`: `GetNumLocalRows`, `GetLocalCOO`, and `GetRawValuesPtr`](https://github.com/KratosMultiphysics/Kratos/commit/c117f845448e49338590e5795ba5eb602c83b0f0)
