### PR TITLE
[CMake] Adding `/usr/lib/aarch64-linux-gnu/` to `FindTrilinos.cmake`

### DIFF
--- a/cmake_modules/FindTRILINOS.cmake
+++ b/cmake_modules/FindTRILINOS.cmake
@@ -61,6 +61,7 @@ ELSE (TRILINOS_LIBRARY_DIR)
         /usr/local/lib64/
         /usr/local/lib/
         /usr/lib/x86_64-linux-gnu/
+        /usr/lib/aarch64-linux-gnu/
     )
 ENDIF (TRILINOS_LIBRARY_DIR)
 # Include directory
@@ -317,6 +318,7 @@ IF(TPETRA_INCLUDE_PATH AND TPETRA_LIBRARY)
             /usr/lib
             /usr/local/lib/
             /usr/lib/x86_64-linux-gnu/
+            /usr/lib/aarch64-linux-gnu/
         )
     ENDIF (KOKKOS_LIBRARY_DIR)
 
@@ -373,6 +375,7 @@ IF(TPETRA_INCLUDE_PATH AND TPETRA_LIBRARY)
             /usr/lib
             /usr/local/lib/
             /usr/lib/x86_64-linux-gnu/
+            /usr/lib/aarch64-linux-gnu/
         )
     ENDIF (TPETRAEXT_LIBRARY_DIR)
 


### PR DESCRIPTION
---
name: ✨ Feature
about: Adding `/usr/lib/aarch64-linux-gnu/` to `FindTrilinos.cmake`

---

## **📝 Description**

Adding `/usr/lib/aarch64-linux-gnu/` to `FindTrilinos.cmake`

## **🆕 Changelog**

-  [Adding `/usr/lib/aarch64-linux-gnu/` to `FindTrilinos.cmake`](https://github.com/KratosMultiphysics/Kratos/commit/0db06558292043bd5fe53a5f8a25a24d4e01391e)
