### PR TITLE
[IGA] New non-linear projection algorithm for IGA curves and surfaces (Levenberg Marquardt)

### DIFF
--- a/kratos/geometries/brep_curve_on_surface.h
+++ b/kratos/geometries/brep_curve_on_surface.h
@@ -431,12 +431,23 @@ public:
     {
         CoordinatesArrayType point_global_coordinates;
 
-        return ProjectionNurbsGeometryUtilities::NewtonRaphsonCurve(
+        if (mpCurveOnSurface->pGetCurve()->GetProjectionAlgorithm() == ProjectionAlgorithm::NewtonRaphson) {
+            return ProjectionNurbsGeometryUtilities::NewtonRaphsonCurve(
+                rProjectedPointLocalCoordinates,
+                rPointGlobalCoordinates,
+                point_global_coordinates,
+                *this,
+                20,
+                Tolerance);
+        }
+
+        return ProjectionNurbsGeometryUtilities::LevenbergMarquardtCurve(
             rProjectedPointLocalCoordinates,
             rPointGlobalCoordinates,
             point_global_coordinates,
             *this,
-            20, Tolerance);
+            50,
+            Tolerance);
     }
 
     ///@}

--- a/kratos/geometries/nurbs_curve_geometry.h
+++ b/kratos/geometries/nurbs_curve_geometry.h
@@ -401,7 +401,7 @@ public:
                 20, Tolerance);
         }
 
-        return ProjectionNurbsGeometryUtilities::NewtonRaphsonCurve(
+        return ProjectionNurbsGeometryUtilities::LevenbergMarquardtCurve(
             rProjectedPointLocalCoordinates,
             rPointGlobalCoordinates,
             point_global_coordinates,

--- a/kratos/geometries/nurbs_curve_geometry.h
+++ b/kratos/geometries/nurbs_curve_geometry.h
@@ -64,10 +64,12 @@ public:
     NurbsCurveGeometry(
         const PointsArrayType& rThisPoints,
         const SizeType PolynomialDegree,
-        const Vector& rKnots)
+        const Vector& rKnots,
+        const ProjectionAlgorithm ProjectionAlgorithm = ProjectionAlgorithm::NewtonRaphson)
         : BaseType(rThisPoints, &msGeometryData)
         , mPolynomialDegree(PolynomialDegree)
         , mKnots(rKnots)
+        , mProjectionAlgorithm(ProjectionAlgorithm)
     {
         CheckAndFitKnotVectors();
     }
@@ -77,11 +79,13 @@ public:
         const PointsArrayType& rThisPoints,
         const SizeType PolynomialDegree,
         const Vector& rKnots,
-        const Vector& rWeights)
+        const Vector& rWeights,
+        const ProjectionAlgorithm ProjectionAlgorithm = ProjectionAlgorithm::NewtonRaphson)
         : BaseType(rThisPoints, &msGeometryData)
         , mPolynomialDegree(PolynomialDegree)
         , mKnots(rKnots)
         , mWeights(rWeights)
+        , mProjectionAlgorithm(ProjectionAlgorithm)
     {
         CheckAndFitKnotVectors();
 
@@ -388,12 +392,21 @@ public:
     {
         CoordinatesArrayType point_global_coordinates;
 
+        if (mProjectionAlgorithm == ProjectionAlgorithm::NewtonRaphson) {
+            return ProjectionNurbsGeometryUtilities::NewtonRaphsonCurve(
+                rProjectedPointLocalCoordinates,
+                rPointGlobalCoordinates,
+                point_global_coordinates,
+                *this,
+                20, Tolerance);
+        }
+
         return ProjectionNurbsGeometryUtilities::NewtonRaphsonCurve(
             rProjectedPointLocalCoordinates,
             rPointGlobalCoordinates,
             point_global_coordinates,
             *this,
-            20, Tolerance);
+            50, Tolerance);
     }
 
     ///@}
@@ -449,6 +462,16 @@ public:
             }
         }
         return rResult;
+    }
+
+    void SetProjectionAlgorithm(const ProjectionAlgorithm ProjectionAlgorithm)
+    {
+        mProjectionAlgorithm = ProjectionAlgorithm;
+    }
+
+    ProjectionAlgorithm GetProjectionAlgorithm() const
+    {
+        return mProjectionAlgorithm;
     }
 
     ///@}
@@ -780,6 +803,7 @@ private:
     SizeType mPolynomialDegree;
     Vector mKnots;
     Vector mWeights;
+    ProjectionAlgorithm mProjectionAlgorithm = ProjectionAlgorithm::NewtonRaphson;
 
     ///@}
     ///@name Private Operations

--- a/kratos/geometries/nurbs_curve_on_surface_geometry.h
+++ b/kratos/geometries/nurbs_curve_on_surface_geometry.h
@@ -448,12 +448,23 @@ public:
     {
         CoordinatesArrayType point_global_coordinates;
 
-        return ProjectionNurbsGeometryUtilities::NewtonRaphsonCurve(
+        if (mpNurbsCurve->GetProjectionAlgorithm() == ProjectionAlgorithm::NewtonRaphson) {
+            return ProjectionNurbsGeometryUtilities::NewtonRaphsonCurve(
+                rProjectedPointLocalCoordinates,
+                rPointGlobalCoordinates,
+                point_global_coordinates,
+                *this,
+                20,
+                Tolerance);
+        }
+
+        return ProjectionNurbsGeometryUtilities::LevenbergMarquardtCurve(
             rProjectedPointLocalCoordinates,
             rPointGlobalCoordinates,
             point_global_coordinates,
             *this,
-            20, Tolerance);
+            50,
+            Tolerance);
     }
 
     ///@}

--- a/kratos/geometries/nurbs_surface_geometry.h
+++ b/kratos/geometries/nurbs_surface_geometry.h
@@ -70,12 +70,14 @@ public:
         const SizeType PolynomialDegreeU,
         const SizeType PolynomialDegreeV,
         const Vector& rKnotsU,
-        const Vector& rKnotsV)
+        const Vector& rKnotsV,
+        const ProjectionAlgorithm ProjectionAlgorithm = ProjectionAlgorithm::NewtonRaphson)
         : BaseType(rThisPoints, &msGeometryData)
         , mPolynomialDegreeU(PolynomialDegreeU)
         , mPolynomialDegreeV(PolynomialDegreeV)
         , mKnotsU(rKnotsU)
         , mKnotsV(rKnotsV)
+        , mProjectionAlgorithm(ProjectionAlgorithm)
     {
         CheckAndFitKnotVectors();
         CheckIsRationalOnlyOnce();
@@ -88,13 +90,15 @@ public:
         const SizeType PolynomialDegreeV,
         const Vector& rKnotsU,
         const Vector& rKnotsV,
-        const Vector& rWeights)
+        const Vector& rWeights,
+        const ProjectionAlgorithm ProjectionAlgorithm = ProjectionAlgorithm::NewtonRaphson)
         : BaseType(rThisPoints, &msGeometryData)
         , mPolynomialDegreeU(PolynomialDegreeU)
         , mPolynomialDegreeV(PolynomialDegreeV)
         , mKnotsU(rKnotsU)
         , mKnotsV(rKnotsV)
         , mWeights(rWeights)
