### PR TITLE
[CI] Enable action-based workflow filter 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,8 +38,8 @@ jobs:
       ci_build: ${{ steps.filter.outputs.ci_build }}
 
     steps:
-      - uses: actions/checkout@v4
-      - uses: dorny/paths-filter@v3
+      - uses: actions/checkout@v6
+      - uses: dorny/paths-filter@v4
         id: filter
         with:
           filters: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
   job-filters:
     runs-on: ubuntu-latest
     outputs:
-      source: ${{ steps.filter.outputs.source }}
+      ci-build: ${{ steps.filter.outputs.ci-build }}
 
     steps:
       - uses: actions/checkout@v4
@@ -44,7 +44,7 @@ jobs:
         with:
           filters: |
             ci-build:
-              - added|modified|deleted: '**'
+              - '**'
               - '!**/*.md'
               - '!licence.txt'
               - '!docs/**'
@@ -52,7 +52,6 @@ jobs:
   ubuntu:
     runs-on: ubuntu-latest
     needs: [changed-files, job-filters]
-    if: needs.job-filters.outputs.source.ci-build == 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -76,13 +75,18 @@ jobs:
     # - name: Installing dependencies
     # => must be added to the docker container to avoid reinstalling it in every CI run
 
+    - name: Show filter result
+      run: echo "CI BUILD = ${{ needs.job-filters.outputs.ci-build }}"
+
     - name: CI configuration
+      if: needs.job-filters.outputs.ci-build == 'true'
       shell: bash
       run: |
         python3 kratos/python_scripts/testing/ci_utilities.py
         python3 -m pip install --upgrade numpy==1.26.4
 
     - name: Build
+      if: needs.job-filters.outputs.ci-build == 'true'
       shell: bash
       run: |
         if [ ${{ matrix.compiler }} = gcc ]; then
@@ -106,6 +110,7 @@ jobs:
         rm -r ${GITHUB_WORKSPACE}/build
 
     - name: Build Dependencies
+      if: needs.job-filters.outputs.ci-build == 'true'
       shell: bash
       run: |
         if [ ${{ matrix.compiler }} = gcc ]; then
@@ -128,6 +133,7 @@ jobs:
         rm -r ${GITHUB_WORKSPACE}/build
 
     - name: Build Core Apps
+      if: needs.job-filters.outputs.ci-build == 'true'
       shell: bash
       run: |
         if [ ${{ matrix.compiler }} = gcc ]; then
@@ -150,6 +156,7 @@ jobs:
         rm -r ${GITHUB_WORKSPACE}/build
 
     - name: Build Research Apps
+      if: needs.job-filters.outputs.ci-build == 'true'
       shell: bash
       run: |
         if [ ${{ matrix.compiler }} = gcc ]; then
@@ -172,6 +179,7 @@ jobs:
         rm -r ${GITHUB_WORKSPACE}/build
 
     - name: Running C++ tests
+      if: needs.job-filters.outputs.ci-build == 'true'
       shell: bash
       run: |
         if [ ${{ matrix.compiler }} = gcc ]; then
@@ -182,6 +190,7 @@ jobs:
         python3 kratos/python_scripts/testing/run_cpp_tests.py
 
     - name: Running python tests
+      if: needs.job-filters.outputs.ci-build == 'true'
       shell: bash
       run: |
         if [ ${{ matrix.compiler }} = gcc ]; then
@@ -192,11 +201,13 @@ jobs:
         python3 kratos/python_scripts/testing/run_python_tests.py -v 2 -l nightly -c python3
 
     - name: Prepare Parallel Env
+      if: needs.job-filters.outputs.ci-build == 'true'
       shell: bash
       run: |
         echo "localhost slots=2" >> ${GITHUB_WORKSPACE}/ci_hostfile
 
     - name: Running MPI C++ tests (2 Cores)
+      if: needs.job-filters.outputs.ci-build == 'true'
       shell: bash
       timeout-minutes : 10
       run: |
@@ -208,6 +219,7 @@ jobs:
         python3 kratos/python_scripts/testing/run_cpp_mpi_tests.py --mpi_flags "--hostfile ${GITHUB_WORKSPACE}/ci_hostfile" -n 2
 
     - name: Running MPI C++ tests (3 Cores)
+      if: needs.job-filters.outputs.ci-build == 'true'
       shell: bash
       timeout-minutes : 10
       run: |
@@ -219,6 +231,7 @@ jobs:
         python3 kratos/python_scripts/testing/run_cpp_mpi_tests.py --mpi_flags "--hostfile ${GITHUB_WORKSPACE}/ci_hostfile" -n 3
 
     - name: Running MPI C++ tests (4 Cores)
+      if: needs.job-filters.outputs.ci-build == 'true'
       shell: bash
       timeout-minutes : 10
       run: |
@@ -230,6 +243,7 @@ jobs:
         python3 kratos/python_scripts/testing/run_cpp_mpi_tests.py --mpi_flags "--hostfile ${GITHUB_WORKSPACE}/ci_hostfile" -n 4
 
     - name: Running Python MPI tests (2 Cores)
+      if: needs.job-filters.outputs.ci-build == 'true'
       shell: bash
       run: |
         if [ ${{ matrix.compiler }} = gcc ]; then
@@ -241,6 +255,7 @@ jobs:
         python3 kratos/python_scripts/testing/run_python_mpi_tests.py --mpi_flags "--hostfile ${GITHUB_WORKSPACE}/ci_hostfile" -l mpi_nightly -n 2
 
     - name: Running Python MPI tests (3 Cores)
+      if: needs.job-filters.outputs.ci-build == 'true'
       shell: bash
       run: |
         if [ ${{ matrix.compiler }} = gcc ]; then
@@ -252,6 +267,7 @@ jobs:
         python3 kratos/python_scripts/testing/run_python_mpi_tests.py --mpi_flags "--hostfile ${GITHUB_WORKSPACE}/ci_hostfile" -l mpi_nightly -n 3
 
     - name: Running Python MPI tests (4 Cores)
+      if: needs.job-filters.outputs.ci-build == 'true'
       shell: bash
       run: |
         if [ ${{ matrix.compiler }} = gcc ]; then
@@ -266,7 +282,6 @@ jobs:
   windows:
     runs-on: windows-2022
     needs: [changed-files, job-filters]
-    if: needs.job-filters.outputs.source.ci-build == 'true'
     env:
       KRATOS_BUILD_TYPE: Custom
       KRATOS_CI_CHANGED_FILES: ${{needs.changed-files.outputs.files}}
@@ -278,11 +293,16 @@ jobs:
       with:
         python-version: '3.8'
 
+    - name: Show filter result
+      run: echo "CI BUILD = ${{ needs.job-filters.outputs.ci-build }}"
+
     - name: CI configuration
+      if: needs.job-filters.outputs.ci-build == 'true'
       shell: bash
       run: python3 kratos/python_scripts/testing/ci_utilities.py
 
     - name: Download boost
+      if: needs.job-filters.outputs.ci-build == 'true'
       run: |
         $url = "https://archives.boost.io/release/1.87.0/source/boost_1_87_0.tar.gz"
         (New-Object System.Net.WebClient).DownloadFile($url, "$env:TEMP\boost.tar.gz")
@@ -290,6 +310,7 @@ jobs:
         7z.exe x "$env:TEMP\boostArchive" -o"$env:TEMP\boost" -y | Out-Null
 
     - name: Installing dependencies
