### PR TITLE
[TrilinosApplication] Fix `ReadMatrix` and `TrilinosExperimentalSpace` function to use `getLocalNumRows` for local row count

### DIFF
--- a/applications/TrilinosApplication/custom_utilities/trilinos_matrix_market_io.cpp
+++ b/applications/TrilinosApplication/custom_utilities/trilinos_matrix_market_io.cpp
@@ -19,11 +19,14 @@
  * CMakeLists.txt so that it never shares a TU with Kratos' mmio.h.
  */
 
+// System includes
+#include <utility>
+
 // Project includes — must come first so the safe Tpetra headers are seen.
 #include "custom_utilities/trilinos_matrix_market_io.h"
 #include "includes/define.h"
 
-// External includes — the conflicting header, isolated here.
+// External includes
 #include <MatrixMarket_Tpetra.hpp>
 
 namespace Kratos::TpetraMatrixMarketIO
@@ -38,6 +41,51 @@ using CrsMatrix  = Tpetra::CrsMatrix<ST, LO, GO, NT>;
 using FEGraph    = Tpetra::FECrsGraph<LO, GO, NT>;
 using MapType    = Tpetra::Map<LO, GO, NT>;
 
+namespace Detail
+{
+
+/**
+ * @brief Helper function to get the number of local rows in a Tpetra matrix.
+ * @details This function uses SFINAE to select the appropriate method for getting the number of local rows, depending on whether the matrix type has a getLocalNumRows() or getNodeNumRows() method.
+ * @tparam TMatrix The type of the Tpetra matrix.
+ * @param rMatrix The Tpetra matrix.
+ * @return The number of local rows in the matrix.
+ */
+template <class TMatrix>
+auto GetNumLocalRowsImpl(const TMatrix& rMatrix, int)
+    -> decltype(std::declval<const TMatrix&>().getLocalNumRows(), LO{})
+{
+    return static_cast<LO>(rMatrix.getLocalNumRows());
+}
+
+/**
+ * @brief Helper function to get the number of local rows in a Tpetra matrix.
+ * @details This function is called when the matrix type does not have a getLocalNumRows() method, and instead has a getNodeNumRows() method.
+ * @tparam TMatrix The type of the Tpetra matrix.
+ * @param rMatrix The Tpetra matrix.
+ * @return The number of local rows in the matrix.
+ */
+template <class TMatrix>
+LO GetNumLocalRowsImpl(const TMatrix& rMatrix, long)
+{
+    return static_cast<LO>(rMatrix.getNodeNumRows());
+}
+
+/**
+ * @brief Get the number of local rows in a Tpetra matrix.
+ * @details This function dispatches to the appropriate implementation based on the presence of getLocalNumRows() or getNodeNumRows() methods in the matrix type.
+ * @tparam TMatrix The type of the Tpetra matrix.
+ * @param rMatrix The Tpetra matrix.
+ * @return The number of local rows in the matrix.
+ */
+template <class TMatrix>
+LO GetNumLocalRows(const TMatrix& rMatrix)
+{
+    return GetNumLocalRowsImpl(rMatrix, 0);
+}
+
+} // namespace Detail
+
 Teuchos::RCP<FEMatrix> ReadMatrix(
     const std::string& rFileName,
     Comm& rComm)