+        , mProjectionAlgorithm(ProjectionAlgorithm)
     {
         CheckAndFitKnotVectors();
 
@@ -521,6 +525,16 @@ public:
         rKnotLengthness[2] = 0;
     }
 
+    void SetProjectionAlgorithm(const ProjectionAlgorithm ProjectionAlgorithm)
+    {
+        mProjectionAlgorithm = ProjectionAlgorithm;
+    }
+
+    ProjectionAlgorithm GetProjectionAlgorithm() const
+    {
+        return mProjectionAlgorithm;
+    }
+
     ///@}
     ///@name Integration Info
     ///@{
@@ -793,13 +807,24 @@ public:
     {
         CoordinatesArrayType point_global_coordinates;
 
-        return ProjectionNurbsGeometryUtilities::NewtonRaphsonSurface(
+        if (mProjectionAlgorithm == ProjectionAlgorithm::NewtonRaphson) {
+            return ProjectionNurbsGeometryUtilities::NewtonRaphsonSurface(
+                rProjectedPointLocalCoordinates,
+                rPointGlobalCoordinates,
+                point_global_coordinates,
+                *this,
+                20,
+                Tolerance);
+        }
+
+        return ProjectionNurbsGeometryUtilities::LevenbergMarquardtSurface(
             rProjectedPointLocalCoordinates,
             rPointGlobalCoordinates,
             point_global_coordinates,
             *this,
-            20, Tolerance);
-    }
+            50,
+            Tolerance);
+    }   
 
     /** This method maps from dimension space to working space.
     * @param rResult array_1d<double, 3> with the coordinates in working space
@@ -1001,6 +1026,7 @@ private:
     Vector mKnotsV;
     Vector mWeights;
     bool mIsRational;
+    ProjectionAlgorithm mProjectionAlgorithm = ProjectionAlgorithm::NewtonRaphson;
 
     /// A NurbsSurface may refer to the BrepSurface as geometry parent.
     BaseType* mpGeometryParent = nullptr;

--- a/kratos/input_output/cad_json_input.h
+++ b/kratos/input_output/cad_json_input.h
@@ -88,18 +88,22 @@ class CadJsonInput : public IO
     /// Constructor with path to input file.
     CadJsonInput(
         const std::string& rDataFileName,
-        SizeType EchoLevel = 0)
+        SizeType EchoLevel = 0,
+        ProjectionAlgorithm ProjectionAlgorithmType = ProjectionAlgorithm::NewtonRaphson)
         : mEchoLevel(EchoLevel)
+        , mProjectionAlgorithm(ProjectionAlgorithmType)
     {
-        mCadJsonParameters = ReadParamatersFile(rDataFileName, EchoLevel);
+        mCadJsonParameters = ReadParametersFile(rDataFileName, EchoLevel);
     }
 
     /// Constructor with KratosParameters.
     CadJsonInput(
         Parameters CadJsonParameters,
-        SizeType EchoLevel = 0)
+        SizeType EchoLevel = 0,
+        ProjectionAlgorithm ProjectionAlgorithmType = ProjectionAlgorithm::NewtonRaphson)
         : mCadJsonParameters(CadJsonParameters)
         , mEchoLevel(EchoLevel)
+        , mProjectionAlgorithm(ProjectionAlgorithmType)
     {
     }
 
@@ -113,7 +117,7 @@ class CadJsonInput : public IO
     /// Adds all CAD geometries to the herin provided model_part.
     void ReadModelPart(ModelPart& rModelPart) override
     {
-        ReadGeometryModelPart(mCadJsonParameters, rModelPart, mEchoLevel);
+        ReadGeometryModelPart(mCadJsonParameters, rModelPart, mProjectionAlgorithm, mEchoLevel);
     }
 
     ///@}
@@ -126,12 +130,13 @@ private:
     static void ReadGeometryModelPart(
         const Parameters rCadJsonParameters,
         ModelPart& rModelPart,
+        ProjectionAlgorithm ProjectionAlgorithmType,
         SizeType EchoLevel = 0)
     {
         KRATOS_ERROR_IF_NOT(rCadJsonParameters.Has("breps"))
             << "Missing \"breps\" section" << std::endl;
 
-        ReadBreps(rCadJsonParameters["breps"], rModelPart, EchoLevel);
+        ReadBreps(rCadJsonParameters["breps"], rModelPart, ProjectionAlgorithmType, EchoLevel);
     }
 
     ///@}
@@ -141,40 +146,32 @@ private:
     static void ReadBreps(
         const Parameters rParameters,
         ModelPart& rModelPart,
+        ProjectionAlgorithm ProjectionAlgorithmType,
         SizeType EchoLevel = 0)
     {
-        for (IndexType brep_index = 0; brep_index < rParameters.size(); brep_index++)
-        {
+        for (IndexType brep_index = 0; brep_index < rParameters.size(); brep_index++) {
             KRATOS_INFO_IF("ReadBreps", (EchoLevel > 0))
                 << "Reading Brep \"" << GetIdOrName(rParameters[brep_index])
                 << "\" - faces." << std::endl;
-
-            if (rParameters[brep_index].Has("faces"))
-            {
-                ReadBrepSurfaces(rParameters[brep_index]["faces"], rModelPart, EchoLevel);
+            if (rParameters[brep_index].Has("faces")) {
+                ReadBrepSurfaces(rParameters[brep_index]["faces"], rModelPart, ProjectionAlgorithmType, EchoLevel);
             }
         }
 
-        for (IndexType brep_index = 0; brep_index < rParameters.size(); brep_index++)
-        {
+        for (IndexType brep_index = 0; brep_index < rParameters.size(); brep_index++) {
             KRATOS_INFO_IF("ReadBreps", (EchoLevel > 0))
                 << "Reading Brep \"" << GetIdOrName(rParameters[brep_index])
                 << "\" - edges." << std::endl;
-
-            if (rParameters[brep_index].Has("edges"))
-            {
-                ReadBrepCurveOnSurfaces(rParameters[brep_index]["edges"], rModelPart, EchoLevel);
+            if (rParameters[brep_index].Has("edges")) {
+                ReadBrepCurveOnSurfaces(rParameters[brep_index]["edges"], rModelPart, ProjectionAlgorithmType, EchoLevel);
             }
         }
 
-        for (IndexType brep_index = 0; brep_index < rParameters.size(); brep_index++)
-        {
+        for (IndexType brep_index = 0; brep_index < rParameters.size(); brep_index++) {
             KRATOS_INFO_IF("ReadBreps", (EchoLevel > 0))
                 << "Reading Brep \"" << GetIdOrName(rParameters[brep_index])
                 << "\" - points." << std::endl;
-
-            if (rParameters[brep_index].Has("vertices"))
-            {
+            if (rParameters[brep_index].Has("vertices")) {
                 ReadPointsOnGeometries(rParameters[brep_index]["vertices"], rModelPart, EchoLevel);
             }
         }
@@ -187,6 +184,7 @@ private:
     static void ReadBrepSurfaces(
         const Parameters rParameters,
         ModelPart& rModelPart,
+        ProjectionAlgorithm ProjectionAlgorithmType,
         SizeType EchoLevel = 0)
     {
         KRATOS_ERROR_IF_NOT(rParameters.IsArray())
@@ -195,15 +193,15 @@ private:
         KRATOS_INFO_IF("ReadBrepSurfaces", EchoLevel > 2)
             << "Reading " << rParameters.size() << " BrepSurfaces..." << std::endl;
 
-        for (IndexType brep_surface_i = 0; brep_surface_i < rParameters.size(); ++brep_surface_i)
-        {
-            ReadBrepSurface(rParameters[brep_surface_i], rModelPart, EchoLevel);
+        for (IndexType brep_surface_i = 0; brep_surface_i < rParameters.size(); ++brep_surface_i) {
+            ReadBrepSurface(rParameters[brep_surface_i], rModelPart, ProjectionAlgorithmType, EchoLevel);
         }
     }
 
     static void ReadBrepSurface(
         const Parameters rParameters,
         ModelPart& rModelPart,
+        ProjectionAlgorithm ProjectionAlgorithmType,
         SizeType EchoLevel = 0)
     {
         KRATOS_INFO_IF("ReadBrepSurface", (EchoLevel > 3))
@@ -216,7 +214,7 @@ private:
             << "Missing 'surface' in brep face." << std::endl;
 
         auto p_surface(ReadNurbsSurface<3, TNodeType>(
-            rParameters["surface"], rModelPart, EchoLevel));
+            rParameters["surface"], rModelPart, ProjectionAlgorithmType, EchoLevel));
 
         const bool is_trimmed = (rParameters["surface"].Has("is_trimmed"))
             ? rParameters["surface"]["is_trimmed"].GetBool()
@@ -230,7 +228,7 @@ private:
         {
             BrepCurveOnSurfaceLoopArrayType outer_loops, inner_loops;
             tie(outer_loops, inner_loops) =
-                ReadBoundaryLoops(rParameters["boundary_loops"], p_surface, rModelPart, EchoLevel);
+                ReadBoundaryLoops(rParameters["boundary_loops"], p_surface, rModelPart, ProjectionAlgorithmType, EchoLevel);
 
             auto p_brep_surface =
                 Kratos::make_shared<BrepSurfaceType>(
@@ -244,7 +242,7 @@ private:
 
             SetIdOrName<BrepSurfaceType>(rParameters, p_brep_surface);
 
-            ReadAndAddEmbeddedEdges(p_brep_surface, rParameters, p_surface, rModelPart, EchoLevel);
+            ReadAndAddEmbeddedEdges(p_brep_surface, rParameters, p_surface, rModelPart, ProjectionAlgorithmType, EchoLevel);
 
             rModelPart.AddGeometry(p_brep_surface);
         }
@@ -261,7 +259,7 @@ private:
 
             SetIdOrName<BrepSurfaceType>(rParameters, p_brep_surface);
 
-            ReadAndAddEmbeddedEdges(p_brep_surface, rParameters, p_surface, rModelPart, EchoLevel);
+            ReadAndAddEmbeddedEdges(p_brep_surface, rParameters, p_surface, rModelPart, ProjectionAlgorithmType, EchoLevel);
 
             rModelPart.AddGeometry(p_brep_surface);
         }
@@ -271,12 +269,12 @@ private:
     ///@name Read in Surface Trimming
     ///@{
 
-    static BrepCurveOnSurfaceLoopType
-        ReadTrimmingCurveVector(
-            const Parameters rParameters,
-            typename NurbsSurfaceType::Pointer pNurbsSurface,
-            ModelPart& rModelPart,
-            SizeType EchoLevel = 0)
+    static BrepCurveOnSurfaceLoopType ReadTrimmingCurveVector(
+        const Parameters rParameters,
+        typename NurbsSurfaceType::Pointer pNurbsSurface,
+        ModelPart& rModelPart,
+        ProjectionAlgorithm ProjectionAlgorithmType,
+        SizeType EchoLevel = 0)
     {
         KRATOS_ERROR_IF(rParameters.size() < 1)
             << "Trimming curve list has no element." << std::endl;
@@ -287,18 +285,18 @@ private:
         for (IndexType tc_idx = 0; tc_idx < rParameters.size(); tc_idx++)
         {
             trimming_brep_curve_vector[tc_idx] = ReadTrimmingCurve(
-                rParameters[tc_idx], pNurbsSurface, rModelPart, EchoLevel);
+                rParameters[tc_idx], pNurbsSurface, rModelPart, ProjectionAlgorithmType, EchoLevel);
         }
 
         return trimming_brep_curve_vector;
     }
 
-    static typename BrepCurveOnSurfaceType::Pointer
-        ReadTrimmingCurve(
-            const Parameters rParameters,
-            typename NurbsSurfaceType::Pointer pNurbsSurface,
-            ModelPart& rModelPart,
-            SizeType EchoLevel = 0)
+    static typename BrepCurveOnSurfaceType::Pointer ReadTrimmingCurve(
+        const Parameters rParameters,
+        typename NurbsSurfaceType::Pointer pNurbsSurface,
+        ModelPart& rModelPart,
+        ProjectionAlgorithm ProjectionAlgorithmType,
+        SizeType EchoLevel = 0)
     {
         KRATOS_ERROR_IF_NOT(rParameters.Has("curve_direction"))
             << "Missing 'curve_direction' in nurbs curve" << std::endl;
@@ -308,7 +306,7 @@ private:
             << "Missing 'parameter_curve' in nurbs curve" << std::endl;
 
         auto p_trimming_curve(ReadNurbsCurve<2, TEmbeddedNodeType>(
-            rParameters["parameter_curve"], rModelPart, EchoLevel));
+            rParameters["parameter_curve"], rModelPart, ProjectionAlgorithmType, EchoLevel));
 
         KRATOS_ERROR_IF_NOT(rParameters["parameter_curve"].Has("active_range"))
             << "Missing 'active_range' in parameter_curve, in trimming curve." << std::endl;
@@ -331,6 +329,7 @@ private:
             const Parameters rParameters,
             typename NurbsSurfaceType::Pointer pNurbsSurface,
             ModelPart& rModelPart,
+            ProjectionAlgorithm ProjectionAlgorithmType,
             SizeType EchoLevel = 0)
     {
         BrepCurveOnSurfaceLoopArrayType outer_loops;
@@ -347,7 +346,7 @@ private:
                 << "Missing 'trimming_curves' in boundary loops"
                 << bl_idx << " loop." << std::endl;
             auto trimming_curves(ReadTrimmingCurveVector(
-                rParameters[bl_idx]["trimming_curves"], pNurbsSurface, rModelPart, EchoLevel));
+                rParameters[bl_idx]["trimming_curves"], pNurbsSurface, rModelPart, ProjectionAlgorithmType, EchoLevel));
 
             if (loop_type == "outer")
             {
@@ -374,12 +373,13 @@ private:
             const Parameters rParameters,
             typename NurbsSurfaceType::Pointer pNurbsSurface,
             ModelPart& rModelPart,
+            ProjectionAlgorithm ProjectionAlgorithmType,
             SizeType EchoLevel = 0)
     {
         if (rParameters.Has("embedded_edges")) {
             if (rParameters["embedded_edges"].size() > 0) {
                 BrepCurveOnSurfaceArrayType embedded_edges(ReadTrimmingCurveVector(
-                    rParameters["embedded_edges"], pNurbsSurface, rModelPart, EchoLevel));
+                    rParameters["embedded_edges"], pNurbsSurface, rModelPart, ProjectionAlgorithmType, EchoLevel));
 
                 pBrepSurface->AddEmbeddedEdges(embedded_edges);
             }
@@ -393,6 +393,7 @@ private:
     static void ReadBrepCurveOnSurfaces(
         const Parameters rParameters,
         ModelPart& rModelPart,
+        ProjectionAlgorithm ProjectionAlgorithmType,
         SizeType EchoLevel = 0)
     {
         KRATOS_ERROR_IF_NOT(rParameters.IsArray())
@@ -403,13 +404,14 @@ private:
 
         for (IndexType i = 0; i < rParameters.size(); i++)
         {
-            ReadBrepEdge(rParameters[i], rModelPart, EchoLevel);
+            ReadBrepEdge(rParameters[i], rModelPart, ProjectionAlgorithmType, EchoLevel);
         }
     }
 
     static void ReadBrepEdge(
         const Parameters rParameters,
         ModelPart& rModelPart,
+        ProjectionAlgorithm ProjectionAlgorithmType,
         SizeType EchoLevel = 0)
     {
         KRATOS_ERROR_IF_NOT(HasIdOrName(rParameters))
@@ -419,7 +421,7 @@ private:
         {
             if (rParameters["topology"].size() == 0)
             {
-                ReadBrepCurve(rParameters, rModelPart, EchoLevel);
+                ReadBrepCurve(rParameters, rModelPart, ProjectionAlgorithmType, EchoLevel);
             }
             else if (rParameters["topology"].size() == 1)
             {
@@ -434,6 +436,7 @@ private:
     static void ReadBrepCurve(
         const Parameters rParameters,
         ModelPart& rModelPart,
+        ProjectionAlgorithm ProjectionAlgorithmType,
         SizeType EchoLevel = 0)
     {
         KRATOS_ERROR_IF_NOT(HasIdOrName(rParameters))
@@ -446,7 +449,7 @@ private:
             << "Missing '3d_curve' in brep curve." << std::endl;
 
         auto p_curve = ReadNurbsCurve<3, TNodeType>(
-            rParameters["3d_curve"], rModelPart, EchoLevel);
+            rParameters["3d_curve"], rModelPart, ProjectionAlgorithmType, EchoLevel);
 
         auto p_brep_curve = Kratos::make_shared<BrepCurveType>(p_curve);
 
@@ -630,10 +633,11 @@ private:
     */
     template<int TWorkingSpaceDimension, class TThisNodeType>
     static typename NurbsCurveGeometry<TWorkingSpaceDimension, PointerVector<TThisNodeType>>::Pointer
