### PR TITLE
[IGA] Fix small bug in VTKHDF output 

### DIFF
--- a/applications/IgaApplication/python_scripts/iga_vtk_output_process.py
+++ b/applications/IgaApplication/python_scripts/iga_vtk_output_process.py
@@ -44,6 +44,10 @@ class IgaVTKOutputProcess(KM.OutputProcess):
         # Ensure correct file extension
         self.output_file_name = self.output_file_name.with_suffix(".vtkhdf")
 
+        # Remove old VTKHDF file at the beginning of a fresh analysis
+        if self.output_file_name.exists():
+            self.output_file_name.unlink()
+
         # IDs of Brep surfaces to be exported
         self.brep_surface_ids = [
             params["brep_surface_ids"][i].GetInt()


### PR DESCRIPTION
## Summary

This PR fixes an issue in the `IgaVTKOutputProcess` where rerunning a simulation with an existing `.vtkhdf` output file could lead to an HDF5 error when opening the file.

The output process now removes any existing output file at the beginning of a new analysis, ensuring that each simulation starts from a clean VTKHDF file and avoiding failures caused by stale or corrupted output files from previous runs.