### PR TITLE
[MappingApplication] Parallelize mapping matrix construction

### DIFF
--- a/applications/MappingApplication/custom_utilities/mapping_matrix_utilities.cpp
+++ b/applications/MappingApplication/custom_utilities/mapping_matrix_utilities.cpp
@@ -50,39 +50,43 @@ void ConstructMatrixStructure(Kratos::unique_ptr<typename MappingSparseSpaceType
                               const SizeType NumNodesDestination)
 {
     // one set for each row storing the corresponding col-IDs
-    std::vector<std::unordered_set<IndexType> > indices(NumNodesDestination);
+    using indices_type = std::vector<std::unordered_set<IndexType>>;
+    indices_type indices(NumNodesDestination);
 
     // preallocate memory for the column indices
-    for (IndexType i=0; i<NumNodesDestination; ++i) {
-        // TODO I guess this can be optimized...
-        // this highly depends on the used mapper => same goes for the Graph in Trilinos
-        indices[i].reserve(3);
+    for (auto& r_indices : indices) {
+        r_indices.reserve(3);
     }
 
-    std::vector<std::vector<std::unordered_set<IndexType>>> thread_indices(
-        ParallelUtilities::GetNumThreads(),
-        std::vector<std::unordered_set<IndexType>>(NumNodesDestination));
+    const auto result = block_for_each<AccumReduction<indices_type>>(
+        rMapperLocalSystems,
+        [NumNodesDestination](auto& rpLocalSys) -> indices_type
+        {
+            indices_type local_indices(NumNodesDestination);
 
-    block_for_each(rMapperLocalSystems, [&](auto& rpLocalSys) {
-        const int thread_id = OpenMPUtils::ThisThread();
+            EquationIdVectorType origin_ids;
+            EquationIdVectorType destination_ids;
 
-        EquationIdVectorType origin_ids;
-        EquationIdVectorType destination_ids;
+            rpLocalSys->EquationIdVectors(origin_ids, destination_ids);
 
-        rpLocalSys->EquationIdVectors(origin_ids, destination_ids);
+            for (const auto id_dest : destination_ids) {
+                auto& r_indices = local_indices[id_dest];
 
-        for (const auto dest_idx : destination_ids) {
-            thread_indices[thread_id][dest_idx].insert(
-                origin_ids.begin(),
-                origin_ids.end());
+                for (const auto id_origin : origin_ids) {
+                    r_indices.insert(id_origin);
+                }
+            }
+
+            return local_indices;
         }
-    });
+    );
 
-    for (auto& r_thread_indices : thread_indices) {
+    for (const auto& r_local_indices : result) {
         for (IndexType i = 0; i < NumNodesDestination; ++i) {
             indices[i].insert(
-                r_thread_indices[i].begin(),
-                r_thread_indices[i].end());
+                r_local_indices[i].begin(),
+                r_local_indices[i].end()
+            );
         }
     }
 

--- a/applications/MappingApplication/custom_utilities/mapping_matrix_utilities.cpp
+++ b/applications/MappingApplication/custom_utilities/mapping_matrix_utilities.cpp
@@ -57,17 +57,20 @@ void ConstructMatrixStructure(Kratos::unique_ptr<typename MappingSparseSpaceType
         indices[i].reserve(3);
     }
 
-    EquationIdVectorType origin_ids;
-    EquationIdVectorType destination_ids;
+    IndexPartition<std::size_t>(rMapperLocalSystems.size()).for_each(
+        [&](std::size_t i) {
+            EquationIdVectorType origin_ids;
+            EquationIdVectorType destination_ids;
 
-    // Looping the local-systems to get the entries for the matrix
-    // TODO omp
-    for (/*const*/auto& r_local_sys : rMapperLocalSystems) { // TODO I think this can be const bcs it is the ptr
-        r_local_sys->EquationIdVectors(origin_ids, destination_ids);
-        for (const auto dest_idx : destination_ids) {
-            indices[dest_idx].insert(origin_ids.begin(), origin_ids.end());
+            auto& r_local_sys = rMapperLocalSystems[i];
+
+            r_local_sys->EquationIdVectors(origin_ids, destination_ids);
+
+            for (const auto dest_idx : destination_ids) {
+                indices[dest_idx].insert(origin_ids.begin(), origin_ids.end());
+            }
         }
-    }
+    );
 
     // computing the number of non-zero entries
     SizeType num_non_zero_entries = 0;
@@ -89,21 +92,24 @@ void ConstructMatrixStructure(Kratos::unique_ptr<typename MappingSparseSpaceType
     for (IndexType i=0; i<NumNodesDestination; ++i) {
         p_matrix_row_indices[i+1] = p_matrix_row_indices[i] + indices[i].size();
     }
+    
+    IndexPartition<IndexType>(NumNodesDestination).for_each(
+        [&](IndexType i) {
+            const IndexType row_begin = p_matrix_row_indices[i];
+            const IndexType row_end = p_matrix_row_indices[i + 1];
 
-    for (IndexType i=0; i<NumNodesDestination; ++i) {
-        const IndexType row_begin = p_matrix_row_indices[i];
-        const IndexType row_end = p_matrix_row_indices[i+1];
-        IndexType j = row_begin;
-        for (const auto index : indices[i]) {
-            p_matrix_col_indices[j] = index;
-            p_matrix_values[j] = 0.0;
-            ++j;
+            IndexType j = row_begin;
+            for (const auto index : indices[i]) {
+                p_matrix_col_indices[j] = index;
+                p_matrix_values[j] = 0.0;
+                ++j;
+            }
+
+            indices[i].clear();
+
+            std::sort(&p_matrix_col_indices[row_begin], &p_matrix_col_indices[row_end]);
         }
-
-        indices[i].clear(); //deallocating the memory // TODO necessary?
-
-        std::sort(&p_matrix_col_indices[row_begin], &p_matrix_col_indices[row_end]);
-    }
+    );  
 
     p_Mdo->set_filled(indices.size()+1, num_non_zero_entries);
 

--- a/applications/MappingApplication/custom_utilities/mapping_matrix_utilities.cpp
+++ b/applications/MappingApplication/custom_utilities/mapping_matrix_utilities.cpp
@@ -22,6 +22,8 @@
 #include "mapping_matrix_utilities.h"
 #include "mappers/mapper_define.h"
 #include "custom_utilities/mapper_utilities.h"
+#include "utilities/parallel_utilities.h"
+#include "utilities/openmp_utils.h"
 
 namespace Kratos {
 
@@ -57,20 +59,32 @@ void ConstructMatrixStructure(Kratos::unique_ptr<typename MappingSparseSpaceType
         indices[i].reserve(3);
     }
 
-    IndexPartition<std::size_t>(rMapperLocalSystems.size()).for_each(
-        [&](std::size_t i) {
-            EquationIdVectorType origin_ids;
-            EquationIdVectorType destination_ids;
+    std::vector<std::vector<std::unordered_set<IndexType>>> thread_indices(
+        ParallelUtilities::GetNumThreads(),
+        std::vector<std::unordered_set<IndexType>>(NumNodesDestination));
 
-            auto& r_local_sys = rMapperLocalSystems[i];
+    block_for_each(rMapperLocalSystems, [&](auto& rpLocalSys) {
+        const int thread_id = OpenMPUtils::ThisThread();
 
-            r_local_sys->EquationIdVectors(origin_ids, destination_ids);
+        EquationIdVectorType origin_ids;
+        EquationIdVectorType destination_ids;
 
-            for (const auto dest_idx : destination_ids) {
-                indices[dest_idx].insert(origin_ids.begin(), origin_ids.end());
-            }
+        rpLocalSys->EquationIdVectors(origin_ids, destination_ids);
+
+        for (const auto dest_idx : destination_ids) {
+            thread_indices[thread_id][dest_idx].insert(
+                origin_ids.begin(),
+                origin_ids.end());
         }
-    );
+    });
+
+    for (auto& r_thread_indices : thread_indices) {
+        for (IndexType i = 0; i < NumNodesDestination; ++i) {
+            indices[i].insert(
+                r_thread_indices[i].begin(),
+                r_thread_indices[i].end());
+        }
+    }
 
     // computing the number of non-zero entries
     SizeType num_non_zero_entries = 0;

--- a/applications/MappingApplication/custom_utilities/mapping_matrix_utilities.cpp
+++ b/applications/MappingApplication/custom_utilities/mapping_matrix_utilities.cpp
@@ -23,7 +23,6 @@
 #include "mappers/mapper_define.h"
 #include "custom_utilities/mapper_utilities.h"
 #include "utilities/parallel_utilities.h"
-#include "utilities/openmp_utils.h"
 
 namespace Kratos {
 

--- a/applications/MappingApplication/custom_utilities/mapping_matrix_utilities.cpp
+++ b/applications/MappingApplication/custom_utilities/mapping_matrix_utilities.cpp
@@ -48,30 +48,34 @@ void ConstructMatrixStructure(Kratos::unique_ptr<typename MappingSparseSpaceType
                               const SizeType NumNodesOrigin,
                               const SizeType NumNodesDestination)
 {
-    // one set for each row storing the corresponding col-IDs
+   // one set for each row storing the corresponding col-IDs
     using indices_type = std::vector<std::unordered_set<IndexType>>;
-    indices_type indices(NumNodesDestination);
 
-    // preallocate memory for the column indices
-    for (auto& r_indices : indices) {
-        r_indices.reserve(3);
-    }
+    struct TLSData
+    {
+        EquationIdVectorType OriginIds;
+        EquationIdVectorType DestinationIds;
+    };
 
     const auto result = block_for_each<AccumReduction<indices_type>>(
-        rMapperLocalSystems,
-        [NumNodesDestination](auto& rpLocalSys) -> indices_type
+        rMapperLocalSystems.begin(),
+        rMapperLocalSystems.end(),
+        TLSData(),
+        [NumNodesDestination](auto& rpLocalSys, TLSData& rTLS) -> indices_type
         {
             indices_type local_indices(NumNodesDestination);
 
-            EquationIdVectorType origin_ids;
-            EquationIdVectorType destination_ids;
+            rTLS.OriginIds.clear();
+            rTLS.DestinationIds.clear();
 
-            rpLocalSys->EquationIdVectors(origin_ids, destination_ids);
+            rpLocalSys->EquationIdVectors(
+                rTLS.OriginIds,
+                rTLS.DestinationIds);
 
-            for (const auto id_dest : destination_ids) {
+            for (const auto id_dest : rTLS.DestinationIds) {
                 auto& r_indices = local_indices[id_dest];
 
-                for (const auto id_origin : origin_ids) {
+                for (const auto id_origin : rTLS.OriginIds) {
                     r_indices.insert(id_origin);
                 }
             }
@@ -80,12 +84,17 @@ void ConstructMatrixStructure(Kratos::unique_ptr<typename MappingSparseSpaceType
         }
     );
 
+    indices_type indices(NumNodesDestination);
+
+    for (auto& r_indices : indices) {
+        r_indices.reserve(3);
+    }
+
     for (const auto& r_local_indices : result) {
         for (IndexType i = 0; i < NumNodesDestination; ++i) {
             indices[i].insert(
                 r_local_indices[i].begin(),
-                r_local_indices[i].end()
-            );
+                r_local_indices[i].end());
         }
     }
 


### PR DESCRIPTION
## Overview

This PR introduces parallelization in the mapping matrix construction procedure to improve mapper initialization performance.

## Changes

- Parallelized matrix connectivity assembly.
- Parallelized non-zero entry counting.
- Parallelized CRS row filling and sorting.

## Thread safety

The implementation is thread-safe since each destination row is assembled by a single mapper local system, ensuring that concurrent writes to the same matrix row do not occur.