-        ReadNurbsCurve(
-            const Parameters rParameters,
-            ModelPart& rModelPart,
-            SizeType EchoLevel = 0)
+    ReadNurbsCurve(
+        const Parameters rParameters,
+        ModelPart& rModelPart,
+        ProjectionAlgorithm ProjectionAlgorithmType = ProjectionAlgorithm::NewtonRaphson,
+        SizeType EchoLevel = 0)
     {
         bool is_rational = true;
         if (rParameters.Has("is_rational")) {
@@ -664,18 +668,20 @@ private:
             Vector control_point_weights = ReadControlPointWeightVector(
                 rParameters["control_points"]);
 
-            return Kratos::make_shared<NurbsCurveGeometry<TWorkingSpaceDimension, PointerVector<TThisNodeType>>>(
+           return Kratos::make_shared<NurbsCurveGeometry<TWorkingSpaceDimension, PointerVector<TThisNodeType>>>(
                 NurbsCurveGeometry<TWorkingSpaceDimension, PointerVector<TThisNodeType>>(
                     control_points,
                     polynomial_degree,
                     knot_vector,
-                    control_point_weights));
+                    control_point_weights,
+                    ProjectionAlgorithmType));
         }
         typename NurbsCurveGeometry<TWorkingSpaceDimension, PointerVector<TThisNodeType>>::Pointer p_nurbs_curve(
             new NurbsCurveGeometry<TWorkingSpaceDimension, PointerVector<TThisNodeType>>(
                 control_points,
                 polynomial_degree,
-                knot_vector));
+                knot_vector,
+                ProjectionAlgorithmType));
 
         return p_nurbs_curve;
     }