+      if: needs.job-filters.outputs.ci-build == 'true'
       shell: cmd
       run: |
         pip install numpy
@@ -299,6 +320,7 @@ jobs:
         pip install parameterized
 
     - name: Build
+      if: needs.job-filters.outputs.ci-build == 'true'
       shell: cmd
       run: |
         copy .\.github\workflows\configure.cmd
@@ -306,6 +328,7 @@ jobs:
         configure.cmd
 
     - name: Running C++ tests
+      if: needs.job-filters.outputs.ci-build == 'true'
       shell: cmd
       run: |
         set PYTHONPATH=%PYTHONPATH%;%GITHUB_WORKSPACE%/bin/%KRATOS_BUILD_TYPE%
@@ -313,6 +336,7 @@ jobs:
         python kratos/python_scripts/testing/run_cpp_tests.py
 
     - name: Running python tests
+      if: needs.job-filters.outputs.ci-build == 'true'
       shell: cmd
       run: |
         set PYTHONPATH=%PYTHONPATH%;%GITHUB_WORKSPACE%/bin/%KRATOS_BUILD_TYPE%
@@ -323,7 +347,6 @@ jobs:
   rocky:
     runs-on: ubuntu-latest
     needs: [changed-files, job-filters]
-    if: needs.job-filters.outputs.source.ci-build == 'true'
     env:
       KRATOS_BUILD_TYPE: Custom
       KRATOS_CI_CHANGED_FILES: ${{needs.changed-files.outputs.files}}
@@ -340,11 +363,16 @@ jobs:
     # - name: Installing dependencies
     # => must be added to the docker container to avoid reinstalling it in every CI run
 
+    - name: Show filter result
+      run: echo "CI BUILD = ${{ needs.job-filters.outputs.ci-build }}"
+
     - name: CI configuration
+      if: needs.job-filters.outputs.ci-build == 'true'
       shell: bash
       run: /usr/local/bin/python3.10  kratos/python_scripts/testing/ci_utilities.py
 
     - name: Build
+      if: needs.job-filters.outputs.ci-build == 'true'
       run: |
         if [ -f /etc/bashrc ]; then source /etc/bashrc; fi
         export KRATOS_CMAKE_CXX_FLAGS="-Werror -Wno-deprecated-declarations -Wignored-qualifiers"
@@ -352,6 +380,7 @@ jobs:
         bash rocky_configure.sh
 
     - name: Running C++ tests
+      if: needs.job-filters.outputs.ci-build == 'true'
       run: |
         if [ -f /etc/bashrc ]; then source /etc/bashrc; fi
         export PYTHONPATH=${GITHUB_WORKSPACE}/bin/Custom
@@ -359,6 +388,7 @@ jobs:
         /usr/local/bin/python3.10  kratos/python_scripts/testing/run_cpp_tests.py
 
     - name: Running python tests
+      if: needs.job-filters.outputs.ci-build == 'true'
       run: |
         if [ -f /etc/bashrc ]; then source /etc/bashrc; fi
         export PYTHONPATH=${GITHUB_WORKSPACE}/bin/Custom
@@ -383,11 +413,16 @@ jobs:
     steps:
     - uses: actions/checkout@v6
 
+    - name: Show filter result
+      run: echo "CI BUILD = ${{ needs.job-filters.outputs.ci-build }}"
+
     - name: CI configuration
+      if: needs.job-filters.outputs.ci-build == 'true'
       shell: bash
       run: python3 kratos/python_scripts/testing/ci_utilities.py
 
     - name: Build
+      if: needs.job-filters.outputs.ci-build == 'true'
       shell: bash
       run: |
         export CC=/usr/bin/clang-14
@@ -425,6 +460,7 @@ jobs:
         cmake --build "${KRATOS_BUILD}/${KRATOS_BUILD_TYPE}" --target install -- -j2
 
     - name: Running C++ tests
+      if: needs.job-filters.outputs.ci-build == 'true'
       shell: bash
       run: |
         export PYTHONPATH=${PYTHONPATH}:${GITHUB_WORKSPACE}/bin/Custom
@@ -432,6 +468,7 @@ jobs:
         python3 kratos/python_scripts/testing/run_cpp_tests.py
 
     - name: Running python tests
+      if: needs.job-filters.outputs.ci-build == 'true'
       shell: bash
       run: |
         export PYTHONPATH=${PYTHONPATH}:${GITHUB_WORKSPACE}/bin/Custom
@@ -439,6 +476,7 @@ jobs:
         python3 kratos/python_scripts/testing/run_python_tests.py -l nightly -c python3
 
     - name: Running MPI C++ tests (2 Cores)
+      if: needs.job-filters.outputs.ci-build == 'true'
       shell: bash
       timeout-minutes : 10
       run: |
@@ -447,6 +485,7 @@ jobs:
         python3 kratos/python_scripts/testing/run_cpp_mpi_tests.py -n 2
 
     - name: Running MPI C++ tests (3 Cores)
+      if: needs.job-filters.outputs.ci-build == 'true'
       shell: bash
       timeout-minutes : 10
       run: |
@@ -455,6 +494,7 @@ jobs:
         python3 kratos/python_scripts/testing/run_cpp_mpi_tests.py -n 3
 
     - name: Running MPI C++ tests (4 Cores)
+      if: needs.job-filters.outputs.ci-build == 'true'
       shell: bash
       timeout-minutes : 10
       run: |
@@ -463,6 +503,7 @@ jobs:
         python3 kratos/python_scripts/testing/run_cpp_mpi_tests.py -n 4
 
     - name: Running Python MPI tests (2 Cores)
+      if: needs.job-filters.outputs.ci-build == 'true'
       shell: bash
       run: |
         export PYTHONPATH=${PYTHONPATH}:${GITHUB_WORKSPACE}/bin/Custom
@@ -470,6 +511,7 @@ jobs:
         python3 kratos/python_scripts/testing/run_python_mpi_tests.py -l mpi_nightly -n 2
 
     - name: Running Python MPI tests (3 Cores)
+      if: needs.job-filters.outputs.ci-build == 'true'
       shell: bash
       run: |
         export PYTHONPATH=${PYTHONPATH}:${GITHUB_WORKSPACE}/bin/Custom
@@ -477,6 +519,7 @@ jobs:
         python3 kratos/python_scripts/testing/run_python_mpi_tests.py -l mpi_nightly -n 3
 
     - name: Running Python MPI tests (4 Cores)
+      if: needs.job-filters.outputs.ci-build == 'true'
       shell: bash
       run: |
         export PYTHONPATH=${PYTHONPATH}:${GITHUB_WORKSPACE}/bin/Custom
@@ -499,11 +542,16 @@ jobs:
       with:
         python-version: '3.8'
 
+    - name: Show filter result
+      run: echo "CI BUILD = ${{ needs.job-filters.outputs.ci-build }}"
+
     - name: CI configuration
+      if: needs.job-filters.outputs.ci-build == 'true'
       shell: bash
       run: python3 kratos/python_scripts/testing/ci_utilities.py
 
     - name: Download boost
+      if: needs.job-filters.outputs.ci-build == 'true'
       run: |
         $url = "https://archives.boost.io/release/1.87.0/source/boost_1_87_0.tar.gz"
         (New-Object System.Net.WebClient).DownloadFile($url, "$env:TEMP\boost.tar.gz")
@@ -511,6 +559,7 @@ jobs:
         7z.exe x "$env:TEMP\boostArchive" -o"$env:TEMP\boost" -y | Out-Null
 
     - name: Installing dependencies
