### PR TITLE
[GeoMechanicsApplication] added element Check in GeoExtrapolateIntegrationPointValuesToNodesProcess

### DIFF
--- a/applications/GeoMechanicsApplication/custom_processes/geo_extrapolate_integration_point_values_to_nodes_process.cpp
+++ b/applications/GeoMechanicsApplication/custom_processes/geo_extrapolate_integration_point_values_to_nodes_process.cpp
@@ -145,14 +145,25 @@ void GeoExtrapolateIntegrationPointValuesToNodesProcess::ExecuteFinalizeSolution
 
     for (const auto& r_model_part : mrModelParts) {
         block_for_each(r_model_part.get().Elements(),
-                       [this, &r_model_part_ref = r_model_part.get(),
-                        &r_process_info = r_model_part.get().GetProcessInfo()](Element& rElement) {
+                       [this, &r_process_info = r_model_part.get().GetProcessInfo()](Element& rElement) {
             if (rElement.IsActive()) {
                 AddIntegrationPointContributionsForAllVariables(
-                    rElement, r_model_part_ref.Name(), GetCachedExtrapolationMatrixFor(rElement), r_process_info);
+                    rElement, GetCachedExtrapolationMatrixFor(rElement), r_process_info);
             }
         });
     }
+}
+
+int GeoExtrapolateIntegrationPointValuesToNodesProcess::Check()
+{
+    for (const auto& r_model_part : mrModelParts) {
+        const auto& r_process_info = r_model_part.get().GetProcessInfo();
+        for (auto& r_element : r_model_part.get().Elements()) {
+            CheckElement(r_element, r_model_part.get().Name(), r_process_info);
+        }
+    }
+
+    return 0;
 }
 
 void GeoExtrapolateIntegrationPointValuesToNodesProcess::CacheExtrapolationMatricesForElements()
@@ -186,8 +197,9 @@ const Matrix& GeoExtrapolateIntegrationPointValuesToNodesProcess::GetCachedExtra
     return mExtrapolationMatrixMap.at(typeid(rElement).hash_code());
 }
 