@@ -702,6 +708,7 @@ private:
         ReadNurbsSurface(
             const Parameters rParameters,
             ModelPart& rModelPart,
+            ProjectionAlgorithm ProjectionAlgorithmType = ProjectionAlgorithm::NewtonRaphson,
             SizeType EchoLevel = 0)
     {
         bool is_rational = true;
@@ -745,7 +752,8 @@ private:
                 q,
                 knot_vector_u,
                 knot_vector_v,
-                control_point_weights);
+                control_point_weights,
+                ProjectionAlgorithmType);
         }
         typename NurbsSurfaceGeometry<TWorkingSpaceDimension, PointerVector<TThisNodeType>>::Pointer p_nurbs_surface(
             new NurbsSurfaceGeometry<TWorkingSpaceDimension, PointerVector<TThisNodeType>>(
@@ -753,7 +761,8 @@ private:
                 p,
                 q,
                 knot_vector_u,
-                knot_vector_v));
+                knot_vector_v,
+                ProjectionAlgorithmType));
 
         return p_nurbs_surface;
     }
@@ -932,7 +941,7 @@ private:
     }
 
     /// Reads in a json formatted file and returns its KratosParameters instance.
-    static Parameters ReadParamatersFile(
+    static Parameters ReadParametersFile(
         const std::string& rDataFileName,
         SizeType EchoLevel = 0)
     {
@@ -944,7 +953,7 @@ private:
         std::ifstream infile(data_file_name);
         KRATOS_ERROR_IF_NOT(infile.good()) << "CAD geometry file: "
             << data_file_name << " cannot be found." << std::endl;
-        KRATOS_INFO_IF("ReadParamatersFile", EchoLevel > 3)
+        KRATOS_INFO_IF("ReadParametersFile", EchoLevel > 3)
             << "Reading file: \"" << data_file_name << "\"" << std::endl;
 
         std::stringstream buffer;
@@ -959,6 +968,7 @@ private:
 
     Parameters mCadJsonParameters;
     int mEchoLevel;
+    ProjectionAlgorithm mProjectionAlgorithm = ProjectionAlgorithm::NewtonRaphson;
 
     ///@}
 }; // Class CadJsonInput

--- a/kratos/modeler/cad_io_modeler.cpp
+++ b/kratos/modeler/cad_io_modeler.cpp
@@ -13,6 +13,7 @@
 #include "cad_io_modeler.h"
 #include "input_output/cad_json_input.h"
 #include "input_output/cad_json_output.h"
+#include "utilities/nurbs_utilities/projection_nurbs_geometry_utilities.h"
 
 
 namespace Kratos
@@ -24,7 +25,9 @@ namespace Kratos
     {
         KRATOS_ERROR_IF_NOT(mParameters.Has("cad_model_part_name"))
             << "Missing \"cad_model_part_name\" in CadIoModeler Parameters." << std::endl;
+
         const std::string cad_model_part_name = mParameters["cad_model_part_name"].GetString();
+
         ModelPart& cad_model_part = mpModel->HasModelPart(cad_model_part_name)
             ? mpModel->GetModelPart(cad_model_part_name)
             : mpModel->CreateModelPart(cad_model_part_name);
@@ -33,10 +36,35 @@ namespace Kratos
             ? mParameters["geometry_file_name"].GetString()
             : "geometry.cad.json";
 
-        KRATOS_INFO_IF("::[CadIoModeler]::", mEchoLevel > 0) << "Importing Cad Model from: " << DataFileName << std::endl;
+        KRATOS_INFO_IF("::[CadIoModeler]::", mEchoLevel > 0)
+            << "Importing Cad Model from: " << DataFileName << std::endl;
+
+        ProjectionAlgorithm projection_algorithm =
+            ProjectionAlgorithm::NewtonRaphson;
+
+        if (mParameters.Has("projection_algorithm")) {
+            const std::string algorithm_name =
+                mParameters["projection_algorithm"].GetString();
+
+            if (algorithm_name == "newton_raphson") {
+                projection_algorithm = ProjectionAlgorithm::NewtonRaphson;
+            } else if (algorithm_name == "levenberg_marquardt") {
+                projection_algorithm = ProjectionAlgorithm::LevenbergMarquardt;
+            } else {
+                KRATOS_ERROR
+                    << "Unknown projection algorithm \""
+                    << algorithm_name
+                    << "\". Available options are:"
+                    << "\n  - newton_raphson"
+                    << "\n  - levenberg_marquardt"
+                    << std::endl;
+            }
+        }
 
         CadJsonInput<Node, Point>(
-            DataFileName, mEchoLevel).ReadModelPart(cad_model_part);
+            DataFileName,
+            mEchoLevel,
+            projection_algorithm).ReadModelPart(cad_model_part);
     }
 
     void CadIoModeler::SetupModelPart()