@@ -49,13 +97,12 @@ Teuchos::RCP<FEMatrix> ReadMatrix(
 
     const auto p_row_map = p_crs->getRowMap();
     const auto p_col_map = p_crs->getColMap();
-    const LO num_local_rows = static_cast<LO>(p_crs->getNodeNumRows());
+    const LO num_local_rows = Detail::GetNumLocalRows(*p_crs);
 
     // Per-row max entry count for the FECrsGraph.
     std::size_t max_entries = 0;
     for (LO i = 0; i < num_local_rows; ++i) {
-        max_entries = std::max(max_entries,
-            static_cast<std::size_t>(p_crs->getNumEntriesInLocalRow(i)));
+        max_entries = std::max(max_entries, static_cast<std::size_t>(p_crs->getNumEntriesInLocalRow(i)));
     }
 
     // Build FECrsGraph mirroring the sparsity pattern.

--- a/applications/TrilinosApplication/tests/cpp_tests/test_trilinos_space_experimental.cpp
+++ b/applications/TrilinosApplication/tests/cpp_tests/test_trilinos_space_experimental.cpp
@@ -1446,7 +1446,7 @@ KRATOS_TEST_CASE_IN_SUITE(TrilinosExperimentalCreateImport, KratosTrilinosApplic
     KRATOS_EXPECT_NE(nullptr, p_import.get());
 
     // The target map must contain exactly the local dof equation ids
-    KRATOS_EXPECT_EQ(static_cast<int>(p_import->getTargetMap()->getNodeNumElements()), local_size);
+    KRATOS_EXPECT_EQ(static_cast<int>(Detail::GetNumLocalElements(*p_import->getTargetMap())), local_size);
 
     // Use the import to gather Dx values locally and verify correctness
     Tpetra::MultiVector<TrilinosSparseSpaceType::ST, LO, GO, TrilinosSparseSpaceType::NT>
@@ -1569,9 +1569,9 @@ KRATOS_TEST_CASE_IN_SUITE(TrilinosExperimentalGetOrCreateMap, KratosTrilinosAppl
     auto p_map = TrilinosSparseSpaceType::GetOrCreateMap(tpetra_comm, local_size, first_my_id);
 
     KRATOS_EXPECT_NE(p_map, Teuchos::null);
-    KRATOS_EXPECT_EQ(static_cast<int>(p_map->getNodeNumElements()), local_size);
+    KRATOS_EXPECT_EQ(static_cast<int>(Detail::GetNumLocalElements(*p_map)), local_size);
     // Check that global IDs for this rank start at first_my_id
-    auto node_elements = p_map->getNodeElementList();
+    auto node_elements = Detail::GetLocalElementList(*p_map);
     KRATOS_EXPECT_EQ(static_cast<int>(node_elements[0]), first_my_id);
     KRATOS_EXPECT_EQ(static_cast<int>(node_elements[1]), first_my_id + 1);
 }

--- a/applications/TrilinosApplication/tests/cpp_tests/test_trilinos_space_experimental.cpp
+++ b/applications/TrilinosApplication/tests/cpp_tests/test_trilinos_space_experimental.cpp
@@ -198,7 +198,7 @@ KRATOS_TEST_CASE_IN_SUITE(TrilinosExperimentalTransposeMultMatrixMatrix, KratosT
     using LO = TrilinosSparseSpaceType::LO;
     using GO = TrilinosSparseSpaceType::GO;
     Teuchos::RCP<TrilinosSparseSpaceType::GraphType> p_graph_mult = Teuchos::rcp(new TrilinosSparseSpaceType::GraphType(matrix_1->getRowMap(), matrix_1->getRowMap(), size));
-    for (LO i = 0; i < static_cast<LO>(matrix_1->getNodeNumRows()); ++i) {
+    for (LO i = 0; i < Detail::GetNumLocalRows(*matrix_1); ++i) {
         const GO global_row = matrix_1->getRowMap()->getGlobalElement(i);
         std::vector<GO> indices(size);
         for (int j = 0; j < size; ++j) indices[j] = j;
@@ -232,7 +232,7 @@ KRATOS_TEST_CASE_IN_SUITE(TrilinosExperimentalBtDBProductOperation, KratosTrilin
     using LO = TrilinosSparseSpaceType::LO;
     using GO = TrilinosSparseSpaceType::GO;
     Teuchos::RCP<TrilinosSparseSpaceType::GraphType> p_graph_mult = Teuchos::rcp(new TrilinosSparseSpaceType::GraphType(matrix_1->getRowMap(), matrix_1->getRowMap(), size));
-    for (LO i = 0; i < static_cast<LO>(matrix_1->getNodeNumRows()); ++i) {
+    for (LO i = 0; i < Detail::GetNumLocalRows(*matrix_1); ++i) {
         const GO global_row = matrix_1->getRowMap()->getGlobalElement(i);
         std::vector<GO> indices(size);
         for (int j = 0; j < size; ++j) indices[j] = j;
@@ -251,7 +251,7 @@ KRATOS_TEST_CASE_IN_SUITE(TrilinosExperimentalBtDBProductOperation, KratosTrilin
 
     // Non zero matrix
     Teuchos::RCP<TrilinosSparseSpaceType::GraphType> graph_second = Teuchos::rcp(new TrilinosSparseSpaceType::GraphType(matrix_1->getRowMap(), matrix_1->getRowMap(), size));
-    for (LO i = 0; i < static_cast<LO>(matrix_1->getNodeNumRows()); ++i) {
+    for (LO i = 0; i < Detail::GetNumLocalRows(*matrix_1); ++i) {
         const GO global_row = matrix_1->getRowMap()->getGlobalElement(i);
         std::vector<GO> indices(size);
         for (int j = 0; j < size; ++j) indices[j] = j;
@@ -282,7 +282,7 @@ KRATOS_TEST_CASE_IN_SUITE(TrilinosExperimentalBDBtProductOperation, KratosTrilin
     using LO = TrilinosSparseSpaceType::LO;
     using GO = TrilinosSparseSpaceType::GO;
     Teuchos::RCP<TrilinosSparseSpaceType::GraphType> p_graph_mult = Teuchos::rcp(new TrilinosSparseSpaceType::GraphType(matrix_1->getRowMap(), matrix_1->getRowMap(), size));
-    for (LO i = 0; i < static_cast<LO>(matrix_1->getNodeNumRows()); ++i) {
+    for (LO i = 0; i < Detail::GetNumLocalRows(*matrix_1); ++i) {
         const GO global_row = matrix_1->getRowMap()->getGlobalElement(i);
         std::vector<GO> indices(size);
         for (int j = 0; j < size; ++j) indices[j] = j;
@@ -301,7 +301,7 @@ KRATOS_TEST_CASE_IN_SUITE(TrilinosExperimentalBDBtProductOperation, KratosTrilin
 
     // Non zero matrix
     Teuchos::RCP<TrilinosSparseSpaceType::GraphType> graph_second = Teuchos::rcp(new TrilinosSparseSpaceType::GraphType(matrix_1->getRowMap(), matrix_1->getRowMap(), size));
-    for (LO i = 0; i < static_cast<LO>(matrix_1->getNodeNumRows()); ++i) {
+    for (LO i = 0; i < Detail::GetNumLocalRows(*matrix_1); ++i) {
         const GO global_row = matrix_1->getRowMap()->getGlobalElement(i);
         std::vector<GO> indices(size);
         for (int j = 0; j < size; ++j) indices[j] = j;
@@ -723,7 +723,7 @@ KRATOS_TEST_CASE_IN_SUITE(TrilinosExperimentalMultMatrixMatrix, KratosTrilinosAp
     using LO = TrilinosSparseSpaceType::LO;
     using GO = TrilinosSparseSpaceType::GO;
     Teuchos::RCP<TrilinosSparseSpaceType::GraphType> p_graph_mult = Teuchos::rcp(new TrilinosSparseSpaceType::GraphType(matrix_1->getRowMap(), matrix_1->getRowMap(), size));
-    for (LO i = 0; i < static_cast<LO>(matrix_1->getNodeNumRows()); ++i) {
+    for (LO i = 0; i < Detail::GetNumLocalRows(*matrix_1); ++i) {
         const GO global_row = matrix_1->getRowMap()->getGlobalElement(i);
         std::vector<GO> indices(size);
         for (int j = 0; j < size; ++j) indices[j] = j;
@@ -776,7 +776,7 @@ KRATOS_TEST_CASE_IN_SUITE(TrilinosExperimentalBtDBProductOperationRealCase, Krat
     using LO = TrilinosSparseSpaceType::LO;
     using GO = TrilinosSparseSpaceType::GO;
     Teuchos::RCP<TrilinosSparseSpaceType::GraphType> p_graph_aux = Teuchos::rcp(new TrilinosSparseSpaceType::GraphType(A->getRowMap(), A->getRowMap(), size));
-    for (LO i = 0; i < static_cast<LO>(A->getNodeNumRows()); ++i) {
+    for (LO i = 0; i < Detail::GetNumLocalRows(*A); ++i) {
         const GO global_row = A->getRowMap()->getGlobalElement(i);
         std::vector<GO> indices(size);
         for (int j = 0; j < size; ++j) indices[j] = j;
@@ -799,7 +799,7 @@ KRATOS_TEST_CASE_IN_SUITE(TrilinosExperimentalBtDBProductOperationRealCase, Krat
     // Compute T^T A T
     // We create a result matrix with enough capacity
     Teuchos::RCP<TrilinosSparseSpaceType::GraphType> p_graph_res = Teuchos::rcp(new TrilinosSparseSpaceType::GraphType(A->getRowMap(), A->getRowMap(), size));
-    for (LO i = 0; i < static_cast<LO>(A->getNodeNumRows()); ++i) {
+    for (LO i = 0; i < Detail::GetNumLocalRows(*A); ++i) {
         const GO global_row = A->getRowMap()->getGlobalElement(i);
         std::vector<GO> indices(size);
         for (int j = 0; j < size; ++j) indices[j] = j;

--- a/applications/TrilinosApplication/tests/cpp_tests/trilinos_cpp_test_experimental_utilities.cpp
+++ b/applications/TrilinosApplication/tests/cpp_tests/trilinos_cpp_test_experimental_utilities.cpp
@@ -346,7 +346,7 @@ void TrilinosCPPTestExperimentalUtilities::GenerateSparseMatrixIndexAndValuesVec
     }
 
     std::vector<double> values;
-    for (std::size_t i = 0; i < Detail::GetNumLocalRows(rA); i++) {
+    for (int i = 0; i < Detail::GetNumLocalRows(rA); i++) {
         typename TrilinosSparseSpaceType::MatrixType::values_host_view_type vals;   // Row non-zero values
         typename TrilinosSparseSpaceType::MatrixType::local_inds_host_view_type cols;      // Column indices of row non-zero values
         rA.getLocalRowView(i, cols, vals);

--- a/applications/TrilinosApplication/tests/cpp_tests/trilinos_cpp_test_experimental_utilities.cpp
+++ b/applications/TrilinosApplication/tests/cpp_tests/trilinos_cpp_test_experimental_utilities.cpp
@@ -60,28 +60,28 @@ TrilinosCPPTestExperimentalUtilities::MatrixPointerType TrilinosCPPTestExperimen
     // Begin graph assembly
     graph->resumeFill();
 
-    const int NumMyElements = map->getNodeNumElements();
-    auto MyGlobalElements = map->getNodeElementList();
+    const int num_my_elements = Detail::GetNumLocalElements(*map);
+    auto my_global_elements = Detail::GetLocalElementList(*map);
     std::vector<GO> nonDiagonalIndices(2); // Define based on your Tpetra types
 
-    for (int i = 0; i < NumMyElements; ++i) {
+    for (int i = 0; i < num_my_elements; ++i) {
         // Non-diagonal values
         if (AddNoDiagonalValues) {
-            if (MyGlobalElements[i] == 0) {
+            if (my_global_elements[i] == 0) {
                 nonDiagonalIndices[0] = 1;
-                graph->insertGlobalIndices(MyGlobalElements[i], Teuchos::ArrayView<const GO>(&nonDiagonalIndices[0], 1));
-            } else if (MyGlobalElements[i] == NumGlobalElements - 1) {
+                graph->insertGlobalIndices(my_global_elements[i], Teuchos::ArrayView<const GO>(&nonDiagonalIndices[0], 1));
+            } else if (my_global_elements[i] == NumGlobalElements - 1) {
                 nonDiagonalIndices[0] = NumGlobalElements - 2;
-                graph->insertGlobalIndices(MyGlobalElements[i], Teuchos::ArrayView<const GO>(&nonDiagonalIndices[0], 1));
+                graph->insertGlobalIndices(my_global_elements[i], Teuchos::ArrayView<const GO>(&nonDiagonalIndices[0], 1));
             } else {
-                nonDiagonalIndices[0] = MyGlobalElements[i] - 1;
-                nonDiagonalIndices[1] = MyGlobalElements[i] + 1;
-                graph->insertGlobalIndices(MyGlobalElements[i], Teuchos::ArrayView<const GO>(nonDiagonalIndices.data(), 2));
+                nonDiagonalIndices[0] = my_global_elements[i] - 1;
+                nonDiagonalIndices[1] = my_global_elements[i] + 1;
+                graph->insertGlobalIndices(my_global_elements[i], Teuchos::ArrayView<const GO>(nonDiagonalIndices.data(), 2));
             }
         }
 
         // Insert diagonal entry
-        graph->insertGlobalIndices(MyGlobalElements[i], Teuchos::ArrayView<const GO>(&MyGlobalElements[i], 1));
+        graph->insertGlobalIndices(my_global_elements[i], Teuchos::ArrayView<const GO>(&my_global_elements[i], 1));
     }
 
     // End graph assembly
@@ -97,25 +97,25 @@ TrilinosCPPTestExperimentalUtilities::MatrixPointerType TrilinosCPPTestExperimen
     // Begin matrix assembly
     A->beginAssembly();
 
-    for (int i = 0; i < NumMyElements; ++i) {
+    for (int i = 0; i < num_my_elements; ++i) {
         // Non-diagonal values
         if (AddNoDiagonalValues) {
-            if (MyGlobalElements[i] == 0) {
+            if (my_global_elements[i] == 0) {
                 nonDiagonalIndices[0] = 1;
-                A->replaceGlobalValues(MyGlobalElements[i], Teuchos::ArrayView<const GO>(&nonDiagonalIndices[0], 1), Teuchos::ArrayView<const double>(&nonDiagonalValues[0], 1));
-            } else if (MyGlobalElements[i] == NumGlobalElements - 1) {
+                A->replaceGlobalValues(my_global_elements[i], Teuchos::ArrayView<const GO>(&nonDiagonalIndices[0], 1), Teuchos::ArrayView<const double>(&nonDiagonalValues[0], 1));
+            } else if (my_global_elements[i] == NumGlobalElements - 1) {
                 nonDiagonalIndices[0] = NumGlobalElements - 2;
-                A->replaceGlobalValues(MyGlobalElements[i], Teuchos::ArrayView<const GO>(&nonDiagonalIndices[0], 1), Teuchos::ArrayView<const double>(&nonDiagonalValues[0], 1));
+                A->replaceGlobalValues(my_global_elements[i], Teuchos::ArrayView<const GO>(&nonDiagonalIndices[0], 1), Teuchos::ArrayView<const double>(&nonDiagonalValues[0], 1));
             } else {
-                nonDiagonalIndices[0] = MyGlobalElements[i] - 1;
-                nonDiagonalIndices[1] = MyGlobalElements[i] + 1;
-                A->replaceGlobalValues(MyGlobalElements[i], Teuchos::ArrayView<const GO>(nonDiagonalIndices.data(), 2), Teuchos::ArrayView<const double>(nonDiagonalValues.data(), 2));
+                nonDiagonalIndices[0] = my_global_elements[i] - 1;
+                nonDiagonalIndices[1] = my_global_elements[i] + 1;
+                A->replaceGlobalValues(my_global_elements[i], Teuchos::ArrayView<const GO>(nonDiagonalIndices.data(), 2), Teuchos::ArrayView<const double>(nonDiagonalValues.data(), 2));
             }
         }
 
         // Insert diagonal entry
-        value = Offset + static_cast<double>(MyGlobalElements[i]);
-        A->replaceGlobalValues(MyGlobalElements[i], Teuchos::ArrayView<const GO>(&MyGlobalElements[i], 1), Teuchos::ArrayView<const double>(&value, 1));
+        value = Offset + static_cast<double>(my_global_elements[i]);
+        A->replaceGlobalValues(my_global_elements[i], Teuchos::ArrayView<const GO>(&my_global_elements[i], 1), Teuchos::ArrayView<const double>(&value, 1));
     }
 
     // End matrix assembly
@@ -156,18 +156,18 @@ TrilinosCPPTestExperimentalUtilities::VectorPointerType TrilinosCPPTestExperimen
     Teuchos::RCP<const MapType> map = Teuchos::rcp(new MapType(NumGlobalElements, 0, tpetra_comm));
 
     // Local number of rows
-    const std::size_t NumMyElements = map->getNodeNumElements();
+    const std::size_t num_my_elements = Detail::GetNumLocalElements(*map);
 
     // Get update list
-    auto MyGlobalElements = map->getNodeElementList();
+    auto my_global_elements = Detail::GetLocalElementList(*map);
 
     // Create a Tpetra_Vector
     Teuchos::RCP<Tpetra::FEMultiVector<>> b = Teuchos::rcp(new Tpetra::FEMultiVector<>(map, Teuchos::null, 1));
 
     // Fill the vector with values
     double value;
-    for (std::size_t i = 0; i < NumMyElements; ++i) {
-        value = Offset + static_cast<double>(MyGlobalElements[i]);
+    for (std::size_t i = 0; i < num_my_elements; ++i) {
+        value = Offset + static_cast<double>(my_global_elements[i]);
         b->replaceLocalValue(i, size_t(0), value);
     }
 
@@ -413,17 +413,17 @@ TrilinosCPPTestExperimentalUtilities::MatrixPointerType TrilinosCPPTestExperimen
     }
 
     // Local number of rows
-    const int NumMyElements = map->getNodeNumElements();
+    const int num_my_elements = Detail::GetNumLocalElements(*map);
 
     // Get update list
-    auto MyGlobalElements = map->getNodeElementList();
+    auto my_global_elements = Detail::GetLocalElementList(*map);
 
     // Create an integer vector NumNz that is used to build the Tpetra Matrix.
     const int size_global_vector = rRowIndexes.size();
-    std::vector<size_t> NumNz(NumMyElements, 0);
+    std::vector<size_t> NumNz(num_my_elements, 0);
     int current_row_index;
     for (current_row_index = 0; current_row_index < size_global_vector; ++current_row_index) {
-        if (MyGlobalElements[0] == rRowIndexes[current_row_index]) {
+        if (my_global_elements[0] == rRowIndexes[current_row_index]) {
             break;
         }
     }
@@ -431,8 +431,8 @@ TrilinosCPPTestExperimentalUtilities::MatrixPointerType TrilinosCPPTestExperimen
     std::size_t nnz = 0;
     GO initial_index, end_index;
     std::unordered_map<int, std::pair<int, int>> initial_and_end_index;
-    for (int i = 0; i < NumMyElements; i++) {
-        if (MyGlobalElements[i] == rRowIndexes[current_row_index]) {
+    for (int i = 0; i < num_my_elements; i++) {
+        if (my_global_elements[i] == rRowIndexes[current_row_index]) {
             initial_index = current_row_index;
             const int start_index = current_row_index;
             for (current_row_index = start_index; current_row_index < size_global_vector; ++current_row_index) {
@@ -455,7 +455,7 @@ TrilinosCPPTestExperimentalUtilities::MatrixPointerType TrilinosCPPTestExperimen
     Teuchos::RCP<GraphType> graph = Teuchos::rcp(new GraphType(map, map, NumNzMax));
 
     // Build the graph
-    for (int i = 0; i < NumMyElements; ++i) {
+    for (int i = 0; i < num_my_elements; ++i) {
         auto it_find = initial_and_end_index.find(i);
         if (it_find != initial_and_end_index.end()) {
             const auto& r_pair = it_find->second;
@@ -463,7 +463,7 @@ TrilinosCPPTestExperimentalUtilities::MatrixPointerType TrilinosCPPTestExperimen
             end_index = r_pair.second;
             std::vector<GO> indexes(rColumnIndexes.begin() + initial_index, rColumnIndexes.begin() + end_index);
             // Insert global indices into the graph
-            graph->insertGlobalIndices(MyGlobalElements[i], Teuchos::ArrayView<const GO>(indexes));
+            graph->insertGlobalIndices(my_global_elements[i], Teuchos::ArrayView<const GO>(indexes));
         }
     }
 
@@ -475,7 +475,7 @@ TrilinosCPPTestExperimentalUtilities::MatrixPointerType TrilinosCPPTestExperimen
     // Begin matrix assembly
     A->beginAssembly();
     // Set the matrix values
-    for (int i = 0; i < NumMyElements; ++i) {
+    for (int i = 0; i < num_my_elements; ++i) {
         auto it_find = initial_and_end_index.find(i);
         if (it_find != initial_and_end_index.end()) {
             const auto& r_pair = it_find->second;
@@ -483,7 +483,7 @@ TrilinosCPPTestExperimentalUtilities::MatrixPointerType TrilinosCPPTestExperimen
             end_index = r_pair.second;
             std::vector<GO> indexes(rColumnIndexes.begin() + initial_index, rColumnIndexes.begin() + end_index);
             std::vector<double> values(rValues.begin() + initial_index, rValues.begin() + end_index);
-            A->replaceGlobalValues(MyGlobalElements[i], Teuchos::ArrayView<const GO>(indexes), Teuchos::ArrayView<const double>(values));
+            A->replaceGlobalValues(my_global_elements[i], Teuchos::ArrayView<const GO>(indexes), Teuchos::ArrayView<const double>(values));
         }
     }
 

--- a/applications/TrilinosApplication/tests/cpp_tests/trilinos_cpp_test_experimental_utilities.cpp
+++ b/applications/TrilinosApplication/tests/cpp_tests/trilinos_cpp_test_experimental_utilities.cpp
@@ -346,7 +346,7 @@ void TrilinosCPPTestExperimentalUtilities::GenerateSparseMatrixIndexAndValuesVec
     }
 
     std::vector<double> values;
-    for (std::size_t i = 0; i < rA.getNodeNumRows(); i++) {
+    for (std::size_t i = 0; i < Detail::GetNumLocalRows(rA); i++) {
         typename TrilinosSparseSpaceType::MatrixType::values_host_view_type vals;   // Row non-zero values
         typename TrilinosSparseSpaceType::MatrixType::local_inds_host_view_type cols;      // Column indices of row non-zero values
         rA.getLocalRowView(i, cols, vals);

--- a/applications/TrilinosApplication/trilinos_space_experimental.h
+++ b/applications/TrilinosApplication/trilinos_space_experimental.h
@@ -2138,10 +2138,10 @@ public:
         // Open the FE graph for insertion (sets fillState_=open)
         graph->beginAssembly();
 
-        const auto numLocalRows = r_row_map->getNodeNumElements();
+        const auto number_of_local_rows = Detail::GetNumLocalElements(*r_row_map);
 
         // Combine graphs using global indexing
-        for (LO i = 0; i < static_cast<LO>(numLocalRows); ++i) {
+        for (LO i = 0; i < static_cast<LO>(number_of_local_rows); ++i) {
             const auto global_row_index = r_row_map->getGlobalElement(i);
             std::set<GO> combined_indices;
 

--- a/applications/TrilinosApplication/trilinos_space_experimental.h
+++ b/applications/TrilinosApplication/trilinos_space_experimental.h
@@ -61,6 +61,33 @@ namespace Kratos
 ///@{
 
 ///@}
+
+/// @cond
+namespace Detail {
+
+/// Prefer getLocalNumRows (Trilinos >= 13); fall back to deprecated getNodeNumRows.
+template <class TMatrix>
+auto GetNumLocalRowsImpl(const TMatrix& rMatrix, int)
+    -> decltype(rMatrix.getLocalNumRows(), typename TMatrix::local_ordinal_type{})
+{
+    return static_cast<typename TMatrix::local_ordinal_type>(rMatrix.getLocalNumRows());
+}
+
+template <class TMatrix>
+typename TMatrix::local_ordinal_type GetNumLocalRowsImpl(const TMatrix& rMatrix, long)
+{
+    return static_cast<typename TMatrix::local_ordinal_type>(rMatrix.getNodeNumRows());
+}
+
+template <class TMatrix>
+typename TMatrix::local_ordinal_type GetNumLocalRows(const TMatrix& rMatrix)
+{
+    return GetNumLocalRowsImpl(rMatrix, 0);
+}
+
+} // namespace Detail
+/// @endcond
+
 ///@name Kratos Classes
 ///@{
 
@@ -403,7 +430,7 @@ public:
         // Reproduce the sparsity pattern through a new FECrsGraph
         const auto p_row_map = rMatrix.getRowMap();
         const auto p_col_map = rMatrix.getColMap();
-        const LO num_local_rows = static_cast<LO>(rMatrix.getNodeNumRows());
+        const LO num_local_rows = Detail::GetNumLocalRows(rMatrix);
 
         // Compute max entries per row to size the FE graph allocation.
         // (FECrsGraph accepts a scalar maxNumEntriesPerRow, not a per-row array.)
@@ -705,7 +732,7 @@ public:
         if (!rC.isFillActive()) rC.resumeFill();
         auto p_fe_rC = dynamic_cast<MatrixType*>(&rC);
         if (p_fe_rC) p_fe_rC->beginAssembly();
-        for (LO i = 0; i < static_cast<LO>(aux_C->getNodeNumRows()); ++i) {
+        for (LO i = 0; i < Detail::GetNumLocalRows(*aux_C); ++i) {
             const auto global_row_index = aux_C->getRowMap()->getGlobalElement(i);
             typename MatrixType::local_inds_host_view_type local_cols;
             typename MatrixType::values_host_view_type vals;
@@ -771,7 +798,7 @@ public:
         if (!rC.isFillActive()) rC.resumeFill();
         auto p_fe_rC = dynamic_cast<MatrixType*>(&rC);
         if (p_fe_rC) p_fe_rC->beginAssembly();
-        for (LO i = 0; i < static_cast<LO>(aux_C->getNodeNumRows()); ++i) {
+        for (LO i = 0; i < Detail::GetNumLocalRows(*aux_C); ++i) {
             const auto global_row_index = aux_C->getRowMap()->getGlobalElement(i);
             typename MatrixType::local_inds_host_view_type local_cols;
             typename MatrixType::values_host_view_type vals;
@@ -818,7 +845,7 @@ public:
 
         auto build_fe_from_crs = [&](const CrsMatrixType& rSrc) {
             std::size_t max_entries_per_row = 0;
-            for (LO i = 0; i < static_cast<LO>(rSrc.getNodeNumRows()); ++i) {
+            for (LO i = 0; i < Detail::GetNumLocalRows(rSrc); ++i) {
                 typename MatrixType::local_inds_host_view_type local_cols;
                 typename MatrixType::values_host_view_type vals;
                 rSrc.getLocalRowView(i, local_cols, vals);
@@ -828,7 +855,7 @@ public:
             Teuchos::RCP<GraphType> p_graph = Teuchos::rcp(new GraphType(
                 rSrc.getRowMap(), rSrc.getColMap(), max_entries_per_row));
             p_graph->beginAssembly();
-            for (LO i = 0; i < static_cast<LO>(rSrc.getNodeNumRows()); ++i) {
+            for (LO i = 0; i < Detail::GetNumLocalRows(rSrc); ++i) {
                 const auto global_row_index = rSrc.getRowMap()->getGlobalElement(i);
                 typename MatrixType::local_inds_host_view_type local_cols;
                 typename MatrixType::values_host_view_type vals;
@@ -846,7 +873,7 @@ public:
             auto p_matrix = Teuchos::rcp(new MatrixType(Teuchos::rcp_const_cast<const GraphType>(p_graph)));
             if (p_matrix->isFillActive()) p_matrix->fillComplete();
             p_matrix->beginAssembly();
-            for (LO i = 0; i < static_cast<LO>(rSrc.getNodeNumRows()); ++i) {
+            for (LO i = 0; i < Detail::GetNumLocalRows(rSrc); ++i) {
                 const auto global_row_index = rSrc.getRowMap()->getGlobalElement(i);
                 typename MatrixType::local_inds_host_view_type local_cols;
                 typename MatrixType::values_host_view_type vals;
@@ -913,7 +940,7 @@ public:
 
         // Preserve existing structure from rD (hard-zero positions) so FE
         // assembly does not shrink the graph to only aux_2 inserted entries.
-        for (LO i = 0; i < static_cast<LO>(rD.getNodeNumRows()); ++i) {
+        for (LO i = 0; i < Detail::GetNumLocalRows(rD); ++i) {
             const auto global_row_index = rD.getRowMap()->getGlobalElement(i);
             typename MatrixType::local_inds_host_view_type local_cols_d;
             typename MatrixType::values_host_view_type vals_d;
@@ -930,7 +957,7 @@ public:
 
         // Zero rA before summing: full replacement, not accumulation.
         rA.setAllToScalar(static_cast<ST>(0));
-        for (LO i = 0; i < static_cast<LO>(aux_2->getNodeNumRows()); ++i) {
+        for (LO i = 0; i < Detail::GetNumLocalRows(*aux_2); ++i) {
             const auto global_row_index = aux_2->getRowMap()->getGlobalElement(i);
             typename MatrixType::local_inds_host_view_type local_cols;
             typename MatrixType::values_host_view_type vals;
@@ -1083,7 +1110,7 @@ public:
         }
         // Zero out rDest before summing to avoid accumulating onto existing values
         rDest.setAllToScalar(static_cast<ST>(0));
-        for (LO i = 0; i < static_cast<LO>(rSrc.getNodeNumRows()); ++i) {
+        for (LO i = 0; i < Detail::GetNumLocalRows(rSrc); ++i) {
             const auto global_row_index = rSrc.getRowMap()->getGlobalElement(i);
             typename MatrixType::local_inds_host_view_type local_cols;
             typename MatrixType::values_host_view_type vals;
@@ -2133,7 +2160,7 @@ public:
         }
         rA.setAllToScalar(static_cast<ST>(0));
 
-        for (LO i = 0; i < static_cast<LO>(rB.getNodeNumRows()); ++i) {
+        for (LO i = 0; i < Detail::GetNumLocalRows(rB); ++i) {
             const auto global_row_index = rB.getRowMap()->getGlobalElement(i);
             typename MatrixType::local_inds_host_view_type local_cols_b;
             typename MatrixType::values_host_view_type vals;

--- a/applications/TrilinosApplication/trilinos_space_experimental.h
+++ b/applications/TrilinosApplication/trilinos_space_experimental.h
@@ -85,6 +85,48 @@ typename TMatrix::local_ordinal_type GetNumLocalRows(const TMatrix& rMatrix)
     return GetNumLocalRowsImpl(rMatrix, 0);
 }
 
+/// Prefer getLocalNumElements (Trilinos >= 13); fall back to deprecated getNodeNumElements.
+template <class TMap>
+auto GetNumLocalElementsImpl(const TMap& rMap, int)
+    -> decltype(rMap.getLocalNumElements(), typename TMap::local_ordinal_type{})
+{
+    return static_cast<typename TMap::local_ordinal_type>(rMap.getLocalNumElements());
+}
+
+template <class TMap>
+typename TMap::local_ordinal_type GetNumLocalElementsImpl(const TMap& rMap, long)
+{
+    return static_cast<typename TMap::local_ordinal_type>(rMap.getNodeNumElements());
+}
+
+template <class TMap>
+typename TMap::local_ordinal_type GetNumLocalElements(const TMap& rMap)
+{
+    return GetNumLocalElementsImpl(rMap, 0);
+}
+
+/// Prefer getLocalElementList (Trilinos >= 13); fall back to deprecated getNodeElementList.
+template <class TMap>
+auto GetLocalElementListImpl(const TMap& rMap, int)
+    -> decltype(rMap.getLocalElementList())
+{
+    return rMap.getLocalElementList();
+}
+
+template <class TMap>
+auto GetLocalElementListImpl(const TMap& rMap, long)
+    -> decltype(rMap.getNodeElementList())
+{
+    return rMap.getNodeElementList();
+}
+
+template <class TMap>
+auto GetLocalElementList(const TMap& rMap)
+    -> decltype(GetLocalElementListImpl(rMap, 0))
+{
+    return GetLocalElementListImpl(rMap, 0);
+}
+
 } // namespace Detail
 /// @endcond
 


### PR DESCRIPTION
---
name: ✨ Feature
about: Support Trilinos 16.1+ by adding API probe for row-count method

---

## **📝 Description**

- **Problem**:  Trilinos 16.1 removed the deprecated `getNodeNumRows()` method from `Tpetra::CrsMatrix`.
Builds against Trilinos 16.1+ fail with:
````sh
  error: 'class Tpetra::CrsMatrix<...>' has no member named 'getNodeNumRows';
         did you mean 'getLocalNumRows'?
````

- **Solution**: Implemented a compile-time API probe using `SFINAE` overload resolution to detect which method is available:
  - Tries `getLocalNumRows()` first (Trilinos 16.1+)
  - Falls back to `getNodeNumRows()` (older versions)

This approach requires no version macros and works automatically across all Trilinos versions without user configuration.

### **Key changes**

- Added `Detail::GetNumLocalRows<TMatrix>()` helper that dispatches to the  appropriate implementation at compile time.
- Uses SFINAE overload ranking: `int` parameter prefers the newer API. `long` parameter acts as fallback.
- Single call site updated in `ReadMatrix()` to use the helper.
- Includes appropriate documentation in the helper functions.
- Also applying the same pattern to other deprecated Tpetra calls in trilinos_space_experimental.h if those also fail on Trilinos 16.1.

### **Validation**

- Code now compiles against both Trilinos < 16.1 (with `getNodeNumRows`) and Trilinos 16.1 (with `getLocalNumRows`)
- Functionality remains unchanged; no behavioral differences

## **🆕 Changelog**

- [Fix `ReadMatrix` function to use `getLocalNumRows` for local row count](https://github.com/KratosMultiphysics/Kratos/commit/e2125ee048a72344c14cf0299aebe7442cd93793)
- [Add Detail namespace and `GetNumLocalRows` utility to `TrilinosExperimemntalSpace`](https://github.com/KratosMultiphysics/Kratos/pull/14506/commits/63d0ccb9258da1e0ef4bfaf9d33c1d2dba0c9f20)
