### PR TITLE
[App][Trilinos] Fixing deprecated funcs 

### DIFF
--- a/applications/TrilinosApplication/custom_utilities/trilinos_matrix_market_io.cpp
+++ b/applications/TrilinosApplication/custom_utilities/trilinos_matrix_market_io.cpp
@@ -49,7 +49,7 @@ Teuchos::RCP<FEMatrix> ReadMatrix(
 
     const auto p_row_map = p_crs->getRowMap();
     const auto p_col_map = p_crs->getColMap();
-    const LO num_local_rows = static_cast<LO>(p_crs->getNodeNumRows());
+    const LO num_local_rows = static_cast<LO>(p_crs->getLocalNumRows());
 
     // Per-row max entry count for the FECrsGraph.
     std::size_t max_entries = 0;

--- a/applications/TrilinosApplication/tests/cpp_tests/test_trilinos_space_experimental.cpp
+++ b/applications/TrilinosApplication/tests/cpp_tests/test_trilinos_space_experimental.cpp
@@ -198,7 +198,7 @@ KRATOS_TEST_CASE_IN_SUITE(TrilinosExperimentalTransposeMultMatrixMatrix, KratosT
     using LO = TrilinosSparseSpaceType::LO;
     using GO = TrilinosSparseSpaceType::GO;
     Teuchos::RCP<TrilinosSparseSpaceType::GraphType> p_graph_mult = Teuchos::rcp(new TrilinosSparseSpaceType::GraphType(matrix_1->getRowMap(), matrix_1->getRowMap(), size));
-    for (LO i = 0; i < static_cast<LO>(matrix_1->getNodeNumRows()); ++i) {
+    for (LO i = 0; i < static_cast<LO>(matrix_1->getLocalNumRows()); ++i) {
         const GO global_row = matrix_1->getRowMap()->getGlobalElement(i);
         std::vector<GO> indices(size);
         for (int j = 0; j < size; ++j) indices[j] = j;
@@ -232,7 +232,7 @@ KRATOS_TEST_CASE_IN_SUITE(TrilinosExperimentalBtDBProductOperation, KratosTrilin
     using LO = TrilinosSparseSpaceType::LO;
     using GO = TrilinosSparseSpaceType::GO;
     Teuchos::RCP<TrilinosSparseSpaceType::GraphType> p_graph_mult = Teuchos::rcp(new TrilinosSparseSpaceType::GraphType(matrix_1->getRowMap(), matrix_1->getRowMap(), size));
-    for (LO i = 0; i < static_cast<LO>(matrix_1->getNodeNumRows()); ++i) {
+    for (LO i = 0; i < static_cast<LO>(matrix_1->getLocalNumRows()); ++i) {
         const GO global_row = matrix_1->getRowMap()->getGlobalElement(i);
         std::vector<GO> indices(size);
         for (int j = 0; j < size; ++j) indices[j] = j;
@@ -251,7 +251,7 @@ KRATOS_TEST_CASE_IN_SUITE(TrilinosExperimentalBtDBProductOperation, KratosTrilin
 
     // Non zero matrix
     Teuchos::RCP<TrilinosSparseSpaceType::GraphType> graph_second = Teuchos::rcp(new TrilinosSparseSpaceType::GraphType(matrix_1->getRowMap(), matrix_1->getRowMap(), size));
-    for (LO i = 0; i < static_cast<LO>(matrix_1->getNodeNumRows()); ++i) {
+    for (LO i = 0; i < static_cast<LO>(matrix_1->getLocalNumRows()); ++i) {
         const GO global_row = matrix_1->getRowMap()->getGlobalElement(i);
         std::vector<GO> indices(size);
         for (int j = 0; j < size; ++j) indices[j] = j;
@@ -282,7 +282,7 @@ KRATOS_TEST_CASE_IN_SUITE(TrilinosExperimentalBDBtProductOperation, KratosTrilin
     using LO = TrilinosSparseSpaceType::LO;
     using GO = TrilinosSparseSpaceType::GO;
     Teuchos::RCP<TrilinosSparseSpaceType::GraphType> p_graph_mult = Teuchos::rcp(new TrilinosSparseSpaceType::GraphType(matrix_1->getRowMap(), matrix_1->getRowMap(), size));
-    for (LO i = 0; i < static_cast<LO>(matrix_1->getNodeNumRows()); ++i) {
+    for (LO i = 0; i < static_cast<LO>(matrix_1->getLocalNumRows()); ++i) {
         const GO global_row = matrix_1->getRowMap()->getGlobalElement(i);
         std::vector<GO> indices(size);
         for (int j = 0; j < size; ++j) indices[j] = j;
@@ -301,7 +301,7 @@ KRATOS_TEST_CASE_IN_SUITE(TrilinosExperimentalBDBtProductOperation, KratosTrilin
 
     // Non zero matrix
     Teuchos::RCP<TrilinosSparseSpaceType::GraphType> graph_second = Teuchos::rcp(new TrilinosSparseSpaceType::GraphType(matrix_1->getRowMap(), matrix_1->getRowMap(), size));
-    for (LO i = 0; i < static_cast<LO>(matrix_1->getNodeNumRows()); ++i) {
+    for (LO i = 0; i < static_cast<LO>(matrix_1->getLocalNumRows()); ++i) {
         const GO global_row = matrix_1->getRowMap()->getGlobalElement(i);
         std::vector<GO> indices(size);
         for (int j = 0; j < size; ++j) indices[j] = j;
@@ -723,7 +723,7 @@ KRATOS_TEST_CASE_IN_SUITE(TrilinosExperimentalMultMatrixMatrix, KratosTrilinosAp
     using LO = TrilinosSparseSpaceType::LO;
     using GO = TrilinosSparseSpaceType::GO;
     Teuchos::RCP<TrilinosSparseSpaceType::GraphType> p_graph_mult = Teuchos::rcp(new TrilinosSparseSpaceType::GraphType(matrix_1->getRowMap(), matrix_1->getRowMap(), size));
-    for (LO i = 0; i < static_cast<LO>(matrix_1->getNodeNumRows()); ++i) {
+    for (LO i = 0; i < static_cast<LO>(matrix_1->getLocalNumRows()); ++i) {
         const GO global_row = matrix_1->getRowMap()->getGlobalElement(i);
         std::vector<GO> indices(size);
         for (int j = 0; j < size; ++j) indices[j] = j;
@@ -776,7 +776,7 @@ KRATOS_TEST_CASE_IN_SUITE(TrilinosExperimentalBtDBProductOperationRealCase, Krat
     using LO = TrilinosSparseSpaceType::LO;
     using GO = TrilinosSparseSpaceType::GO;
     Teuchos::RCP<TrilinosSparseSpaceType::GraphType> p_graph_aux = Teuchos::rcp(new TrilinosSparseSpaceType::GraphType(A->getRowMap(), A->getRowMap(), size));
-    for (LO i = 0; i < static_cast<LO>(A->getNodeNumRows()); ++i) {
+    for (LO i = 0; i < static_cast<LO>(A->getLocalNumRows()); ++i) {
         const GO global_row = A->getRowMap()->getGlobalElement(i);
         std::vector<GO> indices(size);
         for (int j = 0; j < size; ++j) indices[j] = j;
@@ -799,7 +799,7 @@ KRATOS_TEST_CASE_IN_SUITE(TrilinosExperimentalBtDBProductOperationRealCase, Krat
     // Compute T^T A T
     // We create a result matrix with enough capacity
     Teuchos::RCP<TrilinosSparseSpaceType::GraphType> p_graph_res = Teuchos::rcp(new TrilinosSparseSpaceType::GraphType(A->getRowMap(), A->getRowMap(), size));
-    for (LO i = 0; i < static_cast<LO>(A->getNodeNumRows()); ++i) {
+    for (LO i = 0; i < static_cast<LO>(A->getLocalNumRows()); ++i) {
         const GO global_row = A->getRowMap()->getGlobalElement(i);
         std::vector<GO> indices(size);
         for (int j = 0; j < size; ++j) indices[j] = j;
@@ -1446,7 +1446,7 @@ KRATOS_TEST_CASE_IN_SUITE(TrilinosExperimentalCreateImport, KratosTrilinosApplic
     KRATOS_EXPECT_NE(nullptr, p_import.get());
 
     // The target map must contain exactly the local dof equation ids
-    KRATOS_EXPECT_EQ(static_cast<int>(p_import->getTargetMap()->getNodeNumElements()), local_size);
+    KRATOS_EXPECT_EQ(static_cast<int>(p_import->getTargetMap()->getLocalNumElements()), local_size);
 
     // Use the import to gather Dx values locally and verify correctness
     Tpetra::MultiVector<TrilinosSparseSpaceType::ST, LO, GO, TrilinosSparseSpaceType::NT>
@@ -1569,9 +1569,9 @@ KRATOS_TEST_CASE_IN_SUITE(TrilinosExperimentalGetOrCreateMap, KratosTrilinosAppl
     auto p_map = TrilinosSparseSpaceType::GetOrCreateMap(tpetra_comm, local_size, first_my_id);
 
     KRATOS_EXPECT_NE(p_map, Teuchos::null);
-    KRATOS_EXPECT_EQ(static_cast<int>(p_map->getNodeNumElements()), local_size);
+    KRATOS_EXPECT_EQ(static_cast<int>(p_map->getLocalNumElements()), local_size);
     // Check that global IDs for this rank start at first_my_id
-    auto node_elements = p_map->getNodeElementList();
+    auto node_elements = p_map->getLocalElementList();
     KRATOS_EXPECT_EQ(static_cast<int>(node_elements[0]), first_my_id);
     KRATOS_EXPECT_EQ(static_cast<int>(node_elements[1]), first_my_id + 1);
 }

--- a/applications/TrilinosApplication/tests/cpp_tests/trilinos_cpp_test_experimental_utilities.cpp
+++ b/applications/TrilinosApplication/tests/cpp_tests/trilinos_cpp_test_experimental_utilities.cpp
@@ -60,8 +60,8 @@ TrilinosCPPTestExperimentalUtilities::MatrixPointerType TrilinosCPPTestExperimen
     // Begin graph assembly
     graph->resumeFill();
 
-    const int NumMyElements = map->getNodeNumElements();
-    auto MyGlobalElements = map->getNodeElementList();
+    const int NumMyElements = map->getLocalNumElements();
+    auto MyGlobalElements = map->getLocalElementList();
     std::vector<GO> nonDiagonalIndices(2); // Define based on your Tpetra types
 
     for (int i = 0; i < NumMyElements; ++i) {
@@ -156,10 +156,10 @@ TrilinosCPPTestExperimentalUtilities::VectorPointerType TrilinosCPPTestExperimen
     Teuchos::RCP<const MapType> map = Teuchos::rcp(new MapType(NumGlobalElements, 0, tpetra_comm));
 
     // Local number of rows
-    const std::size_t NumMyElements = map->getNodeNumElements();
+    const std::size_t NumMyElements = map->getLocalNumElements();
 
     // Get update list
-    auto MyGlobalElements = map->getNodeElementList();
+    auto MyGlobalElements = map->getLocalElementList();
 
     // Create a Tpetra_Vector
     Teuchos::RCP<Tpetra::FEMultiVector<>> b = Teuchos::rcp(new Tpetra::FEMultiVector<>(map, Teuchos::null, 1));
@@ -346,7 +346,7 @@ void TrilinosCPPTestExperimentalUtilities::GenerateSparseMatrixIndexAndValuesVec
     }
 
     std::vector<double> values;
-    for (std::size_t i = 0; i < rA.getNodeNumRows(); i++) {
+    for (std::size_t i = 0; i < rA.getLocalNumRows(); i++) {
         typename TrilinosSparseSpaceType::MatrixType::values_host_view_type vals;   // Row non-zero values
         typename TrilinosSparseSpaceType::MatrixType::local_inds_host_view_type cols;      // Column indices of row non-zero values
         rA.getLocalRowView(i, cols, vals);
@@ -413,10 +413,10 @@ TrilinosCPPTestExperimentalUtilities::MatrixPointerType TrilinosCPPTestExperimen
     }
 
     // Local number of rows
-    const int NumMyElements = map->getNodeNumElements();
+    const int NumMyElements = map->getLocalNumElements();
 
     // Get update list
-    auto MyGlobalElements = map->getNodeElementList();
+    auto MyGlobalElements = map->getLocalElementList();
 
     // Create an integer vector NumNz that is used to build the Tpetra Matrix.
     const int size_global_vector = rRowIndexes.size();

--- a/applications/TrilinosApplication/trilinos_space_experimental.h
+++ b/applications/TrilinosApplication/trilinos_space_experimental.h
@@ -403,7 +403,7 @@ public:
         // Reproduce the sparsity pattern through a new FECrsGraph
         const auto p_row_map = rMatrix.getRowMap();
         const auto p_col_map = rMatrix.getColMap();
-        const LO num_local_rows = static_cast<LO>(rMatrix.getNodeNumRows());
+        const LO num_local_rows = static_cast<LO>(rMatrix.getLocalNumRows());
 
         // Compute max entries per row to size the FE graph allocation.
         // (FECrsGraph accepts a scalar maxNumEntriesPerRow, not a per-row array.)
@@ -705,7 +705,7 @@ public:
         if (!rC.isFillActive()) rC.resumeFill();
         auto p_fe_rC = dynamic_cast<MatrixType*>(&rC);
         if (p_fe_rC) p_fe_rC->beginAssembly();
-        for (LO i = 0; i < static_cast<LO>(aux_C->getNodeNumRows()); ++i) {
+        for (LO i = 0; i < static_cast<LO>(aux_C->getLocalNumRows()); ++i) {
             const auto global_row_index = aux_C->getRowMap()->getGlobalElement(i);
             typename MatrixType::local_inds_host_view_type local_cols;
             typename MatrixType::values_host_view_type vals;
@@ -771,7 +771,7 @@ public:
         if (!rC.isFillActive()) rC.resumeFill();
         auto p_fe_rC = dynamic_cast<MatrixType*>(&rC);
         if (p_fe_rC) p_fe_rC->beginAssembly();
-        for (LO i = 0; i < static_cast<LO>(aux_C->getNodeNumRows()); ++i) {
+        for (LO i = 0; i < static_cast<LO>(aux_C->getLocalNumRows()); ++i) {
             const auto global_row_index = aux_C->getRowMap()->getGlobalElement(i);
             typename MatrixType::local_inds_host_view_type local_cols;
             typename MatrixType::values_host_view_type vals;
@@ -818,7 +818,7 @@ public:
 
         auto build_fe_from_crs = [&](const CrsMatrixType& rSrc) {
             std::size_t max_entries_per_row = 0;
-            for (LO i = 0; i < static_cast<LO>(rSrc.getNodeNumRows()); ++i) {
+            for (LO i = 0; i < static_cast<LO>(rSrc.getLocalNumRows()); ++i) {
                 typename MatrixType::local_inds_host_view_type local_cols;
                 typename MatrixType::values_host_view_type vals;
                 rSrc.getLocalRowView(i, local_cols, vals);
@@ -828,7 +828,7 @@ public:
             Teuchos::RCP<GraphType> p_graph = Teuchos::rcp(new GraphType(
                 rSrc.getRowMap(), rSrc.getColMap(), max_entries_per_row));
             p_graph->beginAssembly();
-            for (LO i = 0; i < static_cast<LO>(rSrc.getNodeNumRows()); ++i) {
+            for (LO i = 0; i < static_cast<LO>(rSrc.getLocalNumRows()); ++i) {
                 const auto global_row_index = rSrc.getRowMap()->getGlobalElement(i);
                 typename MatrixType::local_inds_host_view_type local_cols;
                 typename MatrixType::values_host_view_type vals;
@@ -846,7 +846,7 @@ public:
             auto p_matrix = Teuchos::rcp(new MatrixType(Teuchos::rcp_const_cast<const GraphType>(p_graph)));
             if (p_matrix->isFillActive()) p_matrix->fillComplete();
             p_matrix->beginAssembly();
-            for (LO i = 0; i < static_cast<LO>(rSrc.getNodeNumRows()); ++i) {
+            for (LO i = 0; i < static_cast<LO>(rSrc.getLocalNumRows()); ++i) {
                 const auto global_row_index = rSrc.getRowMap()->getGlobalElement(i);
                 typename MatrixType::local_inds_host_view_type local_cols;
                 typename MatrixType::values_host_view_type vals;
@@ -913,7 +913,7 @@ public:
 
         // Preserve existing structure from rD (hard-zero positions) so FE
         // assembly does not shrink the graph to only aux_2 inserted entries.
-        for (LO i = 0; i < static_cast<LO>(rD.getNodeNumRows()); ++i) {
+        for (LO i = 0; i < static_cast<LO>(rD.getLocalNumRows()); ++i) {
             const auto global_row_index = rD.getRowMap()->getGlobalElement(i);
             typename MatrixType::local_inds_host_view_type local_cols_d;
             typename MatrixType::values_host_view_type vals_d;
@@ -930,7 +930,7 @@ public:
 
         // Zero rA before summing: full replacement, not accumulation.
         rA.setAllToScalar(static_cast<ST>(0));
-        for (LO i = 0; i < static_cast<LO>(aux_2->getNodeNumRows()); ++i) {
+        for (LO i = 0; i < static_cast<LO>(aux_2->getLocalNumRows()); ++i) {
             const auto global_row_index = aux_2->getRowMap()->getGlobalElement(i);
             typename MatrixType::local_inds_host_view_type local_cols;
             typename MatrixType::values_host_view_type vals;
@@ -1083,7 +1083,7 @@ public:
         }
         // Zero out rDest before summing to avoid accumulating onto existing values
         rDest.setAllToScalar(static_cast<ST>(0));
-        for (LO i = 0; i < static_cast<LO>(rSrc.getNodeNumRows()); ++i) {
+        for (LO i = 0; i < static_cast<LO>(rSrc.getLocalNumRows()); ++i) {
             const auto global_row_index = rSrc.getRowMap()->getGlobalElement(i);
             typename MatrixType::local_inds_host_view_type local_cols;
             typename MatrixType::values_host_view_type vals;
@@ -1703,7 +1703,7 @@ public:
                     row_values[j] = rLHSContribution(i, j);
                 }
                 const int ierr = rA.sumIntoGlobalValues(globalRow, static_cast<LO>(global_indices.size()), row_values.data(), global_indices.data());
-                // Note: sumIntoGlobalValues might return the number of values successfully summed instead of an error code 0 or -1. 
+                // Note: sumIntoGlobalValues might return the number of values successfully summed instead of an error code 0 or -1.
                 // Epetra returns 0, Tpetra returns the number of values (indices.size()) if successful.
                 KRATOS_ERROR_IF(ierr != static_cast<int>(indices.size())) << "Tpetra failure found" << std::endl;
             }
@@ -2069,7 +2069,7 @@ public:
         // Open the FE graph for insertion (sets fillState_=open)
         graph->beginAssembly();
 
-        const auto numLocalRows = r_row_map->getNodeNumElements();
+        const auto numLocalRows = r_row_map->getLocalNumElements();
 
         // Combine graphs using global indexing
         for (LO i = 0; i < static_cast<LO>(numLocalRows); ++i) {
@@ -2133,7 +2133,7 @@ public:
         }
         rA.setAllToScalar(static_cast<ST>(0));
 
-        for (LO i = 0; i < static_cast<LO>(rB.getNodeNumRows()); ++i) {
+        for (LO i = 0; i < static_cast<LO>(rB.getLocalNumRows()); ++i) {
             const auto global_row_index = rB.getRowMap()->getGlobalElement(i);
             typename MatrixType::local_inds_host_view_type local_cols_b;
             typename MatrixType::values_host_view_type vals;


### PR DESCRIPTION
## **📝 Description**
As in the title. A of Trilinos v14.0.0, the methods `getNodeNumRows`, `getNodeNumElements`, `getNodeElementList` has been deprecated and since Trilinos v16.0.0 these methods have been removed making the Trilinos application non-compilable.

## **🆕 Changelog**
- Fixing the deprecated function calls