--- a/kratos/tests/cpp_tests/geometries/test_projection_nurbs_geometry.cpp
+++ b/kratos/tests/cpp_tests/geometries/test_projection_nurbs_geometry.cpp
@@ -117,6 +117,95 @@ typedef Node NodeType;
             points, p, q, knot_vector_u, knot_vector_v, weights);
     }
 
+    NurbsSurfaceGeometry<3, PointerVector<Node>> GenerateReferenceC0HemisphereGeometry(ModelPart& rModelPart)
+    {
+        PointerVector<Node> points;
+
+        points.push_back(rModelPart.CreateNewNode(1, 0.0, 0.25, 0.0));
+        points.push_back(rModelPart.CreateNewNode(2, 0.0, 0.25, 0.0));
+        points.push_back(rModelPart.CreateNewNode(3, 0.0, 0.25, 0.0));
+        points.push_back(rModelPart.CreateNewNode(4, 0.0, 0.25, 0.0));
+        points.push_back(rModelPart.CreateNewNode(5, 0.0, 0.25, 0.0));
+
+        points.push_back(rModelPart.CreateNewNode(6, -0.25, 0.25, 0.0));
+        points.push_back(rModelPart.CreateNewNode(7, -0.25, 0.25, 0.25));
+        points.push_back(rModelPart.CreateNewNode(8, -1.5308084989341915e-17, 0.25, 0.25));
+        points.push_back(rModelPart.CreateNewNode(9, 0.24999999999999994, 0.25, 0.25));
+        points.push_back(rModelPart.CreateNewNode(10, 0.25, 0.25, 3.061616997868383e-17));
+
+        points.push_back(rModelPart.CreateNewNode(11, -0.25, 1.5308084989341915e-17, 0.0));
+        points.push_back(rModelPart.CreateNewNode(12, -0.25, 1.5308084989341915e-17, 0.25));
+        points.push_back(rModelPart.CreateNewNode(13, -1.5308084989341915e-17, 1.5308084989341915e-17, 0.25));
+        points.push_back(rModelPart.CreateNewNode(14, 0.24999999999999994, 1.5308084989341915e-17, 0.25));
+        points.push_back(rModelPart.CreateNewNode(15, 0.25, 1.5308084989341915e-17, 3.061616997868383e-17));
+
+        points.push_back(rModelPart.CreateNewNode(16, -0.25, -0.24999999999999994, 0.0));
+        points.push_back(rModelPart.CreateNewNode(17, -0.25, -0.24999999999999994, 0.25));
+        points.push_back(rModelPart.CreateNewNode(18, -1.5308084989341915e-17, -0.24999999999999994, 0.25));
+        points.push_back(rModelPart.CreateNewNode(19, 0.24999999999999994, -0.24999999999999994, 0.25));
+        points.push_back(rModelPart.CreateNewNode(20, 0.25, -0.24999999999999994, 3.061616997868383e-17));
+
+        points.push_back(rModelPart.CreateNewNode(21, 0.0, -0.25, 0.0));
+        points.push_back(rModelPart.CreateNewNode(22, 0.0, -0.25, 0.0));
+        points.push_back(rModelPart.CreateNewNode(23, 0.0, -0.25, 0.0));
+        points.push_back(rModelPart.CreateNewNode(24, 0.0, -0.25, 0.0));
+        points.push_back(rModelPart.CreateNewNode(25, 0.0, -0.25, 0.0));
+
+        Vector knot_vector_u = ZeroVector(8);
+        knot_vector_u[0] = 0.0;
+        knot_vector_u[1] = 0.0;
+        knot_vector_u[2] = 0.0;
+        knot_vector_u[3] = 0.39269908169872414;
+        knot_vector_u[4] = 0.39269908169872414;
+        knot_vector_u[5] = 0.78539816339744828;
+        knot_vector_u[6] = 0.78539816339744828;
+        knot_vector_u[7] = 0.78539816339744828;
+
+        Vector knot_vector_v = knot_vector_u;
+
+        const int p = 2;
+        const int q = 2;
+
+        Vector weights = ZeroVector(25);
+        weights[0] = 1.0;
+        weights[1] = 0.70710678118654757;
+        weights[2] = 1.0;
+        weights[3] = 0.70710678118654757;
+        weights[4] = 1.0;
+
+        weights[5] = 0.70710678118654757;
+        weights[6] = 0.50000000000000011;
+        weights[7] = 0.70710678118654757;
+        weights[8] = 0.50000000000000011;
+        weights[9] = 0.70710678118654757;
+
+        weights[10] = 1.0;
+        weights[11] = 0.70710678118654757;
+        weights[12] = 1.0;
+        weights[13] = 0.70710678118654757;
+        weights[14] = 1.0;
+
+        weights[15] = 0.70710678118654757;
+        weights[16] = 0.50000000000000011;
+        weights[17] = 0.70710678118654757;
+        weights[18] = 0.50000000000000011;
+        weights[19] = 0.70710678118654757;
+
+        weights[20] = 1.0;
+        weights[21] = 0.70710678118654757;
+        weights[22] = 1.0;
+        weights[23] = 0.70710678118654757;
+        weights[24] = 1.0;
+
+        return NurbsSurfaceGeometry<3, PointerVector<Node>>(
+            points,
+            p,
+            q,
+            knot_vector_u,
+            knot_vector_v,
+            weights);
+    }
+
     /// Tests
     KRATOS_TEST_CASE_IN_SUITE(NurbsCurveGeometryProjection2d, KratosCoreNurbsGeometriesFastSuite) {
         auto curve = GenerateReferenceCurveForProjection2d();
@@ -174,6 +263,78 @@ typedef Node NodeType;
         KRATOS_EXPECT_VECTOR_NEAR(projected_point_extreme, projected_point_extreme1, TOLERANCE);
     }
 