+      if: needs.job-filters.outputs.ci-build == 'true'
       shell: cmd
       run: |
         pip install numpy
@@ -518,6 +567,7 @@ jobs:
         pip install scipy
 
     - name: Build
+      if: needs.job-filters.outputs.ci-build == 'true'
       shell: cmd
       run: |
         call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x64 || goto :error
@@ -555,6 +605,7 @@ jobs:
         exit /b %errorlevel%
 
     - name: Running C++ tests
+      if: needs.job-filters.outputs.ci-build == 'true'
       shell: cmd
       run: |
         set PYTHONPATH=%PYTHONPATH%;%GITHUB_WORKSPACE%/bin/%KRATOS_BUILD_TYPE%
@@ -562,6 +613,7 @@ jobs:
         python kratos/python_scripts/testing/run_cpp_tests.py
 
     - name: Running python tests
+      if: needs.job-filters.outputs.ci-build == 'true'
       shell: cmd
       run: |
         set PYTHONPATH=%PYTHONPATH%;%GITHUB_WORKSPACE%/bin/%KRATOS_BUILD_TYPE%
@@ -590,11 +642,16 @@ jobs:
     # - name: Installing dependencies
     # => must be added to the docker container to avoid reinstalling it in every CI run
 
+    - name: Show filter result
+      run: echo "CI BUILD = ${{ needs.job-filters.outputs.ci-build }}"
+
     - name: CI configuration
+      if: needs.job-filters.outputs.ci-build == 'true'
       shell: bash
       run: python3 kratos/python_scripts/testing/ci_utilities.py
 
     - name: Build
+      if: needs.job-filters.outputs.ci-build == 'true'
       shell: bash
       run: |
         export CC=icx
@@ -604,6 +661,7 @@ jobs:
         bash configure.sh
 
     - name: Running C++ tests
+      if: needs.job-filters.outputs.ci-build == 'true'
       shell: bash
       continue-on-error: true # TODO segfaults in cpp-tests
       run: |
@@ -613,6 +671,7 @@ jobs:
         python3 kratos/python_scripts/testing/run_cpp_tests.py
 
     - name: Running python tests
+      if: needs.job-filters.outputs.ci-build == 'true'
       shell: bash
       continue-on-error: true # TODO segfaults in cpp-tests
       run: |
@@ -622,6 +681,7 @@ jobs:
         python3 kratos/python_scripts/testing/run_python_tests.py -l nightly -c python3
 
     - name: Running MPI C++ tests (2 Cores)
+      if: needs.job-filters.outputs.ci-build == 'true'
       shell: bash
       timeout-minutes : 10
       run: |
@@ -631,6 +691,7 @@ jobs:
         python3 kratos/python_scripts/testing/run_cpp_mpi_tests.py -n 2
 
     - name: Running MPI C++ tests (3 Cores)
+      if: needs.job-filters.outputs.ci-build == 'true'
       shell: bash
       timeout-minutes : 10
       run: |
@@ -640,6 +701,7 @@ jobs:
         python3 kratos/python_scripts/testing/run_cpp_mpi_tests.py -n 3
 
     - name: Running MPI C++ tests (4 Cores)
+      if: needs.job-filters.outputs.ci-build == 'true'
       shell: bash
       timeout-minutes : 10
       run: |
@@ -649,6 +711,7 @@ jobs:
         python3 kratos/python_scripts/testing/run_cpp_mpi_tests.py -n 4
 
     - name: Running Python MPI tests (2 Cores)
+      if: needs.job-filters.outputs.ci-build == 'true'
       shell: bash
       run: |
         source /opt/intel/oneapi/setvars.sh
@@ -658,6 +721,7 @@ jobs:
         python3 kratos/python_scripts/testing/run_python_mpi_tests.py -l mpi_nightly -n 2
 
     - name: Running Python MPI tests (3 Cores)
+      if: needs.job-filters.outputs.ci-build == 'true'
       shell: bash
       run: |
         source /opt/intel/oneapi/setvars.sh
@@ -667,6 +731,7 @@ jobs:
         python3 kratos/python_scripts/testing/run_python_mpi_tests.py -l mpi_nightly -n 3
 
     - name: Running Python MPI tests (4 Cores)
+      if: needs.job-filters.outputs.ci-build == 'true'
       shell: bash
       run: |
         source /opt/intel/oneapi/setvars.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,24 +17,27 @@ permissions:
   contents: read
 
 jobs:
-  changed-files:
+  changes:
     runs-on: ubuntu-latest
-    # see https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-defining-outputs-for-a-job
     outputs:
-      files: ${{ steps.get_files.outputs.changed_files }}
-    steps:
-      - uses: actions/checkout@v6
+      source: ${{ steps.filter.outputs.source }}
 