-void GeoExtrapolateIntegrationPointValuesToNodesProcess::AddIntegrationPointContributionsForAllVariables(
-    Element& rElement, const std::string& rModelPartName, const Matrix& rExtrapolationMatrix, const ProcessInfo& rProcessInfo) const
+void GeoExtrapolateIntegrationPointValuesToNodesProcess::CheckElement(Element& rElement,
+                                                                      const std::string& rModelPartName,
+                                                                      const ProcessInfo& rProcessInfo) const
 {
     int check_result = 0;
     try {
@@ -210,7 +222,11 @@ void GeoExtrapolateIntegrationPointValuesToNodesProcess::AddIntegrationPointCont
                                           "Element Check failed before extrapolation for "
                                        << "element id " << rElement.Id() << " in ModelPart='" << rModelPartName
                                        << "'. Check returned " << check_result << "." << std::endl;
+}
 
+void GeoExtrapolateIntegrationPointValuesToNodesProcess::AddIntegrationPointContributionsForAllVariables(
+    Element& rElement, const Matrix& rExtrapolationMatrix, const ProcessInfo& rProcessInfo) const
+{
     const auto integration_points_number = GeoElementUtilities::GetNumberOfIntegrationPointsOf(rElement);
 
     for (const auto p_var : mDoubleVariables) {

--- a/applications/GeoMechanicsApplication/custom_processes/geo_extrapolate_integration_point_values_to_nodes_process.cpp
+++ b/applications/GeoMechanicsApplication/custom_processes/geo_extrapolate_integration_point_values_to_nodes_process.cpp
@@ -145,10 +145,11 @@ void GeoExtrapolateIntegrationPointValuesToNodesProcess::ExecuteFinalizeSolution
 
     for (const auto& r_model_part : mrModelParts) {
         block_for_each(r_model_part.get().Elements(),
-                       [this, &r_process_info = r_model_part.get().GetProcessInfo()](Element& rElement) {
+                       [this, &r_model_part_ref = r_model_part.get(),
+                        &r_process_info = r_model_part.get().GetProcessInfo()](Element& rElement) {
             if (rElement.IsActive()) {
                 AddIntegrationPointContributionsForAllVariables(
-                    rElement, GetCachedExtrapolationMatrixFor(rElement), r_process_info);
+                    rElement, r_model_part_ref.Name(), GetCachedExtrapolationMatrixFor(rElement), r_process_info);
             }
         });
     }
@@ -186,8 +187,30 @@ const Matrix& GeoExtrapolateIntegrationPointValuesToNodesProcess::GetCachedExtra
 }
 
 void GeoExtrapolateIntegrationPointValuesToNodesProcess::AddIntegrationPointContributionsForAllVariables(
-    Element& rElement, const Matrix& rExtrapolationMatrix, const ProcessInfo& rProcessInfo) const
+    Element& rElement, const std::string& rModelPartName, const Matrix& rExtrapolationMatrix, const ProcessInfo& rProcessInfo) const
 {
+    int check_result = 0;
+    try {
+        check_result = rElement.Check(rProcessInfo);
+    } catch (const std::exception& rException) {
+        KRATOS_ERROR << "GeoExtrapolateIntegrationPointValuesToNodesProcess: Exception while "
+                        "calling Element::Check "
+                     << "before extrapolation for element id " << rElement.Id() << " in ModelPart='"
+                     << rModelPartName << "'. Original error: " << rException.what()
+                     << " Plausible cause: this modelpart is not activated." << std::endl;
+    } catch (...) {
+        KRATOS_ERROR << "GeoExtrapolateIntegrationPointValuesToNodesProcess: Unknown exception "
+                        "while calling "
+                     << "Element::Check before extrapolation for element id " << rElement.Id()
+                     << " in ModelPart='" << rModelPartName
+                     << "'.  Plausible cause: this modelpart is not activated." << std::endl;
+    }
+
+    KRATOS_ERROR_IF(check_result != 0) << "GeoExtrapolateIntegrationPointValuesToNodesProcess: "
+                                          "Element Check failed before extrapolation for "
+                                       << "element id " << rElement.Id() << " in ModelPart='" << rModelPartName
+                                       << "'. Check returned " << check_result << "." << std::endl;
+
     const auto integration_points_number = GeoElementUtilities::GetNumberOfIntegrationPointsOf(rElement);
 
     for (const auto p_var : mDoubleVariables) {

--- a/applications/GeoMechanicsApplication/custom_processes/geo_extrapolate_integration_point_values_to_nodes_process.hpp
+++ b/applications/GeoMechanicsApplication/custom_processes/geo_extrapolate_integration_point_values_to_nodes_process.hpp
@@ -128,6 +128,7 @@ private:
     [[nodiscard]] const Matrix& GetCachedExtrapolationMatrixFor(const Element& rElement) const;
 
     void AddIntegrationPointContributionsForAllVariables(Element&           rElement,
+                                                         const std::string& rModelPartName,
                                                          const Matrix&      rExtrapolationMatrix,
                                                          const ProcessInfo& rProcessInfo) const;
 };

--- a/applications/GeoMechanicsApplication/custom_processes/geo_extrapolate_integration_point_values_to_nodes_process.hpp
+++ b/applications/GeoMechanicsApplication/custom_processes/geo_extrapolate_integration_point_values_to_nodes_process.hpp
@@ -55,6 +55,7 @@ public:
 
     void                           ExecuteBeforeSolutionLoop() override;
     void                           ExecuteFinalizeSolutionStep() override;
+    int                            Check() override;
     [[nodiscard]] const Parameters GetDefaultParameters() const override;
     [[nodiscard]] std::string      Info() const override;
     void                           PrintInfo(std::ostream& rOStream) const override;
@@ -128,9 +129,9 @@ private:
     [[nodiscard]] const Matrix& GetCachedExtrapolationMatrixFor(const Element& rElement) const;
 
     void AddIntegrationPointContributionsForAllVariables(Element&           rElement,
-                                                         const std::string& rModelPartName,
                                                          const Matrix&      rExtrapolationMatrix,
                                                          const ProcessInfo& rProcessInfo) const;
+    void CheckElement(Element& rElement, const std::string& rModelPartName, const ProcessInfo& rProcessInfo) const;
 };
 
 } // namespace Kratos.

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_processes/test_geo_extrapolate_integration_point_values_to_nodes_process.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_processes/test_geo_extrapolate_integration_point_values_to_nodes_process.cpp
@@ -20,6 +20,7 @@
 #include "tests/cpp_tests/test_utilities.h"
 
 #include <numbers>
+#include <stdexcept>
 #include <string>
 
 using namespace std::numbers;
@@ -104,6 +105,54 @@ public:
     std::vector<Vector>              mIntegrationVectorValues = {};
     std::vector<array_1d<double, 3>> mIntegrationArrayValues  = {};
 };