+    KRATOS_TEST_CASE_IN_SUITE(NurbsCurveGeometryLevenbergMarquardtProjection2d, KratosCoreNurbsGeometriesFastSuite)
+    {
+        auto curve = GenerateReferenceCurveForProjection2d();
+
+        array_1d<double, 3> point;
+        point[0] = -2.0;
+        point[1] = 1.0;
+        point[2] = 0.0;
+
+        array_1d<double, 3> projected_point = ZeroVector(3);
+
+        // Test 1: Initial guess at the center of the parameter domain
+        array_1d<double, 3> parameter = ZeroVector(3);
+
+        bool is_converged_1 = ProjectionNurbsGeometryUtilities::LevenbergMarquardtCurve(parameter, point, projected_point, curve, 50, 1e-7);
+
+        KRATOS_EXPECT_EQ(is_converged_1, true);
+
+        KRATOS_EXPECT_NEAR(parameter[0],0.099395977882318, TOLERANCE);
+
+        std::vector<double> projected_point_expected_1 = {
+            -0.129744540301921,
+            -0.044240249340891,
+            0.0
+        };
+
+        KRATOS_EXPECT_VECTOR_NEAR(projected_point, projected_point_expected_1, TOLERANCE);
+        
+
+        // Test 2: Initial guess at the left boundary
+        parameter = ZeroVector(3);
+        parameter[0] = curve.DomainInterval().MinParameter();
+
+        bool is_converged_2 = ProjectionNurbsGeometryUtilities::LevenbergMarquardtCurve(parameter, point, projected_point, curve, 50, 1e-7);
+
+        KRATOS_EXPECT_EQ(is_converged_2, true);
+
+        KRATOS_EXPECT_NEAR(parameter[0], -0.788227217287371, TOLERANCE);
+
+        std::vector<double> projected_point_expected_2 = {
+            -4.694701201131293,
+            -3.571229085898834,
+            0.0
+        };
+
+        KRATOS_EXPECT_VECTOR_NEAR(projected_point, projected_point_expected_2, TOLERANCE);
+
+        // Test 3: Projection of a point already located on the curve end
+        array_1d<double, 3> curve_extreme_point{
+            -9.0,
+            -2.0,
+            0.0
+        };
+
+        array_1d<double, 3> projected_point_extreme = ZeroVector(3);
+        array_1d<double, 3> parameter_extreme = ZeroVector(3);
+
+        bool is_converged_3 = ProjectionNurbsGeometryUtilities::LevenbergMarquardtCurve(parameter_extreme, curve_extreme_point, projected_point_extreme, curve, 50, 1e-7);
+
+        KRATOS_EXPECT_EQ(is_converged_3, true);
+
+        KRATOS_EXPECT_NEAR(parameter_extreme[0], -1.0, TOLERANCE);
+
+        array_1d<double, 3> projected_point_expected_3{
+            -9.0,
+            -2.0,
+            0.0
+        };
+
+        KRATOS_EXPECT_VECTOR_NEAR(projected_point_extreme, projected_point_expected_3, TOLERANCE);
+    }
+
     KRATOS_TEST_CASE_IN_SUITE(NurbsSurfaceGeometryProjection3d, KratosCoreNurbsGeometriesFastSuite) {
         auto surface = GenerateReferenceUnrefinedQuarterSphereGeometry();
 
@@ -223,6 +384,80 @@ typedef Node NodeType;
         KRATOS_EXPECT_NEAR(parameter[0], 0.950782, TOLERANCE);
         KRATOS_EXPECT_NEAR(parameter[1], 0.500000, TOLERANCE);
         KRATOS_EXPECT_VECTOR_NEAR(projected_point, projected_point_expected2, TOLERANCE);
+    }
+
+    KRATOS_TEST_CASE_IN_SUITE(NurbsSurfaceGeometryLevenbergMarquardtProjection3d, KratosCoreNurbsGeometriesFastSuite)
+    {
+        auto surface = GenerateReferenceUnrefinedQuarterSphereGeometry();
+
+        array_1d<double, 3> projected_point = ZeroVector(3);
+        array_1d<double, 3> parameter = ZeroVector(3);
+        array_1d<double, 3> point;
+
+        const double lm_tolerance = 1e-5;
+
+        std::vector<double> projected_point_expected1 = {
+            0.043301282246217,
+            -0.043301264160723,
+            0.043301264160723
+        };
+
+        std::vector<double> projected_point_expected2 = {
+            0.074813167561162,
+            -0.003740986465195,
+            0.003740986465195
+        };
+
+        // Projection far from the singularity
+        point[0] = 0.06;
+        point[1] = -0.06;
+        point[2] = 0.06;
+
+        parameter[0] = 0.5;
+        parameter[1] = 0.5;
+
+        bool is_converged_1 = ProjectionNurbsGeometryUtilities::LevenbergMarquardtSurface(parameter, point, projected_point, surface, 100, 1e-6);
+
+        KRATOS_EXPECT_EQ(is_converged_1, true);
+        KRATOS_EXPECT_NEAR(parameter[0], 0.397197796315686, lm_tolerance);
+        KRATOS_EXPECT_NEAR(parameter[1], 0.5, lm_tolerance);
+        KRATOS_EXPECT_VECTOR_NEAR(projected_point, projected_point_expected1, lm_tolerance);
+    }
+
+    KRATOS_TEST_CASE_IN_SUITE(NurbsSurfaceGeometryC0HemisphereProjectionNewtonVsLevenbergMarquardt, KratosCoreNurbsGeometriesFastSuite)
+    {
+        Model current_model;
+        ModelPart& model_part = current_model.CreateModelPart("TestModelPart");
+
+        auto surface = GenerateReferenceC0HemisphereGeometry(model_part);
+
+        array_1d<double, 3> point;
+        point[0] = -0.25029993;
+        point[1] =  0.00097306;
+        point[2] =  0.10123734;
+
+        array_1d<double, 3> projected_point_nr = ZeroVector(3);
+        array_1d<double, 3> projected_point_lm = ZeroVector(3);
+
+        array_1d<double, 3> parameter_nr = ZeroVector(3);
+        array_1d<double, 3> parameter_lm = ZeroVector(3);
+
+        parameter_nr[0] = 0.39269908169872414;
+        parameter_nr[1] = 0.39269908169872414;
+
+        parameter_lm[0] = 0.39269908169872414;
+        parameter_lm[1] = 0.39269908169872414;
+        
+        // Newton-Raphson fails here
+        const bool is_converged_nr = ProjectionNurbsGeometryUtilities::NewtonRaphsonSurface(parameter_nr, point, projected_point_nr, surface, 20, 1e-6);
+        // LevenbergMarquardt works here
+        const bool is_converged_lm = ProjectionNurbsGeometryUtilities::LevenbergMarquardtSurface(parameter_lm, point, projected_point_lm, surface, 50, 1e-6);
+
+        KRATOS_EXPECT_EQ(is_converged_nr, false);
+        KRATOS_EXPECT_EQ(is_converged_lm, true);
+
+        KRATOS_EXPECT_NEAR(parameter_lm[0], 0.1, 1e-5);
+        KRATOS_EXPECT_NEAR(parameter_lm[1], 0.39169908169872414, 1e-5);
     }
 
 } // namespace Testing.

