### PR TITLE
[IGA][FastPR] Penalty rotation handling in coupling condition

### DIFF
--- a/applications/IgaApplication/custom_conditions/coupling_penalty_condition.cpp
+++ b/applications/IgaApplication/custom_conditions/coupling_penalty_condition.cpp
@@ -104,7 +104,9 @@ namespace Kratos
             // Rotation coupling
             if (Is(IgaFlags::FIX_ROTATION_X) || Is(IgaFlags::FIX_ROTATION_Y) || Is(IgaFlags::FIX_ROTATION_Z))
             {
-                const double penalty_rotation = GetProperties()[PENALTY_ROTATION_FACTOR];
+                const double penalty_rotation = GetProperties().Has(PENALTY_ROTATION_FACTOR)
+                    ? GetProperties()[PENALTY_ROTATION_FACTOR]
+                    : penalty_rotation;
                 const double penalty_rotation_integration = penalty_rotation * integration_points[point_number].Weight() * determinant_jacobian_vector[point_number];
 
                 Vector phi_r = ZeroVector(mat_size);

--- a/applications/IgaApplication/custom_conditions/coupling_penalty_condition.cpp
+++ b/applications/IgaApplication/custom_conditions/coupling_penalty_condition.cpp
@@ -106,7 +106,7 @@ namespace Kratos
             {
                 const double penalty_rotation = GetProperties().Has(PENALTY_ROTATION_FACTOR)
                     ? GetProperties()[PENALTY_ROTATION_FACTOR]
-                    : penalty_rotation;
+                    : penalty;
                 const double penalty_rotation_integration = penalty_rotation * integration_points[point_number].Weight() * determinant_jacobian_vector[point_number];
 
                 Vector phi_r = ZeroVector(mat_size);

--- a/applications/IgaApplication/tests/coupling_condition_tests/two_patch_cantilever_refined_test/two_patch_cantilever_refined_test_materials.json
+++ b/applications/IgaApplication/tests/coupling_condition_tests/two_patch_cantilever_refined_test/two_patch_cantilever_refined_test_materials.json
@@ -20,8 +20,7 @@
         "properties_id": 5,
         "Material": {
             "Variables": {
-                "PENALTY_FACTOR": 10000000,
-                "PENALTY_ROTATION_FACTOR": 10000000
+                "PENALTY_FACTOR": 10000000
             },
             "Tables": {}
         }


### PR DESCRIPTION
This is a quick PR that continues #14548. The flag is added in case the `penalty_rotation_factor` is not determined (by default, it will use the value from `penalty_factor`.
