### PR TITLE
[GeoMechanicsApplication] Fixed issue with reverse search and point conditions

### DIFF
--- a/applications/GeoMechanicsApplication/custom_utilities/neighbouring_element_finder.cpp
+++ b/applications/GeoMechanicsApplication/custom_utilities/neighbouring_element_finder.cpp
@@ -49,7 +49,7 @@ void NeighbouringElementFinder::AddNeighbouringElementsToEntitiesBasedOnOverlapp
 {
     for (const auto& r_boundary_geometry : rBoundaryGeometries) {
         AddNeighbouringElementsBasedOnBoundaryGeometry(rElement, r_boundary_geometry);
-        if (mEnableReverseSearch) {
+        if (r_boundary_geometry.size() > 1 && mEnableReverseSearch) {
             constexpr auto reverse_search = true;
             AddNeighbouringElementsBasedOnBoundaryGeometry(rElement, r_boundary_geometry, reverse_search);
         }

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_utilities/test_neighbouring_element_finder.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_utilities/test_neighbouring_element_finder.cpp
@@ -272,4 +272,28 @@ KRATOS_TEST_CASE_IN_SUITE(NeighbouringElementFinder_FindsNeighbourElementOfCondi
     EXPECT_EQ(r_model_part.GetCondition(1).GetValue(NEIGHBOUR_ELEMENTS).size(), 1);
 }
 
+KRATOS_TEST_CASE_IN_SUITE(NeighbouringElementFinder_FindsNeighbourElementOfPointConditionWhenReverseSearchIsActive,
+                      KratosGeoMechanicsFastSuiteWithoutKernel)
+{
+    // Arrange
+    Model model;
+    auto& r_model_part = model.CreateModelPart("main");
+    auto  nodes        = Testing::ModelSetupUtilities::CreateNodes(
+        r_model_part, {{1, {0.0, 0.0, 0.0}}});
+    auto geometry = Kratos::make_shared<Point2D<Node>>(nodes);
+
+    r_model_part.AddElement(Kratos::make_intrusive<Element>(1, geometry));
+    r_model_part.AddCondition(Kratos::make_intrusive<Condition>(1, geometry));
+
+    NeighbouringElementFinder::BoundaryGeneratorByLocalDim boundary_generators;
+    boundary_generators[std::size_t{0}] = std::make_unique<PointsGenerator>();
+    NeighbouringElementFinder finder(true);
+
+    // Act
+    finder.FindEntityNeighbours(r_model_part.Conditions(), r_model_part.Elements(), boundary_generators);
+
+    // Assert
+    EXPECT_EQ(r_model_part.GetCondition(1).GetValue(NEIGHBOUR_ELEMENTS).size(), 1);
+}
+
 } // namespace Kratos::Testing

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_utilities/test_neighbouring_element_finder.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_utilities/test_neighbouring_element_finder.cpp
@@ -287,7 +287,8 @@ KRATOS_TEST_CASE_IN_SUITE(NeighbouringElementFinder_FindsNeighbourElementOfPoint
 
     NeighbouringElementFinder::BoundaryGeneratorByLocalDim boundary_generators;
     boundary_generators[std::size_t{0}] = std::make_unique<PointsGenerator>();
-    NeighbouringElementFinder finder(true);
+    constexpr auto enable_reverse_search = true;
+    NeighbouringElementFinder finder(enable_reverse_search);
 
     // Act
     finder.FindEntityNeighbours(r_model_part.Conditions(), r_model_part.Elements(), boundary_generators);

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_utilities/test_neighbouring_element_finder.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_utilities/test_neighbouring_element_finder.cpp
@@ -273,21 +273,20 @@ KRATOS_TEST_CASE_IN_SUITE(NeighbouringElementFinder_FindsNeighbourElementOfCondi
 }
 
 KRATOS_TEST_CASE_IN_SUITE(NeighbouringElementFinder_FindsNeighbourElementOfPointConditionWhenReverseSearchIsActive,
-                      KratosGeoMechanicsFastSuiteWithoutKernel)
+                          KratosGeoMechanicsFastSuiteWithoutKernel)
 {
     // Arrange
     Model model;
     auto& r_model_part = model.CreateModelPart("main");
-    auto  nodes        = Testing::ModelSetupUtilities::CreateNodes(
-        r_model_part, {{1, {0.0, 0.0, 0.0}}});
-    auto geometry = Kratos::make_shared<Point2D<Node>>(nodes);
+    auto  nodes = Testing::ModelSetupUtilities::CreateNodes(r_model_part, {{1, {0.0, 0.0, 0.0}}});
+    auto  geometry = Kratos::make_shared<Point2D<Node>>(nodes);
 
     r_model_part.AddElement(Kratos::make_intrusive<Element>(1, geometry));
     r_model_part.AddCondition(Kratos::make_intrusive<Condition>(1, geometry));
 
     NeighbouringElementFinder::BoundaryGeneratorByLocalDim boundary_generators;
-    boundary_generators[std::size_t{0}] = std::make_unique<PointsGenerator>();
-    constexpr auto enable_reverse_search = true;
+    boundary_generators[std::size_t{0}]             = std::make_unique<PointsGenerator>();
+    constexpr auto            enable_reverse_search = true;
     NeighbouringElementFinder finder(enable_reverse_search);
 
     // Act

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_utilities/test_neighbouring_element_finder.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_utilities/test_neighbouring_element_finder.cpp
@@ -290,10 +290,12 @@ KRATOS_TEST_CASE_IN_SUITE(NeighbouringElementFinder_FindsNeighbourElementOfPoint
     NeighbouringElementFinder finder(enable_reverse_search);
 
     // Act
-    finder.FindEntityNeighbours(r_model_part.Conditions(), r_model_part.Elements(), boundary_generators);
+    EXPECT_NO_THROW(finder.FindEntityNeighbours(r_model_part.Conditions(), r_model_part.Elements(),
+                                                boundary_generators));
 
     // Assert
-    EXPECT_EQ(r_model_part.GetCondition(1).GetValue(NEIGHBOUR_ELEMENTS).size(), 1);
+    const auto& r_neighbours = r_model_part.GetCondition(1).GetValue(NEIGHBOUR_ELEMENTS);
+    ASSERT_EQ(r_neighbours.size(), 1);
 }
 
 } // namespace Kratos::Testing


### PR DESCRIPTION
## **📝 Description**
This PR aims to fix an issue with the neighbour finder, which crashes when a point condition is present and the reverse search is enabled.