--- a/kratos/utilities/nurbs_utilities/projection_nurbs_geometry_utilities.h
+++ b/kratos/utilities/nurbs_utilities/projection_nurbs_geometry_utilities.h
@@ -24,6 +24,13 @@
 
 namespace Kratos
 {
+
+    enum class ProjectionAlgorithm
+    {
+        NewtonRaphson,
+        LevenbergMarquardt
+    };
+
 template<int TDimension, class TPointType> class NurbsSurfaceGeometry;
 class ProjectionNurbsGeometryUtilities
 {
@@ -117,6 +124,143 @@ public:
         }
 
         // Return false if the Newton-Raphson iterations did not converge
+        return false;
+    }
+
+    /*
+    * @brief Returns the closest-point projection of a point onto a Nurbs curve
+    *        geometry using a Levenberg-Marquardt iterative method.
+    * @param rProjectedPointLocalCoordinates Initial guess for the iterative
+    *        algorithm. This is overwritten by the local coordinate of the
+    *        projected point onto the Nurbs curve geometry.
+    * @param rPointGlobalCoordinates The global coordinates of the point to be
+    *        projected onto the Nurbs curve geometry.
+    * @param rProjectedPointGlobalCoordinates The global coordinates of the
+    *        projected point on the Nurbs curve geometry. This is overwritten
+    *        in case the projection is successful.
+    * @param rGeometry The Nurbs curve geometry onto which the point is to be
+    *        projected.
+    * @param MaxIterations Maximum number of iterations for the
+    *        Levenberg-Marquardt algorithm.
+    * @param Accuracy Accuracy used for the distance, orthogonality, and step-size
+    *        convergence checks.
+    */
+    template <class TPointType>
+    static bool LevenbergMarquardtCurve(
+        CoordinatesArrayType& rProjectedPointLocalCoordinates,
+        const CoordinatesArrayType& rPointGlobalCoordinates,
+        CoordinatesArrayType& rProjectedPointGlobalCoordinates,
+        const Geometry<TPointType>& rGeometry,
+        const int MaxIterations = 30,
+        const double Accuracy = 1e-6)
+    {
+        double lambda = 1e-8;
+        const double lambda_factor = 10.0;
+        const double max_lambda = 1e12;
+
+        bool projection_reset_to_boundary = false;
+
+        for (int i = 0; i < MaxIterations; ++i) {
+
+            // Compute position and first derivative only
+            std::vector<array_1d<double, 3>> derivatives(2);
+
+            rGeometry.GlobalSpaceDerivatives(derivatives, rProjectedPointLocalCoordinates, 1);
+
+            rProjectedPointGlobalCoordinates = derivatives[0];
+
+            const array_1d<double, 3> distance_vector = rProjectedPointGlobalCoordinates - rPointGlobalCoordinates;
+
+            const double distance = norm_2(distance_vector);
+
+            if (distance < Accuracy) {
+                return true;
+            }
+
+            const double tangent_norm = norm_2(derivatives[1]);
+
+            if (tangent_norm < Accuracy) {
+                return false;
+            }
+
+            // Gradient of 1/2 ||C(t)-x||^2
+            const double gradient = inner_prod(derivatives[1], distance_vector);
+
+            const double tangent_cos = std::abs(gradient) / (tangent_norm * distance);
+
+            // Orthogonality condition
+            if (tangent_cos < Accuracy) {
+                return true;
+            }
+
+            // 1D Levenberg-Marquardt system:
+            // (C_t · C_t + lambda) delta_t = - C_t · (C - x)
+            const double a = inner_prod(derivatives[1], derivatives[1]);
+
+            bool step_accepted = false;
+
+            for (int lm_it = 0; lm_it < 10; ++lm_it) {
+
+                const double denominator = a + lambda;
+
+                if (std::abs(denominator) < Accuracy) {
+                    lambda *= lambda_factor;
+                    continue;
+                }
+
+                const double delta_t = -gradient / denominator;
+
+                if (norm_2(delta_t * derivatives[1]) < Accuracy) {
+                    return tangent_cos < Accuracy;
+                }
+
+                CoordinatesArrayType trial_local_coordinates = rProjectedPointLocalCoordinates;
+
+                trial_local_coordinates[0] += delta_t;
+
+                int check = rGeometry.ClosestPointLocalToLocalSpace(
+                    trial_local_coordinates,
+                    trial_local_coordinates);
+
+                if (check == 0) {
+                    if (projection_reset_to_boundary) {
+                        return false;
+                    } else {
+                        projection_reset_to_boundary = true;
+                    }
+                }
+
+                std::vector<array_1d<double, 3>> trial_derivatives(1);
+
+                rGeometry.GlobalSpaceDerivatives(trial_derivatives, trial_local_coordinates, 0);
+
+                const array_1d<double, 3> trial_distance_vector = trial_derivatives[0] - rPointGlobalCoordinates;
+
+                const double trial_distance = norm_2(trial_distance_vector);
+
+                if (trial_distance < distance) {
+                    rProjectedPointLocalCoordinates = trial_local_coordinates;
+                    rProjectedPointGlobalCoordinates = trial_derivatives[0];
+
+                    lambda /= lambda_factor;
+                    lambda = std::max(lambda, 1e-14);
+
+                    step_accepted = true;
+                    break;
+                } else {
+                    lambda *= lambda_factor;
+
+                    if (lambda > max_lambda) {
+                        return false;
+                    }
+                }
+            }
+
+            if (!step_accepted) {
+                return false;
+            }
+        }
+
         return false;
     }
 
@@ -247,6 +391,148 @@ public:
             // and if so clamp them back to their boundaries
             rNurbsSurface.DomainIntervalU().IsInside(rProjectedPointLocalCoordinates[0]);
             rNurbsSurface.DomainIntervalV().IsInside(rProjectedPointLocalCoordinates[1]);
