### PR TITLE
[IGA][FastPR] Add penalty rotation factor contribution for shell3p

### DIFF
--- a/applications/IgaApplication/custom_conditions/coupling_penalty_condition.cpp
+++ b/applications/IgaApplication/custom_conditions/coupling_penalty_condition.cpp
@@ -99,13 +99,13 @@ namespace Kratos
             }
 
             // Differential area
-            double penalty_integration = penalty * integration_points[point_number].Weight() * determinant_jacobian_vector[point_number];
-            
+            const double penalty_integration = penalty * integration_points[point_number].Weight() * determinant_jacobian_vector[point_number];
+
             // Rotation coupling
             if (Is(IgaFlags::FIX_ROTATION_X) || Is(IgaFlags::FIX_ROTATION_Y) || Is(IgaFlags::FIX_ROTATION_Z))
             {
                 const double penalty_rotation = GetProperties()[PENALTY_ROTATION_FACTOR];
-                double penalty_rotation_integration = penalty_rotation * integration_points[point_number].Weight() * determinant_jacobian_vector[point_number];
+                const double penalty_rotation_integration = penalty_rotation * integration_points[point_number].Weight() * determinant_jacobian_vector[point_number];
 
                 Vector phi_r = ZeroVector(mat_size);
                 Matrix phi_rs = ZeroMatrix(mat_size, mat_size);

--- a/applications/IgaApplication/custom_conditions/coupling_penalty_condition.cpp
+++ b/applications/IgaApplication/custom_conditions/coupling_penalty_condition.cpp
@@ -30,7 +30,6 @@ namespace Kratos
     {
         KRATOS_TRY
         const double penalty = GetProperties()[PENALTY_FACTOR];
-        const double penalty_rotation = GetProperties()[PENALTY_ROTATION_FACTOR];
 
         const auto& r_geometry_master = GetGeometry().GetGeometryPart(0);
         const auto& r_geometry_slave = GetGeometry().GetGeometryPart(1);
@@ -101,11 +100,13 @@ namespace Kratos
 
             // Differential area
             double penalty_integration = penalty * integration_points[point_number].Weight() * determinant_jacobian_vector[point_number];
-            double penalty_rotation_integration = penalty_rotation * integration_points[point_number].Weight() * determinant_jacobian_vector[point_number];
             
             // Rotation coupling
-            if (Is(IgaFlags::FIX_ROTATION_X))
+            if (Is(IgaFlags::FIX_ROTATION_X) || Is(IgaFlags::FIX_ROTATION_Y) || Is(IgaFlags::FIX_ROTATION_Z))
             {
+                const double penalty_rotation = GetProperties()[PENALTY_ROTATION_FACTOR];
+                double penalty_rotation_integration = penalty_rotation * integration_points[point_number].Weight() * determinant_jacobian_vector[point_number];
+
                 Vector phi_r = ZeroVector(mat_size);
                 Matrix phi_rs = ZeroMatrix(mat_size, mat_size);
                 array_1d<double, 2> diff_phi;

--- a/applications/IgaApplication/custom_conditions/coupling_penalty_condition.cpp
+++ b/applications/IgaApplication/custom_conditions/coupling_penalty_condition.cpp
@@ -30,6 +30,7 @@ namespace Kratos
     {
         KRATOS_TRY
         const double penalty = GetProperties()[PENALTY_FACTOR];
+        const double penalty_rotation = GetProperties()[PENALTY_ROTATION_FACTOR];
 
         const auto& r_geometry_master = GetGeometry().GetGeometryPart(0);
         const auto& r_geometry_slave = GetGeometry().GetGeometryPart(1);
@@ -99,8 +100,9 @@ namespace Kratos
             }
 
             // Differential area
-            const double penalty_integration = penalty * integration_points[point_number].Weight() * determinant_jacobian_vector[point_number];
-
+            double penalty_integration = penalty * integration_points[point_number].Weight() * determinant_jacobian_vector[point_number];
+            double penalty_rotation_integration = penalty_rotation * integration_points[point_number].Weight() * determinant_jacobian_vector[point_number];
+            
             // Rotation coupling
             if (Is(IgaFlags::FIX_ROTATION_X))
             {
@@ -115,7 +117,7 @@ namespace Kratos
                     {
                         for (IndexType j = 0; j < mat_size; ++j)
                         {
-                            rLeftHandSideMatrix(i, j) = (phi_r(i) * phi_r(j) + diff_phi(0) * phi_rs(i, j)) * penalty_integration;
+                            rLeftHandSideMatrix(i, j) = (phi_r(i) * phi_r(j) + diff_phi(0) * phi_rs(i, j)) * penalty_rotation_integration;
                         }
                     }
                 }
@@ -123,7 +125,7 @@ namespace Kratos
                 if (CalculateResidualVectorFlag) {
                     for (IndexType i = 0; i < mat_size; ++i)
                     {
-                        rRightHandSideVector[i] = (diff_phi(0) * phi_r(i)) * penalty_integration;
+                        rRightHandSideVector[i] = (diff_phi(0) * phi_r(i)) * penalty_rotation_integration; 
                     }
                 }
             }

--- a/applications/IgaApplication/tests/coupling_condition_tests/two_patch_cantilever_refined_test/two_patch_cantilever_refined_test_materials.json
+++ b/applications/IgaApplication/tests/coupling_condition_tests/two_patch_cantilever_refined_test/two_patch_cantilever_refined_test_materials.json
@@ -20,7 +20,8 @@
         "properties_id": 5,
         "Material": {
             "Variables": {
-                "PENALTY_FACTOR": 10000000
+                "PENALTY_FACTOR": 10000000,
+                "PENALTY_ROTATION_FACTOR": 10000000
             },
             "Tables": {}
         }

--- a/applications/IgaApplication/tests/coupling_condition_tests/two_patch_cantilever_test/two_patch_cantilever_test_materials.json
+++ b/applications/IgaApplication/tests/coupling_condition_tests/two_patch_cantilever_test/two_patch_cantilever_test_materials.json
@@ -20,7 +20,8 @@
         "properties_id": 5,
         "Material": {
             "Variables": {
-                "PENALTY_FACTOR": 10000000
+                "PENALTY_FACTOR": 10000000,
+                "PENALTY_ROTATION_FACTOR": 10000000,
             },
             "Tables": {}
         }

--- a/applications/IgaApplication/tests/coupling_condition_tests/two_patch_cantilever_test/two_patch_cantilever_test_materials.json
+++ b/applications/IgaApplication/tests/coupling_condition_tests/two_patch_cantilever_test/two_patch_cantilever_test_materials.json
@@ -21,7 +21,7 @@
         "Material": {
             "Variables": {
                 "PENALTY_FACTOR": 10000000,
-                "PENALTY_ROTATION_FACTOR": 10000000,
+                "PENALTY_ROTATION_FACTOR": 10000000
             },
             "Tables": {}
         }


### PR DESCRIPTION
This is a quick PR to add the penalty rotation factor for `Shell3pElement`. The idea is to have a more robust penalty formulation by splitting the displacement and rotation factors. 

The to-do list is to estimate a priori penalty factors for both displacement and rotation.