### PR TITLE
[GeoMechanicsApplication] Made function parameter names identical

### DIFF
--- a/applications/GeoMechanicsApplication/custom_utilities/constitutive_law_utilities.h
+++ b/applications/GeoMechanicsApplication/custom_utilities/constitutive_law_utilities.h
@@ -74,7 +74,7 @@ public:
     [[nodiscard]] static double CalculateExcessPorePressureIncrement(const Properties& rProperties,
                                                                      double VolumetricStrainIncrement);
 
-    [[nodiscard]] static bool WantTensionCutOff(const Properties& rProperties);
+    [[nodiscard]] static bool WantTensionCutOff(const Properties& rMaterialProperties);
 
 }; /* Class ConstitutiveLawUtilities*/
 


### PR DESCRIPTION
## **📝 Description**
This resolves an issue found by clang-tidy.