+
+class StubElementWithThrowingCheckForNodalExtrapolationTest : public StubElementForNodalExtrapolationTest
+{
+public:
+    KRATOS_CLASS_INTRUSIVE_POINTER_DEFINITION(StubElementWithThrowingCheckForNodalExtrapolationTest);
+
+    using StubElementForNodalExtrapolationTest::StubElementForNodalExtrapolationTest;
+
+    int Check(const ProcessInfo&) const override
+    {
+        throw std::runtime_error("Synthetic check failure");
+    }
+};
+
+class StubElementWithUnknownThrowingCheckForNodalExtrapolationTest : public StubElementForNodalExtrapolationTest
+{
+public:
+    KRATOS_CLASS_INTRUSIVE_POINTER_DEFINITION(StubElementWithUnknownThrowingCheckForNodalExtrapolationTest);
+
+    using StubElementForNodalExtrapolationTest::StubElementForNodalExtrapolationTest;
+
+    int Check(const ProcessInfo&) const override { throw 42; }
+};
+
+class StubElementWithNonZeroCheckForNodalExtrapolationTest : public StubElementForNodalExtrapolationTest
+{
+public:
+    KRATOS_CLASS_INTRUSIVE_POINTER_DEFINITION(StubElementWithNonZeroCheckForNodalExtrapolationTest);
+
+    using StubElementForNodalExtrapolationTest::StubElementForNodalExtrapolationTest;
+
+    int Check(const ProcessInfo&) const override { return 1; }
+};
+
+template <typename TElementType>
+ModelPart& CreateModelPartWithSingleStubElement(Model& model, const VariableData& rVariable)
+{
+    auto& r_result = model.CreateModelPart("MainModelPart"s);
+    r_result.AddNodalSolutionStepVariable(rVariable);
+
+    Testing::ModelSetupUtilities::CreateNodes(
+        r_result, {{1, {0.0, 0.0, 0.0}}, {2, {1.0, 0.0, 0.0}}, {3, {1.0, 1.0, 0.0}}, {4, {0.0, 1.0, 0.0}}});
+
+    const auto nodes_of_element = Testing::ModelSetupUtilities::GetNodesFromIds(r_result, {1, 2, 3, 4});
+    r_result.AddElement(make_intrusive<TElementType>(1, std::make_shared<Quadrilateral2D4<Node>>(nodes_of_element)));
+
+    return r_result;
+}
 
 ModelPart& CreateModelPartWithTwoStubElements(Model& model, const VariableData& rVariable)
 {
@@ -354,6 +403,45 @@ KRATOS_TEST_CASE_IN_SUITE(TestExtrapolationProcess_ExtrapolatesCorrectlyForLinea
                    r_test_variable));
 
     AssertNodalValues(r_main_model_part.Nodes(), r_test_variable, {-1.0, 0.0, 1.0, -1.0, -1.0, 1.0});
