### PR TITLE
[Core] Add normals to geometries tensor adaptor

### DIFF
--- a/kratos/python/add_tensor_adaptors_to_python.cpp
+++ b/kratos/python/add_tensor_adaptors_to_python.cpp
@@ -259,6 +259,7 @@ void AddTensorAdaptorsToPython(pybind11::module& m)
      py::enum_<GeometriesTensorAdaptorType::DatumType>(geometries_tensor_adaptor,"DatumType")
           .value("ShapeFunctions", GeometriesTensorAdaptorType::DatumType::ShapeFunctions)
           .value("ShapeFunctionDerivatives", GeometriesTensorAdaptorType::DatumType::ShapeFunctionDerivatives)
+          .value("Normals", GeometriesTensorAdaptorType::DatumType::Normals)
           .value("Jacobians", GeometriesTensorAdaptorType::DatumType::Jacobians)
           .value("IntegrationWeights", GeometriesTensorAdaptorType::DatumType::IntegrationWeights)
           .export_values();

--- a/kratos/tensor_adaptors/geometries_tensor_adaptor.cpp
+++ b/kratos/tensor_adaptors/geometries_tensor_adaptor.cpp
@@ -54,6 +54,8 @@ DenseVector<unsigned int> GeometriesTensorAdaptor::GetShape(
             return ZeroVector(3); // N_elem, N_gauss, N_node
         if (Datum == GeometriesTensorAdaptor::DatumType::ShapeFunctionDerivatives)
             return ZeroVector(4); // N_elem, N_gauss, N_node, Dim
+        if (Datum == GeometriesTensorAdaptor::DatumType::Normals)
+            return ZeroVector(3); // N_elem, N_gauss, Dim
         if (Datum == GeometriesTensorAdaptor::DatumType::Jacobians)
             return ZeroVector(4); // N_elem, N_gauss, Dim, LocalDim
         if (Datum == GeometriesTensorAdaptor::DatumType::IntegrationWeights)
@@ -89,6 +91,13 @@ DenseVector<unsigned int> GeometriesTensorAdaptor::GetShape(
         shape[1] = n_gauss;
         shape[2] = n_node;
         shape[3] = working_dim;
+        return shape;
+    } else if (Datum == GeometriesTensorAdaptor::DatumType::Normals) {
+        // [N_elem, N_gauss, WorkingDim]
+        DenseVector<unsigned int> shape(3);
+        shape[0] = n_elem;
+        shape[1] = n_gauss;
+        shape[2] = 3;
         return shape;
     } else if (Datum == GeometriesTensorAdaptor::DatumType::Jacobians) {
         // [N_elem, N_gauss, WorkingDim, LocalDim]
@@ -185,6 +194,29 @@ void GeometriesTensorAdaptor::CollectShapeFunctionsDerivatives(
 }
 
 template <class TContainerType>
+void GeometriesTensorAdaptor::CollectNormals(
+    double* pData,
+    const TContainerType& rContainer,
+    GeometryData::IntegrationMethod Method,
+    const DenseVector<unsigned int>& Shape)
+{
+    const std::size_t n_geom = Shape[0];
+    const std::size_t n_gauss = Shape[1];
+
+    array_1d<double, 3> tls_normal;
+    IndexPartition<std::size_t>(n_geom).for_each(tls_normal, [&](std::size_t i, array_1d<double, 3>& rTLS) {
+        const auto& r_geometry = GetGeometry(*(rContainer.begin() + i));
+
+        for (std::size_t g = 0; g < n_gauss; ++g) {
+            rTLS = r_geometry.Normal(g, Method);
+            for (std::size_t d = 0; d < 3; ++d) {
+                pData[i * n_gauss * 3 + g * 3 + d] = rTLS[d];
+            }
+        }
+    });
+}
+
+template <class TContainerType>
 void GeometriesTensorAdaptor::CollectJacobians(
     double* pData, const TContainerType& rContainer,
     GeometryData::IntegrationMethod Method,
@@ -228,6 +260,8 @@ void GeometriesTensorAdaptor::FillData(double* pData,
     } else if (Datum ==
                GeometriesTensorAdaptor::DatumType::ShapeFunctionDerivatives) {
         CollectShapeFunctionsDerivatives(pData, rContainer, Method, Shape);
+    } else if (Datum == GeometriesTensorAdaptor::DatumType::Normals) {
+        CollectNormals(pData, rContainer, Method, Shape);
     } else if (Datum == GeometriesTensorAdaptor::DatumType::Jacobians) {
         CollectJacobians(pData, rContainer, Method, Shape);
     } else if (Datum == GeometriesTensorAdaptor::DatumType::IntegrationWeights) {

--- a/kratos/tensor_adaptors/geometries_tensor_adaptor.h
+++ b/kratos/tensor_adaptors/geometries_tensor_adaptor.h
@@ -65,6 +65,7 @@ public:
     {
         ShapeFunctions,
         ShapeFunctionDerivatives,
+        Normals,
         Jacobians,
         IntegrationWeights
     };
@@ -176,6 +177,13 @@ private:
 
     template <class TContainerType>
     static void CollectJacobians(
+        double* pData,
+        const TContainerType& rContainer,
+        GeometryData::IntegrationMethod Method,
+        const DenseVector<unsigned int>& Shape);
+
+    template <class TContainerType>
+    static void CollectNormals(
         double* pData,
         const TContainerType& rContainer,
         GeometryData::IntegrationMethod Method,

--- a/kratos/tests/test_geometries_tensor_adaptor.py
+++ b/kratos/tests/test_geometries_tensor_adaptor.py
@@ -8,32 +8,34 @@ class TestGeometriesTensorAdaptor(KratosUnittest.TestCase):
     def setUp(self):
         self.current_model = KM.Model()
         self.model_part = self.current_model.CreateModelPart("Main")
-        
+
         # Create Element 1: Standard Triangle
         # Nodes 1(0,0), 2(1,0), 3(0,1)
         self.model_part.CreateNewNode(1, 0.0, 0.0, 0.0)
         self.model_part.CreateNewNode(2, 1.0, 0.0, 0.0)
         self.model_part.CreateNewNode(3, 0.0, 1.0, 0.0)
-        
+
         # Create Element 2: Distorted Triangle
         self.model_part.CreateNewNode(4, 2.0, 2.0, 0.0)
         self.model_part.CreateNewNode(5, 4.0, 2.5, 0.0)
         self.model_part.CreateNewNode(6, 2.5, 4.0, 0.0)
-        
+
         prop = self.model_part.CreateNewProperties(1)
-        
+
         self.elem1 = self.model_part.CreateNewElement("Element2D3N", 1, [1, 2, 3], prop)
         self.elem2 = self.model_part.CreateNewElement("Element2D3N", 2, [4, 5, 6], prop)
+        self.cond1 = self.model_part.CreateNewCondition("LineCondition2D2N", 1, [1, 2], prop)
+        self.cond2 = self.model_part.CreateNewCondition("LineCondition2D2N", 2, [4, 5], prop)
 
     def test_ShapeFunctions_Gauss1(self):
         # Method: Gauss 1 (1 point)
         adaptor = KM.TensorAdaptors.GeometriesTensorAdaptor(self.model_part.Elements,KM.TensorAdaptors.GeometriesTensorAdaptor.DatumType.ShapeFunctions, KM.GeometryData.IntegrationMethod.GI_GAUSS_1)
         adaptor.CollectData()
-        
+
         data = adaptor.data
         # Shape: [2, 1, 3]
         self.assertEqual(data.shape, (2, 1, 3))
-        
+
         # Check values: should be 1/3 for both elements (Partition of Unity)
         for elem_idx in range(2):
             s = 0.0
@@ -42,7 +44,7 @@ class TestGeometriesTensorAdaptor(KratosUnittest.TestCase):
                 self.assertAlmostEqual(val, 1.0/3.0)
                 s += val
             self.assertAlmostEqual(s, 1.0)
-            
+
         # Specific check for Element 1 (Standard)
         for i in range(3):
             self.assertAlmostEqual(data[0, 0, i], 1.0/3.0)
@@ -51,11 +53,11 @@ class TestGeometriesTensorAdaptor(KratosUnittest.TestCase):
         # Method: Gauss 2 (3 points for Triangle)
         adaptor = KM.TensorAdaptors.GeometriesTensorAdaptor(self.model_part.Elements,KM.TensorAdaptors.GeometriesTensorAdaptor.DatumType.ShapeFunctions, KM.GeometryData.IntegrationMethod.GI_GAUSS_2)
         adaptor.CollectData()
-        
+
         data = adaptor.data
         # Shape: [2, 3, 3] -> 3 Gauss points
         self.assertEqual(data.shape, (2, 3, 3))
-        
+
         # Check Partition of Unity for all points
         for elem_idx in range(2):
             for gp in range(3):
@@ -65,16 +67,16 @@ class TestGeometriesTensorAdaptor(KratosUnittest.TestCase):
     def test_ShapeFunctionsDerivatives_Gauss1(self):
         adaptor = KM.TensorAdaptors.GeometriesTensorAdaptor(self.model_part.Elements,KM.TensorAdaptors.GeometriesTensorAdaptor.DatumType.ShapeFunctionDerivatives, KM.GeometryData.IntegrationMethod.GI_GAUSS_1)
         adaptor.CollectData()
-        
+
         data = adaptor.ViewData()
         # Shape: [2, 1, 3, 2]
         self.assertEqual(data.shape, (2, 1, 3, 2))
-        
+
         # Element 1: Standard
         # N1 = 1 - x - y  => dN1/dx = -1, dN1/dy = -1
         self.assertAlmostEqual(data[0, 0, 0, 0], -1.0) # dN1/dx
         self.assertAlmostEqual(data[0, 0, 0, 1], -1.0) # dN1/dy
-        
+
         # Element 2: Distorted. Check Sum(Grad N) = 0
         for elem_idx in range(2):
             sum_dx = sum(data[elem_idx, 0, :, 0])
@@ -85,11 +87,11 @@ class TestGeometriesTensorAdaptor(KratosUnittest.TestCase):
     def test_ShapeFunctionsDerivatives_Gauss2(self):
         adaptor = KM.TensorAdaptors.GeometriesTensorAdaptor(self.model_part.Elements,KM.TensorAdaptors.GeometriesTensorAdaptor.DatumType.ShapeFunctionDerivatives, KM.GeometryData.IntegrationMethod.GI_GAUSS_2)
         adaptor.CollectData()
-        
+
         data = adaptor.ViewData()
         # Shape: [2, 3, 3, 2]
         self.assertEqual(data.shape, (2, 3, 3, 2))
-        
+
         # Verify Partition of Unity Gradients sum to 0
         for elem_idx in range(2):
             for gp in range(3):
@@ -98,14 +100,31 @@ class TestGeometriesTensorAdaptor(KratosUnittest.TestCase):
                 self.assertAlmostEqual(sum_dx, 0.0)
                 self.assertAlmostEqual(sum_dy, 0.0)
 
+    def test_Normals_Gauss2(self):
+        adaptor = KM.TensorAdaptors.GeometriesTensorAdaptor(self.model_part.Conditions,KM.TensorAdaptors.GeometriesTensorAdaptor.DatumType.Normals, KM.GeometryData.IntegrationMethod.GI_GAUSS_2)
+        adaptor.CollectData()
+
+        data = adaptor.ViewData()
+        # Shape: [2, 2, 3] -> [icond, igauss, 3]
+        self.assertEqual(data.shape, (2, 2, 3))
+
+        # Check normals for conditions 1 and 2. Both integration points have the same normal.
+        for gp in range(2):
+            self.assertAlmostEqual(data[0, gp, 0], 0.0)
+            self.assertAlmostEqual(data[0, gp, 1], -0.5)
+            self.assertAlmostEqual(data[0, gp, 2], 0.0)
+            self.assertAlmostEqual(data[1, gp, 0], 0.25)
+            self.assertAlmostEqual(data[1, gp, 1], -1.0)
+            self.assertAlmostEqual(data[1, gp, 2], 0.0)
+
     def test_Jacobians_Gauss2(self):
         adaptor = KM.TensorAdaptors.GeometriesTensorAdaptor(self.model_part.Elements,KM.TensorAdaptors.GeometriesTensorAdaptor.DatumType.Jacobians, KM.GeometryData.IntegrationMethod.GI_GAUSS_2)
         adaptor.CollectData()
-        
+
         data = adaptor.ViewData()
         # Shape: [2, 3, 2, 2] -> [ielem, igauss, dim, local_dim]
         self.assertEqual(data.shape, (2, 3, 2, 2))
-        
+
         # Element 1 J is constant [[1,0], [0,1]] everywhere?
         # x = (1-L1-L2)*0 + L1*1 + L2*0 = L1
         # y = L2
@@ -116,7 +135,7 @@ class TestGeometriesTensorAdaptor(KratosUnittest.TestCase):
             self.assertAlmostEqual(data[0, gp, 0, 0], 1.0)
             self.assertAlmostEqual(data[0, gp, 0, 1], 0.0)
             self.assertAlmostEqual(data[0, gp, 1, 1], 1.0)
-            
+
         # Element 2 J is constant for linear triangle too.
         # Check that all GPs have same Jacobian for Elem 2.
         for gp in range(1, 3):
@@ -127,7 +146,7 @@ class TestGeometriesTensorAdaptor(KratosUnittest.TestCase):
     def test_Area_Triangle(self):
         # We need Jacobians and Weights to compute Area
         # Area = Sum_gp ( det(J) * W )
-        
+
         # 1. Get Jacobians
         adaptor_J = KM.TensorAdaptors.GeometriesTensorAdaptor(self.model_part.Elements,KM.TensorAdaptors.GeometriesTensorAdaptor.DatumType.Jacobians, KM.GeometryData.IntegrationMethod.GI_GAUSS_2)
         adaptor_J.CollectData()
@@ -142,7 +161,7 @@ class TestGeometriesTensorAdaptor(KratosUnittest.TestCase):
         # Element 1: (0,0), (1,0), (0,1). Area = 0.5 * Base * Height = 0.5 * 1 * 1 = 0.5
         # Element 2: (2.0, 2.0), (4.0, 2.5), (2.5, 4.0).
         # det(J) = 3.75. Sum(w) = 0.5. Area = 3.75 * 0.5 = 1.875.
-        
+
         calculated_areas = []
         for i_elem in range(2):
             area = 0.0
@@ -150,12 +169,12 @@ class TestGeometriesTensorAdaptor(KratosUnittest.TestCase):
             for i_gauss in range(n_gauss):
                 J = J_data[i_elem, i_gauss]
                 det_J = np.linalg.det(J)
-                
+
                 weight = W_data[i_elem, i_gauss]
                 area += det_J * weight
-            
+
             calculated_areas.append(area)
-            
+
         self.assertAlmostEqual(calculated_areas[0], 0.5)
         self.assertAlmostEqual(calculated_areas[1], 1.875)
 
@@ -164,7 +183,7 @@ class TestGeometriesTensorAdaptor(KratosUnittest.TestCase):
         # Create a new ModelPart for this test to avoid mixing with setUp
         current_model = KM.Model()
         model_part = current_model.CreateModelPart("Curved")
-        
+
         # Nodes as specified:
         # (0,0) (1,0) (0,1) (0.5,0.01) (-0.01,0.5) (sqrt(2)/2,sqrt(2)/2)
         # We must map these to the correct Triangle2D6 order: V1, V2, V3, M12, M23, M31
@@ -172,41 +191,41 @@ class TestGeometriesTensorAdaptor(KratosUnittest.TestCase):
         # M12 (Edge 1-2): (0.5, 0.01)
         # M23 (Edge 2-3): (sqrt(2)/2, sqrt(2)/2)
         # M31 (Edge 3-1): (-0.01, 0.5)
-        
+
         n1 = model_part.CreateNewNode(1, 0.0, 0.0, 0.0)
         n2 = model_part.CreateNewNode(2, 1.0, 0.0, 0.0)
         n3 = model_part.CreateNewNode(3, 0.0, 1.0, 0.0)
         n4 = model_part.CreateNewNode(4, 0.5, 0.05, 0.0)
         n5 = model_part.CreateNewNode(5, 0.5, 0.5, 0.0)
         n6 = model_part.CreateNewNode(6, -0.05, 0.5, 0.0)
-        
+
         # Create Geometry Triangle2D6
         # Order: V1, V2, V3, M12, M23, M31
         # IDs: 1, 2, 3, 4, 5, 6
         geom = model_part.CreateNewGeometry("Triangle2D6", 1, [1, 2, 3, 4, 5, 6])
-        
+
         integration_methods = [KM.GeometryData.IntegrationMethod.GI_GAUSS_2, KM.GeometryData.IntegrationMethod.GI_GAUSS_3, KM.GeometryData.IntegrationMethod.GI_GAUSS_4]
         # Verify Area = 0.5
         # Use high order integration (Gauss 2) to capture curved boundaries
-        for method in integration_methods:        
+        for method in integration_methods:
             # 1. Get Jacobians
             adaptor_J = KM.TensorAdaptors.GeometriesTensorAdaptor(
-                model_part.Geometries, 
-                KM.TensorAdaptors.GeometriesTensorAdaptor.DatumType.Jacobians, 
+                model_part.Geometries,
+                KM.TensorAdaptors.GeometriesTensorAdaptor.DatumType.Jacobians,
                 method
             )
             adaptor_J.CollectData()
             J_data = adaptor_J.data
-            
+
             # 2. Get Weights
             adaptor_W = KM.TensorAdaptors.GeometriesTensorAdaptor(
-                model_part.Geometries, 
-                KM.TensorAdaptors.GeometriesTensorAdaptor.DatumType.IntegrationWeights, 
+                model_part.Geometries,
+                KM.TensorAdaptors.GeometriesTensorAdaptor.DatumType.IntegrationWeights,
                 method
             )
             adaptor_W.CollectData()
             W_data = adaptor_W.data
-            
+
             area = 0.0
             n_gauss = W_data.shape[1]
             for i_gauss in range(n_gauss):
@@ -214,7 +233,7 @@ class TestGeometriesTensorAdaptor(KratosUnittest.TestCase):
                 det_J = np.linalg.det(J)
                 weight = W_data[0, i_gauss]
                 area += det_J * weight
-                
+
             self.assertAlmostEqual(area, 0.5)
 
 


### PR DESCRIPTION
This PR adds the capability to retrieve the normals from a geometry set by using the `GeometriesTensorAdaptor`. Tests have been added accordingly.