-      - id: get_files
-        run: |
-          echo "changed_files=$(python3 .github/get_files_changed_in_pr.py)" >> $GITHUB_OUTPUT
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITHUB_PR_NUMBER: ${{ github.event.pull_request.number }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            ci-build:
+              - added|modified|deleted: '**'
+              - '!**/*.md'
+              - '!licence.txt'
+              - '!docs/**'
 
   ubuntu:
     runs-on: ubuntu-latest
-    needs: changed-files
+    needs: changes
+    if: needs.changes.outputs.ci-build == 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -42,8 +45,6 @@ jobs:
         compiler: [gcc, clang]
     env:
       KRATOS_BUILD_TYPE: ${{ matrix.build-type }}
-      KRATOS_CI_CHANGED_FILES: ${{needs.changed-files.outputs.files}}
-      KRATOS_CI_APPLICATIONS: ".github/workflows/ci_apps_linux.json"
       KRATOS_CI_CORES: 4                              # Current limits are 4 CPU and 16 GB Ram
       OMPI_MCA_rmaps_base_oversubscribe: 1            # Allow oversubscription for MPI (needed for OpenMPI >= 3.0)
       OMPI_MCA_btl_vader_single_copy_mechanism: none  # Suppressing some annoying OpenMPI messages
@@ -247,11 +248,10 @@ jobs:
 
   windows:
     runs-on: windows-2022
-    needs: changed-files
+    needs: changes
+    if: needs.changes.outputs.ci-build == 'true'
     env:
       KRATOS_BUILD_TYPE: Custom
-      KRATOS_CI_CHANGED_FILES: ${{needs.changed-files.outputs.files}}
-      KRATOS_CI_APPLICATIONS: ".github/workflows/ci_apps_windows.json"
 
     steps:
     - uses: actions/checkout@v6
@@ -303,11 +303,10 @@ jobs:
 
   rocky:
     runs-on: ubuntu-latest
-    needs: changed-files
+    needs: changes
+    if: needs.changes.outputs.ci-build == 'true'
     env:
       KRATOS_BUILD_TYPE: Custom
-      KRATOS_CI_CHANGED_FILES: ${{needs.changed-files.outputs.files}}
-      KRATOS_CI_APPLICATIONS: ".github/workflows/ci_apps_rocky.json"
       ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
 
     container:
@@ -348,11 +347,10 @@ jobs:
 
   ubuntu-core-without-unity:
     runs-on: ubuntu-latest
-    needs: changed-files
+    needs: changes
+    if: needs.changes.outputs.ci-build == 'true'
     env:
       KRATOS_BUILD_TYPE: Custom
-      KRATOS_CI_CHANGED_FILES: ${{needs.changed-files.outputs.files}}
-      KRATOS_CI_APPLICATIONS: "ONLY_CORE"
       OMPI_MCA_rmaps_base_oversubscribe: 1 # Allow oversubscription for MPI (needed for OpenMPI >= 3.0)
 
     container:
@@ -465,11 +463,10 @@ jobs:
 
   windows-core-without-unity:
     runs-on: windows-2022
-    needs: changed-files
+    needs: changes
+    if: needs.changes.outputs.ci-build == 'true'
     env:
       KRATOS_BUILD_TYPE: Custom
-      KRATOS_CI_CHANGED_FILES: ${{needs.changed-files.outputs.files}}
-      KRATOS_CI_APPLICATIONS: "ONLY_CORE"
 
     steps:
     - uses: actions/checkout@v6
@@ -549,11 +546,10 @@ jobs:
 
   ubuntu-intel:
     runs-on: ubuntu-latest
-    needs: changed-files
+    needs: changes
+    if: needs.changes.outputs.ci-build == 'true'
     env:
       KRATOS_BUILD_TYPE: Custom
-      KRATOS_CI_CHANGED_FILES: ${{needs.changed-files.outputs.files}}
-      KRATOS_CI_APPLICATIONS: ".github/workflows/ci_apps_intel.json"
       OMPI_MCA_rmaps_base_oversubscribe: 1 # Allow oversubscription for MPI (needed for OpenMPI >= 3.0)
       OMPI_MCA_btl_vader_single_copy_mechanism: none # suppressing some annoying OpenMPI messages
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,8 +51,7 @@ jobs:
 
   ubuntu:
     runs-on: ubuntu-latest
-    needs: changed-files
-    needs: job-filters
+    needs: [changed-files, job-filters]
     if: needs.job-filters.outputs.source.ci-build == 'true'
     strategy:
       fail-fast: false
@@ -266,8 +265,7 @@ jobs:
 
   windows:
     runs-on: windows-2022
-    needs: changed-files
-    needs: job-filters
+    needs: [changed-files, job-filters]
     if: needs.job-filters.outputs.source.ci-build == 'true'
     env:
       KRATOS_BUILD_TYPE: Custom
@@ -324,8 +322,7 @@ jobs:
 
   rocky:
     runs-on: ubuntu-latest
-    needs: changed-files
-    needs: job-filters
+    needs: [changed-files, job-filters]
     if: needs.job-filters.outputs.source.ci-build == 'true'
     env:
       KRATOS_BUILD_TYPE: Custom
@@ -371,8 +368,7 @@ jobs:
 
   ubuntu-core-without-unity:
     runs-on: ubuntu-latest
-    needs: changed-files
-    needs: job-filters
+    needs: [changed-files, job-filters]
     if: needs.job-filters.outputs.source.ci-build == 'true'
     env:
       KRATOS_BUILD_TYPE: Custom
@@ -490,8 +486,7 @@ jobs:
 
   windows-core-without-unity:
     runs-on: windows-2022
-    needs: changed-files
-    needs: job-filters
+    needs: [changed-files, job-filters]
     if: needs.job-filters.outputs.source.ci-build == 'true'
     env:
       KRATOS_BUILD_TYPE: Custom
@@ -576,8 +571,7 @@ jobs:
 
   ubuntu-intel:
     runs-on: ubuntu-latest
-    needs: changed-files
-    needs: job-filters
+    needs: [changed-files, job-filters]
     if: needs.job-filters.outputs.source.ci-build == 'true'
     env:
       KRATOS_BUILD_TYPE: Custom

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_PR_NUMBER: ${{ github.event.pull_request.number }}
 
+  # see https://github.com/dorny/paths-filter.
+  # This job is intended to generate a list of files that have changes in the commit and trigger the rest of the jobs based on the result. Specifically, any files matching the documentation folder or *.md / *.txt files are modified, the compilation triggers. Otherwise the jobs accept the changes without triggering the compilation or running test.
   job_filters:
     runs-on: ubuntu-latest
     outputs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,22 @@ permissions:
   contents: read
 
 jobs:
-  changes:
+  changed-files:
+    runs-on: ubuntu-latest
+    # see https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-defining-outputs-for-a-job
+    outputs:
+      files: ${{ steps.get_files.outputs.changed_files }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - id: get_files
+        run: |
+          echo "changed_files=$(python3 .github/get_files_changed_in_pr.py)" >> $GITHUB_OUTPUT
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_PR_NUMBER: ${{ github.event.pull_request.number }}
+
+  job-filters:
     runs-on: ubuntu-latest
     outputs:
       source: ${{ steps.filter.outputs.source }}
@@ -36,8 +51,9 @@ jobs:
 
   ubuntu:
     runs-on: ubuntu-latest
-    needs: changes
-    if: needs.changes.outputs.ci-build == 'true'
+    needs: changed-files
+    needs: job-filters
+    if: needs.job-filters.outputs.source.ci-build == 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -45,6 +61,8 @@ jobs:
         compiler: [gcc, clang]
     env:
       KRATOS_BUILD_TYPE: ${{ matrix.build-type }}
+      KRATOS_CI_CHANGED_FILES: ${{needs.changed-files.outputs.files}}
+      KRATOS_CI_APPLICATIONS: ".github/workflows/ci_apps_linux.json"
       KRATOS_CI_CORES: 4                              # Current limits are 4 CPU and 16 GB Ram
       OMPI_MCA_rmaps_base_oversubscribe: 1            # Allow oversubscription for MPI (needed for OpenMPI >= 3.0)
       OMPI_MCA_btl_vader_single_copy_mechanism: none  # Suppressing some annoying OpenMPI messages
@@ -248,10 +266,13 @@ jobs:
 
   windows:
     runs-on: windows-2022
-    needs: changes
-    if: needs.changes.outputs.ci-build == 'true'
+    needs: changed-files
+    needs: job-filters
+    if: needs.job-filters.outputs.source.ci-build == 'true'
     env:
       KRATOS_BUILD_TYPE: Custom
+      KRATOS_CI_CHANGED_FILES: ${{needs.changed-files.outputs.files}}
+      KRATOS_CI_APPLICATIONS: ".github/workflows/ci_apps_windows.json"
 
     steps:
     - uses: actions/checkout@v6
@@ -303,10 +324,13 @@ jobs:
 
   rocky:
     runs-on: ubuntu-latest
-    needs: changes
-    if: needs.changes.outputs.ci-build == 'true'
+    needs: changed-files
+    needs: job-filters
+    if: needs.job-filters.outputs.source.ci-build == 'true'
     env:
       KRATOS_BUILD_TYPE: Custom
+      KRATOS_CI_CHANGED_FILES: ${{needs.changed-files.outputs.files}}
+      KRATOS_CI_APPLICATIONS: ".github/workflows/ci_apps_rocky.json"
       ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
 
     container:
@@ -347,10 +371,13 @@ jobs:
 
   ubuntu-core-without-unity:
     runs-on: ubuntu-latest
-    needs: changes
-    if: needs.changes.outputs.ci-build == 'true'
+    needs: changed-files
+    needs: job-filters
+    if: needs.job-filters.outputs.source.ci-build == 'true'
     env:
       KRATOS_BUILD_TYPE: Custom
+      KRATOS_CI_CHANGED_FILES: ${{needs.changed-files.outputs.files}}
+      KRATOS_CI_APPLICATIONS: "ONLY_CORE"
       OMPI_MCA_rmaps_base_oversubscribe: 1 # Allow oversubscription for MPI (needed for OpenMPI >= 3.0)
 
     container:
@@ -463,10 +490,13 @@ jobs:
 
   windows-core-without-unity:
     runs-on: windows-2022
-    needs: changes
-    if: needs.changes.outputs.ci-build == 'true'
+    needs: changed-files
+    needs: job-filters
+    if: needs.job-filters.outputs.source.ci-build == 'true'
     env:
       KRATOS_BUILD_TYPE: Custom
+      KRATOS_CI_CHANGED_FILES: ${{needs.changed-files.outputs.files}}
+      KRATOS_CI_APPLICATIONS: "ONLY_CORE"
 
     steps:
     - uses: actions/checkout@v6
@@ -546,10 +576,13 @@ jobs:
 
   ubuntu-intel:
     runs-on: ubuntu-latest
-    needs: changes
-    if: needs.changes.outputs.ci-build == 'true'
+    needs: changed-files
+    needs: job-filters
+    if: needs.job-filters.outputs.source.ci-build == 'true'
     env:
       KRATOS_BUILD_TYPE: Custom
+      KRATOS_CI_CHANGED_FILES: ${{needs.changed-files.outputs.files}}
+      KRATOS_CI_APPLICATIONS: ".github/workflows/ci_apps_intel.json"
       OMPI_MCA_rmaps_base_oversubscribe: 1 # Allow oversubscription for MPI (needed for OpenMPI >= 3.0)
       OMPI_MCA_btl_vader_single_copy_mechanism: none # suppressing some annoying OpenMPI messages
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ permissions:
   contents: read
 
 jobs:
-  changed-files:
+  changed_files:
     runs-on: ubuntu-latest
     # see https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-defining-outputs-for-a-job
     outputs:
@@ -32,10 +32,10 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_PR_NUMBER: ${{ github.event.pull_request.number }}
 
-  job-filters:
+  job_filters:
     runs-on: ubuntu-latest
     outputs:
-      ci-build: ${{ steps.filter.outputs.ci-build }}
+      ci_build: ${{ steps.filter.outputs.ci_build }}
 
     steps:
       - uses: actions/checkout@v4
@@ -43,7 +43,7 @@ jobs:
         id: filter
         with:
           filters: |
-            ci-build:
+            ci_build:
               - '**'
               - '!**/*.md'
               - '!licence.txt'
@@ -51,7 +51,7 @@ jobs:
 
   ubuntu:
     runs-on: ubuntu-latest
-    needs: [changed-files, job-filters]
+    needs: [changed_files, job_filters]
     strategy:
       fail-fast: false
       matrix:
@@ -59,7 +59,7 @@ jobs:
         compiler: [gcc, clang]
     env:
       KRATOS_BUILD_TYPE: ${{ matrix.build-type }}
-      KRATOS_CI_CHANGED_FILES: ${{needs.changed-files.outputs.files}}
+      KRATOS_CI_CHANGED_FILES: ${{needs.changed_files.outputs.files}}
       KRATOS_CI_APPLICATIONS: ".github/workflows/ci_apps_linux.json"
       KRATOS_CI_CORES: 4                              # Current limits are 4 CPU and 16 GB Ram
       OMPI_MCA_rmaps_base_oversubscribe: 1            # Allow oversubscription for MPI (needed for OpenMPI >= 3.0)
@@ -76,17 +76,17 @@ jobs:
     # => must be added to the docker container to avoid reinstalling it in every CI run
 
     - name: Show filter result
-      run: echo "CI BUILD = ${{ needs.job-filters.outputs.ci-build }}"
+      run: echo "CI BUILD = ${{ needs.job_filters.outputs.ci_build }}"
 
     - name: CI configuration
-      if: needs.job-filters.outputs.ci-build == 'true'
+      if: needs.job_filters.outputs.ci_build == 'true'
       shell: bash
       run: |
         python3 kratos/python_scripts/testing/ci_utilities.py
         python3 -m pip install --upgrade numpy==1.26.4
 
     - name: Build
-      if: needs.job-filters.outputs.ci-build == 'true'
+      if: needs.job_filters.outputs.ci_build == 'true'
       shell: bash
       run: |
         if [ ${{ matrix.compiler }} = gcc ]; then
@@ -110,7 +110,7 @@ jobs:
         rm -r ${GITHUB_WORKSPACE}/build
 
     - name: Build Dependencies
-      if: needs.job-filters.outputs.ci-build == 'true'
+      if: needs.job_filters.outputs.ci_build == 'true'
       shell: bash
       run: |
         if [ ${{ matrix.compiler }} = gcc ]; then
@@ -133,7 +133,7 @@ jobs:
         rm -r ${GITHUB_WORKSPACE}/build
 
     - name: Build Core Apps
-      if: needs.job-filters.outputs.ci-build == 'true'
+      if: needs.job_filters.outputs.ci_build == 'true'
       shell: bash
       run: |
         if [ ${{ matrix.compiler }} = gcc ]; then
@@ -156,7 +156,7 @@ jobs:
         rm -r ${GITHUB_WORKSPACE}/build
 
     - name: Build Research Apps
-      if: needs.job-filters.outputs.ci-build == 'true'
+      if: needs.job_filters.outputs.ci_build == 'true'
       shell: bash
       run: |
         if [ ${{ matrix.compiler }} = gcc ]; then
@@ -179,7 +179,7 @@ jobs:
         rm -r ${GITHUB_WORKSPACE}/build
 
     - name: Running C++ tests
-      if: needs.job-filters.outputs.ci-build == 'true'
+      if: needs.job_filters.outputs.ci_build == 'true'
       shell: bash
       run: |
         if [ ${{ matrix.compiler }} = gcc ]; then
@@ -190,7 +190,7 @@ jobs:
         python3 kratos/python_scripts/testing/run_cpp_tests.py
 
     - name: Running python tests
-      if: needs.job-filters.outputs.ci-build == 'true'
+      if: needs.job_filters.outputs.ci_build == 'true'
       shell: bash
       run: |
         if [ ${{ matrix.compiler }} = gcc ]; then
@@ -201,13 +201,13 @@ jobs:
         python3 kratos/python_scripts/testing/run_python_tests.py -v 2 -l nightly -c python3
 
     - name: Prepare Parallel Env
-      if: needs.job-filters.outputs.ci-build == 'true'
+      if: needs.job_filters.outputs.ci_build == 'true'
       shell: bash
       run: |
         echo "localhost slots=2" >> ${GITHUB_WORKSPACE}/ci_hostfile
 
     - name: Running MPI C++ tests (2 Cores)
-      if: needs.job-filters.outputs.ci-build == 'true'
+      if: needs.job_filters.outputs.ci_build == 'true'
       shell: bash
       timeout-minutes : 10
       run: |
@@ -219,7 +219,7 @@ jobs:
         python3 kratos/python_scripts/testing/run_cpp_mpi_tests.py --mpi_flags "--hostfile ${GITHUB_WORKSPACE}/ci_hostfile" -n 2
 
     - name: Running MPI C++ tests (3 Cores)
-      if: needs.job-filters.outputs.ci-build == 'true'
+      if: needs.job_filters.outputs.ci_build == 'true'
       shell: bash
       timeout-minutes : 10
       run: |
@@ -231,7 +231,7 @@ jobs:
         python3 kratos/python_scripts/testing/run_cpp_mpi_tests.py --mpi_flags "--hostfile ${GITHUB_WORKSPACE}/ci_hostfile" -n 3
 
     - name: Running MPI C++ tests (4 Cores)
-      if: needs.job-filters.outputs.ci-build == 'true'
+      if: needs.job_filters.outputs.ci_build == 'true'
       shell: bash
       timeout-minutes : 10
       run: |
@@ -243,7 +243,7 @@ jobs:
         python3 kratos/python_scripts/testing/run_cpp_mpi_tests.py --mpi_flags "--hostfile ${GITHUB_WORKSPACE}/ci_hostfile" -n 4
 
     - name: Running Python MPI tests (2 Cores)
-      if: needs.job-filters.outputs.ci-build == 'true'
+      if: needs.job_filters.outputs.ci_build == 'true'
       shell: bash
       run: |
         if [ ${{ matrix.compiler }} = gcc ]; then
@@ -255,7 +255,7 @@ jobs:
         python3 kratos/python_scripts/testing/run_python_mpi_tests.py --mpi_flags "--hostfile ${GITHUB_WORKSPACE}/ci_hostfile" -l mpi_nightly -n 2
 
     - name: Running Python MPI tests (3 Cores)
-      if: needs.job-filters.outputs.ci-build == 'true'
+      if: needs.job_filters.outputs.ci_build == 'true'
       shell: bash
       run: |
         if [ ${{ matrix.compiler }} = gcc ]; then
@@ -267,7 +267,7 @@ jobs:
         python3 kratos/python_scripts/testing/run_python_mpi_tests.py --mpi_flags "--hostfile ${GITHUB_WORKSPACE}/ci_hostfile" -l mpi_nightly -n 3
 
     - name: Running Python MPI tests (4 Cores)
-      if: needs.job-filters.outputs.ci-build == 'true'
+      if: needs.job_filters.outputs.ci_build == 'true'
       shell: bash
       run: |
         if [ ${{ matrix.compiler }} = gcc ]; then
@@ -281,10 +281,10 @@ jobs:
 
   windows:
     runs-on: windows-2022
-    needs: [changed-files, job-filters]
+    needs: [changed_files, job_filters]
     env:
       KRATOS_BUILD_TYPE: Custom
-      KRATOS_CI_CHANGED_FILES: ${{needs.changed-files.outputs.files}}
+      KRATOS_CI_CHANGED_FILES: ${{needs.changed_files.outputs.files}}
       KRATOS_CI_APPLICATIONS: ".github/workflows/ci_apps_windows.json"
 
     steps:
@@ -294,15 +294,15 @@ jobs:
         python-version: '3.8'
 
     - name: Show filter result
-      run: echo "CI BUILD = ${{ needs.job-filters.outputs.ci-build }}"
+      run: echo "CI BUILD = ${{ needs.job_filters.outputs.ci_build }}"
 
     - name: CI configuration
-      if: needs.job-filters.outputs.ci-build == 'true'
+      if: needs.job_filters.outputs.ci_build == 'true'
       shell: bash
       run: python3 kratos/python_scripts/testing/ci_utilities.py
 
     - name: Download boost
-      if: needs.job-filters.outputs.ci-build == 'true'
+      if: needs.job_filters.outputs.ci_build == 'true'
       run: |
         $url = "https://archives.boost.io/release/1.87.0/source/boost_1_87_0.tar.gz"
         (New-Object System.Net.WebClient).DownloadFile($url, "$env:TEMP\boost.tar.gz")
@@ -310,7 +310,7 @@ jobs:
         7z.exe x "$env:TEMP\boostArchive" -o"$env:TEMP\boost" -y | Out-Null
 
     - name: Installing dependencies
-      if: needs.job-filters.outputs.ci-build == 'true'
+      if: needs.job_filters.outputs.ci_build == 'true'
       shell: cmd
       run: |
         pip install numpy
@@ -320,7 +320,7 @@ jobs:
         pip install parameterized
 
     - name: Build
-      if: needs.job-filters.outputs.ci-build == 'true'
+      if: needs.job_filters.outputs.ci_build == 'true'
       shell: cmd
       run: |
         copy .\.github\workflows\configure.cmd
@@ -328,7 +328,7 @@ jobs:
         configure.cmd
 
     - name: Running C++ tests
-      if: needs.job-filters.outputs.ci-build == 'true'
+      if: needs.job_filters.outputs.ci_build == 'true'
       shell: cmd
       run: |
         set PYTHONPATH=%PYTHONPATH%;%GITHUB_WORKSPACE%/bin/%KRATOS_BUILD_TYPE%
@@ -336,7 +336,7 @@ jobs:
         python kratos/python_scripts/testing/run_cpp_tests.py
 
     - name: Running python tests
-      if: needs.job-filters.outputs.ci-build == 'true'
+      if: needs.job_filters.outputs.ci_build == 'true'
       shell: cmd
       run: |
         set PYTHONPATH=%PYTHONPATH%;%GITHUB_WORKSPACE%/bin/%KRATOS_BUILD_TYPE%
@@ -346,10 +346,10 @@ jobs:
 
   rocky:
     runs-on: ubuntu-latest
-    needs: [changed-files, job-filters]
+    needs: [changed_files, job_filters]
     env:
       KRATOS_BUILD_TYPE: Custom
-      KRATOS_CI_CHANGED_FILES: ${{needs.changed-files.outputs.files}}
+      KRATOS_CI_CHANGED_FILES: ${{needs.changed_files.outputs.files}}
       KRATOS_CI_APPLICATIONS: ".github/workflows/ci_apps_rocky.json"
       ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
 
@@ -364,15 +364,15 @@ jobs:
     # => must be added to the docker container to avoid reinstalling it in every CI run
 
     - name: Show filter result
-      run: echo "CI BUILD = ${{ needs.job-filters.outputs.ci-build }}"
+      run: echo "CI BUILD = ${{ needs.job_filters.outputs.ci_build }}"
 
     - name: CI configuration
-      if: needs.job-filters.outputs.ci-build == 'true'
+      if: needs.job_filters.outputs.ci_build == 'true'
       shell: bash
       run: /usr/local/bin/python3.10  kratos/python_scripts/testing/ci_utilities.py
 
     - name: Build
-      if: needs.job-filters.outputs.ci-build == 'true'
+      if: needs.job_filters.outputs.ci_build == 'true'
       run: |
         if [ -f /etc/bashrc ]; then source /etc/bashrc; fi
         export KRATOS_CMAKE_CXX_FLAGS="-Werror -Wno-deprecated-declarations -Wignored-qualifiers"
@@ -380,7 +380,7 @@ jobs:
         bash rocky_configure.sh
 
     - name: Running C++ tests
-      if: needs.job-filters.outputs.ci-build == 'true'
+      if: needs.job_filters.outputs.ci_build == 'true'
       run: |
         if [ -f /etc/bashrc ]; then source /etc/bashrc; fi
         export PYTHONPATH=${GITHUB_WORKSPACE}/bin/Custom
@@ -388,7 +388,7 @@ jobs:
         /usr/local/bin/python3.10  kratos/python_scripts/testing/run_cpp_tests.py
 
     - name: Running python tests
-      if: needs.job-filters.outputs.ci-build == 'true'
+      if: needs.job_filters.outputs.ci_build == 'true'
       run: |
         if [ -f /etc/bashrc ]; then source /etc/bashrc; fi
         export PYTHONPATH=${GITHUB_WORKSPACE}/bin/Custom
@@ -398,10 +398,10 @@ jobs:
 
   ubuntu-core-without-unity:
     runs-on: ubuntu-latest
-    needs: [changed-files, job-filters]
+    needs: [changed_files, job_filters]
     env:
       KRATOS_BUILD_TYPE: Custom
-      KRATOS_CI_CHANGED_FILES: ${{needs.changed-files.outputs.files}}
+      KRATOS_CI_CHANGED_FILES: ${{needs.changed_files.outputs.files}}
       KRATOS_CI_APPLICATIONS: "ONLY_CORE"
       OMPI_MCA_rmaps_base_oversubscribe: 1 # Allow oversubscription for MPI (needed for OpenMPI >= 3.0)
 
@@ -413,15 +413,15 @@ jobs:
     - uses: actions/checkout@v6
 
     - name: Show filter result
-      run: echo "CI BUILD = ${{ needs.job-filters.outputs.ci-build }}"
+      run: echo "CI BUILD = ${{ needs.job_filters.outputs.ci_build }}"
 
     - name: CI configuration
-      if: needs.job-filters.outputs.ci-build == 'true'
+      if: needs.job_filters.outputs.ci_build == 'true'
       shell: bash
       run: python3 kratos/python_scripts/testing/ci_utilities.py
 
     - name: Build
-      if: needs.job-filters.outputs.ci-build == 'true'
+      if: needs.job_filters.outputs.ci_build == 'true'
       shell: bash
       run: |
         export CC=/usr/bin/clang-14
@@ -459,7 +459,7 @@ jobs:
         cmake --build "${KRATOS_BUILD}/${KRATOS_BUILD_TYPE}" --target install -- -j2
 
     - name: Running C++ tests
-      if: needs.job-filters.outputs.ci-build == 'true'
+      if: needs.job_filters.outputs.ci_build == 'true'
       shell: bash
       run: |
         export PYTHONPATH=${PYTHONPATH}:${GITHUB_WORKSPACE}/bin/Custom
@@ -467,7 +467,7 @@ jobs:
         python3 kratos/python_scripts/testing/run_cpp_tests.py
 
     - name: Running python tests
-      if: needs.job-filters.outputs.ci-build == 'true'
+      if: needs.job_filters.outputs.ci_build == 'true'
       shell: bash
       run: |
         export PYTHONPATH=${PYTHONPATH}:${GITHUB_WORKSPACE}/bin/Custom
@@ -475,7 +475,7 @@ jobs:
         python3 kratos/python_scripts/testing/run_python_tests.py -l nightly -c python3
 
     - name: Running MPI C++ tests (2 Cores)
-      if: needs.job-filters.outputs.ci-build == 'true'
+      if: needs.job_filters.outputs.ci_build == 'true'
       shell: bash
       timeout-minutes : 10
       run: |
@@ -484,7 +484,7 @@ jobs:
         python3 kratos/python_scripts/testing/run_cpp_mpi_tests.py -n 2
 
     - name: Running MPI C++ tests (3 Cores)
-      if: needs.job-filters.outputs.ci-build == 'true'
+      if: needs.job_filters.outputs.ci_build == 'true'
       shell: bash
       timeout-minutes : 10
       run: |
@@ -493,7 +493,7 @@ jobs:
         python3 kratos/python_scripts/testing/run_cpp_mpi_tests.py -n 3
 
     - name: Running MPI C++ tests (4 Cores)
-      if: needs.job-filters.outputs.ci-build == 'true'
+      if: needs.job_filters.outputs.ci_build == 'true'
       shell: bash
       timeout-minutes : 10
       run: |
@@ -502,7 +502,7 @@ jobs:
         python3 kratos/python_scripts/testing/run_cpp_mpi_tests.py -n 4
 
     - name: Running Python MPI tests (2 Cores)
-      if: needs.job-filters.outputs.ci-build == 'true'
+      if: needs.job_filters.outputs.ci_build == 'true'
       shell: bash
       run: |
         export PYTHONPATH=${PYTHONPATH}:${GITHUB_WORKSPACE}/bin/Custom
@@ -510,7 +510,7 @@ jobs:
         python3 kratos/python_scripts/testing/run_python_mpi_tests.py -l mpi_nightly -n 2
 
     - name: Running Python MPI tests (3 Cores)
-      if: needs.job-filters.outputs.ci-build == 'true'
+      if: needs.job_filters.outputs.ci_build == 'true'
       shell: bash
       run: |
         export PYTHONPATH=${PYTHONPATH}:${GITHUB_WORKSPACE}/bin/Custom
@@ -518,7 +518,7 @@ jobs:
         python3 kratos/python_scripts/testing/run_python_mpi_tests.py -l mpi_nightly -n 3
 
     - name: Running Python MPI tests (4 Cores)
-      if: needs.job-filters.outputs.ci-build == 'true'
+      if: needs.job_filters.outputs.ci_build == 'true'
       shell: bash
       run: |
         export PYTHONPATH=${PYTHONPATH}:${GITHUB_WORKSPACE}/bin/Custom
@@ -528,10 +528,10 @@ jobs:
 
   windows-core-without-unity:
     runs-on: windows-2022
-    needs: [changed-files, job-filters]
+    needs: [changed_files, job_filters]
     env:
       KRATOS_BUILD_TYPE: Custom
-      KRATOS_CI_CHANGED_FILES: ${{needs.changed-files.outputs.files}}
+      KRATOS_CI_CHANGED_FILES: ${{needs.changed_files.outputs.files}}
       KRATOS_CI_APPLICATIONS: "ONLY_CORE"
 
     steps:
@@ -541,15 +541,15 @@ jobs:
         python-version: '3.8'
 
     - name: Show filter result
-      run: echo "CI BUILD = ${{ needs.job-filters.outputs.ci-build }}"
+      run: echo "CI BUILD = ${{ needs.job_filters.outputs.ci_build }}"
 
     - name: CI configuration
-      if: needs.job-filters.outputs.ci-build == 'true'
+      if: needs.job_filters.outputs.ci_build == 'true'
       shell: bash
       run: python3 kratos/python_scripts/testing/ci_utilities.py
 
     - name: Download boost
-      if: needs.job-filters.outputs.ci-build == 'true'
+      if: needs.job_filters.outputs.ci_build == 'true'
       run: |
         $url = "https://archives.boost.io/release/1.87.0/source/boost_1_87_0.tar.gz"
         (New-Object System.Net.WebClient).DownloadFile($url, "$env:TEMP\boost.tar.gz")
@@ -557,7 +557,7 @@ jobs:
         7z.exe x "$env:TEMP\boostArchive" -o"$env:TEMP\boost" -y | Out-Null
 
     - name: Installing dependencies
-      if: needs.job-filters.outputs.ci-build == 'true'
+      if: needs.job_filters.outputs.ci_build == 'true'
       shell: cmd
       run: |
         pip install numpy
@@ -565,7 +565,7 @@ jobs:
         pip install scipy
 
     - name: Build
-      if: needs.job-filters.outputs.ci-build == 'true'
+      if: needs.job_filters.outputs.ci_build == 'true'
       shell: cmd
       run: |
         call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x64 || goto :error
@@ -603,7 +603,7 @@ jobs:
         exit /b %errorlevel%
 
     - name: Running C++ tests
-      if: needs.job-filters.outputs.ci-build == 'true'
+      if: needs.job_filters.outputs.ci_build == 'true'
       shell: cmd
       run: |
         set PYTHONPATH=%PYTHONPATH%;%GITHUB_WORKSPACE%/bin/%KRATOS_BUILD_TYPE%
@@ -611,7 +611,7 @@ jobs:
         python kratos/python_scripts/testing/run_cpp_tests.py
 
     - name: Running python tests
-      if: needs.job-filters.outputs.ci-build == 'true'
+      if: needs.job_filters.outputs.ci_build == 'true'
       shell: cmd
       run: |
         set PYTHONPATH=%PYTHONPATH%;%GITHUB_WORKSPACE%/bin/%KRATOS_BUILD_TYPE%
@@ -621,10 +621,10 @@ jobs:
 
   ubuntu-intel:
     runs-on: ubuntu-latest
-    needs: [changed-files, job-filters]
+    needs: [changed_files, job_filters]
     env:
       KRATOS_BUILD_TYPE: Custom
-      KRATOS_CI_CHANGED_FILES: ${{needs.changed-files.outputs.files}}
+      KRATOS_CI_CHANGED_FILES: ${{needs.changed_files.outputs.files}}
       KRATOS_CI_APPLICATIONS: ".github/workflows/ci_apps_intel.json"
       OMPI_MCA_rmaps_base_oversubscribe: 1 # Allow oversubscription for MPI (needed for OpenMPI >= 3.0)
       OMPI_MCA_btl_vader_single_copy_mechanism: none # suppressing some annoying OpenMPI messages
@@ -640,15 +640,15 @@ jobs:
     # => must be added to the docker container to avoid reinstalling it in every CI run
 
     - name: Show filter result
-      run: echo "CI BUILD = ${{ needs.job-filters.outputs.ci-build }}"
+      run: echo "CI BUILD = ${{ needs.job_filters.outputs.ci_build }}"
 
     - name: CI configuration
-      if: needs.job-filters.outputs.ci-build == 'true'
+      if: needs.job_filters.outputs.ci_build == 'true'
       shell: bash
       run: python3 kratos/python_scripts/testing/ci_utilities.py
 
     - name: Build
-      if: needs.job-filters.outputs.ci-build == 'true'
+      if: needs.job_filters.outputs.ci_build == 'true'
       shell: bash
       run: |
         export CC=icx
@@ -658,7 +658,7 @@ jobs:
         bash configure.sh
 
     - name: Running C++ tests
-      if: needs.job-filters.outputs.ci-build == 'true'
+      if: needs.job_filters.outputs.ci_build == 'true'
       shell: bash
       continue-on-error: true # TODO segfaults in cpp-tests
       run: |
@@ -668,7 +668,7 @@ jobs:
         python3 kratos/python_scripts/testing/run_cpp_tests.py
 
     - name: Running python tests
-      if: needs.job-filters.outputs.ci-build == 'true'
+      if: needs.job_filters.outputs.ci_build == 'true'
       shell: bash
       continue-on-error: true # TODO segfaults in cpp-tests
       run: |
@@ -678,7 +678,7 @@ jobs:
         python3 kratos/python_scripts/testing/run_python_tests.py -l nightly -c python3
 
     - name: Running MPI C++ tests (2 Cores)
-      if: needs.job-filters.outputs.ci-build == 'true'
+      if: needs.job_filters.outputs.ci_build == 'true'
       shell: bash
       timeout-minutes : 10
       run: |
@@ -688,7 +688,7 @@ jobs:
         python3 kratos/python_scripts/testing/run_cpp_mpi_tests.py -n 2
 
     - name: Running MPI C++ tests (3 Cores)
-      if: needs.job-filters.outputs.ci-build == 'true'
+      if: needs.job_filters.outputs.ci_build == 'true'
       shell: bash
       timeout-minutes : 10
       run: |
@@ -698,7 +698,7 @@ jobs:
         python3 kratos/python_scripts/testing/run_cpp_mpi_tests.py -n 3
 
     - name: Running MPI C++ tests (4 Cores)
-      if: needs.job-filters.outputs.ci-build == 'true'
+      if: needs.job_filters.outputs.ci_build == 'true'
       shell: bash
       timeout-minutes : 10
       run: |
@@ -708,7 +708,7 @@ jobs:
         python3 kratos/python_scripts/testing/run_cpp_mpi_tests.py -n 4
 
     - name: Running Python MPI tests (2 Cores)
-      if: needs.job-filters.outputs.ci-build == 'true'
+      if: needs.job_filters.outputs.ci_build == 'true'
       shell: bash
       run: |
         source /opt/intel/oneapi/setvars.sh
@@ -718,7 +718,7 @@ jobs:
         python3 kratos/python_scripts/testing/run_python_mpi_tests.py -l mpi_nightly -n 2
 
     - name: Running Python MPI tests (3 Cores)
-      if: needs.job-filters.outputs.ci-build == 'true'
+      if: needs.job_filters.outputs.ci_build == 'true'
       shell: bash
       run: |
         source /opt/intel/oneapi/setvars.sh
@@ -728,7 +728,7 @@ jobs:
         python3 kratos/python_scripts/testing/run_python_mpi_tests.py -l mpi_nightly -n 3
 
     - name: Running Python MPI tests (4 Cores)
-      if: needs.job-filters.outputs.ci-build == 'true'
+      if: needs.job_filters.outputs.ci_build == 'true'
       shell: bash
       run: |
         source /opt/intel/oneapi/setvars.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -399,7 +399,6 @@ jobs:
   ubuntu-core-without-unity:
     runs-on: ubuntu-latest
     needs: [changed-files, job-filters]
-    if: needs.job-filters.outputs.source.ci-build == 'true'
     env:
       KRATOS_BUILD_TYPE: Custom
       KRATOS_CI_CHANGED_FILES: ${{needs.changed-files.outputs.files}}
@@ -530,7 +529,6 @@ jobs:
   windows-core-without-unity:
     runs-on: windows-2022
     needs: [changed-files, job-filters]
-    if: needs.job-filters.outputs.source.ci-build == 'true'
     env:
       KRATOS_BUILD_TYPE: Custom
       KRATOS_CI_CHANGED_FILES: ${{needs.changed-files.outputs.files}}
@@ -624,7 +622,6 @@ jobs:
   ubuntu-intel:
     runs-on: ubuntu-latest
     needs: [changed-files, job-filters]
-    if: needs.job-filters.outputs.source.ci-build == 'true'
     env:
       KRATOS_BUILD_TYPE: Custom
       KRATOS_CI_CHANGED_FILES: ${{needs.changed-files.outputs.files}}


### PR DESCRIPTION
## **📝 Description**
This PR tries to enable our workflow filter back.

We formerly had this feature enabled with a `ci-dummy.yml` which triggered based on file changed rules. As for now both mechanism that allowed that solution no longer work ( 1- acceptance rules based on workflow with same names from different sources and `paths-ignore` as a filter on pull-request trigger) 

### **Key changes**

Added "job-filters" job with a action based filter with files excluded for the builds (can be extended with more filters on demand)
Added conditional trigger for the builds for all jobs based on the exclusion file list.

### **Validation**

I am afraid in order to validate this we will have to fork the repo, merge, and try to trigger different builds based on different conditions.

@philbucher I will take the opportunity to ask: Do we still need the old `changed-files job`? I see that is used on some tests but it has no real usage insde Kratos. I if I remember correctly this was meant to be the foundation to allow application exclusions from the builds. Chan we achieve the same with those filters maybe? Do you use it for something on your side?