+}
+
+KRATOS_TEST_CASE_IN_SUITE(TestExtrapolationProcess_ThrowsWhenElementCheckThrowsStdException,
+                          KratosGeoMechanicsFastSuiteWithoutKernel)
+{
+    auto        model           = Model{};
+    const auto& r_test_variable = HYDRAULIC_HEAD;
+    const auto& r_model_part =
+        CreateModelPartWithSingleStubElement<StubElementWithThrowingCheckForNodalExtrapolationTest>(
+            model, r_test_variable);
+
+    KRATOS_EXPECT_EXCEPTION_IS_THROWN(
+        CreateAndRunExtrapolationProcess(model, CreateExtrapolationProcessSettings(r_model_part, r_test_variable)), "GeoExtrapolateIntegrationPointValuesToNodesProcess: Exception while calling Element::Check")
+}
+
+KRATOS_TEST_CASE_IN_SUITE(TestExtrapolationProcess_ThrowsWhenElementCheckThrowsUnknownException,
+                          KratosGeoMechanicsFastSuiteWithoutKernel)
+{
+    auto        model           = Model{};
+    const auto& r_test_variable = HYDRAULIC_HEAD;
+    const auto& r_model_part =
+        CreateModelPartWithSingleStubElement<StubElementWithUnknownThrowingCheckForNodalExtrapolationTest>(
+            model, r_test_variable);
+
+    KRATOS_EXPECT_EXCEPTION_IS_THROWN(
+        CreateAndRunExtrapolationProcess(model, CreateExtrapolationProcessSettings(r_model_part, r_test_variable)), "GeoExtrapolateIntegrationPointValuesToNodesProcess: Unknown exception while calling Element::Check")
+}
+
+KRATOS_TEST_CASE_IN_SUITE(TestExtrapolationProcess_ThrowsWhenElementCheckReturnsNonZero,
+                          KratosGeoMechanicsFastSuiteWithoutKernel)
+{
+    auto        model           = Model{};
+    const auto& r_test_variable = HYDRAULIC_HEAD;
+    const auto& r_model_part =
+        CreateModelPartWithSingleStubElement<StubElementWithNonZeroCheckForNodalExtrapolationTest>(
+            model, r_test_variable);
+
+    KRATOS_EXPECT_EXCEPTION_IS_THROWN(
+        CreateAndRunExtrapolationProcess(model, CreateExtrapolationProcessSettings(r_model_part, r_test_variable)), "GeoExtrapolateIntegrationPointValuesToNodesProcess: Element Check failed before extrapolation")
 }
 
 KRATOS_TEST_CASE_IN_SUITE(TestExtrapolationProcess_ExtrapolatesMatrixCorrectlyForLinearFields,

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_processes/test_geo_extrapolate_integration_point_values_to_nodes_process.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_processes/test_geo_extrapolate_integration_point_values_to_nodes_process.cpp
@@ -413,9 +413,12 @@ KRATOS_TEST_CASE_IN_SUITE(TestExtrapolationProcess_ThrowsWhenElementCheckThrowsS
     const auto& r_model_part =
         CreateModelPartWithSingleStubElement<StubElementWithThrowingCheckForNodalExtrapolationTest>(
             model, r_test_variable);
+    auto process = GeoExtrapolateIntegrationPointValuesToNodesProcess{
+        model, CreateExtrapolationProcessSettings(r_model_part, r_test_variable)};
 
-    KRATOS_EXPECT_EXCEPTION_IS_THROWN(
-        CreateAndRunExtrapolationProcess(model, CreateExtrapolationProcessSettings(r_model_part, r_test_variable)), "GeoExtrapolateIntegrationPointValuesToNodesProcess: Exception while calling Element::Check")
+    KRATOS_EXPECT_EXCEPTION_IS_THROWN(process.Check(),
+                                      "GeoExtrapolateIntegrationPointValuesToNodesProcess: "
+                                      "Exception while calling Element::Check")
 }
 
 KRATOS_TEST_CASE_IN_SUITE(TestExtrapolationProcess_ThrowsWhenElementCheckThrowsUnknownException,
@@ -426,9 +429,12 @@ KRATOS_TEST_CASE_IN_SUITE(TestExtrapolationProcess_ThrowsWhenElementCheckThrowsU
     const auto& r_model_part =
         CreateModelPartWithSingleStubElement<StubElementWithUnknownThrowingCheckForNodalExtrapolationTest>(
             model, r_test_variable);
+    auto process = GeoExtrapolateIntegrationPointValuesToNodesProcess{
+        model, CreateExtrapolationProcessSettings(r_model_part, r_test_variable)};
 
-    KRATOS_EXPECT_EXCEPTION_IS_THROWN(
-        CreateAndRunExtrapolationProcess(model, CreateExtrapolationProcessSettings(r_model_part, r_test_variable)), "GeoExtrapolateIntegrationPointValuesToNodesProcess: Unknown exception while calling Element::Check")
+    KRATOS_EXPECT_EXCEPTION_IS_THROWN(process.Check(),
+                                      "GeoExtrapolateIntegrationPointValuesToNodesProcess: Unknown "
+                                      "exception while calling Element::Check")
 }
 
 KRATOS_TEST_CASE_IN_SUITE(TestExtrapolationProcess_ThrowsWhenElementCheckReturnsNonZero,
@@ -439,9 +445,12 @@ KRATOS_TEST_CASE_IN_SUITE(TestExtrapolationProcess_ThrowsWhenElementCheckReturns
     const auto& r_model_part =
         CreateModelPartWithSingleStubElement<StubElementWithNonZeroCheckForNodalExtrapolationTest>(
             model, r_test_variable);
+    auto process = GeoExtrapolateIntegrationPointValuesToNodesProcess{
+        model, CreateExtrapolationProcessSettings(r_model_part, r_test_variable)};
 
-    KRATOS_EXPECT_EXCEPTION_IS_THROWN(
-        CreateAndRunExtrapolationProcess(model, CreateExtrapolationProcessSettings(r_model_part, r_test_variable)), "GeoExtrapolateIntegrationPointValuesToNodesProcess: Element Check failed before extrapolation")
+    KRATOS_EXPECT_EXCEPTION_IS_THROWN(process.Check(),
+                                      "GeoExtrapolateIntegrationPointValuesToNodesProcess: Element "
+                                      "Check failed before extrapolation")
 }
 
 KRATOS_TEST_CASE_IN_SUITE(TestExtrapolationProcess_ExtrapolatesMatrixCorrectlyForLinearFields,


### PR DESCRIPTION
-  added a call of element `Check `in GeoExtrapolateIntegrationPointValuesToNodesProcess to prevent using inactive elements. This may happen due to a user mistake.