### PR TITLE
Geo/use diff order shape functions for mid node Pw

### DIFF
--- a/applications/GeoMechanicsApplication/custom_elements/small_strain_U_Pw_diff_order_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/small_strain_U_Pw_diff_order_element.cpp
@@ -204,7 +204,6 @@ void SmallStrainUPwDiffOrderElement::AssignPressureToIntermediateNodes()
 
     for (auto node = num_p_nodes; node < num_u_nodes; ++node) {
         auto shape_functions_values = Vector(num_p_nodes);
-        KRATOS_INFO("local coords") << row(local_coordinates, node) << std::endl;
         // new object as a 3 long array is expected even for local space dimensions 1 and 2
         auto local_node_coordinate = array_1d<double, 3>{3, 0.0};
         std::ranges::copy(row(local_coordinates, node), local_node_coordinate.begin());

--- a/applications/GeoMechanicsApplication/custom_elements/small_strain_U_Pw_diff_order_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/small_strain_U_Pw_diff_order_element.cpp
@@ -188,192 +188,31 @@ void SmallStrainUPwDiffOrderElement::FinalizeSolutionStep(const ProcessInfo& rCu
     KRATOS_CATCH("")
 }
 
-Vector SmallStrainUPwDiffOrderElement::GetPressures(const size_t n_nodes) const
-{
-    const auto& r_geom = GetGeometry();
-    Vector      pressure(n_nodes);
-    std::transform(r_geom.begin(), r_geom.begin() + static_cast<std::ptrdiff_t>(n_nodes), pressure.begin(),
-                   [](const auto& node) { return node.FastGetSolutionStepValue(WATER_PRESSURE); });
-    return pressure;
-}
-
-void set_arithmetic_average_pressure(Geometry<Node>&                               rGeometry,
-                                     const Vector&                                 rPressure,
-                                     const std::vector<std::pair<size_t, size_t>>& rIndexPpairs,
-                                     size_t DestinationOffset = 0)
-{
-    for (size_t i = 0; const auto& [first_index, second_index] : rIndexPpairs) {
-        NodeUtilities::ThreadSafeNodeWrite(rGeometry[DestinationOffset + i], WATER_PRESSURE,
-                                           0.5 * (rPressure[first_index] + rPressure[second_index]));
-        ++i;
-    }
-}
-
-void set_arithmetic_average_pressure(Geometry<Node>& rGeometry,
-                                     const Vector&   rPressure,
-                                     const std::vector<std::tuple<size_t, size_t, size_t, size_t>>& rIndices,
-                                     size_t DestinationOffset = 0)
-{
-    for (size_t i = 0; const auto& [first_index, second_index, third_index, fourth_index] : rIndices) {
-        NodeUtilities::ThreadSafeNodeWrite(rGeometry[DestinationOffset + i], WATER_PRESSURE,
-                                           0.25 * (rPressure[first_index] + rPressure[second_index] +
-                                                   rPressure[third_index] + rPressure[fourth_index]));
-        ++i;
-    }
-}
-
 void SmallStrainUPwDiffOrderElement::AssignPressureToIntermediateNodes()
 {
     // Assign pressure values to the intermediate nodes for post-processing
     KRATOS_TRY
 
-    GeometryType&  r_geom      = GetGeometry();
-    const SizeType num_u_nodes = r_geom.PointsNumber();
-    const SizeType n_dim       = r_geom.WorkingSpaceDimension();
+    auto&      r_displacement_geometry = GetGeometry();
+    const auto num_u_nodes             = r_displacement_geometry.PointsNumber();
+    const auto num_p_nodes             = mpPressureGeometry->PointsNumber();
 
-    switch (num_u_nodes) {
-    case 6: // 2D T6P3
-    {
-        const Vector                                 pressure = GetPressures(3);
-        const std::vector<std::pair<size_t, size_t>> pairs    = {{0, 1}, {1, 2}, {2, 0}};
-        set_arithmetic_average_pressure(r_geom, pressure, pairs, 3);
-        break;
-    }
-    case 8: // 2D Q8P4
-    {
-        const Vector                                 pressure = GetPressures(4);
-        const std::vector<std::pair<size_t, size_t>> pairs    = {{0, 1}, {1, 2}, {2, 3}, {3, 0}};
-        set_arithmetic_average_pressure(r_geom, pressure, pairs, 4);
-        break;
-    }
-    case 9: // 2D Q9P4
-    {
-        const Vector                                 pressure = GetPressures(4);
-        const std::vector<std::pair<size_t, size_t>> pairs    = {{0, 1}, {1, 2}, {2, 3}, {3, 0}};
-        set_arithmetic_average_pressure(r_geom, pressure, pairs, 4);
-        const std::vector<std::tuple<size_t, size_t, size_t, size_t>>& indices = {{0, 1, 2, 3}};
-        set_arithmetic_average_pressure(r_geom, pressure, indices, 8);
-        break;
-    }
-    case 10: // 3D T10P4  //2D T10P6
-    {
-        if (n_dim == 3) {
-            const Vector                                 pressure = GetPressures(4);
-            const std::vector<std::pair<size_t, size_t>> pairs    = {{0, 1}, {1, 2}, {2, 0},
-                                                                     {0, 3}, {1, 3}, {2, 3}};
-            set_arithmetic_average_pressure(r_geom, pressure, pairs, 4);
-        } else if (n_dim == 2) {
-            constexpr double c1 = 1.0 / 9.0;
-            const Vector     p  = GetPressures(6);
-            NodeUtilities::ThreadSafeNodeWrite(r_geom[3], WATER_PRESSURE,
-                                               (2.0 * p[0] - p[1] + 8.0 * p[3]) * c1);
-            NodeUtilities::ThreadSafeNodeWrite(r_geom[4], WATER_PRESSURE,
-                                               (2.0 * p[1] - p[0] + 8.0 * p[3]) * c1);
-            NodeUtilities::ThreadSafeNodeWrite(r_geom[5], WATER_PRESSURE,
-                                               (2.0 * p[1] - p[2] + 8.0 * p[4]) * c1);
-            NodeUtilities::ThreadSafeNodeWrite(r_geom[6], WATER_PRESSURE,
-                                               (2.0 * p[2] - p[1] + 8.0 * p[4]) * c1);
-            NodeUtilities::ThreadSafeNodeWrite(r_geom[7], WATER_PRESSURE,
-                                               (2.0 * p[2] - p[0] + 8.0 * p[5]) * c1);
-            NodeUtilities::ThreadSafeNodeWrite(r_geom[8], WATER_PRESSURE,
-                                               (2.0 * p[0] - p[2] + 8.0 * p[5]) * c1);
-            NodeUtilities::ThreadSafeNodeWrite(
-                r_geom[9], WATER_PRESSURE, (4.0 * (p[3] + p[4] + p[5]) - (p[0] + p[1] + p[2])) * c1);
-        }
-        break;
-    }
-    case 15: // 2D T15P10
-    {
-        constexpr double c1 = 0.0390625;
-        const Vector     p  = GetPressures(10);
-        NodeUtilities::ThreadSafeNodeWrite(r_geom[3], WATER_PRESSURE,
-                                           (3.0 * p[0] + p[1] + 27.0 * p[3] - 5.4 * p[4]) * c1);
-        NodeUtilities::ThreadSafeNodeWrite(r_geom[4], WATER_PRESSURE,
-                                           (14.4 * (p[3] + p[4]) - 1.6 * (p[0] + p[1])) * c1);
-        NodeUtilities::ThreadSafeNodeWrite(r_geom[5], WATER_PRESSURE,
-                                           (3.0 * p[1] + p[0] + 27.0 * p[4] - 5.4 * p[3]) * c1);
-        NodeUtilities::ThreadSafeNodeWrite(r_geom[6], WATER_PRESSURE,
-                                           (3.0 * p[1] + p[2] + 27.0 * p[5] - 5.4 * p[6]) * c1);
-        NodeUtilities::ThreadSafeNodeWrite(r_geom[7], WATER_PRESSURE,
-                                           (14.4 * (p[5] + p[6]) - 1.6 * (p[1] + p[2])) * c1);
-        NodeUtilities::ThreadSafeNodeWrite(r_geom[8], WATER_PRESSURE,
-                                           (3.0 * p[2] + p[1] + 27.0 * p[6] - 5.4 * p[5]) * c1);
-        NodeUtilities::ThreadSafeNodeWrite(r_geom[9], WATER_PRESSURE,
-                                           (3.0 * p[2] + p[0] + 27.0 * p[7] - 5.4 * p[8]) * c1);
-        NodeUtilities::ThreadSafeNodeWrite(r_geom[10], WATER_PRESSURE,
-                                           (14.4 * (p[7] + p[8]) - 1.6 * (p[0] + p[2])) * c1);
-        NodeUtilities::ThreadSafeNodeWrite(r_geom[11], WATER_PRESSURE,
-                                           (3.0 * p[0] + p[2] + 27.0 * p[8] - 5.4 * p[7]) * c1);
-        NodeUtilities::ThreadSafeNodeWrite(r_geom[12], WATER_PRESSURE,
-                                           (p[1] + p[2] + 7.2 * (p[3] + p[8]) - 3.6 * (p[4] + p[7]) -
-                                            1.8 * (p[5] + p[6]) + 21.6 * p[9] - 1.6 * p[0]) *
-                                               c1);
-        NodeUtilities::ThreadSafeNodeWrite(r_geom[13], WATER_PRESSURE,
-                                           (p[0] + p[2] + 7.2 * (p[4] + p[5]) - 3.6 * (p[3] + p[6]) -
-                                            1.8 * (p[7] + p[8]) + 21.6 * p[9] - 1.6 * p[1]) *
-                                               c1);
-        NodeUtilities::ThreadSafeNodeWrite(r_geom[14], WATER_PRESSURE,
-                                           (p[0] + p[1] + 7.2 * (p[6] + p[7]) - 3.6 * (p[5] + p[8]) -
-                                            1.8 * (p[3] + p[4]) + 21.6 * p[9] - 1.6 * p[2]) *
-                                               c1);
-        break;
-    }
-    case 20: // 3D H20P8
-    {
-        const Vector                                 pressure = GetPressures(8);
-        const std::vector<std::pair<size_t, size_t>> pairs =
-            // edges -- bottom
-            {{0, 1},
-             {1, 2},
-             {2, 3},
-             {3, 0},
-             // edges -- middle
-             {4, 0},
-             {5, 1},
-             {6, 2},
-             {7, 3},
-             // edges -- top
-             {4, 5},
-             {5, 6},
-             {6, 7},
-             {7, 4}};
-        set_arithmetic_average_pressure(r_geom, pressure, pairs, 8);
-        break;
-    }
-    case 27: // 3D H27P8
-    {
-        const Vector                                 pressure = GetPressures(8);
-        const std::vector<std::pair<size_t, size_t>> pairs =
-            // edges -- bottom
-            {{0, 1},
-             {1, 2},
-             {2, 3},
-             {3, 0},
-             // edges -- middle
-             {4, 0},
-             {5, 1},
-             {6, 2},
-             {7, 3},
-             // edges -- top
-             {4, 5},
-             {5, 6},
-             {6, 7},
-             {7, 0}};
-        set_arithmetic_average_pressure(r_geom, pressure, pairs, 8);
-        // face centers
-        const std::vector<std::tuple<size_t, size_t, size_t, size_t>>& indices = {
-            {0, 1, 2, 3}, {0, 1, 4, 5}, {1, 2, 5, 6}, {2, 3, 6, 7}, {3, 0, 7, 4}, {4, 5, 6, 7}};
-        set_arithmetic_average_pressure(r_geom, pressure, indices, 20);
-        // element center
-        NodeUtilities::ThreadSafeNodeWrite(r_geom[26], WATER_PRESSURE,
-                                           0.125 * (pressure[0] + pressure[1] + pressure[2] + pressure[3] +
-                                                    pressure[4] + pressure[5] + pressure[6] + pressure[7]));
-        break;
-    }
-    default:
-        KRATOS_ERROR << "Unexpected geometry type for different order "
-                        "interpolation element"
-                     << this->Id() << std::endl;
+    auto local_coordinates = Matrix{};
+    r_displacement_geometry.PointsLocalCoordinates(local_coordinates);
+    auto corner_pressures = Vector(num_p_nodes);
+    corner_pressures      = GetPressureSolutionVector();
+
+    for (auto node = num_p_nodes; node < num_u_nodes; ++node) {
+        auto shape_functions_values = Vector(num_p_nodes);
+        KRATOS_INFO("local coords") << row(local_coordinates, node) << std::endl;
+        // new object as a 3 long array is expected even for local space dimensions 1 and 2
+        auto local_node_coordinate = array_1d<double, 3>{3, 0.0};
+        std::ranges::copy(row(local_coordinates, node), local_node_coordinate.begin());
+        mpPressureGeometry->ShapeFunctionsValues(shape_functions_values, local_node_coordinate);
+
+        auto mid_node_pressure = std::inner_product(
+            shape_functions_values.begin(), shape_functions_values.end(), corner_pressures.begin(), 0.0);
+        NodeUtilities::ThreadSafeNodeWrite(r_displacement_geometry[node], WATER_PRESSURE, mid_node_pressure);
     }
 
     KRATOS_CATCH("")

--- a/applications/GeoMechanicsApplication/custom_elements/small_strain_U_Pw_diff_order_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/small_strain_U_Pw_diff_order_element.cpp
@@ -37,6 +37,7 @@
 #include "custom_utilities/output_utilities.hpp"
 #include "custom_utilities/stress_strain_utilities.h"
 #include "custom_utilities/transport_equation_utilities.hpp"
+#include "custom_utilities/variables_utilities.hpp"
 #include "geo_mechanics_application_constants.h"
 #include "stress_state_policy.h"
 
@@ -122,8 +123,10 @@ void SmallStrainUPwDiffOrderElement::CalculateMassMatrix(MatrixType& rMassMatrix
         r_geom.IntegrationPoints(integration_method);
     const auto Np_container = mpPressureGeometry->ShapeFunctionsValues(integration_method);
 
-    const auto fluid_pressures = GeoTransportEquationUtilities::CalculateFluidPressures(
-        Np_container, this->GetPressureSolutionVector());
+    Vector corner_pressures(mpPressureGeometry->PointsNumber());
+    VariablesUtilities::GetNodalValues(*mpPressureGeometry, WATER_PRESSURE, corner_pressures.begin());
+    const auto fluid_pressures =
+        GeoTransportEquationUtilities::CalculateFluidPressures(Np_container, corner_pressures);
     const auto degrees_saturation = this->CalculateDegreesOfSaturation(fluid_pressures);
 
     const auto solid_densities =
@@ -199,8 +202,7 @@ void SmallStrainUPwDiffOrderElement::AssignPressureToIntermediateNodes()
 
     auto local_coordinates = Matrix{};
     r_displacement_geometry.PointsLocalCoordinates(local_coordinates);
-    auto corner_pressures = Vector(num_p_nodes);
-    corner_pressures      = GetPressureSolutionVector();
+    const auto corner_pressures = VariablesUtilities::GetNodalValues(*mpPressureGeometry, WATER_PRESSURE);
 
     for (auto node = num_p_nodes; node < num_u_nodes; ++node) {
         auto shape_functions_values = Vector(num_p_nodes);
@@ -209,7 +211,7 @@ void SmallStrainUPwDiffOrderElement::AssignPressureToIntermediateNodes()
         std::ranges::copy(row(local_coordinates, node), local_node_coordinate.begin());
         mpPressureGeometry->ShapeFunctionsValues(shape_functions_values, local_node_coordinate);
 
-        auto mid_node_pressure = std::inner_product(
+        const auto mid_node_pressure = std::inner_product(
             shape_functions_values.begin(), shape_functions_values.end(), corner_pressures.begin(), 0.0);
         NodeUtilities::ThreadSafeNodeWrite(r_displacement_geometry[node], WATER_PRESSURE, mid_node_pressure);
     }
@@ -1462,14 +1464,6 @@ void SmallStrainUPwDiffOrderElement::load(Serializer& rSerializer)
 {
     KRATOS_SERIALIZE_LOAD_BASE_CLASS(rSerializer, UPwBaseElement)
     rSerializer.load("PressureGeometry", mpPressureGeometry);
-}
-
-Vector SmallStrainUPwDiffOrderElement::GetPressureSolutionVector() const
-{
-    Vector result(mpPressureGeometry->PointsNumber());
-    std::transform(mpPressureGeometry->begin(), mpPressureGeometry->end(), result.begin(),
-                   [](const auto& node) { return node.FastGetSolutionStepValue(WATER_PRESSURE); });
-    return result;
 }
 
 void SmallStrainUPwDiffOrderElement::CalculateAnyOfMaterialResponse(

--- a/applications/GeoMechanicsApplication/custom_elements/small_strain_U_Pw_diff_order_element.h
+++ b/applications/GeoMechanicsApplication/custom_elements/small_strain_U_Pw_diff_order_element.h
@@ -224,8 +224,6 @@ protected:
                                         std::vector<Vector>& rStressVectors,
                                         std::vector<Matrix>& rConstitutiveMatrices);
 
-    [[nodiscard]] Vector GetPressureSolutionVector() const;
-
     [[nodiscard]] std::vector<double> CalculateDegreesOfSaturation(const std::vector<double>& rFluidPressures);
     [[nodiscard]] std::vector<double> CalculateDerivativesOfSaturation(const std::vector<double>& rFluidPressures);
     [[nodiscard]] virtual std::vector<double> GetOptionalPermeabilityUpdateFactors(const std::vector<Vector>& rStrainVectors) const;

--- a/applications/GeoMechanicsApplication/custom_elements/small_strain_U_Pw_diff_order_element.h
+++ b/applications/GeoMechanicsApplication/custom_elements/small_strain_U_Pw_diff_order_element.h
@@ -203,8 +203,7 @@ protected:
     std::vector<Matrix> CalculateBMatrices(const GeometryType::ShapeFunctionsGradientsType& rDN_DXContainer,
                                            const Matrix& rNContainer) const;
 
-    Vector GetPressures(size_t n_nodes) const;
-    void   AssignPressureToIntermediateNodes();
+    void AssignPressureToIntermediateNodes();
 
     virtual Vector CalculateGreenLagrangeStrain(const Matrix& rDeformationGradient) const;
 

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_elements/test_small_strain_u_pw_diff_order_element.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_elements/test_small_strain_u_pw_diff_order_element.cpp
@@ -314,4 +314,32 @@ KRATOS_TEST_CASE_IN_SUITE(SmallStrainUPwDiffOrderElement_CalculatesFluidFluxVect
         KRATOS_EXPECT_VECTOR_RELATIVE_NEAR(fluid_flux, expected_fluid_flux, Defaults::relative_tolerance);
 }
 
+KRATOS_TEST_CASE_IN_SUITE(SmallStrainUPwDiffOrderElement_MidNodePressuresAreInterpolatedFromCornerPressures,
+                          KratosGeoMechanicsFastSuiteWithoutKernel)
+{
+    // Arrange
+    auto p_properties = CreatePropertiesForUPwDiffOrderElementTest();
+    auto p_element    = CreateSmallStrainUPwDiffOrderElementWithUPwDofs(p_properties);
+    SetSolutionStepValuesForGeneralCheck(p_element);
+
+    const auto dummy_process_info = ProcessInfo{};
+    p_element->Initialize(dummy_process_info);
+
+    auto& r_geometry = p_element->GetGeometry();
+    for (auto counter = 0; auto& node : r_geometry) {
+        node.FastGetSolutionStepValue(WATER_PRESSURE) = counter * 1.0e5;
+        ++counter;
+    }
+    p_element->Initialize(dummy_process_info);
+    p_element->FinalizeNonLinearIteration(dummy_process_info);
+
+    // Act
+    p_element->FinalizeSolutionStep(dummy_process_info);
+
+    // Assert
+    KRATOS_EXPECT_DOUBLE_EQ(p_element->GetGeometry()[3].FastGetSolutionStepValue(WATER_PRESSURE), 5.0e4);
+    KRATOS_EXPECT_DOUBLE_EQ(p_element->GetGeometry()[4].FastGetSolutionStepValue(WATER_PRESSURE), 1.5e5);
+    KRATOS_EXPECT_DOUBLE_EQ(p_element->GetGeometry()[5].FastGetSolutionStepValue(WATER_PRESSURE), 1.0e5);
+}
+
 } // namespace Kratos::Testing

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_elements/test_small_strain_u_pw_diff_order_element.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_elements/test_small_strain_u_pw_diff_order_element.cpp
@@ -330,8 +330,6 @@ KRATOS_TEST_CASE_IN_SUITE(SmallStrainUPwDiffOrderElement_MidNodePressuresAreInte
         node.FastGetSolutionStepValue(WATER_PRESSURE) = counter * 1.0e5;
         ++counter;
     }
-    p_element->Initialize(dummy_process_info);
-    p_element->FinalizeNonLinearIteration(dummy_process_info);
 
     // Act
     p_element->FinalizeSolutionStep(dummy_process_info);

--- a/kratos/geometries/hexahedra_3d_20.h
+++ b/kratos/geometries/hexahedra_3d_20.h
@@ -494,6 +494,98 @@ public:
     }
 
     /**
+     * Returns a matrix of the local coordinates of all points
+     * @param rResult a Matrix that will be overwritten by the results
+     * @return the coordinates of all points of the current geometry
+     */
+    Matrix& PointsLocalCoordinates( Matrix& rResult ) const override
+    {
+        rResult.resize( 20, 3, false );
+
+        rResult( 0, 0 ) = -1.0;
+        rResult( 0, 1 ) = -1.0;
+        rResult( 0, 2 ) = -1.0;
+
+        rResult( 1, 0 ) =  1.0;
+        rResult( 1, 1 ) = -1.0;
+        rResult( 1, 2 ) = -1.0;
+
+        rResult( 2, 0 ) =  1.0;
+        rResult( 2, 1 ) =  1.0;
+        rResult( 2, 2 ) = -1.0;
+
+        rResult( 3, 0 ) = -1.0;
+        rResult( 3, 1 ) =  1.0;
+        rResult( 3, 2 ) = -1.0;
+
+        rResult( 4, 0 ) = -1.0;
+        rResult( 4, 1 ) = -1.0;
+        rResult( 4, 2 ) =  1.0;
+
+        rResult( 5, 0 ) =  1.0;
+        rResult( 5, 1 ) = -1.0;
+        rResult( 5, 2 ) =  1.0;
+
+        rResult( 6, 0 ) =  1.0;
+        rResult( 6, 1 ) =  1.0;
+        rResult( 6, 2 ) =  1.0;
+
+        rResult( 7, 0 ) = -1.0;
+        rResult( 7, 1 ) =  1.0;
+        rResult( 7, 2 ) =  1.0;
+
+        rResult( 8, 0 ) =  0.0;
+        rResult( 8, 1 ) = -1.0;
+        rResult( 8, 2 ) = -1.0;
+
+        rResult( 9, 0 ) =  1.0;
+        rResult( 9, 1 ) =  0.0;
+        rResult( 9, 2 ) = -1.0;
+
+        rResult( 10, 0 ) =  0.0;
+        rResult( 10, 1 ) =  1.0;
+        rResult( 10, 2 ) = -1.0;
+
+        rResult( 11, 0 ) = -1.0;
+        rResult( 11, 1 ) =  0.0;
+        rResult( 11, 2 ) = -1.0;
+
+        rResult( 12, 0 ) = -1.0;
+        rResult( 12, 1 ) = -1.0;
+        rResult( 12, 2 ) =  0.0;
+
+        rResult( 13, 0 ) =  1.0;
+        rResult( 13, 1 ) = -1.0;
+        rResult( 13, 2 ) =  0.0;
+
+        rResult( 14, 0 ) =  1.0;
+        rResult( 14, 1 ) =  1.0;
+        rResult( 14, 2 ) =  0.0;
+
+        rResult( 15, 0 ) = -1.0;
+        rResult( 15, 1 ) =  1.0;
+        rResult( 15, 2 ) =  0.0;
+
+        rResult( 16, 0 ) =  0.0;
+        rResult( 16, 1 ) = -1.0;
+        rResult( 16, 2 ) =  1.0;
+
+        rResult( 17, 0 ) =  1.0;
+        rResult( 17, 1 ) =  0.0;
+        rResult( 17, 2 ) =  1.0;
+
+        rResult( 18, 0 ) =  0.0;
+        rResult( 18, 1 ) =  1.0;
+        rResult( 18, 2 ) =  1.0;
+
+        rResult( 19, 0 ) = -1.0;
+        rResult( 19, 1 ) =  0.0;
+        rResult( 19, 2 ) =  1.0;
+
+        return rResult;
+    }
+
+    /**
      * @brief Returns whether given arbitrary point is inside the Geometry and the respective
      * local point for the given global point
      * @param rPoint The point to be checked if is inside o note in global coordinates


### PR DESCRIPTION
## **📝 Description**
Use PointsLocalCoordinates of geometries to compute shapefunctions and use these for interpolation of Pw

### **Key changes**
- Replaced interpolation of midnode Pw in small strain diff order element.
- Added unit test

### **Validation**
- in test for small strain diff order element