+        }
+
+        return false;
+    }
+
+    /*
+    * @brief Returns the closest-point projection of a point onto a Nurbs surface
+    *        geometry using a Levenberg-Marquardt iterative method.
+    * @param rProjectedPointLocalCoordinates Initial guess for the iterative algorithm.
+    *        This is overwritten by the local coordinates of the projected point
+    *        onto the Nurbs surface geometry.
+    * @param rPointGlobalCoordinates The global coordinates of the point to be
+    *        projected onto the Nurbs surface geometry.
+    * @param rProjectedPointGlobalCoordinates The global coordinates of the
+    *        projected point on the Nurbs surface geometry. This is overwritten
+    *        in case the projection is successful.
+    * @param rNurbsSurface The Nurbs surface geometry onto which the point is
+    *        to be projected.
+    * @param MaxIterations Maximum number of iterations for the
+    *        Levenberg-Marquardt algorithm.
+    * @param Accuracy Accuracy used for the distance, orthogonality, and step-size
+    *        convergence checks.
+    */
+    template <int TDimension, class TPointType>
+    static bool LevenbergMarquardtSurface(
+        CoordinatesArrayType& rProjectedPointLocalCoordinates,
+        const CoordinatesArrayType& rPointGlobalCoordinates,
+        CoordinatesArrayType& rProjectedPointGlobalCoordinates,
+        const NurbsSurfaceGeometry<TDimension, TPointType>& rNurbsSurface,
+        const int MaxIterations = 30,
+        const double Accuracy = 1e-6)
+    {
+        double lambda = 1e-8;
+        const double lambda_factor = 10.0;
+        const double max_lambda = 1e12;
+        // Orthogonality condition
+        const double orthogonality_tolerance = 1e-4;
+
+        for (int i = 0; i < MaxIterations; ++i) {
+
+            // Compute position and first derivatives only
+            std::vector<array_1d<double, 3>> s;
+            rNurbsSurface.GlobalSpaceDerivatives(s, rProjectedPointLocalCoordinates, 1);
+
+            rProjectedPointGlobalCoordinates = s[0];
+
+            const array_1d<double, 3> distance_vector = s[0] - rPointGlobalCoordinates;
+
+            const double distance = norm_2(distance_vector);
+
+            if (distance < Accuracy) {
+                return true;
+            }
+
+            const double norm_su = norm_2(s[1]);
+            const double norm_sv = norm_2(s[2]);
+
+            if (norm_su < Accuracy || norm_sv < Accuracy) {
+                return false;
+            }
+
+            // Gradient of 1/2 ||S(u,v)-x||^2
+            const double g_u = inner_prod(s[1], distance_vector);
+            const double g_v = inner_prod(s[2], distance_vector);
+
+            const double xi_cos = std::abs(g_u) / (norm_su * distance);
+
+            const double eta_cos = std::abs(g_v) / (norm_sv * distance);
+
+            if (xi_cos < orthogonality_tolerance && eta_cos < orthogonality_tolerance) {
+                return true;
+            }
+
+            // Gauss-Newton matrix J^T J with LM damping
+            const double a_00 = inner_prod(s[1], s[1]);
+            const double a_01 = inner_prod(s[1], s[2]);
+            const double a_11 = inner_prod(s[2], s[2]);
+
+            bool step_accepted = false;
+
+            for (int lm_it = 0; lm_it < 10; ++lm_it) {
+
+                const double j_00 = a_00 + lambda;
+                const double j_01 = a_01;
+                const double j_11 = a_11 + lambda;
+
+                const double det_j = j_00 * j_11 - j_01 * j_01;
+
+                if (std::abs(det_j) < Accuracy * (std::abs(j_00 * j_11) + std::abs(j_01 * j_01))) {
+                    lambda *= lambda_factor;
+                    continue;
+                }
+
+                // Solve:
+                // (J^T J + lambda I) d = -g
+                const double d_u =
+                    (-g_u * j_11 + g_v * j_01) / det_j;
+
+                const double d_v =
+                    ( g_u * j_01 - g_v * j_00) / det_j;
+
+                if (norm_2(d_u * s[1] + d_v * s[2]) < Accuracy) {
+                    return xi_cos < orthogonality_tolerance && eta_cos < orthogonality_tolerance;
+                }
+
+                CoordinatesArrayType trial_local_coordinates =
+                    rProjectedPointLocalCoordinates;
+
+                trial_local_coordinates[0] += d_u;
+                trial_local_coordinates[1] += d_v;
+
+                rNurbsSurface.DomainIntervalU().IsInside(trial_local_coordinates[0]);
+                rNurbsSurface.DomainIntervalV().IsInside(trial_local_coordinates[1]);
+
+                std::vector<array_1d<double, 3>> trial_s;
+                rNurbsSurface.GlobalSpaceDerivatives(trial_s, trial_local_coordinates, 0);
+
+                const array_1d<double, 3> trial_distance_vector = trial_s[0] - rPointGlobalCoordinates;
+
+                const double trial_distance = norm_2(trial_distance_vector);
+
+                if (trial_distance < distance) {
+                    rProjectedPointLocalCoordinates = trial_local_coordinates;
+                    rProjectedPointGlobalCoordinates = trial_s[0];
+
+                    lambda /= lambda_factor;
+                    lambda = std::max(lambda, 1e-14);
+
+                    step_accepted = true;
+                    break;
+                } else {
+                    lambda *= lambda_factor;
+
+                    if (lambda > max_lambda) {
+                        return false;
+                    }
+                }
+            }
+
+            if (!step_accepted) {
+                return false;
+            }
         }
 
         return false;


### PR DESCRIPTION
## Description

This PR introduces support for the **Levenberg–Marquardt projection algorithm** for NURBS curve and surface geometries.

Previously, projection operations relied exclusively on the Newton–Raphson algorithm. With this contribution, the projection strategy can be selected at geometry creation time and is propagated through the CAD import pipeline and the corresponding geometry classes.

## Main Changes

* Added `ProjectionAlgorithm::LevenbergMarquardt`.
* Added storage of the selected projection algorithm in:

  * `NurbsCurveGeometry`
  * `NurbsSurfaceGeometry`
* Extended geometry constructors to accept a projection algorithm.
* Added accessors to retrieve the selected projection strategy.
* Propagated the projection algorithm through the CAD JSON import pipeline.
* Updated projection routines to use the projection algorithm associated with the underlying geometry.
* Preserved backward compatibility by keeping `ProjectionAlgorithm::NewtonRaphson` as the default option.

## Validation

As part of this PR, a projection test case based on a geometry with a **$C^0$ parameterization** has been added.

For this example, the Newton–Raphson projection algorithm fails to converge to the correct projection point, whereas the Levenberg–Marquardt algorithm successfully computes the projection. This example highlights the usefulness of having an alternative projection strategy available for geometries that are challenging for Newton-based approaches.

## Backward Compatibility

This PR is fully backward compatible. Existing applications continue to use the Newton–Raphson projection algorithm unless a different projection strategy is explicitly specified.
