### PR TITLE
[Core] Adding new data containers

### DIFF
--- a/docs/pages/Kratos/For_Developers/Data_Structures/Data_Container.md
+++ b/docs/pages/Kratos/For_Developers/Data_Structures/Data_Container.md
@@ -1,0 +1,57 @@
+---
+title: DataContainer
+keywords:
+tags: [DataContainer DataChunk DataAccessor DataValuePolicy DataHistoryPolicy]
+sidebar: kratos_for_developers
+summary:
+---
+
+# DataContainer
+
+A chunked, type-erased, variable-keyed storage system for entity data, intended as the future backend for the data held by `Node`, geometric entities and constraints (Phase II). In this first phase it is a standalone module: nothing in the core uses it yet.
+
+## Storage model
+
+A `DataContainer` maps each added `Variable` to one **`DataChunk`**: a single contiguous block of memory holding the values of that variable for *all* entities (struct-of-arrays layout), instead of scattering per-entity values across entity objects. A chunk additionally holds one such block *per stored step slot*, laid out step-by-step.
+
+```
+DataContainer
+ ├── DataChunk<double>   (PRESSURE)    [step0: e0 e1 e2 ...][step1: ...][step2: ...]
+ ├── DataChunk<int>      (STEP)        [e0 e1 e2 ...]
+ └── DataChunk<array_1d> (VELOCITY)    [e0 e1 e2 ...]
+```
+
+How a chunk behaves is decided by two orthogonal policies passed to `DataContainer::Add`:
+
+- **Value policy** (`DataValuePolicy<T>` hierarchy) — *what* is stored and how. `DataValuePolicy<T>` stores one dense value of type `T` per entity and also owns the **zero value** used to initialize entries (note: the zero belongs to the policy, not to the `Variable`; e.g. `DataValuePolicy<int>(-1)` for sparse index variables). `LayeredDataValuePolicy<T>` stores a fixed number of layers (`std::vector<T>`) per entity. `SparseDataValuePolicy<T>` stores values for only a subset of entities (see below). The base class also carries the type-erased operations (`Clone`/`Copy`/`Assign`/`AssignZero`/`Delete`/`Destruct`/`Print`/`Allocate`) that let `DataChunkBase` be manipulated without knowing `T`.
+- **History policy** (`DataHistoryPolicyBase` hierarchy) — *how many steps* are kept. `NonHistoricalDataPolicy` keeps a single slot, no history. `HistoricalDataPolicy(category, n)` keeps a ring buffer of `n` step slots bound to one `StepCategory` (time step, iteration step, sub-step); `DataContainer::CloneStepData(category)` advances the ring only for chunks of that category and copies the current data onto the new current slot, so time-step history can be cloned without touching iteration-level data.
+
+Policy comparison semantics matter for lookups: `IsSameType` compares only the dynamic type (used by `Has`/`GetAccessor` — the *configuration*, e.g. number of layers or buffer size, does not need to match), while `IsSame` also compares the configuration (used by `Add` to detect conflicting re-additions and by the variable+policy `GetDataSpan` overloads). Note that `SparseDataValuePolicy` does not override `IsSameType`: a sparse and a dense policy of the same value type compare as the same *type* (sparseness itself is queried through `IsSparse`).
+
+## Accessors
+
+`Add`/`GetAccessor` return a **`DataAccessor<T>`**: a small, trivially copyable handle caching the *index* of the chunk inside the container, so `GetDataSpan(accessor)` addresses the chunk in O(1) — no search by variable — resolving only the step slot through the history policy. An accessor also records which step it refers to (`StepCategory` + steps before current); `GetStepAccessor` derives an accessor to another step of the same data. Accessors do not own anything and are only valid for the container that created them (the variable identity is verified on access).
+
+## Variable canonicalization
+
+`Add` looks the variable up in the Kratos `Registry` (`variables.all.<name>`) and binds the chunk and accessors to the *registry-owned* variable object, so the stored data is independent of the lifetime of the `Variable` object passed by the caller. Consequently only registered variables can be added (all standard Kratos variables are; locally created ones must call `Variable::Register()` first) — `Add` does not register variables itself, it only canonicalizes already-registered ones.
+
+## Sparse storage
+
+Sparse data (values existing for only a few entities) is driven by a dense *index variable* (`Variable<int>`) stored in the same container: entry `i` holds the sparse position of entity `i`, or a negative value if the entity has no data. A chunk created with `SparseDataValuePolicy<T>(index_accessor)` starts **empty** and grows on demand: `UpdateSparseStorage(index_accessor)` rebuilds every sparse chunk keyed on that index to the number of active entries (existing values are discarded, all entries re-zero-initialized), while `AddToSparseStorage(index_accessor, entity_indices)` assigns the next free sparse indices to currently inactive entities and grows the chunks, **preserving** existing values and zero-initializing only the appended entries. Both operations reallocate chunk storage, so previously obtained spans (and NumPy views) are invalidated and must be re-fetched.
+
+## Header/source split
+
+Only the non-template classes (`DataValuePolicyBase`, `DataHistoryPolicyBase` and its two concrete policies, `DataChunkBase`, and the non-template methods of `DataContainer`) have their logic-bearing bodies in a matching `.cpp` file, mirroring how `VariableData` (non-template) has `variable_data.cpp` while `Variable<T>` (template) stays fully inline in `variable.h`. `DataAccessor<T>`, `DataValuePolicy<T>`, `LayeredDataValuePolicy<T>`, `SparseDataValuePolicy<T>` and `DataChunk<T>` are templates and stay header-only, since the module must remain generic over arbitrary user value types (as exercised by the tests); the same applies to `DataContainer::Add`/`GetAccessor`/`GetDataSpan`/`Has`, which are templates for the same reason.
+
+## Python interface
+
+`DataContainer`, the policies and accessors are exposed per value type (`double`, `int`, `array_1d<double,3>`, `std::string`) following the `DoubleVariable` naming precedent: `DoubleDataValuePolicy`, `IntegerSparseDataValuePolicy`, `Array1DDataValuePolicy3`, `StringDataAccessor`, ... `GetDataSpan` returns a zero-copy NumPy view (shape `(n,)`, or `(n, 3)` for `array_1d<double,3>`) whose base object keeps the container alive; string data is exposed through a `StringDataSpan` proxy instead. The same invalidation caveat as in C++ applies: re-fetch views after sparse storage updates. `LayeredDataValuePolicy` is not bound in this phase.
+
+## Semantics worth knowing
+
+- Copying a `DataContainer` is **shallow**: copies share the chunks (`std::shared_ptr`).
+- Thread-safety: only `Add` is internally locked; everything else needs external synchronization.
+- `DataChunk` owns its storage manually (`new[]`/`delete[]`) and is non-copyable; chunks with zero entities are valid (that is how sparse chunks start).
+- `HistoricalDataPolicy::Clone()` resets the running step index — freshly created chunks (`CreateNew`, `Initialize`) start their history at slot 0.
+- `Initialize(other, chunk_size)` mirrors another container's chunk *structure* with fresh zero-initialized chunks (dense at `chunk_size`, sparse empty); it does not copy data.

--- a/docs/pages/Kratos/For_Developers/Data_Structures/Data_Container.md
+++ b/docs/pages/Kratos/For_Developers/Data_Structures/Data_Container.md
@@ -55,3 +55,4 @@ Only the non-template classes (`DataValuePolicyBase`, `DataHistoryPolicyBase` an
 - `DataChunk` owns its storage manually (`new[]`/`delete[]`) and is non-copyable; chunks with zero entities are valid (that is how sparse chunks start).
 - `HistoricalDataPolicy::Clone()` resets the running step index — freshly created chunks (`CreateNew`, `Initialize`) start their history at slot 0.
 - `Initialize(other, chunk_size)` mirrors another container's chunk *structure* with fresh zero-initialized chunks (dense at `chunk_size`, sparse empty); it does not copy data.
+- `Resize(n)` grows/shrinks all **dense** chunks to `n` entities per step, preserving the first `min(old, new)` values of every step slot and zero-filling the tails (sparse chunks are skipped; previously obtained spans are invalidated).

--- a/kratos/containers/data_container/data_accessor.h
+++ b/kratos/containers/data_container/data_accessor.h
@@ -1,0 +1,199 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
+//
+//  Main authors:    Pooyan Dadvand
+//  Collaborator:    Vicente Mataix Ferrandiz
+//
+//
+
+#pragma once
+
+// System includes
+
+// External includes
+#include <span/span.hpp>
+
+// Project includes
+#include "containers/variable_data.h"
+#include "containers/data_container/step_category.h"
+
+namespace Kratos
+{
+///@addtogroup KratosCore
+///@{
+
+///@name Kratos Classes
+///@{
+
+/**
+ * @class DataAccessor
+ * @ingroup KratosCore
+ * @brief Lightweight, non-owning handle to the data of one variable stored in a DataContainer.
+ * @details The accessor caches the index of the corresponding DataChunk inside its DataContainer, so the data can be retrieved in O(1) via DataContainer::GetDataSpan without searching the container by variable. It additionally stores which step of the chunk history it refers to (a StepCategory plus a number of steps before the current one), so re-parameterized accessors for other steps can be derived cheaply with GetStepAccessor.
+ *
+ * Accessors are produced by DataContainer::Add and DataContainer::GetAccessor; they hold a raw pointer to the canonical (Registry-owned) variable and do not own any data or keep the container alive. An accessor is only valid for the container that created it and as long as that container exists; DataContainer::GetDataSpan verifies the variable identity before returning data.
+ *
+ * @note This class is trivially copyable and cheap to pass by value. It provides no thread-safety guarantees of its own (it is immutable after construction).
+ * @tparam TValueType Type of the values stored in the referenced DataChunk.
+ * @author Pooyan Dadvand
+ */
+template<typename TValueType>
+class DataAccessor
+{
+public:
+    ///@name Type Definitions
+    ///@{
+
+    /// Type of the data stored in the chunk
+    using ValueType = TValueType;
+
+    /// Type of the span of data for a specific step
+    using StepSpanType = Kratos::span<TValueType>;
+
+    ///@}
+    ///@name Life Cycle
+    ///@{
+
+    /**
+     * @brief Default constructor.
+     * @details Creates an uninitialized accessor (null variable, index 0, StepCategory::AnyStep). Using it with DataContainer::GetDataSpan raises an error.
+     */
+    DataAccessor()
+        : mpVariable(nullptr),
+          mIndex(0),
+          mStepCategory(StepCategory::AnyStep),
+          mStepBeforeCurrent(0)
+    {}
+
+    /**
+     * @brief Constructor.
+     * @param rVariable The variable associated with the data chunk. The accessor stores a pointer to it, so it must outlive the accessor (DataContainer passes the Registry-owned canonical variable, which lives for the whole program).
+     * @param Index The index of the data chunk in the container.
+     * @param StepCat The step category the accessor refers to.
+     * @param StepBeforeCurrent How many steps before the current one the accessor refers to.
+     */
+    template<typename TVariableType>
+    DataAccessor(
+        TVariableType const& rVariable,
+        std::size_t Index,
+        StepCategory StepCat = StepCategory::TimeStep,
+        int StepBeforeCurrent = 0)
+        : mpVariable(&rVariable),
+          mIndex(Index),
+          mStepCategory(StepCat),
+          mStepBeforeCurrent(StepBeforeCurrent)
+    {}
+
+    ///@}
+    ///@name Operators
+    ///@{
+
+    /**
+     * @brief Equality comparison.
+     * @details Two accessors are equal if they point to the same variable object (pointer identity, which holds for accessors produced by the same container thanks to the Registry canonicalization in DataContainer::Add), reference the same chunk index and the same step (category and steps before current).
+     * @param rOther The accessor to compare against.
+     * @return true if both accessors refer to the same data and step.
+     */
+    bool operator==(const DataAccessor<TValueType>& rOther) const
+    {
+        return (
+            mpVariable == rOther.mpVariable &&
+            mIndex == rOther.mIndex &&
+            mStepCategory == rOther.mStepCategory &&
+            mStepBeforeCurrent == rOther.mStepBeforeCurrent
+        );
+    }
+
+    ///@}
+    ///@name Operations
+    ///@{
+
+    /**
+     * @brief Get an accessor to the same data but a different step.
+     * @param StepCat The step category of the new accessor.
+     * @param StepBeforeCurrent How many steps before the current one the new accessor refers to.
+     * @return A new accessor for the same variable and chunk index, re-parameterized to the given step.
+     */
+    DataAccessor<TValueType> GetStepAccessor(StepCategory StepCat, int StepBeforeCurrent = 0) const
+    {
+        return DataAccessor<TValueType>(*mpVariable, mIndex, StepCat, StepBeforeCurrent);
+    }
+
+    ///@}
+    ///@name Access
+    ///@{
+
+    /**
+     * @brief Get the index of the data chunk in the container.
+     * @return The chunk index cached by this accessor.
+     */
+    std::size_t GetIndex() const
+    {
+        return mIndex;
+    }
+
+    /**
+     * @brief Get the step category this accessor refers to.
+     * @return The step category.
+     */
+    StepCategory GetStepCategory() const
+    {
+        return mStepCategory;
+    }
+
+    /**
+     * @brief Get how many steps before the current one this accessor refers to.
+     * @return The number of steps before the current one.
+     */
+    int GetStepBeforeCurrent() const
+    {
+        return mStepBeforeCurrent;
+    }
+
+    /**
+     * @brief Get the variable associated with the data chunk.
+     * @return Reference to the variable data. Must not be called on a default-constructed accessor.
+     */
+    const VariableData& GetVariableData() const
+    {
+        return *mpVariable;
+    }
+
+    /**
+     * @brief Get the pointer to the variable associated with the data chunk.
+     * @return Pointer to the variable data (nullptr for a default-constructed accessor).
+     */
+    const VariableData* pGetVariableData() const
+    {
+        return mpVariable;
+    }
+
+    ///@}
+
+private:
+    ///@name Member Variables
+    ///@{
+
+    const VariableData* mpVariable;  /// Pointer to the variable associated with the data chunk
+
+    std::size_t mIndex;              /// The index of the data chunk in the container
+
+    StepCategory mStepCategory = StepCategory::AnyStep;  /// The step category for the data chunk (AnyStep when default-constructed, TimeStep by default otherwise)
+
+    int mStepBeforeCurrent = 0;      /// The step before current for the data chunk, default is 0
+
+    ///@}
+
+}; // Class DataAccessor
+
+///@}
+
+///@} addtogroup block
+
+} // namespace Kratos

--- a/kratos/containers/data_container/data_chunk.cpp
+++ b/kratos/containers/data_container/data_chunk.cpp
@@ -1,0 +1,31 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
+//
+//  Main authors:    Pooyan Dadvand
+//  Collaborator:    Vicente Mataix Ferrandiz
+//
+//
+
+// System includes
+
+// External includes
+
+// Project includes
+#include "containers/data_container/data_chunk.h"
+
+namespace Kratos
+{
+
+void DataChunkBase::ResizeData(std::size_t NumberOfEntities)
+{
+    this->ResizeDataContainer(NumberOfEntities);
+    mNumberOfEntitiesPerStep = NumberOfEntities;
+}
+
+} // namespace Kratos

--- a/kratos/containers/data_container/data_chunk.h
+++ b/kratos/containers/data_container/data_chunk.h
@@ -1,0 +1,437 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
+//
+//  Main authors:    Pooyan Dadvand
+//  Collaborator:    Vicente Mataix Ferrandiz
+//
+//
+
+#pragma once
+
+// System includes
+#include <algorithm>
+
+// External includes
+
+// Project includes
+#include "containers/data_container/data_value_policy.h"
+#include "containers/data_container/data_history_policy.h"
+
+namespace Kratos
+{
+///@addtogroup KratosCore
+///@{
+
+///@name Kratos Classes
+///@{
+
+/**
+ * @class DataChunkBase
+ * @ingroup KratosCore
+ * @brief Type-erased base class of the storage chunks held by a DataContainer.
+ * @details Provides the type-independent part of a chunk: the number of entities stored per step and the virtual interface used by DataContainer to work with chunks without knowing their value type (query the associated variable and policies, create sibling chunks, clone step data and resize the storage).
+ *
+ * Chunks are usually constructed and owned (as std::shared_ptr) by DataContainer::Add, not directly. A chunk with zero entities is valid: chunks governed by a sparse value policy start empty and grow via DataContainer::UpdateSparseStorage / DataContainer::AddToSparseStorage.
+ * @note This class provides no thread-safety guarantees; concurrent access must be synchronized externally (DataContainer only locks chunk creation in Add).
+ * @see DataChunk, DataContainer, DataValuePolicyBase, DataHistoryPolicyBase
+ * @author Pooyan Dadvand
+ */
+class KRATOS_API(KRATOS_CORE) DataChunkBase
+{
+public:
+    ///@name Life Cycle
+    ///@{
+
+    /**
+     * @brief Constructor.
+     * @param NumberOfEntities Number of entities per step in the chunk. May be zero for (initially empty) sparse chunks.
+     */
+    DataChunkBase(std::size_t NumberOfEntities)
+        : mNumberOfEntitiesPerStep(NumberOfEntities)
+    {
+    }
+
+    /// Destructor.
+    virtual ~DataChunkBase() = default;
+
+    ///@}
+    ///@name Operations
+    ///@{
+
+    /**
+     * @brief Create a new chunk of the same dynamic type, variable and policies with the given number of entities.
+     * @param NumberOfEntities Number of entities per step of the new chunk.
+     * @return A shared pointer to the newly created chunk (its data is zero-initialized and its history ring starts at slot 0, see HistoricalDataPolicy::Clone).
+     */
+    virtual std::shared_ptr<DataChunkBase> CreateNew(std::size_t NumberOfEntities) const = 0;
+
+    /**
+     * @brief Allocate the raw storage for the given number of entities.
+     * @details Any previously held data is released (without copying); the new storage is uninitialized. Allocates NumberOfEntities times the total number of steps values.
+     * @param NumberOfEntities Number of entities per step to allocate for. May be zero (no storage is allocated).
+     */
+    virtual void AllocateData(std::size_t NumberOfEntities) = 0;
+
+    /**
+     * @brief Clone the data of the current step onto the next step slot of the given category.
+     * @details Delegates the ring-buffer advance to the history policy: data is copied only when the policy's category matches and the step index actually changes; otherwise this is a no-op.
+     * @param Category The step category being cloned.
+     */
+    virtual void CloneStepData(StepCategory Category) = 0;
+
+    /**
+     * @brief Reallocate the storage preserving existing data.
+     * @details For each stored step the first min(old, new) entity values are preserved; newly added entries are zero-initialized with the value policy zero. Resizing to zero releases the storage. This reallocates and copies (O(entities * steps)).
+     * @param NumberOfEntities The new number of entities per step.
+     */
+    void ResizeData(std::size_t NumberOfEntities);
+
+    ///@}
+    ///@name Access
+    ///@{
+
+    /**
+     * @brief Get the variable associated with the data chunk.
+     * @return Reference to the variable data.
+     */
+    virtual const VariableData& GetVariableData() const = 0;
+
+    /**
+     * @brief Get the value policy associated with the data chunk.
+     * @return Reference to the value policy.
+     */
+    virtual const DataValuePolicyBase& GetValuePolicy() const = 0;
+
+    /**
+     * @brief Get the history policy associated with the data chunk.
+     * @return Reference to the history policy.
+     */
+    virtual const DataHistoryPolicyBase& GetHistoryPolicy() const = 0;
+
+    ///@}
+    ///@name Inquiry
+    ///@{
+
+    /**
+     * @brief Get the number of entities stored per step.
+     * @return The number of entities per step.
+     */
+    std::size_t NumberOfEntitiesPerStep() const
+    {
+        return mNumberOfEntitiesPerStep;
+    }
+
+    ///@}
+
+protected:
+    ///@name Protected Operations
+    ///@{
+
+    /**
+     * @brief Reallocate the storage for the new number of entities preserving existing data.
+     * @details Implemented by DataChunk; called by ResizeData, which afterwards updates the stored number of entities.
+     * @param NumberOfEntities The new number of entities per step.
+     */
+    virtual void ResizeDataContainer(std::size_t NumberOfEntities) = 0;
+
+    ///@}
+
+private:
+    ///@name Member Variables
+    ///@{
+
+    std::size_t mNumberOfEntitiesPerStep; /// Number of entities per step in the chunk. This is used to determine the size of the data
+
+    ///@}
+
+}; // Class DataChunkBase
+
+/**
+ * @class DataChunk
+ * @ingroup KratosCore
+ * @brief Contiguous storage for the values of one variable over the entities of a DataContainer.
+ * @details The chunk owns a single raw array of NumberOfEntitiesPerStep() times GetTotalNumberOfSteps() values of type TValueType, laid out step-by-step (all entities of step slot 0, then all entities of step slot 1, ...). Ownership is manual (new[] / delete[]) to keep the storage a plain contiguous block, mirroring how other performance-critical Kratos containers manage their memory; the chunk is therefore non-copyable (it is shared via std::shared_ptr from the DataContainer instead).
+ *
+ * On construction all values are initialized with the value policy zero. The value policy and history policy passed in are cloned and owned by the chunk; the variable is held by reference and must outlive the chunk (DataContainer passes the Registry-owned canonical variable).
+ * @note This class provides no thread-safety guarantees.
+ * @see DataChunkBase, DataContainer, DataValuePolicy, DataHistoryPolicyBase
+ * @tparam TValueType Type of the stored values.
+ * @author Pooyan Dadvand
+ */
+template <typename TValueType>
+class DataChunk : public DataChunkBase
+{
+public:
+    ///@name Type Definitions
+    ///@{
+
+    /// Type of the stored values
+    using ValueType = TValueType;
+
+    ///@}
+    ///@name Life Cycle
+    ///@{
+
+    /**
+     * @brief Constructor.
+     * @param rVariable The variable associated with the data chunk. Held by reference; it must outlive the chunk.
+     * @param rValuePolicy The value policy; it is cloned into the chunk.
+     * @param rHistoryPolicy The history policy; it is cloned into the chunk.
+     * @param NumberOfEntities Number of entities per step. May be zero for sparse chunks.
+     */
+    DataChunk(
+        const VariableData& rVariable,
+        const DataValuePolicy<TValueType>& rValuePolicy,
+        const DataHistoryPolicyBase& rHistoryPolicy,
+        std::size_t NumberOfEntities)
+        : DataChunkBase(NumberOfEntities),
+          mData(nullptr),
+          mpValuePolicy(rValuePolicy.Clone()),
+          mpHistoryPolicy(rHistoryPolicy.Clone()),
+          mrVariable(rVariable)
+    {
+        KRATOS_DEBUG_ERROR_IF_NOT(mpHistoryPolicy && mpHistoryPolicy->GetTotalNumberOfSteps() > 0) << "Number of buffers must be greater than zero." << std::endl;
+
+        AllocateData(NumberOfEntities);
+        if (mData != nullptr) {
+            std::fill(mData, mData + NumberOfEntities * mpHistoryPolicy->GetTotalNumberOfSteps(), rValuePolicy.Zero());
+        }
+    }
+
+    /**
+     * @brief Constructor taking ownership of already cloned policies.
+     * @param rVariable The variable associated with the data chunk. Held by reference; it must outlive the chunk.
+     * @param pValuePolicy The value policy; ownership is transferred to the chunk.
+     * @param pHistoryPolicy The history policy; ownership is transferred to the chunk.
+     * @param NumberOfEntities Number of entities per step. May be zero for sparse chunks.
+     */
+    template <typename TValuePolicyType>
+    DataChunk(
+        const VariableData& rVariable,
+        std::unique_ptr<TValuePolicyType> pValuePolicy,
+        std::unique_ptr<DataHistoryPolicyBase> pHistoryPolicy,
+        std::size_t NumberOfEntities)
+        : DataChunkBase(NumberOfEntities),
+          mData(nullptr),
+          mpValuePolicy(std::move(pValuePolicy)),
+          mpHistoryPolicy(std::move(pHistoryPolicy)),
+          mrVariable(rVariable)
+    {
+        KRATOS_DEBUG_ERROR_IF_NOT(mpHistoryPolicy && mpHistoryPolicy->GetTotalNumberOfSteps() > 0) << "Number of buffers must be greater than zero." << std::endl;
+
+        AllocateData(NumberOfEntities);
+        if (mData != nullptr) {
+            std::fill(mData, mData + NumberOfEntities * mpHistoryPolicy->GetTotalNumberOfSteps(), mpValuePolicy->Zero());
+        }
+    }
+
+    /// Copy constructor (deleted: the chunk owns raw storage and is shared via std::shared_ptr instead).
+    DataChunk(const DataChunk&) = delete;
+
+    /// Destructor.
+    ~DataChunk() override
+    {
+        delete[] mData;
+    }
+
+    ///@}
+    ///@name Operators
+    ///@{
+
+    /// Assignment operator (deleted: the chunk owns raw storage and is shared via std::shared_ptr instead).
+    DataChunk& operator=(const DataChunk&) = delete;
+
+    ///@}
+    ///@name Operations
+    ///@{
+
+    /**
+     * @brief Create a new DataChunk of the same type, variable and policies to store NumberOfEntities objects.
+     * @param NumberOfEntities Number of entities per step of the new chunk.
+     * @return A shared pointer to the newly created, zero-initialized chunk. Its history ring starts at slot 0 (the history policy is cloned, see HistoricalDataPolicy::Clone).
+     */
+    std::shared_ptr<DataChunkBase> CreateNew(std::size_t NumberOfEntities) const override
+    {
+        return std::make_shared<DataChunk<TValueType>>(mrVariable, mpValuePolicy->Clone(), mpHistoryPolicy->Clone(), NumberOfEntities);
+    }
+
+    /**
+     * @brief Allocate the raw storage for the given number of entities.
+     * @details Releases any previously held data (without copying); the new storage is uninitialized (values are default-constructed by new[]). Allocates NumberOfEntities times the total number of steps values; with zero entities no storage is allocated.
+     * @param NumberOfEntities Number of entities per step to allocate for.
+     */
+    void AllocateData(std::size_t NumberOfEntities) override
+    {
+        delete[] mData;
+        mData = nullptr;
+        const std::size_t total_size = NumberOfEntities * mpHistoryPolicy->GetTotalNumberOfSteps();
+        if (total_size > 0) {
+            mData = new ValueType[total_size];
+        }
+    }
+
+    /**
+     * @brief Clone the data of the current step onto the next step slot of the given category.
+     * @details The history policy advances its ring only when the category matches its own; when the step index changes, the values of the previous current step are copied onto the new current step (so the new step starts as a copy of the old one). Otherwise this is a no-op.
+     * @param Category The step category being cloned.
+     */
+    void CloneStepData(StepCategory Category) override
+    {
+        const std::size_t current_step_index = mpHistoryPolicy->GetLatestStepIndex();
+        const std::size_t next_step_index = mpHistoryPolicy->CloneStepIndex(Category);
+
+        if (next_step_index != current_step_index) {
+            const std::size_t offset_current = current_step_index * NumberOfEntitiesPerStep();
+            const std::size_t offset_next = next_step_index * NumberOfEntitiesPerStep();
+            std::copy(mData + offset_current, mData + offset_current + NumberOfEntitiesPerStep(),
+                      mData + offset_next);
+        }
+    }
+
+    ///@}
+    ///@name Access
+    ///@{
+
+    /**
+     * @brief Get the variable associated with the data chunk.
+     * @return Reference to the variable data.
+     */
+    const VariableData& GetVariableData() const override
+    {
+        return mrVariable;
+    }
+
+    /**
+     * @brief Get the value policy associated with the data chunk.
+     * @return Reference to the value policy.
+     */
+    const DataValuePolicy<TValueType>& GetValuePolicy() const override
+    {
+        return *mpValuePolicy;
+    }
+
+    /**
+     * @brief Get the history policy associated with the data chunk.
+     * @return Reference to the history policy.
+     */
+    const DataHistoryPolicyBase& GetHistoryPolicy() const override
+    {
+        return *mpHistoryPolicy;
+    }
+
+    /**
+     * @brief Get the raw data pointer (all steps).
+     * @return Pointer to the first value of step slot 0 (nullptr for empty chunks).
+     */
+    ValueType* GetData()
+    {
+        return mData;
+    }
+
+    /**
+     * @brief Get the raw data pointer (all steps, const version).
+     * @return Pointer to the first value of step slot 0 (nullptr for empty chunks).
+     */
+    const ValueType* GetData() const
+    {
+        return mData;
+    }
+
+    /**
+     * @brief Get the iterator to the data of the given step slot.
+     * @param StepIndex The step slot index (see DataHistoryPolicyBase::GetStepIndex).
+     * @return Pointer to the first value of the given step slot.
+     */
+    ValueType* GetDataIterator(std::size_t StepIndex)
+    {
+        KRATOS_DEBUG_ERROR_IF(StepIndex >= mpHistoryPolicy->GetTotalNumberOfSteps()) << "Step index out of bounds." << std::endl;
+        const std::size_t offset = StepIndex * NumberOfEntitiesPerStep();
+        return mData + offset;
+    }
+
+    /**
+     * @brief Get the pointer to the data of the given step slot.
+     * @details Same as GetDataIterator (kept for interface compatibility).
+     * @param StepIndex The step slot index (see DataHistoryPolicyBase::GetStepIndex).
+     * @return Pointer to the first value of the given step slot.
+     */
+    ValueType* GetDataPointer(std::size_t StepIndex)
+    {
+        KRATOS_DEBUG_ERROR_IF(StepIndex >= mpHistoryPolicy->GetTotalNumberOfSteps()) << "Step index out of bounds." << std::endl;
+        const std::size_t offset = StepIndex * NumberOfEntitiesPerStep();
+        return mData + offset;
+    }
+
+    ///@}
+
+protected:
+    ///@name Protected Operations
+    ///@{
+
+    /**
+     * @brief Reallocate the storage preserving existing data.
+     * @details For each stored step slot the first min(old, new) entity values are copied into the new storage and newly added entries are initialized with the value policy zero, so per-step data is preserved independently of the history depth. Resizing to zero releases the storage. Reallocates and copies (O(entities * steps)).
+     * @param NewNumberOfEntities The new number of entities per step.
+     */
+    void ResizeDataContainer(std::size_t NewNumberOfEntities) override
+    {
+        if (NewNumberOfEntities == 0) {
+            delete[] mData;
+            mData = nullptr;
+            return;
+        }
+
+        const std::size_t num_steps = mpHistoryPolicy->GetTotalNumberOfSteps();
+        const std::size_t current_num_entities = NumberOfEntitiesPerStep();
+        // Per-step number of preserved entries (the old data may be empty)
+        const std::size_t copy_entities = (mData != nullptr) ? std::min(current_num_entities, NewNumberOfEntities) : 0;
+
+        ValueType* p_data = mData;
+        mData = new ValueType[NewNumberOfEntities * num_steps];
+
+        for (std::size_t step = 0; step < num_steps; step++) {
+            if (copy_entities > 0) {
+                std::copy(
+                    p_data + step * current_num_entities,
+                    p_data + step * current_num_entities + copy_entities,
+                    mData + step * NewNumberOfEntities);
+            }
+
+            std::fill(
+                mData + step * NewNumberOfEntities + copy_entities,
+                mData + (step + 1) * NewNumberOfEntities,
+                mpValuePolicy->Zero());
+        }
+
+        delete[] p_data;
+    }
+
+    ///@}
+
+private:
+    ///@name Member Variables
+    ///@{
+
+    TValueType* mData = nullptr;                              /// The data stored in the chunk as a raw owning pointer
+
+    std::unique_ptr<DataValuePolicy<TValueType>> mpValuePolicy; /// The value policy associated with the data chunk. This is used to determine the type of the data to store
+
+    std::unique_ptr<DataHistoryPolicyBase> mpHistoryPolicy;   /// Storing the history policy as a unique pointer allows for polymorphic behavior and memory management
+
+    const VariableData& mrVariable;                           /// The variable associated with the data chunk
+
+    ///@}
+
+}; // Class DataChunk
+
+///@}
+
+///@} addtogroup block
+
+} // namespace Kratos

--- a/kratos/containers/data_container/data_container.cpp
+++ b/kratos/containers/data_container/data_container.cpp
@@ -1,0 +1,191 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
+//
+//  Main authors:    Pooyan Dadvand
+//  Collaborator:    Vicente Mataix Ferrandiz
+//
+//
+
+// System includes
+
+// External includes
+
+// Project includes
+#include "containers/data_container/data_container.h"
+
+namespace Kratos
+{
+
+DataContainer::DataContainer(std::size_t ChunkSize)
+    : mChunkSize(ChunkSize)
+{
+    KRATOS_DEBUG_ERROR_IF(mChunkSize == 0) << "Chunk size must be greater than zero." << std::endl;
+}
+
+/***********************************************************************************/
+/***********************************************************************************/
+
+DataContainer::DataContainer(const DataContainer& rOther)
+    : mData(rOther.mData),
+      mChunkSize(rOther.mChunkSize)
+{
+}
+
+/***********************************************************************************/
+/***********************************************************************************/
+
+DataContainer::DataContainer(DataContainer&& rOther) noexcept
+    : mData(std::move(rOther.mData)),
+      mChunkSize(rOther.mChunkSize)
+{
+}
+
+/***********************************************************************************/
+/***********************************************************************************/
+
+DataContainer& DataContainer::operator=(const DataContainer& rOther)
+{
+    mData = rOther.mData;
+    mChunkSize = rOther.mChunkSize;
+    return *this;
+}
+
+/***********************************************************************************/
+/***********************************************************************************/
+
+DataContainer& DataContainer::operator=(DataContainer&& rOther) noexcept
+{
+    mData = std::move(rOther.mData);
+    mChunkSize = rOther.mChunkSize;
+    return *this;
+}
+
+/***********************************************************************************/
+/***********************************************************************************/
+
+void DataContainer::Initialize(const DataContainer& rOther, std::size_t ChunkSize)
+{
+    KRATOS_TRY
+
+    KRATOS_ERROR_IF(ChunkSize == 0) << "Chunk size must be greater than zero." << std::endl;
+    mChunkSize = ChunkSize;
+
+    // Copy chunks from the other data container
+    for (const auto& p_chunk : rOther.mData) {
+        if (p_chunk->GetValuePolicy().IsSparse()) {
+            mData.push_back(p_chunk->CreateNew(0));
+        } else {
+            mData.push_back(p_chunk->CreateNew(ChunkSize));
+        }
+    }
+
+    KRATOS_CATCH("")
+}
+
+/***********************************************************************************/
+/***********************************************************************************/
+
+void DataContainer::UpdateSparseStorage(const DataAccessor<int>& rIndexAccessor)
+{
+    KRATOS_TRY
+
+    for (auto& p_chunk : mData) {
+        if (p_chunk->GetValuePolicy().IsSparse()) {
+            auto index_accessor = p_chunk->GetValuePolicy().GetSparseIndexAccessor();
+            if (index_accessor == rIndexAccessor) {
+                auto index_span = GetDataSpan(index_accessor);
+                std::size_t sparse_count = 0;
+                for (const auto index : index_span) {
+                    if (index > -1) {
+                        ++sparse_count;
+                    }
+                }
+
+                auto p_new_chunk = p_chunk->CreateNew(sparse_count);
+                p_chunk.swap(p_new_chunk);
+            }
+        }
+    }
+
+    KRATOS_CATCH("")
+}
+
+/***********************************************************************************/
+/***********************************************************************************/
+
+void DataContainer::AddToSparseStorage(const DataAccessor<int>& rIndexAccessor, const std::vector<int>& rEntityIndices)
+{
+    KRATOS_TRY
+
+    if (rEntityIndices.size() == 0) return;
+
+    int new_size = -1;
+    for (auto& p_chunk : mData) {
+        if (p_chunk->GetValuePolicy().IsSparse()) {
+            auto index_accessor = p_chunk->GetValuePolicy().GetSparseIndexAccessor();
+            if (index_accessor == rIndexAccessor) {
+                if (new_size < 0) {
+                    new_size = static_cast<int>(p_chunk->NumberOfEntitiesPerStep());
+                    auto index_span = GetDataSpan(index_accessor);
+                    for (auto entity_id : rEntityIndices) {
+                        if (index_span[entity_id] == -1) {
+                            index_span[entity_id] = new_size++;
+                        }
+                    }
+                }
+
+                p_chunk->ResizeData(new_size);
+            }
+        }
+    }
+
+    KRATOS_CATCH("")
+}
+
+/***********************************************************************************/
+/***********************************************************************************/
+
+void DataContainer::CloneStepData(StepCategory rStepCategory)
+{
+    for (auto& p_chunk : mData) {
+        p_chunk->CloneStepData(rStepCategory);
+    }
+}
+
+/***********************************************************************************/
+/***********************************************************************************/
+
+std::string DataContainer::Info() const
+{
+    return "DataContainer";
+}
+
+/***********************************************************************************/
+/***********************************************************************************/
+
+void DataContainer::PrintInfo(std::ostream& rOStream) const
+{
+    rOStream << Info();
+}
+
+/***********************************************************************************/
+/***********************************************************************************/
+
+void DataContainer::PrintData(std::ostream& rOStream) const
+{
+    rOStream << "Number of chunks: " << mData.size() << std::endl;
+    rOStream << "Chunk size      : " << mChunkSize << std::endl;
+    for (const auto& p_chunk : mData) {
+        rOStream << "    " << p_chunk->GetVariableData().Name()
+                 << " (" << p_chunk->NumberOfEntitiesPerStep() << " entities per step, "
+                 << p_chunk->GetHistoryPolicy().GetTotalNumberOfSteps() << " steps)" << std::endl;
+    }
+}
+
+} // namespace Kratos

--- a/kratos/containers/data_container/data_container.cpp
+++ b/kratos/containers/data_container/data_container.cpp
@@ -151,6 +151,22 @@ void DataContainer::AddToSparseStorage(const DataAccessor<int>& rIndexAccessor, 
 /***********************************************************************************/
 /***********************************************************************************/
 
+void DataContainer::Resize(std::size_t NewNumberOfEntities)
+{
+    KRATOS_TRY
+
+    for (auto& p_chunk : mData) {
+        if (p_chunk->GetValuePolicy().IsSparse()) continue; // sparse sizing is governed by UpdateSparseStorage/AddToSparseStorage
+        if (p_chunk->NumberOfEntitiesPerStep() == NewNumberOfEntities) continue;
+        p_chunk->ResizeData(NewNumberOfEntities);
+    }
+
+    KRATOS_CATCH("")
+}
+
+/***********************************************************************************/
+/***********************************************************************************/
+
 void DataContainer::CloneStepData(StepCategory rStepCategory)
 {
     for (auto& p_chunk : mData) {

--- a/kratos/containers/data_container/data_container.h
+++ b/kratos/containers/data_container/data_container.h
@@ -222,6 +222,13 @@ public:
     void AddToSparseStorage(const DataAccessor<int>& rIndexAccessor, const std::vector<int>& rEntityIndices);
 
     /**
+     * @brief Resize all dense (non-sparse) chunks to the given number of entities per step.
+     * @details Delegates to DataChunkBase::ResizeData, which preserves the first min(old, new) values of every step slot and zero-initializes appended entries with the chunk's policy zero. Chunks already holding NewNumberOfEntities entities are left untouched, so repeated calls with the same size are cheap. Sparse chunks are skipped entirely: their sizing is governed by UpdateSparseStorage / AddToSparseStorage. All previously obtained spans over resized chunks are invalidated. Not thread-safe; external synchronization is required.
+     * @param NewNumberOfEntities The new number of entities per step of the dense chunks.
+     */
+    void Resize(std::size_t NewNumberOfEntities);
+
+    /**
      * @brief Clone the data of the current step onto the next step slot for all chunks of the given category.
      * @details Delegates to DataChunk::CloneStepData: only chunks whose history policy matches the category advance their ring and copy their data; all other chunks are untouched.
      * @param rStepCategory The step category being cloned.

--- a/kratos/containers/data_container/data_container.h
+++ b/kratos/containers/data_container/data_container.h
@@ -1,0 +1,446 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
+//
+//  Main authors:    Pooyan Dadvand
+//  Collaborator:    Vicente Mataix Ferrandiz
+//
+//
+
+#pragma once
+
+// System includes
+
+// External includes
+
+// Project includes
+#include "includes/lock_object.h"
+#include "includes/registry.h"
+#include "containers/variable.h"
+#include "containers/data_container/data_accessor.h"
+#include "containers/data_container/data_chunk.h"
+
+namespace Kratos
+{
+///@addtogroup KratosCore
+///@{
+
+///@name Kratos Classes
+///@{
+
+/**
+ * @class DataContainer
+ * @ingroup KratosCore
+ * @brief Chunked, type-erased, variable-keyed storage of entity data.
+ * @details The container stores the data associated with each added Variable in one DataChunk: a contiguous block holding the values of that variable for all entities (struct-of-arrays layout) and, depending on the chunk's history policy, for several step slots. How values are stored is governed by a DataValuePolicy (dense, layered or sparse) and how step history is kept by a DataHistoryPolicy, both passed to Add.
+ *
+ * Add returns a DataAccessor caching the chunk index, giving O(1) access to the data span later on (GetDataSpan). Variables passed to Add are canonicalized through the Kratos Registry ("variables.all.<name>"): the chunks and accessors reference the Registry-owned variable, so the stored data remains valid and retrievable even if the Variable object passed by the caller goes out of scope. Consequently, only registered variables can be added (see KRATOS_REGISTER_VARIABLE / Variable::Register); Add does not register variables itself, it only canonicalizes already-registered ones.
+ *
+ * Dense chunks are created with mChunkSize entities; chunks with a sparse value policy start with zero entities and grow via UpdateSparseStorage / AddToSparseStorage.
+ *
+ * Copying a DataContainer is shallow: the copy shares the chunks (std::shared_ptr) with the original. Thread-safety: only Add is internally locked (chunk creation); all other operations require external synchronization.
+ * @see DataChunk, DataAccessor, DataValuePolicy, SparseDataValuePolicy, DataHistoryPolicyBase
+ * @author Pooyan Dadvand
+ */
+class KRATOS_API(KRATOS_CORE) DataContainer
+{
+public:
+    ///@name Type Definitions
+    ///@{
+
+    /// Pointer definition of DataContainer
+    KRATOS_CLASS_POINTER_DEFINITION(DataContainer);
+
+    /// Accessor type alias for the stored data of a given value type
+    template<typename TValueType>
+    using DataAccessor = Kratos::DataAccessor<TValueType>;
+
+    ///@}
+    ///@name Life Cycle
+    ///@{
+
+    /**
+     * @brief Constructor.
+     * @param ChunkSize Number of entities each dense chunk stores per step. Must be greater than zero.
+     */
+    DataContainer(std::size_t ChunkSize = 256);
+
+    /// Destructor.
+    ~DataContainer() = default;
+
+    /**
+     * @brief Copy constructor.
+     * @details The copy is shallow: it shares the chunks with rOther. The lock is default-constructed (locks are not copyable).
+     * @param rOther The container to copy from.
+     */
+    DataContainer(const DataContainer& rOther);
+
+    /**
+     * @brief Move constructor.
+     * @details The lock is default-constructed (locks are not movable); rOther is left without chunks.
+     * @param rOther The container to move from.
+     */
+    DataContainer(DataContainer&& rOther) noexcept;
+
+    ///@}
+    ///@name Operators
+    ///@{
+
+    /**
+     * @brief Copy assignment operator.
+     * @details The copy is shallow: this container shares the chunks with rOther afterwards. The lock of each container is untouched.
+     * @param rOther The container to copy from.
+     * @return Reference to this container.
+     */
+    DataContainer& operator=(const DataContainer& rOther);
+
+    /**
+     * @brief Move assignment operator.
+     * @param rOther The container to move from; it is left without chunks.
+     * @return Reference to this container.
+     */
+    DataContainer& operator=(DataContainer&& rOther) noexcept;
+
+    ///@}
+    ///@name Operations
+    ///@{
+
+    /**
+     * @brief Initialize this container with fresh chunks mirroring another container.
+     * @details For every chunk of rOther a new sibling chunk (same variable and policies) is appended to this container: dense chunks are created with the given chunk size, sparse chunks start empty. The data itself is not copied (all new chunks are zero-initialized) and the given chunk size is stored for future Add calls.
+     * @param rOther The container whose chunk structure is mirrored.
+     * @param ChunkSize Number of entities per step of the new dense chunks. Must be greater than zero.
+     */
+    void Initialize(const DataContainer& rOther, std::size_t ChunkSize);
+
+    /**
+     * @brief Add a data chunk for the given variable and policies.
+     * @details The variable is canonicalized through the Kratos Registry ("variables.all.<name>"), so it must be registered beforehand (see KRATOS_REGISTER_VARIABLE / Variable::Register); the chunk and the returned accessor reference the Registry-owned variable, making the stored data independent of the lifetime of rVariable. If the variable was already added with the same value policy (IsSame), the accessor of the existing chunk is returned; adding it with a different policy is an error. New dense chunks are created with the container chunk size, sparse chunks start with zero entities.
+     * @note This method is internally locked and safe to call from multiple threads.
+     * @tparam TVariableValueType The value type of the variable.
+     * @tparam TValuePolicyType The concrete value policy type.
+     * @param rVariable The variable for which the data chunk is to be added.
+     * @param rValuePolicy The value policy governing the stored values (cloned into the chunk).
+     * @param rHistoryPolicy The history policy governing the step slots (cloned into the chunk).
+     * @return An accessor to the data of the added (or already existing) chunk.
+     */
+    template<typename TVariableValueType, typename TValuePolicyType>
+    DataAccessor<typename TValuePolicyType::ValueType> Add(
+        const Variable<TVariableValueType>& rVariable,
+        const TValuePolicyType& rValuePolicy,
+        const DataHistoryPolicyBase& rHistoryPolicy = NonHistoricalDataPolicy())
+    {
+        KRATOS_TRY
+
+        KRATOS_ERROR_IF_NOT(rValuePolicy.IsCompatible(rVariable)) << rVariable.Name() << " is not compatible with the given value policy." << std::endl;
+
+        // Guard for mutual exclusion if this function is called from multiple threads
+        std::lock_guard<LockObject> lock(mMutex);
+
+        // Always use the reference variable from the registry so that we do not need to care if rVariable goes out of scope
+        using VariableType = Variable<TVariableValueType>;
+
+        const std::string variable_path = "variables.all." + rVariable.Name();
+        KRATOS_ERROR_IF_NOT(Registry::HasItem(variable_path)) << "Variable " << rVariable.Name()
+            << " is not registered in the Registry. DataContainer only accepts registered variables"
+            << " (see KRATOS_REGISTER_VARIABLE or Variable::Register)." << std::endl;
+        const VariableType& r_reference_variable = Registry::GetValue<VariableType>(variable_path);
+
+        // Check if the variable already exists in the container
+        for (auto i_chunk = mData.begin(); i_chunk != mData.end(); ++i_chunk) {
+            if ((*i_chunk)->GetVariableData() == r_reference_variable) {
+                // If the variable exists, check if the policy matches
+                if ((*i_chunk)->GetValuePolicy().IsSame(rValuePolicy)) {
+                    return DataAccessor<typename TValuePolicyType::ValueType>(r_reference_variable, std::distance(mData.begin(), i_chunk),
+                                                                              rHistoryPolicy.GetStepCategory());
+                } else {
+                    KRATOS_ERROR << "Variable " << r_reference_variable.Name() << " exists with a different policy." << std::endl;
+                }
+            }
+        }
+
+        // Variable does not exist, create a new data chunk and add it to the container
+        const std::size_t initial_chunk_size = rValuePolicy.IsSparse() ? 0 : mChunkSize;
+        auto p_new_chunk = std::make_shared<DataChunk<typename TValuePolicyType::ValueType>>(r_reference_variable, rValuePolicy, rHistoryPolicy, initial_chunk_size);
+        mData.push_back(p_new_chunk);
+        return DataAccessor<typename TValuePolicyType::ValueType>(r_reference_variable, mData.size() - 1,
+                                                                  rHistoryPolicy.GetStepCategory());
+
+        KRATOS_CATCH("")
+    }
+
+    /**
+     * @brief Get an accessor for existing data with matching variable and policy types.
+     * @details Policy details do not need to match, only the types (IsSameType): e.g. an accessor for data added with HistoricalDataPolicy(TimeStep, 3) can be obtained with HistoricalDataPolicy(TimeStep, 2). Raises an error if no matching chunk exists.
+     * @tparam TVariableType The variable type.
+     * @tparam TValuePolicyType The concrete value policy type.
+     * @param rVariable The variable of the requested data.
+     * @param rValuePolicy A value policy of the type the data was added with.
+     * @param rHistoryPolicy A history policy of the type the data was added with.
+     * @return An accessor to the data of the matching chunk.
+     */
+    template<typename TVariableType, typename TValuePolicyType>
+    DataAccessor<typename TValuePolicyType::ValueType> GetAccessor(
+        const TVariableType& rVariable,
+        const TValuePolicyType& rValuePolicy,
+        const DataHistoryPolicyBase& rHistoryPolicy = NonHistoricalDataPolicy())
+    {
+        for (auto i_chunk = mData.begin(); i_chunk != mData.end(); ++i_chunk) {
+            if ((*i_chunk)->GetVariableData() == rVariable &&
+                (*i_chunk)->GetValuePolicy().IsSameType(rValuePolicy)) {
+                auto const& r_stored_history_policy = (*i_chunk)->GetHistoryPolicy();
+                if (r_stored_history_policy.IsSameType(rHistoryPolicy)) {
+                    return DataAccessor<typename TValuePolicyType::ValueType>(
+                        (*i_chunk)->GetVariableData(),
+                        std::distance(mData.begin(), i_chunk),
+                        r_stored_history_policy.GetStepCategory());
+                }
+            }
+        }
+
+        KRATOS_ERROR << "No data found in container for " << rVariable.Name() << " with the requested policies" << std::endl;
+    }
+
+    /**
+     * @brief Resize all sparse data chunks indexed by the given accessor.
+     * @details Every sparse chunk whose policy references rIndexAccessor is rebuilt (its data is discarded and zero-initialized) with as many entities as there are active entries (index > -1) in the index span. Existing spans/accessors into the old chunk data are invalidated.
+     * @param rIndexAccessor Accessor for a Variable<int> set to the sparse index for active entries or to a negative value otherwise.
+     */
+    void UpdateSparseStorage(const DataAccessor<int>& rIndexAccessor);
+
+    /**
+     * @brief Append entries for new entities to the sparse chunks indexed by the given accessor.
+     * @details Entities of rEntityIndices whose index span entry is -1 get the next free sparse index assigned (updating the index span), and every sparse chunk referencing rIndexAccessor is grown accordingly, preserving its existing values and zero-initializing the appended entries (contrary to UpdateSparseStorage, which rebuilds from scratch). Spans obtained before the call are invalidated.
+     * @param rIndexAccessor Accessor for the Variable<int> holding the sparse indices.
+     * @param rEntityIndices The (entity) positions in the index span to add to the sparse storage.
+     */
+    void AddToSparseStorage(const DataAccessor<int>& rIndexAccessor, const std::vector<int>& rEntityIndices);
+
+    /**
+     * @brief Clone the data of the current step onto the next step slot for all chunks of the given category.
+     * @details Delegates to DataChunk::CloneStepData: only chunks whose history policy matches the category advance their ring and copy their data; all other chunks are untouched.
+     * @param rStepCategory The step category being cloned.
+     */
+    void CloneStepData(StepCategory rStepCategory);
+
+    ///@}
+    ///@name Access
+    ///@{
+
+    /**
+     * @brief Get the data span of the current step for the given variable and policy.
+     * @details The chunk is searched by variable and value policy (IsSame, i.e. the configuration must match too); the span covers the latest step slot. Raises an error if no matching chunk exists.
+     * @tparam TVariableType The variable type.
+     * @tparam TValuePolicyType The concrete value policy type.
+     * @param rVariable The variable of the requested data.
+     * @param rValuePolicy The value policy the data was added with.
+     * @return A span over the values of the current step (one value per entity).
+     */
+    template<typename TVariableType, typename TValuePolicyType>
+    typename TValuePolicyType::StepSpanType GetDataSpan(const TVariableType& rVariable, const TValuePolicyType& rValuePolicy)
+    {
+        for (const auto& p_chunk : mData) {
+            if (p_chunk->GetVariableData() == rVariable && p_chunk->GetValuePolicy().IsSame(rValuePolicy)) {
+                auto p_typed_chunk = std::dynamic_pointer_cast<DataChunk<typename TValuePolicyType::ValueType>>(p_chunk);
+                if (p_typed_chunk) {
+                    auto& r_history_policy = p_typed_chunk->GetHistoryPolicy();
+                    const std::size_t current_step_index = r_history_policy.GetLatestStepIndex();
+                    return typename TValuePolicyType::StepSpanType(p_typed_chunk->GetDataPointer(current_step_index),
+                                                                   p_typed_chunk->NumberOfEntitiesPerStep());
+                } else {
+                    KRATOS_ERROR << "Failed to cast DataChunkBase to DataChunk<TValueType>." << std::endl;
+                }
+            }
+        }
+
+        // If the variable and policy are not found, throw an error
+        KRATOS_ERROR << "Variable or policy not found in DataContainer for " << rVariable.Name() << "." << std::endl;
+    }
+
+    /**
+     * @brief Get the data span of a specific step for the given variable and policy.
+     * @details Like GetDataSpan(rVariable, rValuePolicy) but for the step slot given by the category and the number of steps before the current one (resolved by the chunk's history policy).
+     * @tparam TVariableType The variable type.
+     * @tparam TValuePolicyType The concrete value policy type.
+     * @param rVariable The variable of the requested data.
+     * @param rValuePolicy The value policy the data was added with.
+     * @param rStepCategory The step category of the request.
+     * @param rStepBeforeCurrent How many steps before the current one is requested.
+     * @return A span over the values of the requested step (one value per entity).
+     */
+    template<typename TVariableType, typename TValuePolicyType>
+    typename TValuePolicyType::StepSpanType GetDataSpan(const TVariableType& rVariable, const TValuePolicyType& rValuePolicy, StepCategory rStepCategory, int rStepBeforeCurrent = 0)
+    {
+        for (const auto& p_chunk : mData) {
+            if (p_chunk->GetVariableData() == rVariable && p_chunk->GetValuePolicy().IsSame(rValuePolicy)) {
+                auto p_typed_chunk = std::dynamic_pointer_cast<DataChunk<typename TValuePolicyType::ValueType>>(p_chunk);
+                if (p_typed_chunk) {
+                    auto& r_history_policy = p_typed_chunk->GetHistoryPolicy();
+                    const std::size_t current_step_index = r_history_policy.GetStepIndex(rStepCategory, rStepBeforeCurrent);
+                    return typename TValuePolicyType::StepSpanType(p_typed_chunk->GetDataPointer(current_step_index),
+                                                                   p_typed_chunk->NumberOfEntitiesPerStep());
+                } else {
+                    KRATOS_ERROR << "Failed to cast DataChunkBase to DataChunk<TValueType>." << std::endl;
+                }
+            }
+        }
+
+        // If the variable and policy are not found, throw an error
+        KRATOS_ERROR << "Variable or policy not found in DataContainer for " << rVariable.Name() << "." << std::endl;
+    }
+
+    /**
+     * @brief Get the data span for the given accessor.
+     * @details O(1): the chunk is addressed directly by the index cached in the accessor; the step slot is resolved from the accessor's category and step offset. The accessor must have been produced by this container (the variable identity is verified; an accessor from a different container raises an error).
+     * @tparam TAccessorType The accessor type.
+     * @param rAccessor The accessor of the requested data.
+     * @return A span over the values of the accessor's step (one value per entity).
+     */
+    template<typename TAccessorType>
+    typename TAccessorType::StepSpanType GetDataSpan(const TAccessorType& rAccessor)
+    {
+        KRATOS_ERROR_IF_NOT(rAccessor.GetIndex() < mData.size())
+            << "Accessor index out of bounds: " << rAccessor.GetIndex() << ". DataContainer size: " << mData.size() << std::endl;
+
+        auto& p_chunk = mData[rAccessor.GetIndex()];
+        // check has the same variable. (This can happen when the accessor is from a different container)
+        KRATOS_ERROR_IF_NOT(p_chunk->GetVariableData() == rAccessor.GetVariableData())
+            << "Variable mismatch in DataContainer." << std::endl;
+
+        // we should check if this affects the performance, if so we can use a static_cast and dynamic_cast only in full debug mode
+        auto p_typed_chunk = std::dynamic_pointer_cast<DataChunk<typename TAccessorType::ValueType>>(p_chunk);
+        if (p_typed_chunk) {
+            auto& r_history_policy = p_typed_chunk->GetHistoryPolicy();
+            const std::size_t current_step_index = r_history_policy.GetStepIndex(rAccessor.GetStepCategory(), rAccessor.GetStepBeforeCurrent());
+            return typename TAccessorType::StepSpanType(p_typed_chunk->GetDataPointer(current_step_index),
+                                                        p_typed_chunk->NumberOfEntitiesPerStep());
+        } else {
+            if (rAccessor.pGetVariableData() == nullptr)
+                KRATOS_ERROR << "Accessor variable is null. The accessor is not initialized properly. Please check if the variable is added to this container" << std::endl;
+            else if (rAccessor.GetVariableData().Name() != p_chunk->GetVariableData().Name())
+                KRATOS_ERROR << "Accessor variable mismatch. Accessor variable: " << rAccessor.GetVariableData().Name()
+                    << ", Chunk variable: " << p_chunk->GetVariableData().Name() << std::endl;
+            else
+                KRATOS_ERROR << "Failed to find the corresponding data for the given accessor. Please check if the accessor is for this container."
+                    << "Accessor variable: " << rAccessor.GetVariableData().Name() << ", Chunk variable: " << p_chunk->GetVariableData().Name() << std::endl;
+        }
+    }
+
+    ///@}
+    ///@name Inquiry
+    ///@{
+
+    /**
+     * @brief Check if the variable exists in the container.
+     * @tparam TVariableType The variable type.
+     * @param rVariable The variable to look for.
+     * @return true if a chunk for the variable exists.
+     */
+    template<typename TVariableType>
+    bool Has(const TVariableType& rVariable) const
+    {
+        for (const auto& p_chunk : mData) {
+            if (p_chunk->GetVariableData() == rVariable) {
+                return true; // Variable found
+            }
+        }
+        return false; // Variable not found
+    }
+
+    /**
+     * @brief Check if the variable exists in the container with the given value policy type.
+     * @details Only the policy type is compared (IsSameType), not its configuration.
+     * @tparam TVariableType The variable type.
+     * @tparam TValuePolicyType The concrete value policy type.
+     * @param rVariable The variable to look for.
+     * @param rValuePolicy A value policy of the type to look for.
+     * @return true if a chunk for the variable with the given value policy type exists.
+     */
+    template<typename TVariableType, typename TValuePolicyType>
+    bool Has(const TVariableType& rVariable, const TValuePolicyType& rValuePolicy) const
+    {
+        for (const auto& p_chunk : mData) {
+            if (p_chunk->GetVariableData() == rVariable && p_chunk->GetValuePolicy().IsSameType(rValuePolicy)) {
+                return true; // Variable with the specific policy found
+            }
+        }
+        return false; // Variable with the specific policy not found
+    }
+
+    /**
+     * @brief Check if the variable exists in the container with the given value and history policy types.
+     * @details Only the policy types are compared (IsSameType), not their configuration.
+     * @tparam TVariableType The variable type.
+     * @param rVariable The variable to look for.
+     * @param rValuePolicy A value policy of the type to look for.
+     * @param rHistoryPolicy A history policy of the type to look for.
+     * @return true if a chunk for the variable with the given policy types exists.
+     */
+    template<typename TVariableType>
+    bool Has(const TVariableType& rVariable, const DataValuePolicyBase& rValuePolicy, const DataHistoryPolicyBase& rHistoryPolicy) const
+    {
+        for (const auto& p_chunk : mData) {
+            if (p_chunk->GetVariableData() == rVariable &&
+                p_chunk->GetValuePolicy().IsSameType(rValuePolicy) &&
+                p_chunk->GetHistoryPolicy().IsSameType(rHistoryPolicy)) {
+                return true; // Variable with the specific policies found
+            }
+        }
+        return false; // Variable with the specific policies not found
+    }
+
+    ///@}
+    ///@name Input and output
+    ///@{
+
+    /// Turn back information as a string.
+    std::string Info() const;
+
+    /// Print information about this object.
+    void PrintInfo(std::ostream& rOStream) const;
+
+    /// Print object's data.
+    void PrintData(std::ostream& rOStream) const;
+
+    ///@}
+
+private:
+    ///@name Member Variables
+    ///@{
+
+    std::vector<std::shared_ptr<DataChunkBase>> mData; /// The data stored in the container. Each element is a shared pointer to the chunk
+
+    std::size_t mChunkSize = 256;                      /// Number of entities in each dense chunk
+
+    LockObject mMutex;                                 /// Lock for mutual exclusion when adding data chunks to the container
+
+    ///@}
+
+}; // Class DataContainer
+
+///@}
+///@name Input and output
+///@{
+
+/// output stream function
+inline std::ostream& operator << (
+    std::ostream& rOStream,
+    const DataContainer& rThis)
+{
+    rThis.PrintInfo(rOStream);
+    rOStream << std::endl;
+    rThis.PrintData(rOStream);
+
+    return rOStream;
+}
+
+///@}
+
+///@} addtogroup block
+
+} // namespace Kratos

--- a/kratos/containers/data_container/data_history_policy.cpp
+++ b/kratos/containers/data_container/data_history_policy.cpp
@@ -1,0 +1,170 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
+//
+//  Main authors:    Pooyan Dadvand
+//  Collaborator:    Vicente Mataix Ferrandiz
+//
+//
+
+// System includes
+
+// External includes
+
+// Project includes
+#include "includes/define.h"
+#include "containers/data_container/data_history_policy.h"
+
+namespace Kratos
+{
+
+std::unique_ptr<DataHistoryPolicyBase> NonHistoricalDataPolicy::Clone() const
+{
+    return std::make_unique<NonHistoricalDataPolicy>();
+}
+
+/***********************************************************************************/
+/***********************************************************************************/
+
+std::size_t NonHistoricalDataPolicy::CloneStepIndex(StepCategory Category)
+{
+    return 0; // Non-historical data policy does not support cloning steps
+}
+
+/***********************************************************************************/
+/***********************************************************************************/
+
+bool NonHistoricalDataPolicy::IsSameType(const DataHistoryPolicyBase& rOther) const
+{
+    return dynamic_cast<const NonHistoricalDataPolicy*>(&rOther) != nullptr;
+}
+
+/***********************************************************************************/
+/***********************************************************************************/
+
+bool NonHistoricalDataPolicy::IsSame(const DataHistoryPolicyBase& rOther) const
+{
+    return IsSameType(rOther);
+}
+
+/***********************************************************************************/
+/***********************************************************************************/
+
+std::size_t NonHistoricalDataPolicy::GetLatestStepIndex() const
+{
+    return 0;
+}
+
+/***********************************************************************************/
+/***********************************************************************************/
+
+std::size_t NonHistoricalDataPolicy::GetStepIndex(StepCategory Category, int /*StepBeforeCurrent*/) const
+{
+    KRATOS_ERROR_IF(Category != StepCategory::AnyStep) << "NonHistoricalDataPolicy does not support step categories." << std::endl;
+    return 0;
+}
+
+/***********************************************************************************/
+/***********************************************************************************/
+
+StepCategory NonHistoricalDataPolicy::GetStepCategory() const
+{
+    return StepCategory::AnyStep;
+}
+
+/***********************************************************************************/
+/***********************************************************************************/
+
+HistoricalDataPolicy::HistoricalDataPolicy(StepCategory TheCategory, std::size_t TotalNumberOfSteps)
+    : DataHistoryPolicyBase(TotalNumberOfSteps),
+      mCategory(TheCategory),
+      mLatestStepIndex(0)
+{
+    KRATOS_DEBUG_ERROR_IF(TotalNumberOfSteps == 0) << "Total number of steps must be greater than zero." << std::endl;
+}
+
+/***********************************************************************************/
+/***********************************************************************************/
+
+std::unique_ptr<DataHistoryPolicyBase> HistoricalDataPolicy::Clone() const
+{
+    return std::make_unique<HistoricalDataPolicy>(mCategory, mTotalNumberOfSteps);
+}
+
+/***********************************************************************************/
+/***********************************************************************************/
+
+std::size_t HistoricalDataPolicy::CloneStepIndex(StepCategory Category)
+{
+    if (mCategory != Category) {
+        return mLatestStepIndex; // No cloning if the category does not match
+    }
+
+    const std::size_t next_step_index = (mLatestStepIndex + 1) % mTotalNumberOfSteps;
+    mLatestStepIndex = next_step_index;
+    return next_step_index;
+}
+
+/***********************************************************************************/
+/***********************************************************************************/
+
+bool HistoricalDataPolicy::IsSameType(const DataHistoryPolicyBase& rOther) const
+{
+    return dynamic_cast<const HistoricalDataPolicy*>(&rOther) != nullptr;
+}
+
+/***********************************************************************************/
+/***********************************************************************************/
+
+bool HistoricalDataPolicy::IsSame(const DataHistoryPolicyBase& rOther) const
+{
+    const auto* p_typed_other = dynamic_cast<const HistoricalDataPolicy*>(&rOther);
+    if (p_typed_other) {
+        return mTotalNumberOfSteps == p_typed_other->mTotalNumberOfSteps && mCategory == p_typed_other->mCategory;
+    }
+    return false; // Different type
+}
+
+/***********************************************************************************/
+/***********************************************************************************/
+
+std::size_t HistoricalDataPolicy::GetLatestStepIndex() const
+{
+    return mLatestStepIndex;
+}
+
+/***********************************************************************************/
+/***********************************************************************************/
+
+std::size_t HistoricalDataPolicy::GetStepIndex(StepCategory Category, int StepBeforeCurrent) const
+{
+    KRATOS_DEBUG_ERROR_IF(static_cast<std::size_t>(Category) >= static_cast<std::size_t>(StepCategory::NumberOfCategories))
+        << "Invalid step category." << std::endl;
+    KRATOS_DEBUG_ERROR_IF(StepBeforeCurrent < 0)
+        << "StepBeforeCurrent must be non-negative." << std::endl;
+
+    const std::size_t steps_before_current = static_cast<std::size_t>(StepBeforeCurrent);
+    KRATOS_DEBUG_ERROR_IF(steps_before_current >= mTotalNumberOfSteps)
+        << "StepBeforeCurrent must be less than the total number of steps." << std::endl;
+
+    const std::size_t index = (mLatestStepIndex >= steps_before_current) ?
+                              (mLatestStepIndex - steps_before_current) :
+                              (mTotalNumberOfSteps + mLatestStepIndex - steps_before_current);
+
+    return index;
+}
+
+/***********************************************************************************/
+/***********************************************************************************/
+
+StepCategory HistoricalDataPolicy::GetStepCategory() const
+{
+    return mCategory;
+}
+
+} // namespace Kratos

--- a/kratos/containers/data_container/data_history_policy.h
+++ b/kratos/containers/data_container/data_history_policy.h
@@ -1,0 +1,338 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
+//
+//  Main authors:    Pooyan Dadvand
+//  Collaborator:    Vicente Mataix Ferrandiz
+//
+//
+
+#pragma once
+
+// System includes
+#include <cstddef>
+#include <memory>
+
+// External includes
+
+// Project includes
+#include "includes/define.h"
+#include "containers/data_container/step_category.h"
+
+namespace Kratos
+{
+///@addtogroup KratosCore
+///@{
+
+///@name Kratos Classes
+///@{
+
+/**
+ * @class DataHistoryPolicyBase
+ * @ingroup KratosCore
+ * @brief Interface defining how the step history of the data is stored in each DataChunk.
+ * @details A history policy determines how many steps of data a DataChunk keeps (GetTotalNumberOfSteps) and maps step requests (a StepCategory plus a number of steps before the current one) to the index of the corresponding step slot inside the chunk storage. Historical policies implement a ring buffer over the step slots: cloning a step (CloneStepIndex) advances the latest-step index only when the requested category matches the policy's own category, so containers holding chunks of mixed categories can be cloned selectively per category.
+ *
+ * Policies are cloned into each DataChunk; HistoricalDataPolicy is stateful (it tracks the latest step index) and provides no thread-safety guarantees.
+ * @see NonHistoricalDataPolicy, HistoricalDataPolicy, DataChunk, DataContainer
+ * @author Pooyan Dadvand
+ */
+class KRATOS_API(KRATOS_CORE) DataHistoryPolicyBase
+{
+public:
+    ///@name Life Cycle
+    ///@{
+
+    /**
+     * @brief Constructor.
+     * @param TotalNumberOfSteps Number of steps to be stored including the current one.
+     */
+    explicit DataHistoryPolicyBase(std::size_t TotalNumberOfSteps = 1)
+        : mTotalNumberOfSteps(TotalNumberOfSteps) {}
+
+    /// Destructor.
+    virtual ~DataHistoryPolicyBase() = default;
+
+    ///@}
+    ///@name Operations
+    ///@{
+
+    /**
+     * @brief Clone the history policy.
+     * @return A newly allocated copy of this policy. Note stateful policies reset their running step index (see HistoricalDataPolicy::Clone).
+     */
+    virtual std::unique_ptr<DataHistoryPolicyBase> Clone() const = 0;
+
+    /**
+     * @brief Advance the step ring buffer for the given category.
+     * @details Only advances (and returns the new latest index) when the given category matches the policy's own category; otherwise the latest step index is returned unchanged. This is what makes DataContainer::CloneStepData act selectively on the chunks of the requested category.
+     * @param Category The step category being cloned.
+     * @return The step index that became (or remains) the latest one.
+     */
+    virtual std::size_t CloneStepIndex(StepCategory Category) = 0;
+
+    ///@}
+    ///@name Inquiry
+    ///@{
+
+    /**
+     * @brief Check if the given policy has the same dynamic type as this one.
+     * @details Configuration details (category, number of steps) are ignored; see IsSame.
+     * @param rOther The policy to compare against.
+     * @return true if both policies are of the same dynamic type.
+     */
+    virtual bool IsSameType(const DataHistoryPolicyBase& rOther) const = 0;
+
+    /**
+     * @brief Check if the given policy is the same as this one (type and configuration).
+     * @param rOther The policy to compare against.
+     * @return true if both policies are of the same dynamic type with identical configuration.
+     */
+    virtual bool IsSame(const DataHistoryPolicyBase& rOther) const = 0;
+
+    ///@}
+    ///@name Access
+    ///@{
+
+    /**
+     * @brief Get the total number of steps to be stored (including the current one).
+     * @return The total number of steps.
+     */
+    std::size_t GetTotalNumberOfSteps() const
+    {
+        return mTotalNumberOfSteps;
+    }
+
+    /**
+     * @brief Set the total number of steps to be stored (including the current one).
+     * @param TotalNumberOfSteps The new total number of steps.
+     */
+    void SetTotalNumberOfSteps(std::size_t TotalNumberOfSteps)
+    {
+        mTotalNumberOfSteps = TotalNumberOfSteps;
+    }
+
+    /**
+     * @brief Get the index of the latest (current) step slot.
+     * @return The latest step index.
+     */
+    virtual std::size_t GetLatestStepIndex() const = 0;
+
+    /**
+     * @brief Get the step slot index for a specific category and step offset.
+     * @param Category The step category of the request.
+     * @param StepBeforeCurrent How many steps before the current one is requested.
+     * @return The index of the corresponding step slot.
+     */
+    virtual std::size_t GetStepIndex(StepCategory Category, int StepBeforeCurrent = 0) const = 0;
+
+    /**
+     * @brief Get the step category tracked by this policy.
+     * @return The step category.
+     */
+    virtual StepCategory GetStepCategory() const = 0;
+
+    ///@}
+
+protected:
+    ///@name Protected member Variables
+    ///@{
+
+    std::size_t mTotalNumberOfSteps; /// Number of steps to be stored including the current one
+
+    ///@}
+
+}; // Class DataHistoryPolicyBase
+
+/**
+ * @class NonHistoricalDataPolicy
+ * @ingroup KratosCore
+ * @brief History policy storing only one value (no history) per entity.
+ * @details The single stored step always has index 0 and belongs to StepCategory::AnyStep. Requesting a step index for any other category is an error, and cloning never advances anything.
+ * @see DataHistoryPolicyBase, HistoricalDataPolicy
+ * @author Pooyan Dadvand
+ */
+class KRATOS_API(KRATOS_CORE) NonHistoricalDataPolicy : public DataHistoryPolicyBase
+{
+public:
+    ///@name Life Cycle
+    ///@{
+
+    /// Constructor.
+    NonHistoricalDataPolicy() : DataHistoryPolicyBase(1) {}
+
+    /// Destructor.
+    ~NonHistoricalDataPolicy() override = default;
+
+    ///@}
+    ///@name Operations
+    ///@{
+
+    /**
+     * @brief Clone the history policy.
+     * @return A newly allocated NonHistoricalDataPolicy.
+     */
+    std::unique_ptr<DataHistoryPolicyBase> Clone() const override;
+
+    /**
+     * @brief Advance the step ring buffer for the given category.
+     * @details Non-historical data has no history to clone; the single step index 0 is always returned.
+     * @return Always 0.
+     */
+    std::size_t CloneStepIndex(StepCategory Category) override;
+
+    ///@}
+    ///@name Inquiry
+    ///@{
+
+    /**
+     * @brief Check if the given policy has the same dynamic type as this one.
+     * @param rOther The policy to compare against.
+     * @return true if rOther is a NonHistoricalDataPolicy.
+     */
+    bool IsSameType(const DataHistoryPolicyBase& rOther) const override;
+
+    /**
+     * @brief Check if the given policy is the same as this one.
+     * @param rOther The policy to compare against.
+     * @return true if rOther is a NonHistoricalDataPolicy (the policy has no configuration).
+     */
+    bool IsSame(const DataHistoryPolicyBase& rOther) const override;
+
+    ///@}
+    ///@name Access
+    ///@{
+
+    /**
+     * @brief Get the index of the latest (current) step slot.
+     * @return Always 0 (non-historical data has only one step, the current one).
+     */
+    std::size_t GetLatestStepIndex() const override;
+
+    /**
+     * @brief Get the step slot index for a specific category and step offset.
+     * @param Category The step category of the request. Must be StepCategory::AnyStep.
+     * @return Always 0.
+     */
+    std::size_t GetStepIndex(StepCategory Category, int StepBeforeCurrent = 0) const override;
+
+    /**
+     * @brief Get the step category tracked by this policy.
+     * @return StepCategory::AnyStep (non-historical data has no specific category).
+     */
+    StepCategory GetStepCategory() const override;
+
+    ///@}
+
+}; // Class NonHistoricalDataPolicy
+
+/**
+ * @class HistoricalDataPolicy
+ * @ingroup KratosCore
+ * @brief History policy storing data for each step, up to a maximum number of steps, in a ring buffer.
+ * @details The policy is bound to one StepCategory (e.g. time steps, iteration steps, sub-steps) and keeps track of the latest step slot index. Cloning advances the ring (wrapping around at the total number of steps) only when the cloned category matches the policy's own category. GetStepIndex maps "N steps before the current one" onto the ring, wrapping backwards.
+ * @note Cloning the policy object itself (Clone) resets the running latest-step index to zero: freshly created chunks (DataChunk::CreateNew, DataContainer::Initialize) start their history at slot 0.
+ * @see DataHistoryPolicyBase, NonHistoricalDataPolicy
+ * @author Pooyan Dadvand
+ */
+class KRATOS_API(KRATOS_CORE) HistoricalDataPolicy : public DataHistoryPolicyBase
+{
+public:
+    ///@name Life Cycle
+    ///@{
+
+    /**
+     * @brief Constructor.
+     * @param TheCategory Category of the step tracked by this policy (e.g. TimeStep, IterationStep).
+     * @param TotalNumberOfSteps Number of steps to store including the current one. Must be greater than zero.
+     */
+    explicit HistoricalDataPolicy(StepCategory TheCategory, std::size_t TotalNumberOfSteps);
+
+    /// Destructor.
+    ~HistoricalDataPolicy() override = default;
+
+    ///@}
+    ///@name Operations
+    ///@{
+
+    /**
+     * @brief Clone the history policy.
+     * @return A newly allocated HistoricalDataPolicy with the same category and number of steps, but with the latest step index reset to zero.
+     */
+    std::unique_ptr<DataHistoryPolicyBase> Clone() const override;
+
+    /**
+     * @brief Advance the step ring buffer for the given category.
+     * @details Advances the latest step index (wrapping around at the total number of steps) only when the given category matches this policy's category; otherwise the index is left untouched.
+     * @param Category The step category being cloned.
+     * @return The step index that became (or remains) the latest one.
+     */
+    std::size_t CloneStepIndex(StepCategory Category) override;
+
+    ///@}
+    ///@name Inquiry
+    ///@{
+
+    /**
+     * @brief Check if the given policy has the same dynamic type as this one.
+     * @param rOther The policy to compare against.
+     * @return true if rOther is a HistoricalDataPolicy (category and number of steps are ignored).
+     */
+    bool IsSameType(const DataHistoryPolicyBase& rOther) const override;
+
+    /**
+     * @brief Check if the given policy is the same as this one.
+     * @param rOther The policy to compare against.
+     * @return true if rOther is a HistoricalDataPolicy with the same category and total number of steps.
+     */
+    bool IsSame(const DataHistoryPolicyBase& rOther) const override;
+
+    ///@}
+    ///@name Access
+    ///@{
+
+    /**
+     * @brief Get the index of the latest (current) step slot.
+     * @return The latest step index.
+     */
+    std::size_t GetLatestStepIndex() const override;
+
+    /**
+     * @brief Get the step slot index for a specific category and step offset.
+     * @details Maps "StepBeforeCurrent steps before the latest one" onto the ring buffer, wrapping backwards over the total number of steps.
+     * @param Category The step category of the request.
+     * @param StepBeforeCurrent How many steps before the current one is requested. Must be non-negative and less than the total number of steps.
+     * @return The index of the corresponding step slot.
+     */
+    std::size_t GetStepIndex(StepCategory Category, int StepBeforeCurrent = 0) const override;
+
+    /**
+     * @brief Get the step category tracked by this policy.
+     * @return The step category.
+     */
+    StepCategory GetStepCategory() const override;
+
+    ///@}
+
+private:
+    ///@name Member Variables
+    ///@{
+
+    StepCategory mCategory;           /// Category of the step (e.g., TimeStep, IterationStep, etc.)
+
+    std::size_t mLatestStepIndex = 0; /// Index of the latest step added
+
+    ///@}
+
+}; // Class HistoricalDataPolicy
+
+///@}
+
+///@} addtogroup block
+
+} // namespace Kratos

--- a/kratos/containers/data_container/data_value_policy.cpp
+++ b/kratos/containers/data_container/data_value_policy.cpp
@@ -1,0 +1,54 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
+//
+//  Main authors:    Pooyan Dadvand
+//  Collaborator:    Vicente Mataix Ferrandiz
+//
+//
+
+// System includes
+
+// External includes
+
+// Project includes
+#include "containers/data_container/data_value_policy.h"
+
+namespace Kratos
+{
+
+DataValuePolicyBase::DataValuePolicyBase(std::size_t SizeOfData) : mSizeOfData(SizeOfData)
+{
+    KRATOS_DEBUG_ERROR_IF_NOT(SizeOfData > 0) << "Size must be greater than zero." << std::endl;
+}
+
+/***********************************************************************************/
+/***********************************************************************************/
+
+std::size_t DataValuePolicyBase::SizeOfData() const
+{
+    return mSizeOfData;
+}
+
+/***********************************************************************************/
+/***********************************************************************************/
+
+bool DataValuePolicyBase::IsSparse() const
+{
+    return false;
+}
+
+/***********************************************************************************/
+/***********************************************************************************/
+
+DataAccessor<int> DataValuePolicyBase::GetSparseIndexAccessor() const
+{
+    KRATOS_ERROR << "Calling base class DataValuePolicyBase::GetSparseIndexAccessor" << std::endl;
+}
+
+} // namespace Kratos

--- a/kratos/containers/data_container/data_value_policy.h
+++ b/kratos/containers/data_container/data_value_policy.h
@@ -1,0 +1,449 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
+//
+//  Main authors:    Pooyan Dadvand
+//  Collaborator:    Vicente Mataix Ferrandiz
+//
+//
+
+#pragma once
+
+// System includes
+#include <type_traits>
+
+// External includes
+
+// Project includes
+#include "containers/variable.h"
+#include "containers/data_container/data_accessor.h"
+
+namespace Kratos
+{
+///@addtogroup KratosCore
+///@{
+
+///@name Kratos Classes
+///@{
+
+/**
+ * @class DataValuePolicyBase
+ * @ingroup KratosCore
+ * @brief Type-erased interface defining how the values of a DataChunk are stored and managed.
+ * @details A value policy encapsulates all type-dependent operations on the values kept in a DataChunk (allocation, copy, assignment, zero-initialization, destruction and printing) behind a type-erased interface working on void pointers, together with the comparison semantics used by DataContainer to match chunks: IsSameType (same dynamic policy type, ignoring configuration details such as the zero value or the number of layers), IsSame (same dynamic type and configuration), IsCompatible (whether the policy can be used with a given Variable, i.e. the variable value type matches the policy value type) and IsSparse (whether the policy stores data sparsely; sparse chunks start empty and grow via DataContainer::UpdateSparseStorage / DataContainer::AddToSparseStorage).
+ *
+ * Policies are usually not used directly: they are passed to DataContainer::Add, which clones them into the created DataChunk. The class provides no thread-safety guarantees; policy objects are immutable after construction and safe to share for reading.
+ * @see DataValuePolicy, LayeredDataValuePolicy, SparseDataValuePolicy, DataChunk, DataContainer
+ * @author Pooyan Dadvand
+ */
+class KRATOS_API(KRATOS_CORE) DataValuePolicyBase
+{
+public:
+    ///@name Life Cycle
+    ///@{
+
+    /**
+     * @brief Constructor.
+     * @param SizeOfData Size of one value in bytes. Must be greater than zero.
+     */
+    DataValuePolicyBase(std::size_t SizeOfData);
+
+    /// Destructor.
+    virtual ~DataValuePolicyBase() = default;
+
+    ///@}
+    ///@name Operations
+    ///@{
+
+    /**
+     * @brief Allocate a new value copy-constructed from the given source.
+     * @param pSource Pointer to the source value.
+     * @return Pointer to the newly allocated value (owned by the caller, release with Delete).
+     */
+    virtual void* CloneData(const void* pSource) const = 0;
+
+    /**
+     * @brief Copy-construct a value at an already allocated destination (placement new).
+     * @param pSource Pointer to the source value.
+     * @param pDestination Pointer to raw memory of at least SizeOfData() bytes.
+     * @return Pointer to the constructed value.
+     */
+    virtual void* Copy(const void* pSource, void* pDestination) const = 0;
+
+    /**
+     * @brief Assign the source value to an already constructed destination value.
+     * @param pSource Pointer to the source value.
+     * @param pDestination Pointer to the destination value.
+     */
+    virtual void Assign(const void* pSource, void* pDestination) const = 0;
+
+    /**
+     * @brief Construct the policy zero value at the given destination (placement new).
+     * @param pDestination Pointer to raw memory of at least SizeOfData() bytes.
+     */
+    virtual void AssignZero(void* pDestination) const = 0;
+
+    /**
+     * @brief Destroy and deallocate a value previously created with CloneData or Allocate.
+     * @param pSource Pointer to the value to delete.
+     */
+    virtual void Delete(void* pSource) const = 0;
+
+    /**
+     * @brief Call the destructor of the value without releasing its memory.
+     * @param pSource Pointer to the value to destruct.
+     */
+    virtual void Destruct(void* pSource) const = 0;
+
+    /**
+     * @brief Print the value to the given stream.
+     * @param pSource Pointer to the value to print.
+     * @param rOStream The output stream.
+     */
+    virtual void Print(const void* pSource, std::ostream& rOStream) const = 0;
+
+    /**
+     * @brief Print the value with a leading "Data: " label to the given stream.
+     * @param pSource Pointer to the value to print.
+     * @param rOStream The output stream.
+     */
+    virtual void PrintData(const void* pSource, std::ostream& rOStream) const = 0;
+
+    /**
+     * @brief Allocate a new default-constructed value.
+     * @param pData Output: receives the pointer to the newly allocated value (owned by the caller, release with Delete).
+     */
+    virtual void Allocate(void** pData) const = 0;
+
+    ///@}
+    ///@name Inquiry
+    ///@{
+
+    /**
+     * @brief Get the size of one value in bytes.
+     * @return The size of the data to be allocated per value.
+     */
+    virtual std::size_t SizeOfData() const;
+
+    /**
+     * @brief Check if the given policy has the same dynamic type as this one.
+     * @details Configuration details (e.g. the zero value) are ignored; see IsSame for a full comparison.
+     * @param rOther The policy to compare against.
+     * @return true if both policies are of the same dynamic type.
+     */
+    virtual bool IsSameType(const DataValuePolicyBase& rOther) const = 0;
+
+    /**
+     * @brief Check if the given policy is the same as this one (type and configuration).
+     * @param rOther The policy to compare against.
+     * @return true if both policies are of the same dynamic type with identical configuration.
+     */
+    virtual bool IsSame(const DataValuePolicyBase& rOther) const = 0;
+
+    /**
+     * @brief Check if this policy can be used with the given variable.
+     * @details The base overload always returns false; DataValuePolicy<TValueType> shadows it, returning true when the variable value type matches the policy value type. Note this is a non-virtual template shadowing pattern: the check resolves on the static type of the policy, which is the concrete type at the DataContainer::Add call site.
+     * @tparam TVariableValueType The value type of the variable.
+     * @param rVariable The variable to check against.
+     * @return false (in the base class).
+     */
+    template<typename TVariableValueType>
+    bool IsCompatible(const Variable<TVariableValueType>& rVariable) const
+    {
+        return false;
+    }
+
+    /**
+     * @brief Check if the policy is expected to work with sparse data.
+     * @return false unless overridden (see SparseDataValuePolicy).
+     */
+    virtual bool IsSparse() const;
+
+    /**
+     * @brief Get the accessor of the sparse index variable driving the sparse storage.
+     * @details Only meaningful for sparse policies; the base implementation raises an error.
+     * @return The accessor of the sparse index variable.
+     */
+    virtual DataAccessor<int> GetSparseIndexAccessor() const;
+
+    ///@}
+
+private:
+    ///@name Member Variables
+    ///@{
+
+    std::size_t mSizeOfData; /// Size of the data to be allocated in bytes
+
+    ///@}
+
+}; // Class DataValuePolicyBase
+
+/**
+ * @class DataValuePolicy
+ * @ingroup KratosCore
+ * @brief Value policy implementing dense, contiguous storage of values of type TValueType.
+ * @details Implements the type-erased operations of DataValuePolicyBase for a concrete value type, and holds the zero value used to initialize newly allocated entries of a DataChunk (note this zero belongs to the policy, not to the Variable; it can be customized per policy instance, e.g. DataValuePolicy<int>(-1) for sparse index variables). Two DataValuePolicy instances IsSame only when their zero values match.
+ * @see DataValuePolicyBase, LayeredDataValuePolicy, SparseDataValuePolicy, DataChunk
+ * @tparam TValueType The type of the data value to be stored.
+ * @author Pooyan Dadvand
+ */
+template<typename TValueType>
+class DataValuePolicy : public DataValuePolicyBase
+{
+public:
+    ///@name Type Definitions
+    ///@{
+
+    /// Type alias for the data type
+    using ValueType = TValueType;
+
+    /// Span type for the data. Used to access step data in a DataChunk
+    using StepSpanType = Kratos::span<TValueType>;
+
+    ///@}
+    ///@name Life Cycle
+    ///@{
+
+    /**
+     * @brief Constructor.
+     * @param rZero The value used to zero-initialize entries governed by this policy.
+     */
+    DataValuePolicy(TValueType const& rZero = TValueType())
+        : DataValuePolicyBase(sizeof(TValueType)), mZero(rZero)
+    {
+    }
+
+    ///@}
+    ///@name Operations
+    ///@{
+
+    /**
+     * @brief Clone the policy.
+     * @return A newly allocated copy of this policy.
+     */
+    virtual std::unique_ptr<DataValuePolicy<TValueType>> Clone() const
+    {
+        return std::make_unique<DataValuePolicy<TValueType>>(*this);
+    }
+
+    void* CloneData(const void* pSource) const override
+    {
+        return new TValueType(*static_cast<const TValueType*>(pSource));
+    }
+
+    void* Copy(const void* pSource, void* pDestination) const override
+    {
+        return new(pDestination) TValueType(*static_cast<const TValueType*>(pSource));
+    }
+
+    void Assign(const void* pSource, void* pDestination) const override
+    {
+        (*static_cast<TValueType*>(pDestination)) = (*static_cast<const TValueType*>(pSource));
+    }
+
+    void AssignZero(void* pDestination) const override
+    {
+        new(pDestination) TValueType(mZero);
+    }
+
+    void Delete(void* pSource) const override
+    {
+        delete static_cast<TValueType*>(pSource);
+    }
+
+    void Destruct(void* pSource) const override
+    {
+        static_cast<TValueType*>(pSource)->~TValueType();
+    }
+
+    void Print(const void* pSource, std::ostream& rOStream) const override
+    {
+        rOStream << *static_cast<const TValueType*>(pSource);
+    }
+
+    void PrintData(const void* pSource, std::ostream& rOStream) const override
+    {
+        rOStream << "Data: " << *static_cast<const TValueType*>(pSource);
+    }
+
+    void Allocate(void** pData) const override
+    {
+        *pData = new TValueType();
+    }
+
+    ///@}
+    ///@name Inquiry
+    ///@{
+
+    bool IsSameType(const DataValuePolicyBase& rOther) const override
+    {
+        return dynamic_cast<const DataValuePolicy<TValueType>*>(&rOther) != nullptr;
+    }
+
+    bool IsSame(const DataValuePolicyBase& rOther) const override
+    {
+        // Check if the other policy is of the same type
+        const DataValuePolicy<TValueType>* p_other_policy = dynamic_cast<const DataValuePolicy<TValueType>*>(&rOther);
+        if (!p_other_policy) {
+            return false; // different type
+        }
+        // check if all data members are the same
+        return (mZero == p_other_policy->mZero &&
+                SizeOfData() == p_other_policy->SizeOfData());
+    }
+
+    /**
+     * @brief Check if this policy can be used with the given variable.
+     * @details Shadows DataValuePolicyBase::IsCompatible; returns true only when the variable value type matches the policy value type.
+     * @tparam TVariableValueType The value type of the variable.
+     * @param rVariable The variable to check against.
+     * @return true if the variable value type matches TValueType.
+     */
+    template<typename TVariableValueType>
+    bool IsCompatible(const Variable<TVariableValueType>& rVariable) const
+    {
+        if constexpr (std::is_same_v<TValueType, TVariableValueType>) {
+            return true;
+        }
+
+        return false;
+    }
+
+    ///@}
+    ///@name Access
+    ///@{
+
+    /**
+     * @brief Get the zero value of this policy.
+     * @return The value used to zero-initialize entries governed by this policy.
+     */
+    const TValueType& Zero() const
+    {
+        return mZero;
+    }
+
+    ///@}
+
+private:
+    ///@name Member Variables
+    ///@{
+
+    TValueType mZero; /// Zero value of the data type
+
+    ///@}
+
+}; // Class DataValuePolicy
+
+/**
+ * @class LayeredDataValuePolicy
+ * @ingroup KratosCore
+ * @brief Value policy storing a fixed number of layers (a std::vector<TValueType>) per entity.
+ * @details Each entry governed by this policy is a std::vector<TValueType> of NumberOfLayers() elements, all zero-initialized with the given per-layer zero value. Two layered policies IsSame only when their number of layers matches (IsSameType ignores it).
+ * @see DataValuePolicy, DataChunk
+ * @tparam TValueType The type of the per-layer value.
+ * @author Pooyan Dadvand
+ */
+template<typename TValueType>
+class LayeredDataValuePolicy : public DataValuePolicy<std::vector<TValueType>>
+{
+public:
+    ///@name Life Cycle
+    ///@{
+
+    /**
+     * @brief Constructor.
+     * @param NumberOfLayers The number of layers to store per entity. Must be greater than zero.
+     * @param rZero The per-layer zero value.
+     */
+    LayeredDataValuePolicy(std::size_t NumberOfLayers, TValueType const& rZero = TValueType())
+        : DataValuePolicy<std::vector<TValueType>>(std::vector<TValueType>(NumberOfLayers, rZero)),
+          mNumberOfLayers(NumberOfLayers)
+    {
+        KRATOS_DEBUG_ERROR_IF_NOT(NumberOfLayers > 0) << "Number of layers must be greater than zero." << std::endl;
+    }
+
+    ///@}
+    ///@name Operations
+    ///@{
+
+    /**
+     * @brief Clone the policy.
+     * @return A newly allocated copy of this policy.
+     */
+    std::unique_ptr<DataValuePolicy<std::vector<TValueType>>> Clone() const override
+    {
+        return std::make_unique<LayeredDataValuePolicy<TValueType>>(*this);
+    }
+
+    ///@}
+    ///@name Inquiry
+    ///@{
+
+    bool IsSameType(const DataValuePolicyBase& rOther) const override
+    {
+        return dynamic_cast<const LayeredDataValuePolicy<TValueType>*>(&rOther) != nullptr;
+    }
+
+    bool IsSame(const DataValuePolicyBase& rOther) const override
+    {
+        // Check if the other policy is of the same type
+        const LayeredDataValuePolicy<TValueType>* p_other_policy = dynamic_cast<const LayeredDataValuePolicy<TValueType>*>(&rOther);
+        if (!p_other_policy) {
+            return false; // different type
+        }
+        // check if all data members are the same
+        return (mNumberOfLayers == p_other_policy->mNumberOfLayers);
+    }
+
+    /**
+     * @brief Check if this policy can be used with the given variable.
+     * @details A layered policy is compatible with variables of the per-layer value type (not with variables of the stored std::vector type).
+     * @tparam TVariableValueType The value type of the variable.
+     * @param rVariable The variable to check against.
+     * @return true if the variable value type matches TValueType.
+     */
+    template<typename TVariableValueType>
+    bool IsCompatible(const Variable<TVariableValueType>& rVariable) const
+    {
+        if constexpr (std::is_same_v<TValueType, TVariableValueType>) {
+            return true;
+        }
+
+        return false;
+    }
+
+    ///@}
+    ///@name Access
+    ///@{
+
+    /**
+     * @brief Get the number of layers stored per entity.
+     * @return The number of layers.
+     */
+    std::size_t NumberOfLayers() const
+    {
+        return mNumberOfLayers;
+    }
+
+    ///@}
+
+private:
+    ///@name Member Variables
+    ///@{
+
+    std::size_t mNumberOfLayers; /// Number of layers to be stored
+
+    ///@}
+
+}; // Class LayeredDataValuePolicy
+
+///@}
+
+///@} addtogroup block
+
+} // namespace Kratos

--- a/kratos/containers/data_container/data_value_policy.h
+++ b/kratos/containers/data_container/data_value_policy.h
@@ -211,6 +211,7 @@ public:
 
     /**
      * @brief Constructor.
+     * @details The default value of rZero relies on TValueType()'s default constructor producing a meaningful zero, which holds for scalar types, std::string and std::vector, but not for lightweight ublas-derived types such as array_1d, Vector or Matrix, whose default constructors deliberately leave their storage uninitialized for performance; callers using such value types must pass an explicit rZero.
      * @param rZero The value used to zero-initialize entries governed by this policy.
      */
     DataValuePolicy(TValueType const& rZero = TValueType())

--- a/kratos/containers/data_container/sparse_data_value_policy.h
+++ b/kratos/containers/data_container/sparse_data_value_policy.h
@@ -1,0 +1,132 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
+//
+//  Main authors:    Pooyan Dadvand
+//  Collaborator:    Vicente Mataix Ferrandiz
+//
+//
+
+#pragma once
+
+// System includes
+
+// External includes
+
+// Project includes
+#include "containers/data_container/data_accessor.h"
+#include "containers/data_container/data_value_policy.h"
+
+namespace Kratos
+{
+///@addtogroup KratosCore
+///@{
+
+///@name Kratos Classes
+///@{
+
+/**
+ * @class SparseDataValuePolicy
+ * @ingroup KratosCore
+ * @brief Value policy for chunks that store values only for a sparse subset of entities.
+ * @details A sparse chunk does not allocate one value per entity; instead it is driven by a dense index variable (a Variable<int> stored in the same DataContainer, referenced through the index accessor passed at construction): entities with a non-negative index own the value at that position of the sparse chunk, entities with a negative index own no value. Chunks created with a sparse policy start empty (zero entities, see DataContainer::Add) and grow via DataContainer::UpdateSparseStorage (rebuild to the number of active indices) or DataContainer::AddToSparseStorage (append entries for new entities, preserving existing values).
+ * @see DataValuePolicy, DataAccessor, DataContainer
+ * @tparam TValueType The type of the data value to be stored.
+ * @author Pooyan Dadvand
+ */
+template<typename TValueType>
+class SparseDataValuePolicy : public DataValuePolicy<TValueType>
+{
+public:
+    ///@name Type Definitions
+    ///@{
+
+    /// Type of the accessor of the sparse index variable
+    using IndexAccessorType = DataAccessor<int>;
+
+    ///@}
+    ///@name Life Cycle
+    ///@{
+
+    /**
+     * @brief Constructor.
+     * @param IndexAccessor Accessor of the Variable<int> holding the sparse index for each entity (non-negative for active entries, negative otherwise). It must belong to the same DataContainer in which this policy is used.
+     * @param rZero The value used to zero-initialize entries governed by this policy.
+     */
+    SparseDataValuePolicy(IndexAccessorType IndexAccessor, const TValueType& rZero = TValueType())
+        : DataValuePolicy<TValueType>(rZero),
+          mIndexAccessor(IndexAccessor)
+    {
+    }
+
+    /// Copy constructor.
+    SparseDataValuePolicy(const SparseDataValuePolicy<TValueType>& rOther)
+        : DataValuePolicy<TValueType>(rOther),
+          mIndexAccessor(rOther.mIndexAccessor)
+    {
+    }
+
+    /// Destructor.
+    ~SparseDataValuePolicy() override = default;
+
+    ///@}
+    ///@name Operations
+    ///@{
+
+    /**
+     * @brief Clone the policy.
+     * @return A newly allocated copy of this policy (preserving the index accessor).
+     */
+    std::unique_ptr<DataValuePolicy<TValueType>> Clone() const override
+    {
+        return std::make_unique<SparseDataValuePolicy<TValueType>>(*this);
+    }
+
+    ///@}
+    ///@name Inquiry
+    ///@{
+
+    /**
+     * @brief Check if the policy is expected to work with sparse data.
+     * @return true.
+     */
+    bool IsSparse() const override
+    {
+        return true;
+    }
+
+    ///@}
+    ///@name Access
+    ///@{
+
+    /**
+     * @brief Get the accessor of the sparse index variable driving the sparse storage.
+     * @return The accessor of the sparse index variable.
+     */
+    DataAccessor<int> GetSparseIndexAccessor() const override
+    {
+        return mIndexAccessor;
+    }
+
+    ///@}
+
+private:
+    ///@name Member Variables
+    ///@{
+
+    IndexAccessorType mIndexAccessor; /// Accessor of the sparse index variable
+
+    ///@}
+
+}; // Class SparseDataValuePolicy
+
+///@}
+
+///@} addtogroup block
+
+} // namespace Kratos

--- a/kratos/containers/data_container/step_category.h
+++ b/kratos/containers/data_container/step_category.h
@@ -1,0 +1,47 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
+//
+//  Main authors:    Pooyan Dadvand
+//  Collaborator:    Vicente Mataix Ferrandiz
+//
+//
+
+#pragma once
+
+// System includes
+
+// External includes
+
+// Project includes
+
+namespace Kratos
+{
+///@addtogroup KratosCore
+///@{
+
+///@name  Enum's
+///@{
+
+/**
+ * @brief Categories of solution steps tracked by the data container history policies.
+ * @details Used by DataHistoryPolicyBase and its derived classes to decide which stored step ring buffer a given operation refers to, and by DataAccessor / DataContainer to request the data of a specific step. Cloning the step data of a DataChunk only advances the internal step index of chunks whose history policy matches the requested category (see HistoricalDataPolicy::CloneStepIndex).
+ */
+enum class StepCategory {
+    AnyStep,            /// Not bound to a specific step category (e.g. non-historical data)
+    TimeStep,           /// Time step
+    IterationStep,      /// Non-linear iteration step
+    SubStep,            /// Sub-step within a time step
+    NumberOfCategories  /// Sentinel value holding the number of categories (for array sizing)
+};
+
+///@}
+
+///@} addtogroup block
+
+} // namespace Kratos

--- a/kratos/python/add_data_container_to_python.cpp
+++ b/kratos/python/add_data_container_to_python.cpp
@@ -1,0 +1,292 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
+//
+//  Main authors:    Pooyan Dadvand
+//  Collaborator:    Vicente Mataix Ferrandiz
+//
+
+// System includes
+
+// External includes
+#include <pybind11/numpy.h>
+#include <pybind11/operators.h>
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+// Project includes
+#include "add_data_container_to_python.h"
+#include "containers/array_1d.h"
+#include "containers/data_container/data_container.h"
+#include "containers/data_container/sparse_data_value_policy.h"
+#include "includes/define_python.h"
+
+namespace Kratos::Python
+{
+
+namespace py = pybind11;
+
+namespace
+{
+
+/**
+ * @brief Python-side view over the std::string data of a DataContainer.
+ * @details std::string values cannot be exposed through the NumPy buffer protocol; this
+ * proxy re-fetches the span from the container on every access (making it robust against
+ * sparse storage updates) and keeps the container Python object alive.
+ */
+class StringDataSpan
+{
+public:
+    StringDataSpan(py::object Container, DataAccessor<std::string> Accessor)
+        : mContainer(Container), mAccessor(Accessor) {}
+
+    std::size_t size() const
+    {
+        return GetSpan().size();
+    }
+
+    std::string GetItem(py::ssize_t Index) const
+    {
+        auto span = GetSpan();
+        return span[CheckedIndex(Index, span.size())];
+    }
+
+    void SetItem(py::ssize_t Index, const std::string& rValue)
+    {
+        auto span = GetSpan();
+        span[CheckedIndex(Index, span.size())] = rValue;
+    }
+
+    std::vector<std::string> ToList() const
+    {
+        auto span = GetSpan();
+        return std::vector<std::string>(span.begin(), span.end());
+    }
+
+private:
+    Kratos::span<std::string> GetSpan() const
+    {
+        return mContainer.cast<DataContainer&>().GetDataSpan(mAccessor);
+    }
+
+    static std::size_t CheckedIndex(py::ssize_t Index, std::size_t Size)
+    {
+        if (Index < 0) Index += static_cast<py::ssize_t>(Size);
+        if (Index < 0 || static_cast<std::size_t>(Index) >= Size) throw py::index_error();
+        return static_cast<std::size_t>(Index);
+    }
+
+    py::object mContainer;                 /// The DataContainer Python object (kept alive by the proxy)
+    DataAccessor<std::string> mAccessor;   /// The accessor of the string data
+};
+
+using DataContainerBinderType = py::class_<DataContainer, DataContainer::Pointer>;
+
+/**
+ * @brief Bind the DataAccessor / DataValuePolicy / SparseDataValuePolicy triple and the
+ * typed DataContainer methods for one value type.
+ * @details Class names follow the Variable naming precedent (DoubleVariable ->
+ * DoubleDataValuePolicy etc.); for array_1d<double, 3> the dimension goes into the
+ * suffix (Array1DDataValuePolicy3, matching Array1DVariable3).
+ */
+template<class TValueType>
+void AddDataContainerTypeInterface(
+    py::module& m,
+    DataContainerBinderType& rContainerBinder,
+    const std::string& rPrefix,
+    const std::string& rSuffix = "")
+{
+    // Accessor: produced by DataContainer.Add / DataContainer.GetAccessor, no Python constructor
+    py::class_<DataAccessor<TValueType>>(m, (rPrefix + "DataAccessor" + rSuffix).c_str(),
+        "Lightweight handle to the data of one variable in a DataContainer. Obtained from DataContainer.Add or DataContainer.GetAccessor.")
+        .def("GetIndex", &DataAccessor<TValueType>::GetIndex,
+             "Index of the data chunk inside its container.")
+        .def("GetStepAccessor", &DataAccessor<TValueType>::GetStepAccessor,
+             py::arg("category"), py::arg("step_before_current") = 0,
+             "Accessor to the same data re-parameterized to another step.")
+        .def("GetStepCategory", &DataAccessor<TValueType>::GetStepCategory,
+             "Step category this accessor refers to.")
+        .def("GetStepBeforeCurrent", &DataAccessor<TValueType>::GetStepBeforeCurrent,
+             "How many steps before the current one this accessor refers to.")
+        .def(py::self == py::self);
+
+    // Dense value policy
+    py::class_<DataValuePolicy<TValueType>, DataValuePolicyBase>(m, (rPrefix + "DataValuePolicy" + rSuffix).c_str(),
+        "Value policy storing one dense value per entity. The optional zero argument customizes the value used to initialize new entries.")
+        .def(py::init<>())
+        .def(py::init<const TValueType&>(), py::arg("zero"))
+        .def("Zero", &DataValuePolicy<TValueType>::Zero, py::return_value_policy::copy,
+             "Value used to zero-initialize entries governed by this policy.");
+
+    // Sparse value policy
+    py::class_<SparseDataValuePolicy<TValueType>, DataValuePolicy<TValueType>>(m, (rPrefix + "SparseDataValuePolicy" + rSuffix).c_str(),
+        "Value policy for sparse storage driven by an integer index variable: entities with a non-negative index own a value, the others do not. Chunks start empty and grow via DataContainer.UpdateSparseStorage / DataContainer.AddToSparseStorage.")
+        .def(py::init<DataAccessor<int>>(), py::arg("index_accessor"))
+        .def(py::init<DataAccessor<int>, const TValueType&>(), py::arg("index_accessor"), py::arg("zero"));
+
+    // Typed container methods (overloads dispatch on the bound Variable / policy types)
+    rContainerBinder.def("Add",
+        [](DataContainer& rSelf, const Variable<TValueType>& rVariable, const DataValuePolicy<TValueType>& rValuePolicy, const DataHistoryPolicyBase& rHistoryPolicy) {
+            return rSelf.Add(rVariable, rValuePolicy, rHistoryPolicy);
+        },
+        py::arg("variable"), py::arg("value_policy"), py::arg("history_policy"),
+        "Add a data chunk for the given registered variable and policies; returns an accessor to its data.");
+
+    rContainerBinder.def("Add",
+        [](DataContainer& rSelf, const Variable<TValueType>& rVariable, const DataValuePolicy<TValueType>& rValuePolicy) {
+            return rSelf.Add(rVariable, rValuePolicy);
+        },
+        py::arg("variable"), py::arg("value_policy"),
+        "Add a non-historical data chunk for the given registered variable; returns an accessor to its data.");
+
+    rContainerBinder.def("GetAccessor",
+        [](DataContainer& rSelf, const Variable<TValueType>& rVariable, const DataValuePolicy<TValueType>& rValuePolicy, const DataHistoryPolicyBase& rHistoryPolicy) {
+            return rSelf.GetAccessor(rVariable, rValuePolicy, rHistoryPolicy);
+        },
+        py::arg("variable"), py::arg("value_policy"), py::arg("history_policy"),
+        "Get an accessor for existing data with matching variable and policy types.");
+
+    rContainerBinder.def("GetAccessor",
+        [](DataContainer& rSelf, const Variable<TValueType>& rVariable, const DataValuePolicy<TValueType>& rValuePolicy) {
+            return rSelf.GetAccessor(rVariable, rValuePolicy);
+        },
+        py::arg("variable"), py::arg("value_policy"),
+        "Get an accessor for existing non-historical data with a matching variable and value policy type.");
+
+    rContainerBinder.def("Has",
+        [](const DataContainer& rSelf, const Variable<TValueType>& rVariable) {
+            return rSelf.Has(rVariable);
+        },
+        py::arg("variable"),
+        "Check if the variable exists in the container.");
+
+    rContainerBinder.def("Has",
+        [](const DataContainer& rSelf, const Variable<TValueType>& rVariable, const DataValuePolicyBase& rValuePolicy) {
+            return rSelf.Has(rVariable, rValuePolicy);
+        },
+        py::arg("variable"), py::arg("value_policy"),
+        "Check if the variable exists in the container with the given value policy type.");
+
+    rContainerBinder.def("Has",
+        [](const DataContainer& rSelf, const Variable<TValueType>& rVariable, const DataValuePolicyBase& rValuePolicy, const DataHistoryPolicyBase& rHistoryPolicy) {
+            return rSelf.Has(rVariable, rValuePolicy, rHistoryPolicy);
+        },
+        py::arg("variable"), py::arg("value_policy"), py::arg("history_policy"),
+        "Check if the variable exists in the container with the given value and history policy types.");
+
+    // GetDataSpan: NumPy view for numeric types, proxy object for strings.
+    // The container Python object is passed as the array base, so NumPy neither frees the
+    // memory nor lets the container die while the array is referenced. The view aliases
+    // the chunk storage directly: UpdateSparseStorage / AddToSparseStorage / Initialize
+    // reallocate chunks, invalidating previously obtained arrays - re-fetch after them.
+    if constexpr (std::is_same_v<TValueType, array_1d<double, 3>>) {
+        static_assert(sizeof(array_1d<double, 3>) == 3 * sizeof(double),
+                      "array_1d<double, 3> must be laid out as 3 contiguous doubles to be exposed as a NumPy view.");
+        rContainerBinder.def("GetDataSpan",
+            [](py::object Self, const DataAccessor<TValueType>& rAccessor) {
+                auto& r_self = Self.cast<DataContainer&>();
+                auto data_span = r_self.GetDataSpan(rAccessor);
+                return py::array_t<double>(
+                    {static_cast<py::ssize_t>(data_span.size()), static_cast<py::ssize_t>(3)},
+                    {static_cast<py::ssize_t>(sizeof(array_1d<double, 3>)), static_cast<py::ssize_t>(sizeof(double))},
+                    reinterpret_cast<double*>(data_span.data()),
+                    Self);
+            },
+            py::arg("accessor"),
+            "NumPy view of shape (n_entities, 3) over the data of the given accessor's step. The view aliases the chunk memory; re-fetch it after sparse storage updates.");
+    } else if constexpr (std::is_same_v<TValueType, std::string>) {
+        rContainerBinder.def("GetDataSpan",
+            [](py::object Self, const DataAccessor<TValueType>& rAccessor) {
+                return StringDataSpan(Self, rAccessor);
+            },
+            py::arg("accessor"),
+            "StringDataSpan view over the string data of the given accessor's step.");
+    } else {
+        rContainerBinder.def("GetDataSpan",
+            [](py::object Self, const DataAccessor<TValueType>& rAccessor) {
+                auto& r_self = Self.cast<DataContainer&>();
+                auto data_span = r_self.GetDataSpan(rAccessor);
+                return py::array_t<TValueType>(
+                    {static_cast<py::ssize_t>(data_span.size())},
+                    {static_cast<py::ssize_t>(sizeof(TValueType))},
+                    data_span.data(),
+                    Self);
+            },
+            py::arg("accessor"),
+            "NumPy view over the data of the given accessor's step (one value per entity). The view aliases the chunk memory; re-fetch it after sparse storage updates.");
+    }
+}
+
+} // anonymous namespace
+
+void AddDataContainerToPython(pybind11::module& m)
+{
+    // Step categories used by the history policies and accessors
+    py::enum_<StepCategory>(m, "StepCategory")
+        .value("AnyStep", StepCategory::AnyStep)
+        .value("TimeStep", StepCategory::TimeStep)
+        .value("IterationStep", StepCategory::IterationStep)
+        .value("SubStep", StepCategory::SubStep);
+
+    // History policies
+    py::class_<DataHistoryPolicyBase>(m, "DataHistoryPolicyBase",
+        "Base class of the history policies governing how many step slots a chunk stores.")
+        .def("GetTotalNumberOfSteps", &DataHistoryPolicyBase::GetTotalNumberOfSteps,
+             "Number of stored steps including the current one.")
+        .def("GetLatestStepIndex", &DataHistoryPolicyBase::GetLatestStepIndex,
+             "Index of the current step slot.")
+        .def("GetStepCategory", &DataHistoryPolicyBase::GetStepCategory,
+             "Step category tracked by this policy.");
+
+    py::class_<NonHistoricalDataPolicy, DataHistoryPolicyBase>(m, "NonHistoricalDataPolicy",
+        "History policy storing a single value (no history) per entity.")
+        .def(py::init<>());
+
+    py::class_<HistoricalDataPolicy, DataHistoryPolicyBase>(m, "HistoricalDataPolicy",
+        "History policy storing a ring buffer of steps of one category (e.g. time steps).")
+        .def(py::init<StepCategory, std::size_t>(), py::arg("category"), py::arg("buffer_size"));
+
+    // Value policy base (concrete policies are bound per value type)
+    py::class_<DataValuePolicyBase>(m, "DataValuePolicyBase",
+        "Base class of the value policies governing how chunk values are stored.")
+        .def("IsSparse", &DataValuePolicyBase::IsSparse,
+             "Whether the policy stores data sparsely.");
+
+    // Python-side view for std::string spans
+    py::class_<StringDataSpan>(m, "StringDataSpan",
+        "View over the string data of a DataContainer; re-fetches the underlying span on every access.")
+        .def("__len__", &StringDataSpan::size)
+        .def("__getitem__", &StringDataSpan::GetItem)
+        .def("__setitem__", &StringDataSpan::SetItem)
+        .def("ToList", &StringDataSpan::ToList,
+             "Copy the values into a Python list.");
+
+    // The container itself
+    DataContainerBinderType container_binder(m, "DataContainer",
+        "Chunked, type-erased, variable-keyed storage of entity data. Variables must be registered Kratos variables.");
+    container_binder.def(py::init<>());
+    container_binder.def(py::init<std::size_t>(), py::arg("chunk_size"));
+    container_binder.def("Initialize", &DataContainer::Initialize, py::arg("other"), py::arg("chunk_size"),
+        "Mirror the chunk structure of another container with fresh zero-initialized chunks of the given chunk size.");
+    container_binder.def("UpdateSparseStorage", &DataContainer::UpdateSparseStorage, py::arg("index_accessor"),
+        "Rebuild all sparse chunks keyed on the given index accessor to the number of active (non-negative) indices. Discards their previous values.");
+    container_binder.def("AddToSparseStorage", &DataContainer::AddToSparseStorage, py::arg("index_accessor"), py::arg("entity_indices"),
+        "Assign sparse indices to the given (currently inactive) entities and grow the sparse chunks keyed on the index accessor, preserving existing values.");
+    container_binder.def("CloneStepData", &DataContainer::CloneStepData, py::arg("step_category"),
+        "Clone the current step onto the next step slot for all chunks of the given category.");
+    container_binder.def("__str__", PrintObject<DataContainer>);
+
+    // Typed interfaces, following the Variable naming precedent
+    AddDataContainerTypeInterface<double>(m, container_binder, "Double");
+    AddDataContainerTypeInterface<int>(m, container_binder, "Integer");
+    AddDataContainerTypeInterface<array_1d<double, 3>>(m, container_binder, "Array1D", "3");
+    AddDataContainerTypeInterface<std::string>(m, container_binder, "String");
+}
+
+}  // namespace Kratos::Python.

--- a/kratos/python/add_data_container_to_python.cpp
+++ b/kratos/python/add_data_container_to_python.cpp
@@ -274,6 +274,8 @@ void AddDataContainerToPython(pybind11::module& m)
     container_binder.def(py::init<std::size_t>(), py::arg("chunk_size"));
     container_binder.def("Initialize", &DataContainer::Initialize, py::arg("other"), py::arg("chunk_size"),
         "Mirror the chunk structure of another container with fresh zero-initialized chunks of the given chunk size.");
+    container_binder.def("Resize", &DataContainer::Resize, py::arg("number_of_entities"),
+        "Resize all dense (non-sparse) chunks to the given number of entities per step, preserving existing per-step values and zero-initializing appended entries. Previously obtained NumPy views over resized chunks are invalidated - re-fetch them.");
     container_binder.def("UpdateSparseStorage", &DataContainer::UpdateSparseStorage, py::arg("index_accessor"),
         "Rebuild all sparse chunks keyed on the given index accessor to the number of active (non-negative) indices. Discards their previous values.");
     container_binder.def("AddToSparseStorage", &DataContainer::AddToSparseStorage, py::arg("index_accessor"), py::arg("entity_indices"),

--- a/kratos/python/add_data_container_to_python.h
+++ b/kratos/python/add_data_container_to_python.h
@@ -1,0 +1,28 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
+//
+//  Main authors:    Pooyan Dadvand
+//  Collaborator:    Vicente Mataix Ferrandiz
+//
+
+#pragma once
+
+// System includes
+
+// External includes
+#include <pybind11/pybind11.h>
+
+// Project includes
+
+namespace Kratos::Python
+{
+
+void AddDataContainerToPython(pybind11::module& m);
+
+}  // namespace Kratos::Python.

--- a/kratos/python/kratos_python.cpp
+++ b/kratos/python/kratos_python.cpp
@@ -30,6 +30,7 @@
 #include "add_fsi_variables_to_python.h"
 #include "add_mat_variables_to_python.h"
 #include "add_containers_to_python.h"
+#include "add_data_container_to_python.h"
 #include "add_matrix_to_python.h"
 #include "add_quaternion_to_python.h"
 #include "add_points_to_python.h"
@@ -106,6 +107,7 @@ PYBIND11_MODULE(Kratos, m)
     AddPointsToPython(m);
     AddKernelToPython(m);
     AddContainersToPython(m);
+    AddDataContainerToPython(m);
     AddModelPartToPython(m);
     AddDofsToPython(m);
     AddNodeToPython(m);

--- a/kratos/tests/cpp_tests/containers/data_container/test_data_chunk.cpp
+++ b/kratos/tests/cpp_tests/containers/data_container/test_data_chunk.cpp
@@ -1,0 +1,203 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
+//
+//  Main authors:    Pooyan Dadvand
+//  Collaborator:    Vicente Mataix Ferrandiz
+//
+//
+
+// System includes
+
+// External includes
+
+// Project includes
+#include "containers/data_container/data_chunk.h"
+#include "includes/expect.h"
+#include "includes/variables.h"
+#include "testing/testing.h"
+
+namespace Kratos {
+namespace Testing {
+
+KRATOS_TEST_CASE_IN_SUITE(DataChunkConstructionAndZeroInitialization, KratosCoreFastSuite)
+{
+    // Default zero
+    DataChunk<double> chunk(PRESSURE, DataValuePolicy<double>(), NonHistoricalDataPolicy(), 8);
+
+    KRATOS_EXPECT_EQ(chunk.NumberOfEntitiesPerStep(), 8);
+    KRATOS_EXPECT_TRUE(chunk.GetVariableData() == PRESSURE);
+    for (std::size_t i = 0; i < 8; ++i) {
+        KRATOS_EXPECT_EQ(chunk.GetData()[i], 0.0);
+    }
+
+    // Custom policy zero initializes every entry
+    DataChunk<double> custom_zero_chunk(PRESSURE, DataValuePolicy<double>(3.5), NonHistoricalDataPolicy(), 8);
+    for (std::size_t i = 0; i < 8; ++i) {
+        KRATOS_EXPECT_EQ(custom_zero_chunk.GetData()[i], 3.5);
+    }
+
+    // A historical chunk allocates and zero-fills all step slots
+    DataChunk<double> historical_chunk(PRESSURE, DataValuePolicy<double>(1.25), HistoricalDataPolicy(StepCategory::TimeStep, 3), 4);
+    for (std::size_t i = 0; i < 4 * 3; ++i) {
+        KRATOS_EXPECT_EQ(historical_chunk.GetData()[i], 1.25);
+    }
+}
+
+KRATOS_TEST_CASE_IN_SUITE(DataChunkZeroEntities, KratosCoreFastSuite)
+{
+    // Sparse chunks legitimately start with zero entities: construction, CreateNew(0) and
+    // growing from empty must all work (also in debug builds)
+    DataChunk<double> empty_chunk(PRESSURE, DataValuePolicy<double>(), NonHistoricalDataPolicy(), 0);
+    KRATOS_EXPECT_EQ(empty_chunk.NumberOfEntitiesPerStep(), 0);
+    KRATOS_EXPECT_EQ(empty_chunk.GetData(), nullptr);
+
+    auto p_new_empty = empty_chunk.CreateNew(0);
+    KRATOS_EXPECT_EQ(p_new_empty->NumberOfEntitiesPerStep(), 0);
+
+    // Growing from empty zero-fills the new entries
+    empty_chunk.ResizeData(5);
+    KRATOS_EXPECT_EQ(empty_chunk.NumberOfEntitiesPerStep(), 5);
+    for (std::size_t i = 0; i < 5; ++i) {
+        KRATOS_EXPECT_EQ(empty_chunk.GetData()[i], 0.0);
+    }
+}
+
+KRATOS_TEST_CASE_IN_SUITE(DataChunkMultiStepLayout, KratosCoreFastSuite)
+{
+    DataChunk<double> chunk(PRESSURE, DataValuePolicy<double>(), HistoricalDataPolicy(StepCategory::TimeStep, 3), 4);
+
+    // Write distinct values per step slot through the per-step pointers
+    for (std::size_t step = 0; step < 3; ++step) {
+        double* p_step_data = chunk.GetDataPointer(step);
+        for (std::size_t i = 0; i < 4; ++i) {
+            p_step_data[i] = 10.0 * step + i;
+        }
+    }
+
+    // The storage is laid out step-by-step
+    for (std::size_t step = 0; step < 3; ++step) {
+        for (std::size_t i = 0; i < 4; ++i) {
+            KRATOS_EXPECT_EQ(chunk.GetData()[step * 4 + i], 10.0 * step + i);
+            KRATOS_EXPECT_EQ(chunk.GetDataIterator(step)[i], 10.0 * step + i);
+        }
+    }
+}
+
+KRATOS_TEST_CASE_IN_SUITE(DataChunkCloneStepData, KratosCoreFastSuite)
+{
+    DataChunk<double> chunk(PRESSURE, DataValuePolicy<double>(), HistoricalDataPolicy(StepCategory::TimeStep, 3), 4);
+
+    // Fill the current step (slot 0)
+    for (std::size_t i = 0; i < 4; ++i) {
+        chunk.GetDataPointer(0)[i] = 1.0;
+    }
+
+    // Cloning a non-matching category is a no-op
+    chunk.CloneStepData(StepCategory::IterationStep);
+    KRATOS_EXPECT_EQ(chunk.GetHistoryPolicy().GetLatestStepIndex(), 0);
+    for (std::size_t i = 0; i < 4; ++i) {
+        KRATOS_EXPECT_EQ(chunk.GetDataPointer(1)[i], 0.0);
+    }
+
+    // Cloning the matching category advances the ring and copies the current data
+    chunk.CloneStepData(StepCategory::TimeStep);
+    KRATOS_EXPECT_EQ(chunk.GetHistoryPolicy().GetLatestStepIndex(), 1);
+    for (std::size_t i = 0; i < 4; ++i) {
+        KRATOS_EXPECT_EQ(chunk.GetDataPointer(1)[i], 1.0); // new current step is a copy
+        KRATOS_EXPECT_EQ(chunk.GetDataPointer(0)[i], 1.0); // previous step untouched
+    }
+
+    // Two more clones wrap around: slot 0 becomes the current step again and is
+    // overwritten with the data of slot 2
+    chunk.GetDataPointer(1)[0] = 7.0;
+    chunk.CloneStepData(StepCategory::TimeStep); // latest: 2, copy of slot 1
+    chunk.CloneStepData(StepCategory::TimeStep); // latest: 0 (wrap), copy of slot 2
+    KRATOS_EXPECT_EQ(chunk.GetHistoryPolicy().GetLatestStepIndex(), 0);
+    KRATOS_EXPECT_EQ(chunk.GetDataPointer(0)[0], 7.0);
+}
+
+KRATOS_TEST_CASE_IN_SUITE(DataChunkResizePreservesPerStepData, KratosCoreFastSuite)
+{
+    // Regression test: the resize copy has to work per step slot, not on the total size
+    DataChunk<double> chunk(PRESSURE, DataValuePolicy<double>(), HistoricalDataPolicy(StepCategory::TimeStep, 3), 8);
+
+    for (std::size_t step = 0; step < 3; ++step) {
+        for (std::size_t i = 0; i < 8; ++i) {
+            chunk.GetDataPointer(step)[i] = 100.0 * step + i;
+        }
+    }
+
+    // Shrink: each step keeps its first 5 values
+    chunk.ResizeData(5);
+    KRATOS_EXPECT_EQ(chunk.NumberOfEntitiesPerStep(), 5);
+    for (std::size_t step = 0; step < 3; ++step) {
+        for (std::size_t i = 0; i < 5; ++i) {
+            KRATOS_EXPECT_EQ(chunk.GetDataPointer(step)[i], 100.0 * step + i);
+        }
+    }
+
+    // Grow: each step keeps its 5 values and zero-fills the new tail
+    chunk.ResizeData(12);
+    KRATOS_EXPECT_EQ(chunk.NumberOfEntitiesPerStep(), 12);
+    for (std::size_t step = 0; step < 3; ++step) {
+        for (std::size_t i = 0; i < 5; ++i) {
+            KRATOS_EXPECT_EQ(chunk.GetDataPointer(step)[i], 100.0 * step + i);
+        }
+        for (std::size_t i = 5; i < 12; ++i) {
+            KRATOS_EXPECT_EQ(chunk.GetDataPointer(step)[i], 0.0);
+        }
+    }
+}
+
+KRATOS_TEST_CASE_IN_SUITE(DataChunkResizeToZeroAndBack, KratosCoreFastSuite)
+{
+    // Regression test: resizing to zero releases the storage without leaving a dangling
+    // pointer (the destructor must not double-free), and the chunk can grow again
+    DataChunk<double> chunk(PRESSURE, DataValuePolicy<double>(2.0), NonHistoricalDataPolicy(), 6);
+
+    chunk.ResizeData(0);
+    KRATOS_EXPECT_EQ(chunk.NumberOfEntitiesPerStep(), 0);
+    KRATOS_EXPECT_EQ(chunk.GetData(), nullptr);
+
+    chunk.ResizeData(4);
+    KRATOS_EXPECT_EQ(chunk.NumberOfEntitiesPerStep(), 4);
+    for (std::size_t i = 0; i < 4; ++i) {
+        KRATOS_EXPECT_EQ(chunk.GetData()[i], 2.0); // zero-filled with the policy zero
+    }
+
+    // Destruction after ResizeData(0) alone must also be safe
+    {
+        DataChunk<double> to_destroy(PRESSURE, DataValuePolicy<double>(), NonHistoricalDataPolicy(), 3);
+        to_destroy.ResizeData(0);
+    } // no double delete here
+}
+
+KRATOS_TEST_CASE_IN_SUITE(DataChunkCreateNewPreservesPolicies, KratosCoreFastSuite)
+{
+    DataValuePolicy<double> value_policy(4.5);
+    HistoricalDataPolicy history_policy(StepCategory::TimeStep, 2);
+    DataChunk<double> chunk(PRESSURE, value_policy, history_policy, 3);
+
+    auto p_new = chunk.CreateNew(7);
+
+    KRATOS_EXPECT_EQ(p_new->NumberOfEntitiesPerStep(), 7);
+    KRATOS_EXPECT_TRUE(p_new->GetVariableData() == PRESSURE);
+    KRATOS_EXPECT_TRUE(p_new->GetValuePolicy().IsSame(value_policy));
+    KRATOS_EXPECT_TRUE(p_new->GetHistoryPolicy().IsSame(history_policy));
+
+    // The new chunk is zero-initialized with the (cloned) policy zero
+    auto p_typed = std::dynamic_pointer_cast<DataChunk<double>>(p_new);
+    KRATOS_EXPECT_TRUE(p_typed != nullptr);
+    for (std::size_t i = 0; i < 7 * 2; ++i) {
+        KRATOS_EXPECT_EQ(p_typed->GetData()[i], 4.5);
+    }
+}
+
+} // namespace Testing
+} // namespace Kratos

--- a/kratos/tests/cpp_tests/containers/data_container/test_data_container.cpp
+++ b/kratos/tests/cpp_tests/containers/data_container/test_data_container.cpp
@@ -112,8 +112,11 @@ KRATOS_TEST_CASE_IN_SUITE(DataContainerGetData, KratosCoreFastSuite)
     DataContainerGetDataTest<double>(PRESSURE, DataValuePolicy<double>(), 0.0, 1.0);
 
     // Test with array_1d<double, 3> data type
-    DataContainerGetDataTest(VELOCITY, DataValuePolicy<array_1d<double, 3>>(),
-                             array_1d<double, 3>{{0.0, 0.0, 0.0}}, array_1d<double, 3>{{1.0, 1.0, 1.0}});
+    // Note: array_1d's default constructor does not zero-initialize its storage (unlike
+    // std::array), so the policy zero must be passed explicitly here.
+    const array_1d<double, 3> array_zero{{0.0, 0.0, 0.0}};
+    DataContainerGetDataTest(VELOCITY, DataValuePolicy<array_1d<double, 3>>(array_zero),
+                             array_zero, array_1d<double, 3>{{1.0, 1.0, 1.0}});
 
     // Test with a layered policy over a double variable
     const std::size_t number_of_layers = 10;

--- a/kratos/tests/cpp_tests/containers/data_container/test_data_container.cpp
+++ b/kratos/tests/cpp_tests/containers/data_container/test_data_container.cpp
@@ -378,5 +378,122 @@ KRATOS_TEST_CASE_IN_SUITE(DataContainerInitialize, KratosCoreFastSuite)
         "Chunk size must be greater than zero.");
 }
 
+KRATOS_TEST_CASE_IN_SUITE(DataContainerResizeGrowPreservesData, KratosCoreFastSuite)
+{
+    DataContainer container(4);
+    auto double_accessor = container.Add(PRESSURE, DataValuePolicy<double>(), NonHistoricalDataPolicy());
+    const array_1d<double, 3> array_zero{{0.0, 0.0, 0.0}};
+    auto array_accessor = container.Add(VELOCITY, DataValuePolicy<array_1d<double, 3>>(array_zero), NonHistoricalDataPolicy());
+
+    auto double_span = container.GetDataSpan(double_accessor);
+    for (std::size_t i = 0; i < 4; ++i) {
+        double_span[i] = 10.0 + i;
+    }
+    auto array_span = container.GetDataSpan(array_accessor);
+    for (std::size_t i = 0; i < 4; ++i) {
+        array_span[i] = array_1d<double, 3>{{1.0 * i, 2.0 * i, 3.0 * i}};
+    }
+
+    container.Resize(7);
+
+    // Existing values preserved, appended entries zero-initialized with the policy zero
+    auto grown_double_span = container.GetDataSpan(double_accessor);
+    KRATOS_EXPECT_EQ(grown_double_span.size(), 7);
+    for (std::size_t i = 0; i < 4; ++i) {
+        KRATOS_EXPECT_EQ(grown_double_span[i], 10.0 + i);
+    }
+    for (std::size_t i = 4; i < 7; ++i) {
+        KRATOS_EXPECT_EQ(grown_double_span[i], 0.0);
+    }
+
+    auto grown_array_span = container.GetDataSpan(array_accessor);
+    KRATOS_EXPECT_EQ(grown_array_span.size(), 7);
+    for (std::size_t i = 0; i < 4; ++i) {
+        KRATOS_EXPECT_EQ(grown_array_span[i], (array_1d<double, 3>{{1.0 * i, 2.0 * i, 3.0 * i}}));
+    }
+    for (std::size_t i = 4; i < 7; ++i) {
+        KRATOS_EXPECT_EQ(grown_array_span[i], array_zero);
+    }
+}
+
+KRATOS_TEST_CASE_IN_SUITE(DataContainerResizeShrinkDropsTail, KratosCoreFastSuite)
+{
+    DataContainer container(6);
+    auto accessor = container.Add(PRESSURE, DataValuePolicy<double>(), NonHistoricalDataPolicy());
+
+    auto span = container.GetDataSpan(accessor);
+    for (std::size_t i = 0; i < 6; ++i) {
+        span[i] = 1.0 + i;
+    }
+
+    container.Resize(3);
+
+    auto shrunk_span = container.GetDataSpan(accessor);
+    KRATOS_EXPECT_EQ(shrunk_span.size(), 3);
+    for (std::size_t i = 0; i < 3; ++i) {
+        KRATOS_EXPECT_EQ(shrunk_span[i], 1.0 + i); // leading values preserved
+    }
+}
+
+KRATOS_TEST_CASE_IN_SUITE(DataContainerResizeHistoricalChunks, KratosCoreFastSuite)
+{
+    // Every step slot of a historical chunk must be preserved independently on resize
+    DataContainer container(4);
+    DataValuePolicy<double> value_policy;
+    auto accessor = container.Add(PRESSURE, value_policy, HistoricalDataPolicy(StepCategory::TimeStep, 3));
+
+    // Fill the three step slots with distinct values via step accessors
+    for (int step = 0; step < 3; ++step) {
+        auto step_span = container.GetDataSpan(accessor.GetStepAccessor(StepCategory::TimeStep, step));
+        for (std::size_t i = 0; i < 4; ++i) {
+            step_span[i] = 100.0 * step + i;
+        }
+    }
+
+    container.Resize(6);
+
+    for (int step = 0; step < 3; ++step) {
+        auto step_span = container.GetDataSpan(accessor.GetStepAccessor(StepCategory::TimeStep, step));
+        KRATOS_EXPECT_EQ(step_span.size(), 6);
+        for (std::size_t i = 0; i < 4; ++i) {
+            KRATOS_EXPECT_EQ(step_span[i], 100.0 * step + i); // per-step values preserved
+        }
+        for (std::size_t i = 4; i < 6; ++i) {
+            KRATOS_EXPECT_EQ(step_span[i], 0.0); // per-step tails zero-initialized
+        }
+    }
+}
+
+KRATOS_TEST_CASE_IN_SUITE(DataContainerResizeSkipsSparseChunks, KratosCoreFastSuite)
+{
+    DataContainer container(8);
+    auto index_accessor = container.Add(STEP, DataValuePolicy<int>(-1), NonHistoricalDataPolicy());
+    auto sparse_accessor = container.Add(PRESSURE, SparseDataValuePolicy<double>(index_accessor), NonHistoricalDataPolicy());
+
+    // Activate three sparse entries
+    container.AddToSparseStorage(index_accessor, {0, 2, 4});
+    KRATOS_EXPECT_EQ(container.GetDataSpan(sparse_accessor).size(), 3);
+
+    container.Resize(16);
+
+    // The dense index chunk grew, the sparse chunk kept its own size
+    KRATOS_EXPECT_EQ(container.GetDataSpan(index_accessor).size(), 16);
+    KRATOS_EXPECT_EQ(container.GetDataSpan(sparse_accessor).size(), 3);
+}
+
+KRATOS_TEST_CASE_IN_SUITE(DataContainerResizeCustomZeroTail, KratosCoreFastSuite)
+{
+    DataContainer container(3);
+    auto accessor = container.Add(STEP, DataValuePolicy<int>(-1), NonHistoricalDataPolicy());
+
+    container.Resize(5);
+
+    auto span = container.GetDataSpan(accessor);
+    KRATOS_EXPECT_EQ(span.size(), 5);
+    for (std::size_t i = 0; i < 5; ++i) {
+        KRATOS_EXPECT_EQ(span[i], -1); // whole span holds the policy zero
+    }
+}
+
 } // namespace Testing
 } // namespace Kratos

--- a/kratos/tests/cpp_tests/containers/data_container/test_data_container.cpp
+++ b/kratos/tests/cpp_tests/containers/data_container/test_data_container.cpp
@@ -1,0 +1,379 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
+//
+//  Main authors:    Pooyan Dadvand
+//  Collaborator:    Vicente Mataix Ferrandiz
+//
+//
+
+// System includes
+
+// External includes
+
+// Project includes
+#include "containers/array_1d.h"
+#include "containers/data_container/data_container.h"
+#include "containers/data_container/sparse_data_value_policy.h"
+#include "includes/expect.h"
+#include "includes/ublas_interface.h"
+#include "includes/variables.h"
+#include "testing/testing.h"
+
+namespace Kratos {
+namespace Testing {
+namespace {
+
+// Custom user type stored in the container: needs default construction, operator== and
+// operator<<; save/load are required by the Serializer support of the real Variable<T>
+class CustomClass
+{
+public:
+    int value = 0;
+    bool operator==(const CustomClass& rOther) const { return value == rOther.value; }
+    bool operator!=(const CustomClass& rOther) const { return !(*this == rOther); }
+    CustomClass& operator=(const CustomClass& rOther) { value = rOther.value; return *this; }
+    void save(Serializer& rSerializer) const { rSerializer.save("value", value); }
+    void load(Serializer& rSerializer) { rSerializer.load("value", value); }
+};
+
+std::ostream& operator<<(std::ostream& rOStream, const CustomClass& rObject)
+{
+    rOStream << "CustomClass(value=" << rObject.value << ")";
+    return rOStream;
+}
+
+// Generic round trip: adding a variable creates a zero-initialized span of the default
+// chunk size; writing through the span is visible through a fresh accessor-based span
+template<typename T, typename TVariableValueType, typename TPolicyType>
+void DataContainerGetDataTest(
+    const Variable<TVariableValueType>& rVariable,
+    TPolicyType const& rValuePolicy,
+    T const& rZero,
+    T const& rOne)
+{
+    DataContainer container;
+
+    auto accessor = container.Add(rVariable, rValuePolicy, NonHistoricalDataPolicy());
+
+    // data container initializes values to zero
+    auto data_span = container.GetDataSpan(rVariable, rValuePolicy);
+    KRATOS_EXPECT_EQ(data_span.size(), 256); // default chunk size
+    for (auto& r_value : data_span) {
+        KRATOS_EXPECT_EQ(r_value, rZero);
+    }
+
+    for (auto& r_value : data_span) {
+        r_value = rOne; // modify the data
+    }
+
+    auto data_span2 = container.GetDataSpan(accessor);
+    KRATOS_EXPECT_EQ(data_span2.size(), 256); // default chunk size
+    for (auto& r_value : data_span2) {
+        KRATOS_EXPECT_EQ(r_value, rOne); // check that the data was modified
+    }
+}
+
+// Helper for DataContainerVariableLifeTime: defines a variable on the spot, registers it
+// and uses it to store data; the variable object dies when the function returns
+void AddDataForLocalVariable(DataContainer& rContainer)
+{
+    Variable<double> local{"DATA_CONTAINER_TEST_LOCAL"};
+    local.Register();
+    auto accessor = rContainer.Add(local, DataValuePolicy<double>(), NonHistoricalDataPolicy());
+    for (auto& r_value : rContainer.GetDataSpan(accessor)) {
+        r_value = 5.7;
+    }
+}
+
+} // anonymous namespace
+
+KRATOS_TEST_CASE_IN_SUITE(DataContainerAdd, KratosCoreFastSuite)
+{
+    DataContainer container;
+
+    KRATOS_EXPECT_EQ(container.Has(PRESSURE), false);
+    KRATOS_EXPECT_EQ(container.Has(PRESSURE, DataValuePolicy<double>()), false);
+
+    container.Add(PRESSURE, DataValuePolicy<double>(), NonHistoricalDataPolicy());
+
+    KRATOS_EXPECT_EQ(container.Has(PRESSURE), true);
+    KRATOS_EXPECT_EQ(container.Has(PRESSURE, DataValuePolicy<double>()), true);
+}
+
+KRATOS_TEST_CASE_IN_SUITE(DataContainerGetData, KratosCoreFastSuite)
+{
+    // Test with double data type
+    DataContainerGetDataTest<double>(PRESSURE, DataValuePolicy<double>(), 0.0, 1.0);
+
+    // Test with array_1d<double, 3> data type
+    DataContainerGetDataTest(VELOCITY, DataValuePolicy<array_1d<double, 3>>(),
+                             array_1d<double, 3>{{0.0, 0.0, 0.0}}, array_1d<double, 3>{{1.0, 1.0, 1.0}});
+
+    // Test with a layered policy over a double variable
+    const std::size_t number_of_layers = 10;
+    DataContainerGetDataTest(TEMPERATURE, LayeredDataValuePolicy<double>(number_of_layers),
+                             std::vector<double>(number_of_layers, 0.0), std::vector<double>(number_of_layers, 1.0));
+
+    // Test with int data type
+    DataContainerGetDataTest<int>(STEP, DataValuePolicy<int>(), 0, 1);
+
+    // Test with std::string data type
+    DataContainerGetDataTest<std::string>(IDENTIFIER, DataValuePolicy<std::string>(), "", "Test");
+
+    // Test with a custom user type (registered on the spot)
+    Variable<CustomClass> custom_variable("DATA_CONTAINER_TEST_CUSTOM");
+    custom_variable.Register();
+    DataContainerGetDataTest(custom_variable, DataValuePolicy<CustomClass>(), CustomClass(), CustomClass{1});
+}
+
+KRATOS_TEST_CASE_IN_SUITE(DataContainerTimeStep, KratosCoreFastSuite)
+{
+    DataContainer container;
+    DataValuePolicy<double> value_policy;
+    HistoricalDataPolicy historical_policy(StepCategory::TimeStep, 3); // Storing 3 time steps including the current one
+
+    auto double_accessor = container.Add(PRESSURE, value_policy, historical_policy);
+
+    // data container initializes values to zero
+    auto current_step_data = container.GetDataSpan(PRESSURE, value_policy, StepCategory::TimeStep);
+    KRATOS_EXPECT_EQ(current_step_data.size(), 256); // default chunk size
+    for (auto& r_value : current_step_data) {
+        KRATOS_EXPECT_EQ(r_value, 0.0);
+    }
+
+    for (auto& r_value : current_step_data) {
+        r_value = 1.0; // modify the data
+    }
+
+    auto previous_step_data = container.GetDataSpan(PRESSURE, value_policy, StepCategory::TimeStep, 1);
+    KRATOS_EXPECT_EQ(previous_step_data.size(), 256); // default chunk size
+    for (auto& r_value : previous_step_data) {
+        KRATOS_EXPECT_EQ(r_value, 0.0); // previous step should still be zero
+    }
+
+    for (auto& r_value : previous_step_data) {
+        r_value = 2.0; // modify the data again
+    }
+
+    auto current_accessed = container.GetDataSpan(double_accessor);
+    KRATOS_EXPECT_EQ(current_accessed.size(), 256); // default chunk size
+    for (auto& r_value : current_accessed) {
+        KRATOS_EXPECT_EQ(r_value, 1.0); // check that the data was modified
+    }
+
+    auto previous_accessed = container.GetDataSpan(double_accessor.GetStepAccessor(StepCategory::TimeStep, 1));
+    KRATOS_EXPECT_EQ(previous_accessed.size(), 256); // default chunk size
+    for (auto& r_value : previous_accessed) {
+        KRATOS_EXPECT_EQ(r_value, 2.0);
+    }
+}
+
+KRATOS_TEST_CASE_IN_SUITE(DataContainerCloneStep, KratosCoreFastSuite)
+{
+    DataContainer container;
+    DataValuePolicy<double> value_policy;
+    HistoricalDataPolicy historical_policy(StepCategory::TimeStep, 3); // Storing 3 time steps including the current one
+
+    auto current_data_accessor = container.Add(PRESSURE, value_policy, historical_policy);
+    auto previous_data_accessor = current_data_accessor.GetStepAccessor(StepCategory::TimeStep, 1);
+
+    // initialize current step data
+    auto current_step_data = container.GetDataSpan(current_data_accessor);
+    for (auto& r_value : current_step_data) {
+        r_value = 1.0;
+    }
+
+    // initialize previous step data
+    auto previous_step_data = container.GetDataSpan(previous_data_accessor);
+    for (auto& r_value : previous_step_data) {
+        r_value = 2.0;
+    }
+
+    container.CloneStepData(StepCategory::TimeStep);
+
+    // now both the current and the previous step hold the pre-clone current data
+    auto new_current_step_data = container.GetDataSpan(current_data_accessor);
+    for (auto& r_value : new_current_step_data) {
+        KRATOS_EXPECT_EQ(r_value, 1.0); // new current step is a copy of the pre-clone current step
+    }
+
+    auto new_previous_step_data = container.GetDataSpan(previous_data_accessor);
+    for (auto& r_value : new_previous_step_data) {
+        KRATOS_EXPECT_EQ(r_value, 1.0); // the pre-clone current step is now the previous one
+    }
+
+    auto two_steps_ago_data = container.GetDataSpan(current_data_accessor.GetStepAccessor(StepCategory::TimeStep, 2));
+    for (auto& r_value : two_steps_ago_data) {
+        KRATOS_EXPECT_EQ(r_value, 2.0); // the pre-clone previous step is now two steps ago
+    }
+}
+
+KRATOS_TEST_CASE_IN_SUITE(DataContainerAccessorRetrieval, KratosCoreFastSuite)
+{
+    DataContainer container;
+
+    auto original_double_accessor = container.Add(PRESSURE, DataValuePolicy<double>(), NonHistoricalDataPolicy());
+    container.Add(STEP, LayeredDataValuePolicy<int>(10), HistoricalDataPolicy(StepCategory::TimeStep, 3));
+
+    for (auto& r_value : container.GetDataSpan(original_double_accessor)) {
+        r_value = 3.14;
+    }
+
+    // Correct data
+    KRATOS_EXPECT_TRUE(container.Has(PRESSURE, DataValuePolicy<double>(), NonHistoricalDataPolicy()));
+
+    // For a valid combination, we can get a new accessor to existing data
+    auto new_accessor = container.GetAccessor(PRESSURE, DataValuePolicy<double>(), NonHistoricalDataPolicy());
+    for (const auto& r_value : container.GetDataSpan(new_accessor)) {
+        KRATOS_EXPECT_EQ(r_value, 3.14);
+    }
+
+    // Variable mismatch
+    KRATOS_EXPECT_FALSE(container.Has(TEMPERATURE, DataValuePolicy<double>(), NonHistoricalDataPolicy()));
+
+    // Value policy mismatch
+    KRATOS_EXPECT_FALSE(container.Has(PRESSURE, LayeredDataValuePolicy<double>(3), NonHistoricalDataPolicy()));
+
+    // History policy mismatch
+    KRATOS_EXPECT_FALSE(container.Has(PRESSURE, DataValuePolicy<double>(), HistoricalDataPolicy(StepCategory::TimeStep, 3)));
+
+    // We do not need to match the policy details (layer number, num steps), knowing the types is enough
+    KRATOS_EXPECT_TRUE(container.Has(STEP, LayeredDataValuePolicy<int>(1), HistoricalDataPolicy(StepCategory::TimeStep, 2)));
+
+    // GetAccessor for data not in the container raises an error
+    KRATOS_EXPECT_EXCEPTION_IS_THROWN(
+        container.GetAccessor(TEMPERATURE, DataValuePolicy<double>(), NonHistoricalDataPolicy()),
+        "No data found in container for TEMPERATURE");
+}
+
+KRATOS_TEST_CASE_IN_SUITE(DataContainerVariableLifeTime, KratosCoreFastSuite)
+{
+    // Ensure that variables defined on the spot can be used to define stored data
+    // and that the data is still retrievable even if the original variable goes out of scope
+    DataContainer container;
+
+    // This function defines and registers a local variable and uses it to store data in the container
+    AddDataForLocalVariable(container);
+
+    // Even though the original variable has gone out of scope, we can still access the associated data
+    Variable<double> local_var{"DATA_CONTAINER_TEST_LOCAL"};
+    KRATOS_EXPECT_TRUE(container.Has(local_var));
+
+    auto accessor = container.GetAccessor(local_var, DataValuePolicy<double>());
+    for (const auto& r_value : container.GetDataSpan(accessor)) {
+        KRATOS_EXPECT_EQ(r_value, 5.7);
+    }
+}
+
+KRATOS_TEST_CASE_IN_SUITE(DataContainerAddErrors, KratosCoreFastSuite)
+{
+    DataContainer container;
+
+    // Value policy incompatible with the variable type
+    KRATOS_EXPECT_EXCEPTION_IS_THROWN(
+        container.Add(STEP, DataValuePolicy<double>(), NonHistoricalDataPolicy()),
+        "STEP is not compatible with the given value policy.");
+
+    // Unregistered variables are rejected (the container canonicalizes through the Registry)
+    Variable<double> unregistered("DATA_CONTAINER_TEST_UNREGISTERED");
+    KRATOS_EXPECT_EXCEPTION_IS_THROWN(
+        container.Add(unregistered, DataValuePolicy<double>(), NonHistoricalDataPolicy()),
+        "DATA_CONTAINER_TEST_UNREGISTERED is not registered in the Registry.");
+
+    // Re-adding with the same policy returns an accessor to the existing chunk
+    auto first_accessor = container.Add(PRESSURE, DataValuePolicy<double>(), NonHistoricalDataPolicy());
+    auto second_accessor = container.Add(PRESSURE, DataValuePolicy<double>(), NonHistoricalDataPolicy());
+    KRATOS_EXPECT_TRUE(first_accessor == second_accessor);
+
+    // Re-adding with a different policy configuration is an error
+    KRATOS_EXPECT_EXCEPTION_IS_THROWN(
+        container.Add(PRESSURE, DataValuePolicy<double>(5.0), NonHistoricalDataPolicy()),
+        "Variable PRESSURE exists with a different policy.");
+}
+
+KRATOS_TEST_CASE_IN_SUITE(DataContainerForeignAccessorErrors, KratosCoreFastSuite)
+{
+    DataContainer container;
+    container.Add(PRESSURE, DataValuePolicy<double>(), NonHistoricalDataPolicy());
+
+    // Accessor pointing beyond the chunks of this container
+    DataAccessor<double> out_of_bounds_accessor(PRESSURE, 5, StepCategory::AnyStep);
+    KRATOS_EXPECT_EXCEPTION_IS_THROWN(
+        container.GetDataSpan(out_of_bounds_accessor),
+        "Accessor index out of bounds");
+
+    // Accessor of another variable at an existing chunk index
+    DataAccessor<double> mismatched_accessor(TEMPERATURE, 0, StepCategory::AnyStep);
+    KRATOS_EXPECT_EXCEPTION_IS_THROWN(
+        container.GetDataSpan(mismatched_accessor),
+        "Variable mismatch in DataContainer.");
+}
+
+KRATOS_TEST_CASE_IN_SUITE(DataContainerCopyIsShallow, KratosCoreFastSuite)
+{
+    DataContainer container;
+    auto accessor = container.Add(PRESSURE, DataValuePolicy<double>(), NonHistoricalDataPolicy());
+
+    // Copies share the chunks with the original
+    DataContainer copy(container);
+    KRATOS_EXPECT_TRUE(copy.Has(PRESSURE));
+
+    for (auto& r_value : container.GetDataSpan(accessor)) {
+        r_value = 4.2;
+    }
+    for (const auto& r_value : copy.GetDataSpan(accessor)) {
+        KRATOS_EXPECT_EQ(r_value, 4.2);
+    }
+
+    // Copy assignment behaves the same
+    DataContainer assigned;
+    assigned = container;
+    for (const auto& r_value : assigned.GetDataSpan(accessor)) {
+        KRATOS_EXPECT_EQ(r_value, 4.2);
+    }
+}
+
+KRATOS_TEST_CASE_IN_SUITE(DataContainerInitialize, KratosCoreFastSuite)
+{
+    DataContainer container;
+    auto index_accessor = container.Add(STEP, DataValuePolicy<int>(-1), NonHistoricalDataPolicy());
+    container.Add(PRESSURE, SparseDataValuePolicy<double>(index_accessor), NonHistoricalDataPolicy());
+    container.Add(TEMPERATURE, DataValuePolicy<double>(), NonHistoricalDataPolicy());
+
+    // Initialize mirrors the chunk structure with fresh, zero-initialized chunks:
+    // dense chunks at the new chunk size, sparse chunks empty
+    DataContainer initialized;
+    initialized.Initialize(container, 64);
+
+    KRATOS_EXPECT_TRUE(initialized.Has(STEP));
+    KRATOS_EXPECT_TRUE(initialized.Has(PRESSURE));
+    KRATOS_EXPECT_TRUE(initialized.Has(TEMPERATURE));
+
+    auto index_span = initialized.GetDataSpan(index_accessor);
+    KRATOS_EXPECT_EQ(index_span.size(), 64);
+    for (const auto& r_value : index_span) {
+        KRATOS_EXPECT_EQ(r_value, -1); // zero-initialized with the policy zero
+    }
+
+    auto sparse_accessor = initialized.GetAccessor(PRESSURE, SparseDataValuePolicy<double>(index_accessor));
+    KRATOS_EXPECT_EQ(initialized.GetDataSpan(sparse_accessor).size(), 0);
+
+    // The chunk size argument is stored: chunks added afterwards use it
+    auto late_accessor = initialized.Add(TEMPERATURE_OLD_IT, DataValuePolicy<double>(), NonHistoricalDataPolicy());
+    KRATOS_EXPECT_EQ(initialized.GetDataSpan(late_accessor).size(), 64);
+
+    // A zero chunk size is rejected
+    DataContainer invalid;
+    KRATOS_EXPECT_EXCEPTION_IS_THROWN(
+        invalid.Initialize(container, 0),
+        "Chunk size must be greater than zero.");
+}
+
+} // namespace Testing
+} // namespace Kratos

--- a/kratos/tests/cpp_tests/containers/data_container/test_data_history_policy.cpp
+++ b/kratos/tests/cpp_tests/containers/data_container/test_data_history_policy.cpp
@@ -1,0 +1,113 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
+//
+//  Main authors:    Pooyan Dadvand
+//  Collaborator:    Vicente Mataix Ferrandiz
+//
+//
+
+// System includes
+
+// External includes
+
+// Project includes
+#include "containers/data_container/data_history_policy.h"
+#include "includes/expect.h"
+#include "testing/testing.h"
+
+namespace Kratos {
+namespace Testing {
+
+KRATOS_TEST_CASE_IN_SUITE(DataHistoryPolicyComparison, KratosCoreFastSuite)
+{
+    NonHistoricalDataPolicy non_historical_policy;
+
+    KRATOS_EXPECT_TRUE(NonHistoricalDataPolicy().IsSameType(non_historical_policy));
+    KRATOS_EXPECT_TRUE(NonHistoricalDataPolicy().IsSame(non_historical_policy));
+
+    HistoricalDataPolicy historical_policy(StepCategory::TimeStep, 3);
+
+    KRATOS_EXPECT_FALSE(historical_policy.IsSameType(non_historical_policy));
+    KRATOS_EXPECT_FALSE(non_historical_policy.IsSameType(historical_policy));
+
+    HistoricalDataPolicy other_historical_policy(StepCategory::TimeStep, 2);
+
+    KRATOS_EXPECT_TRUE(historical_policy.IsSameType(other_historical_policy)); // same type
+    KRATOS_EXPECT_FALSE(historical_policy.IsSame(other_historical_policy)); // different number of steps
+
+    HistoricalDataPolicy different_category_policy(StepCategory::IterationStep, 3);
+    KRATOS_EXPECT_TRUE(historical_policy.IsSameType(different_category_policy)); // same type
+    KRATOS_EXPECT_FALSE(historical_policy.IsSame(different_category_policy)); // different category
+
+    HistoricalDataPolicy equal_policy(StepCategory::TimeStep, 3);
+    KRATOS_EXPECT_TRUE(historical_policy.IsSame(equal_policy)); // same category and number of steps
+}
+
+KRATOS_TEST_CASE_IN_SUITE(NonHistoricalDataPolicyStepIndex, KratosCoreFastSuite)
+{
+    NonHistoricalDataPolicy policy;
+
+    KRATOS_EXPECT_EQ(policy.GetTotalNumberOfSteps(), 1);
+    KRATOS_EXPECT_EQ(policy.GetLatestStepIndex(), 0);
+    KRATOS_EXPECT_TRUE(policy.GetStepCategory() == StepCategory::AnyStep);
+
+    // The single step slot is only reachable through AnyStep
+    KRATOS_EXPECT_EQ(policy.GetStepIndex(StepCategory::AnyStep), 0);
+    KRATOS_EXPECT_EXCEPTION_IS_THROWN(
+        policy.GetStepIndex(StepCategory::TimeStep),
+        "NonHistoricalDataPolicy does not support step categories.");
+
+    // Cloning never advances anything
+    KRATOS_EXPECT_EQ(policy.CloneStepIndex(StepCategory::TimeStep), 0);
+    KRATOS_EXPECT_EQ(policy.CloneStepIndex(StepCategory::AnyStep), 0);
+    KRATOS_EXPECT_EQ(policy.GetLatestStepIndex(), 0);
+
+    // Clone produces an equal policy
+    auto p_clone = policy.Clone();
+    KRATOS_EXPECT_TRUE(p_clone->IsSame(policy));
+}
+
+KRATOS_TEST_CASE_IN_SUITE(HistoricalDataPolicyStepCycling, KratosCoreFastSuite)
+{
+    HistoricalDataPolicy policy(StepCategory::TimeStep, 3);
+
+    KRATOS_EXPECT_EQ(policy.GetTotalNumberOfSteps(), 3);
+    KRATOS_EXPECT_EQ(policy.GetLatestStepIndex(), 0);
+    KRATOS_EXPECT_TRUE(policy.GetStepCategory() == StepCategory::TimeStep);
+
+    // Cloning a non-matching category does not advance the ring
+    KRATOS_EXPECT_EQ(policy.CloneStepIndex(StepCategory::IterationStep), 0);
+    KRATOS_EXPECT_EQ(policy.CloneStepIndex(StepCategory::SubStep), 0);
+    KRATOS_EXPECT_EQ(policy.GetLatestStepIndex(), 0);
+
+    // Wrap-around indexing with latest index 0: previous steps wrap backwards
+    KRATOS_EXPECT_EQ(policy.GetStepIndex(StepCategory::TimeStep, 0), 0);
+    KRATOS_EXPECT_EQ(policy.GetStepIndex(StepCategory::TimeStep, 1), 2);
+    KRATOS_EXPECT_EQ(policy.GetStepIndex(StepCategory::TimeStep, 2), 1);
+
+    // Cloning the matching category cycles 0 -> 1 -> 2 -> 0
+    KRATOS_EXPECT_EQ(policy.CloneStepIndex(StepCategory::TimeStep), 1);
+    KRATOS_EXPECT_EQ(policy.GetLatestStepIndex(), 1);
+    KRATOS_EXPECT_EQ(policy.GetStepIndex(StepCategory::TimeStep, 0), 1);
+    KRATOS_EXPECT_EQ(policy.GetStepIndex(StepCategory::TimeStep, 1), 0);
+    KRATOS_EXPECT_EQ(policy.GetStepIndex(StepCategory::TimeStep, 2), 2);
+
+    KRATOS_EXPECT_EQ(policy.CloneStepIndex(StepCategory::TimeStep), 2);
+    KRATOS_EXPECT_EQ(policy.CloneStepIndex(StepCategory::TimeStep), 0); // wrap around
+    KRATOS_EXPECT_EQ(policy.GetLatestStepIndex(), 0);
+
+    // Clone re-creates the policy configuration but resets the running step index
+    KRATOS_EXPECT_EQ(policy.CloneStepIndex(StepCategory::TimeStep), 1);
+    auto p_clone = policy.Clone();
+    KRATOS_EXPECT_TRUE(p_clone->IsSame(policy));
+    KRATOS_EXPECT_EQ(p_clone->GetLatestStepIndex(), 0);
+}
+
+} // namespace Testing
+} // namespace Kratos

--- a/kratos/tests/cpp_tests/containers/data_container/test_data_value_policy.cpp
+++ b/kratos/tests/cpp_tests/containers/data_container/test_data_value_policy.cpp
@@ -1,0 +1,220 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
+//
+//  Main authors:    Pooyan Dadvand
+//  Collaborator:    Vicente Mataix Ferrandiz
+//
+//
+
+// System includes
+
+// External includes
+
+// Project includes
+#include "containers/array_1d.h"
+#include "containers/data_container/data_value_policy.h"
+#include "containers/data_container/sparse_data_value_policy.h"
+#include "includes/expect.h"
+#include "includes/ublas_interface.h"
+#include "includes/variables.h"
+#include "testing/testing.h"
+
+namespace Kratos {
+namespace Testing {
+
+KRATOS_TEST_CASE_IN_SUITE(DataValuePolicyComparison, KratosCoreFastSuite)
+{
+    DataValuePolicy<double> double_value_policy;
+
+    KRATOS_EXPECT_TRUE(DataValuePolicy<double>().IsSameType(double_value_policy));
+    KRATOS_EXPECT_FALSE(DataValuePolicy<int>().IsSameType(double_value_policy));
+
+    LayeredDataValuePolicy<double> double_layer_policy(3);
+
+    KRATOS_EXPECT_FALSE(double_layer_policy.IsSameType(double_value_policy));
+
+    LayeredDataValuePolicy<double> other_layer_policy(10);
+    KRATOS_EXPECT_TRUE(double_layer_policy.IsSameType(other_layer_policy)); // same type
+    KRATOS_EXPECT_FALSE(double_layer_policy.IsSame(other_layer_policy)); // different number of layers
+}
+
+KRATOS_TEST_CASE_IN_SUITE(DataValuePolicyIsCompatible, KratosCoreFastSuite)
+{
+    // Real core variables of the three value types
+    const auto& r_int_variable = STEP;
+    const auto& r_double_variable = PRESSURE;
+    const auto& r_array_variable = VELOCITY;
+
+    DataValuePolicy<int> int_value_policy;
+
+    KRATOS_EXPECT_TRUE(int_value_policy.IsCompatible(r_int_variable));
+    KRATOS_EXPECT_FALSE(int_value_policy.IsCompatible(r_double_variable));
+    KRATOS_EXPECT_FALSE(int_value_policy.IsCompatible(r_array_variable));
+
+    DataValuePolicy<double> double_value_policy;
+
+    KRATOS_EXPECT_FALSE(double_value_policy.IsCompatible(r_int_variable));
+    KRATOS_EXPECT_TRUE(double_value_policy.IsCompatible(r_double_variable));
+    KRATOS_EXPECT_FALSE(double_value_policy.IsCompatible(r_array_variable));
+
+    DataValuePolicy<array_1d<double, 3>> array_value_policy;
+
+    KRATOS_EXPECT_FALSE(array_value_policy.IsCompatible(r_int_variable));
+    KRATOS_EXPECT_FALSE(array_value_policy.IsCompatible(r_double_variable));
+    KRATOS_EXPECT_TRUE(array_value_policy.IsCompatible(r_array_variable));
+
+    LayeredDataValuePolicy<int> int_layer_policy(3);
+
+    KRATOS_EXPECT_TRUE(int_layer_policy.IsCompatible(r_int_variable));
+    KRATOS_EXPECT_FALSE(int_layer_policy.IsCompatible(r_double_variable));
+    KRATOS_EXPECT_FALSE(int_layer_policy.IsCompatible(r_array_variable));
+
+    LayeredDataValuePolicy<double> double_layer_policy(3);
+
+    KRATOS_EXPECT_FALSE(double_layer_policy.IsCompatible(r_int_variable));
+    KRATOS_EXPECT_TRUE(double_layer_policy.IsCompatible(r_double_variable));
+    KRATOS_EXPECT_FALSE(double_layer_policy.IsCompatible(r_array_variable));
+
+    LayeredDataValuePolicy<array_1d<double, 3>> array_layer_policy(3);
+
+    KRATOS_EXPECT_FALSE(array_layer_policy.IsCompatible(r_int_variable));
+    KRATOS_EXPECT_FALSE(array_layer_policy.IsCompatible(r_double_variable));
+    KRATOS_EXPECT_TRUE(array_layer_policy.IsCompatible(r_array_variable));
+}
+
+KRATOS_TEST_CASE_IN_SUITE(DataValuePolicyZero, KratosCoreFastSuite)
+{
+    // Default zero values
+    KRATOS_EXPECT_EQ(DataValuePolicy<double>().Zero(), 0.0);
+    KRATOS_EXPECT_EQ(DataValuePolicy<int>().Zero(), 0);
+    KRATOS_EXPECT_EQ(DataValuePolicy<std::string>().Zero(), std::string(""));
+
+    // Custom zero values (as used for sparse index variables)
+    DataValuePolicy<int> minus_one_policy(-1);
+    KRATOS_EXPECT_EQ(minus_one_policy.Zero(), -1);
+
+    // Policies with different zeros are the same type but not the same policy
+    KRATOS_EXPECT_TRUE(minus_one_policy.IsSameType(DataValuePolicy<int>()));
+    KRATOS_EXPECT_FALSE(minus_one_policy.IsSame(DataValuePolicy<int>()));
+    KRATOS_EXPECT_TRUE(minus_one_policy.IsSame(DataValuePolicy<int>(-1)));
+
+    // The layered policy zero is a vector of per-layer zeros
+    LayeredDataValuePolicy<double> layer_policy(4, 1.5);
+    KRATOS_EXPECT_EQ(layer_policy.Zero(), std::vector<double>(4, 1.5));
+    KRATOS_EXPECT_EQ(layer_policy.NumberOfLayers(), 4);
+}
+
+KRATOS_TEST_CASE_IN_SUITE(DataValuePolicyRawOperations, KratosCoreFastSuite)
+{
+    // Exercise the type-erased operations through the base class interface
+    DataValuePolicy<double> typed_policy(2.5);
+    const DataValuePolicyBase& r_policy = typed_policy;
+
+    KRATOS_EXPECT_EQ(r_policy.SizeOfData(), sizeof(double));
+    KRATOS_EXPECT_FALSE(r_policy.IsSparse());
+
+    // Allocate a default-constructed value
+    void* p_data = nullptr;
+    r_policy.Allocate(&p_data);
+    KRATOS_EXPECT_TRUE(p_data != nullptr);
+
+    // AssignZero constructs the policy zero in place
+    r_policy.AssignZero(p_data);
+    KRATOS_EXPECT_EQ(*static_cast<double*>(p_data), 2.5);
+
+    // Assign copies an existing value
+    const double source = 7.25;
+    r_policy.Assign(&source, p_data);
+    KRATOS_EXPECT_EQ(*static_cast<double*>(p_data), 7.25);
+
+    // CloneData allocates a copy
+    void* p_clone = r_policy.CloneData(p_data);
+    KRATOS_EXPECT_EQ(*static_cast<double*>(p_clone), 7.25);
+
+    // Copy placement-constructs into already allocated memory
+    double destination = 0.0;
+    r_policy.Copy(&source, &destination);
+    KRATOS_EXPECT_EQ(destination, 7.25);
+
+    // Print writes the plain value, PrintData adds the label
+    std::stringstream print_stream;
+    r_policy.Print(p_data, print_stream);
+    KRATOS_EXPECT_EQ(print_stream.str(), "7.25");
+
+    std::stringstream print_data_stream;
+    r_policy.PrintData(p_data, print_data_stream);
+    KRATOS_EXPECT_EQ(print_data_stream.str(), "Data: 7.25");
+
+    r_policy.Delete(p_data);
+    r_policy.Delete(p_clone);
+}
+
+KRATOS_TEST_CASE_IN_SUITE(SparseDataValuePolicyBasics, KratosCoreFastSuite)
+{
+    DataValuePolicy<double> dense_policy;
+    KRATOS_EXPECT_FALSE(dense_policy.IsSparse());
+
+    // The base class refuses to provide a sparse index accessor
+    const DataValuePolicyBase& r_dense_base = dense_policy;
+    KRATOS_EXPECT_EXCEPTION_IS_THROWN(
+        r_dense_base.GetSparseIndexAccessor(),
+        "Calling base class DataValuePolicyBase::GetSparseIndexAccessor");
+
+    // A sparse policy reports IsSparse and returns its index accessor
+    DataAccessor<int> index_accessor(STEP, 0, StepCategory::AnyStep);
+    SparseDataValuePolicy<double> sparse_policy(index_accessor);
+
+    KRATOS_EXPECT_TRUE(sparse_policy.IsSparse());
+    KRATOS_EXPECT_TRUE(sparse_policy.GetSparseIndexAccessor() == index_accessor);
+
+    // SparseDataValuePolicy does not override IsSameType: sparse and dense policies of the
+    // same value type compare as the same type (sparseness is queried via IsSparse instead)
+    KRATOS_EXPECT_TRUE(sparse_policy.IsSameType(dense_policy));
+    KRATOS_EXPECT_TRUE(dense_policy.IsSameType(sparse_policy));
+    KRATOS_EXPECT_TRUE(sparse_policy.IsSameType(SparseDataValuePolicy<double>(index_accessor)));
+    KRATOS_EXPECT_FALSE(sparse_policy.IsSameType(DataValuePolicy<int>()));
+
+    // Clone preserves sparseness and the index accessor
+    auto p_clone = sparse_policy.Clone();
+    KRATOS_EXPECT_TRUE(p_clone->IsSparse());
+    KRATOS_EXPECT_TRUE(p_clone->GetSparseIndexAccessor() == index_accessor);
+}
+
+KRATOS_TEST_CASE_IN_SUITE(DataAccessorEquality, KratosCoreFastSuite)
+{
+    // Default-constructed accessors compare equal to each other
+    KRATOS_EXPECT_TRUE(DataAccessor<double>() == DataAccessor<double>());
+    KRATOS_EXPECT_EQ(DataAccessor<double>().pGetVariableData(), nullptr);
+
+    DataAccessor<double> accessor(PRESSURE, 3, StepCategory::TimeStep, 0);
+    KRATOS_EXPECT_EQ(accessor.GetIndex(), 3);
+    KRATOS_EXPECT_TRUE(accessor.GetStepCategory() == StepCategory::TimeStep);
+    KRATOS_EXPECT_EQ(accessor.GetStepBeforeCurrent(), 0);
+    KRATOS_EXPECT_TRUE(accessor.GetVariableData() == PRESSURE);
+
+    // Same variable, index and step: equal
+    KRATOS_EXPECT_TRUE(accessor == DataAccessor<double>(PRESSURE, 3, StepCategory::TimeStep, 0));
+
+    // Different index, variable, category or step: not equal
+    KRATOS_EXPECT_FALSE(accessor == DataAccessor<double>(PRESSURE, 4, StepCategory::TimeStep, 0));
+    KRATOS_EXPECT_FALSE(accessor == DataAccessor<double>(TEMPERATURE, 3, StepCategory::TimeStep, 0));
+    KRATOS_EXPECT_FALSE(accessor == DataAccessor<double>(PRESSURE, 3, StepCategory::IterationStep, 0));
+    KRATOS_EXPECT_FALSE(accessor == DataAccessor<double>(PRESSURE, 3, StepCategory::TimeStep, 1));
+
+    // GetStepAccessor re-parameterizes step information keeping variable and index
+    auto previous_step_accessor = accessor.GetStepAccessor(StepCategory::TimeStep, 1);
+    KRATOS_EXPECT_EQ(previous_step_accessor.GetIndex(), 3);
+    KRATOS_EXPECT_EQ(previous_step_accessor.GetStepBeforeCurrent(), 1);
+    KRATOS_EXPECT_TRUE(previous_step_accessor.GetVariableData() == PRESSURE);
+    KRATOS_EXPECT_FALSE(previous_step_accessor == accessor);
+    KRATOS_EXPECT_TRUE(previous_step_accessor.GetStepAccessor(StepCategory::TimeStep, 0) == accessor);
+}
+
+} // namespace Testing
+} // namespace Kratos

--- a/kratos/tests/cpp_tests/containers/data_container/test_sparse_data_value_policy.cpp
+++ b/kratos/tests/cpp_tests/containers/data_container/test_sparse_data_value_policy.cpp
@@ -1,0 +1,198 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
+//
+//  Main authors:    Pooyan Dadvand
+//  Collaborator:    Vicente Mataix Ferrandiz
+//
+//
+
+// System includes
+
+// External includes
+
+// Project includes
+#include "containers/data_container/data_container.h"
+#include "containers/data_container/sparse_data_value_policy.h"
+#include "includes/expect.h"
+#include "includes/variables.h"
+#include "testing/testing.h"
+
+namespace Kratos {
+namespace Testing {
+namespace {
+
+// Number of entities used in the sparse scenarios (mirrors the 5x5x5 = 125 nodes of one
+// voxel block in the original prototype tests)
+constexpr std::size_t SparseTestNumberOfEntities = 125;
+
+// Mark every even entity as active with a running sparse index and every odd one as
+// inactive (-1): 63 active entries for 125 entities
+void SetEvenIndexPattern(DataContainer& rContainer, const DataAccessor<int>& rIndexAccessor)
+{
+    int index = 0;
+    auto index_span = rContainer.GetDataSpan(rIndexAccessor);
+    for (std::size_t i = 0; i < index_span.size(); ++i) {
+        if ((i % 2) == 0) {
+            index_span[i] = index++;
+        } else {
+            index_span[i] = -1;
+        }
+    }
+}
+
+} // anonymous namespace
+
+KRATOS_TEST_CASE_IN_SUITE(SparseDataValuePolicyIsSparse, KratosCoreFastSuite)
+{
+    DataValuePolicy<double> test_policy;
+    KRATOS_EXPECT_FALSE(test_policy.IsSparse());
+
+    DataContainer container(SparseTestNumberOfEntities);
+    auto index_accessor = container.Add(STEP, DataValuePolicy<int>());
+    SparseDataValuePolicy<double> test_sparse_policy(index_accessor);
+
+    KRATOS_EXPECT_TRUE(test_sparse_policy.IsSparse());
+
+    // A chunk created with a sparse policy starts empty
+    auto value_accessor = container.Add(PRESSURE, test_sparse_policy);
+    KRATOS_EXPECT_EQ(container.GetDataSpan(value_accessor).size(), 0);
+}
+
+KRATOS_TEST_CASE_IN_SUITE(SparseDataValuePolicyUpdateSparseStorage, KratosCoreFastSuite)
+{
+    DataContainer container(SparseTestNumberOfEntities);
+    auto index_accessor = container.Add(STEP, DataValuePolicy<int>());
+    auto value_accessor = container.Add(PRESSURE, SparseDataValuePolicy<double>(index_accessor));
+
+    auto span_before_size_update = container.GetDataSpan(value_accessor);
+    KRATOS_EXPECT_EQ(span_before_size_update.size(), 0);
+
+    SetEvenIndexPattern(container, index_accessor);
+
+    container.UpdateSparseStorage(index_accessor);
+
+    auto span_after_size_update = container.GetDataSpan(value_accessor);
+    KRATOS_EXPECT_EQ(span_after_size_update.size(), 125/2 + 1);
+}
+
+KRATOS_TEST_CASE_IN_SUITE(SparseDataValuePolicyUpdateMultiple, KratosCoreFastSuite)
+{
+    DataContainer container(SparseTestNumberOfEntities);
+
+    // Two independent sparse index variables: value1 keyed on the first one,
+    // value2 and value3 keyed on the second one
+    auto index1_accessor = container.Add(STEP, DataValuePolicy<int>());
+    auto index2_accessor = container.Add(DOMAIN_SIZE, DataValuePolicy<int>());
+    auto value1_accessor = container.Add(PRESSURE, SparseDataValuePolicy<double>(index1_accessor));
+    auto value2_accessor = container.Add(TEMPERATURE, SparseDataValuePolicy<double>(index2_accessor));
+    auto value3_accessor = container.Add(TEMPERATURE_OLD_IT, SparseDataValuePolicy<double>(index2_accessor));
+
+    KRATOS_EXPECT_EQ(container.GetDataSpan(value1_accessor).size(), 0);
+    KRATOS_EXPECT_EQ(container.GetDataSpan(value2_accessor).size(), 0);
+    KRATOS_EXPECT_EQ(container.GetDataSpan(value3_accessor).size(), 0);
+
+    // Update the first index: only value1 grows
+    SetEvenIndexPattern(container, index1_accessor);
+    container.UpdateSparseStorage(index1_accessor);
+
+    KRATOS_EXPECT_EQ(container.GetDataSpan(value1_accessor).size(), 125/2 + 1);
+    KRATOS_EXPECT_EQ(container.GetDataSpan(value2_accessor).size(), 0);
+    KRATOS_EXPECT_EQ(container.GetDataSpan(value3_accessor).size(), 0);
+
+    // Second index: the first 32 entities are active, the rest inactive
+    {
+        auto index2_span = container.GetDataSpan(index2_accessor);
+        for (std::size_t i = 0; i < 32; ++i) {
+            index2_span[i] = static_cast<int>(i);
+        }
+        for (std::size_t i = 32; i < index2_span.size(); ++i) {
+            index2_span[i] = -1;
+        }
+    }
+
+    container.UpdateSparseStorage(index2_accessor);
+
+    // value1 remains untouched, value2 and value3 grow to 32
+    KRATOS_EXPECT_EQ(container.GetDataSpan(value1_accessor).size(), 125/2 + 1);
+    KRATOS_EXPECT_EQ(container.GetDataSpan(value2_accessor).size(), 32);
+    KRATOS_EXPECT_EQ(container.GetDataSpan(value3_accessor).size(), 32);
+}
+
+KRATOS_TEST_CASE_IN_SUITE(SparseDataValuePolicyResize, KratosCoreFastSuite)
+{
+    DataContainer container(SparseTestNumberOfEntities);
+    auto index1_accessor = container.Add(STEP, DataValuePolicy<int>());
+    auto value1_accessor = container.Add(PRESSURE, SparseDataValuePolicy<double>(index1_accessor));
+    auto value2_accessor = container.Add(TEMPERATURE, SparseDataValuePolicy<double>(index1_accessor));
+
+    SetEvenIndexPattern(container, index1_accessor);
+    container.UpdateSparseStorage(index1_accessor);
+
+    auto value1_span_after_update = container.GetDataSpan(value1_accessor);
+    KRATOS_EXPECT_EQ(value1_span_after_update.size(), 125/2 + 1);
+
+    auto value2_span_after_update = container.GetDataSpan(value2_accessor);
+    KRATOS_EXPECT_EQ(value2_span_after_update.size(), 125/2 + 1);
+
+    std::fill(value1_span_after_update.begin(), value1_span_after_update.end(), 1.0);
+
+    std::vector<int> additional_entities;
+    for (int i = 0; i < 125; i += 5) {
+        additional_entities.push_back(i);
+    }
+
+    container.AddToSparseStorage(index1_accessor, additional_entities);
+
+    // we added 12 new terms (indices 5, 15, 25, 35, 45, 55, 65, 75, 85, 95, 105, 115)
+    // to both containers indexed by index1
+    auto value1_span_after_addition = container.GetDataSpan(value1_accessor);
+    KRATOS_EXPECT_EQ(value1_span_after_addition.size(), 125/2 + 13);
+
+    auto value2_span_after_addition = container.GetDataSpan(value2_accessor);
+    KRATOS_EXPECT_EQ(value2_span_after_addition.size(), 125/2 + 13);
+
+    auto index_span = container.GetDataSpan(index1_accessor);
+    for (std::size_t i = 0; i < index_span.size(); ++i) {
+        if (i % 2 == 0) {
+            // original sparse entries kept their value
+            KRATOS_EXPECT_EQ(value1_span_after_addition[index_span[i]], 1.0);
+        } else if (i % 5 == 0) {
+            // added entries are set to the default
+            KRATOS_EXPECT_EQ(value1_span_after_addition[index_span[i]], 0.0);
+        } else {
+            // not in sparse container
+            KRATOS_EXPECT_EQ(index_span[i], -1);
+        }
+    }
+}
+
+KRATOS_TEST_CASE_IN_SUITE(SparseDataValuePolicyResizeFromZero, KratosCoreFastSuite)
+{
+    DataContainer container(SparseTestNumberOfEntities);
+
+    // The index variable uses -1 as its zero, so the whole index span starts inactive
+    auto index1_accessor = container.Add(STEP, DataValuePolicy<int>(-1));
+    auto value1_accessor = container.Add(PRESSURE, SparseDataValuePolicy<double>(index1_accessor));
+    auto value2_accessor = container.Add(TEMPERATURE, SparseDataValuePolicy<double>(index1_accessor));
+
+    KRATOS_EXPECT_EQ(container.GetDataSpan(value1_accessor).size(), 0);
+
+    std::vector<int> additional_entities;
+    for (int i = 0; i < 125; i += 5) {
+        additional_entities.push_back(i);
+    }
+
+    container.AddToSparseStorage(index1_accessor, additional_entities);
+
+    KRATOS_EXPECT_EQ(container.GetDataSpan(value1_accessor).size(), 25);
+    KRATOS_EXPECT_EQ(container.GetDataSpan(value2_accessor).size(), 25);
+}
+
+} // namespace Testing
+} // namespace Kratos

--- a/kratos/tests/test_KratosCore.py
+++ b/kratos/tests/test_KratosCore.py
@@ -13,6 +13,7 @@ except:
 # Import the tests or test_classes to create the suites
 import test_bounding_box
 import test_calculate_distance_to_skin
+import test_data_container
 import test_embedded_skin_mapping
 import test_model_part
 import test_model_part_io
@@ -137,6 +138,7 @@ def AssembleTestSuites():
     smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([test_print_info_in_file.TestPrintElementalInfoInFile]))
     smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([test_calculate_distance_to_skin.TestCalculateDistanceToSkin]))
     smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([test_embedded_skin_mapping.TestEmbeddedSkinMapping]))
+    smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([test_data_container.TestDataContainer]))
     smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([test_model_part.TestModelPart]))
     smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([test_model_part_io.TestModelPartIO]))
     smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([test_model_part_io.TestModelPartIOMPI]))

--- a/kratos/tests/test_data_container.py
+++ b/kratos/tests/test_data_container.py
@@ -1,0 +1,177 @@
+import KratosMultiphysics as KM
+import KratosMultiphysics.KratosUnittest as KratosUnittest
+
+
+class TestDataContainer(KratosUnittest.TestCase):
+    """Tests for the pybind11 bindings of Kratos::DataContainer."""
+
+    def test_add_and_has(self):
+        container = KM.DataContainer()
+
+        self.assertFalse(container.Has(KM.PRESSURE))
+        self.assertFalse(container.Has(KM.PRESSURE, KM.DoubleDataValuePolicy()))
+
+        container.Add(KM.PRESSURE, KM.DoubleDataValuePolicy())
+
+        self.assertTrue(container.Has(KM.PRESSURE))
+        self.assertTrue(container.Has(KM.PRESSURE, KM.DoubleDataValuePolicy()))
+        self.assertTrue(container.Has(KM.PRESSURE, KM.DoubleDataValuePolicy(), KM.NonHistoricalDataPolicy()))
+        self.assertFalse(container.Has(KM.PRESSURE, KM.DoubleDataValuePolicy(), KM.HistoricalDataPolicy(KM.StepCategory.TimeStep, 3)))
+        self.assertFalse(container.Has(KM.TEMPERATURE))
+
+    def test_get_data_span_numpy_view(self):
+        container = KM.DataContainer()
+        accessor = container.Add(KM.PRESSURE, KM.DoubleDataValuePolicy())
+
+        span = container.GetDataSpan(accessor)
+        self.assertEqual(span.shape, (256,))  # default chunk size
+        self.assertEqual(str(span.dtype), "float64")
+        for value in span:
+            self.assertEqual(value, 0.0)  # zero-initialized
+
+        # Writing through the NumPy array modifies the stored data (view, not copy)
+        span[:] = 1.5
+        span_refetched = container.GetDataSpan(accessor)
+        for value in span_refetched:
+            self.assertEqual(value, 1.5)
+
+    def test_chunk_size(self):
+        container = KM.DataContainer(32)
+        accessor = container.Add(KM.PRESSURE, KM.DoubleDataValuePolicy())
+        self.assertEqual(len(container.GetDataSpan(accessor)), 32)
+
+    def test_custom_zero_value(self):
+        container = KM.DataContainer(16)
+        accessor = container.Add(KM.STEP, KM.IntegerDataValuePolicy(-1))
+        span = container.GetDataSpan(accessor)
+        for value in span:
+            self.assertEqual(value, -1)
+        self.assertEqual(KM.IntegerDataValuePolicy(-1).Zero(), -1)
+
+    def test_array3_span_shape(self):
+        container = KM.DataContainer(8)
+        accessor = container.Add(KM.VELOCITY, KM.Array1DDataValuePolicy3())
+
+        span = container.GetDataSpan(accessor)
+        self.assertEqual(span.shape, (8, 3))
+        self.assertTrue((span == 0.0).all())
+
+        # Per-component write through the view
+        span[:, 1] = 2.5
+        span_refetched = container.GetDataSpan(accessor)
+        self.assertTrue((span_refetched[:, 0] == 0.0).all())
+        self.assertTrue((span_refetched[:, 1] == 2.5).all())
+        self.assertTrue((span_refetched[:, 2] == 0.0).all())
+
+    def test_string_span(self):
+        container = KM.DataContainer(4)
+        accessor = container.Add(KM.IDENTIFIER, KM.StringDataValuePolicy())
+
+        span = container.GetDataSpan(accessor)
+        self.assertEqual(len(span), 4)
+        self.assertEqual(span[0], "")
+
+        span[2] = "hello"
+        self.assertEqual(span[2], "hello")
+        self.assertEqual(span[-2], "hello")  # negative indices supported
+        self.assertEqual(container.GetDataSpan(accessor).ToList(), ["", "", "hello", ""])
+
+        with self.assertRaises(IndexError):
+            span[4]
+
+    def test_historical_steps(self):
+        container = KM.DataContainer(8)
+        history = KM.HistoricalDataPolicy(KM.StepCategory.TimeStep, 3)
+        self.assertEqual(history.GetTotalNumberOfSteps(), 3)
+
+        accessor = container.Add(KM.PRESSURE, KM.DoubleDataValuePolicy(), history)
+
+        current = container.GetDataSpan(accessor)
+        current[:] = 1.0
+
+        previous_accessor = accessor.GetStepAccessor(KM.StepCategory.TimeStep, 1)
+        previous = container.GetDataSpan(previous_accessor)
+        for value in previous:
+            self.assertEqual(value, 0.0)  # previous step untouched
+        previous[:] = 2.0
+
+        container.CloneStepData(KM.StepCategory.TimeStep)
+
+        # After cloning, the new current step is a copy of the pre-clone current one
+        self.assertTrue((container.GetDataSpan(accessor) == 1.0).all())
+        self.assertTrue((container.GetDataSpan(previous_accessor) == 1.0).all())
+        two_ago = container.GetDataSpan(accessor.GetStepAccessor(KM.StepCategory.TimeStep, 2))
+        self.assertTrue((two_ago == 2.0).all())
+
+    def test_accessor_equality(self):
+        container = KM.DataContainer()
+        accessor = container.Add(KM.PRESSURE, KM.DoubleDataValuePolicy())
+        again = container.Add(KM.PRESSURE, KM.DoubleDataValuePolicy())
+
+        self.assertTrue(accessor == again)
+        self.assertEqual(accessor.GetIndex(), 0)
+        self.assertFalse(accessor == accessor.GetStepAccessor(KM.StepCategory.TimeStep, 1))
+        self.assertEqual(accessor.GetStepAccessor(KM.StepCategory.TimeStep, 1).GetStepBeforeCurrent(), 1)
+
+    def test_sparse_workflow(self):
+        # Mirror of the C++ sparse scenarios: 125 entities, activate the even ones (63),
+        # then add the multiples of 5 (12 new entries -> 75)
+        container = KM.DataContainer(125)
+        index_accessor = container.Add(KM.STEP, KM.IntegerDataValuePolicy())
+        value_accessor = container.Add(KM.PRESSURE, KM.DoubleSparseDataValuePolicy(index_accessor))
+
+        self.assertTrue(KM.DoubleSparseDataValuePolicy(index_accessor).IsSparse())
+        self.assertFalse(KM.DoubleDataValuePolicy().IsSparse())
+
+        # Sparse chunks start empty
+        self.assertEqual(len(container.GetDataSpan(value_accessor)), 0)
+
+        index_span = container.GetDataSpan(index_accessor)
+        counter = 0
+        for i in range(len(index_span)):
+            if i % 2 == 0:
+                index_span[i] = counter
+                counter += 1
+            else:
+                index_span[i] = -1
+
+        container.UpdateSparseStorage(index_accessor)
+        value_span = container.GetDataSpan(value_accessor)
+        self.assertEqual(len(value_span), 125 // 2 + 1)
+
+        value_span[:] = 1.0
+
+        container.AddToSparseStorage(index_accessor, list(range(0, 125, 5)))
+
+        value_span = container.GetDataSpan(value_accessor)  # re-fetch: storage was reallocated
+        index_span = container.GetDataSpan(index_accessor)
+        self.assertEqual(len(value_span), 125 // 2 + 13)
+
+        for i in range(len(index_span)):
+            if i % 2 == 0:
+                self.assertEqual(value_span[index_span[i]], 1.0)  # original entries preserved
+            elif i % 5 == 0:
+                self.assertEqual(value_span[index_span[i]], 0.0)  # added entries zero-initialized
+            else:
+                self.assertEqual(index_span[i], -1)  # still inactive
+
+    def test_errors(self):
+        container = KM.DataContainer()
+
+        # Incompatible value policy: no matching Add overload exists for this combination
+        with self.assertRaises(TypeError):
+            container.Add(KM.STEP, KM.DoubleDataValuePolicy())
+
+        # Missing data
+        with self.assertRaises(RuntimeError):
+            container.GetAccessor(KM.TEMPERATURE, KM.DoubleDataValuePolicy())
+
+        # Existing variable with a different policy configuration
+        container.Add(KM.PRESSURE, KM.DoubleDataValuePolicy())
+        with self.assertRaises(RuntimeError):
+            container.Add(KM.PRESSURE, KM.DoubleDataValuePolicy(5.0))
+
+
+if __name__ == '__main__':
+    KM.Logger.GetDefaultOutput().SetSeverity(KM.Logger.Severity.WARNING)
+    KratosUnittest.main()

--- a/kratos/tests/test_data_container.py
+++ b/kratos/tests/test_data_container.py
@@ -157,6 +157,24 @@ class TestDataContainer(KratosUnittest.TestCase):
             else:
                 self.assertEqual(index_span[i], -1)  # still inactive
 
+    def test_resize(self):
+        container = KM.DataContainer(4)
+        accessor = container.Add(KM.PRESSURE, KM.DoubleDataValuePolicy())
+
+        span = container.GetDataSpan(accessor)
+        span[:] = [1.0, 2.0, 3.0, 4.0]
+
+        container.Resize(6)
+
+        span = container.GetDataSpan(accessor)  # re-fetch: the old view is invalidated
+        self.assertEqual(len(span), 6)
+        self.assertEqual(list(span[:4]), [1.0, 2.0, 3.0, 4.0])  # values preserved
+        self.assertEqual(list(span[4:]), [0.0, 0.0])            # tail zero-initialized
+
+        container.Resize(2)
+        span = container.GetDataSpan(accessor)
+        self.assertEqual(list(span), [1.0, 2.0])                # shrink keeps leading values
+
     def test_errors(self):
         container = KM.DataContainer()
 

--- a/kratos/tests/test_data_container.py
+++ b/kratos/tests/test_data_container.py
@@ -50,7 +50,9 @@ class TestDataContainer(KratosUnittest.TestCase):
 
     def test_array3_span_shape(self):
         container = KM.DataContainer(8)
-        accessor = container.Add(KM.VELOCITY, KM.Array1DDataValuePolicy3())
+        # array_1d's default constructor does not zero-initialize its storage (unlike a
+        # plain Python/NumPy sequence), so the policy zero must be passed explicitly here.
+        accessor = container.Add(KM.VELOCITY, KM.Array1DDataValuePolicy3([0.0, 0.0, 0.0]))
 
         span = container.GetDataSpan(accessor)
         self.assertEqual(span.shape, (8, 3))


### PR DESCRIPTION
---
name: ✨ Feature
about: New applications, new features or wider changes

---

## **📝 Description**

Phase I of a two-phase effort to port a standalone, type-erased, variable-indexed data storage prototype (`DataContainer` / `DataChunk` / `DataValuePolicy` / `DataHistoryPolicy` / `DataAccessor`) into the Kratos core, replacing the facilities it mimicked (error macros, `VariableData`/`Variable<T>`, the `Registry`) with the real ones already provided by Kratos.

This PR ports the data structure itself with **minimal behavioural modification**, adapts it to core style and conventions, adds full C++ and Python test coverage, and exposes it to Python via pybind11. **The class is not yet wired into `Node`, `Element`, `Condition`, `Geometry` or `MasterSlaveConstraint`** — that is Phase II, tracked separately. A few `// TODO(Phase II)` markers are left at the obvious future integration points, but nothing is implemented there yet.

Tags: `Api Addition` (new opt-in core module; no existing API is touched)

### **Key changes**

New module `kratos/containers/data_container/`, organized as four logically separable pieces (mirrored in the commit history):

1. **`DataAccessor` / `DataValuePolicy` / `SparseDataValuePolicy`** — a lightweight, index-caching accessor and the type-erased value-policy hierarchy (dense, layered, sparse) that defines *what* is stored per entity and how it is cloned/copied/printed.
2. **`DataHistoryPolicy`** — `NonHistoricalDataPolicy` / `HistoricalDataPolicy`, defining *how many steps* are kept per chunk via a `StepCategory`-scoped ring buffer.
3. **`DataChunk`** — the contiguous, manually-managed (`new[]`/`delete[]`) raw storage for one variable's values across all entities and step slots.
4. **`DataContainer`** — ties the above together: `Add`/`GetAccessor`/`Has`/`GetDataSpan`, sparse-storage growth (`UpdateSparseStorage`/`AddToSparseStorage`), step cloning, plus the pybind11 bindings and cross-cutting tests.

**Header/source split.** Non-template classes (`DataValuePolicyBase`, `DataHistoryPolicyBase` + its two concrete policies, `DataChunkBase`, and the non-template members of `DataContainer`) now have a matching `.cpp`, mirroring how `VariableData` (non-template) has `variable_data.cpp` while `Variable<T>` (template) stays fully inline. Template classes (`DataAccessor<T>`, `DataValuePolicy<T>`, `LayeredDataValuePolicy<T>`, `SparseDataValuePolicy<T>`, `DataChunk<T>`, and `DataContainer::Add`/`GetAccessor`/`GetDataSpan`/`Has`) stay header-only, since the module must remain generic over arbitrary user value types (exercised by the tests with a custom `CustomClass`).

**Design decisions / judgment calls for reviewers:**
- `DataContainer::Add` canonicalizes variables through the Kratos `Registry` (`variables.all.<name>`), so **only already-registered variables can be added**; it does **not** auto-register them as a side effect. Unregistered variables raise a clear error instead of the opaque `Registry::GetValue` throw the prototype would have hit.
- `std::mutex` replaced by `LockObject`; `DataContainer` copy/move are explicit and documented as **shallow** (chunks are shared via `std::shared_ptr`).
- `SparseDataValuePolicy` intentionally does **not** override `IsSameType` — a sparse and a dense policy of the same value type compare as the same *type* (sparseness is queried through `IsSparse()` instead), matching the prototype's semantics.
- `HistoricalDataPolicy::Clone()` resets the running step index to 0 (prototype-faithful, documented) — freshly created chunks (`CreateNew`, `Initialize`) always start their history at slot 0.
- `LayeredDataValuePolicy` is not exposed to Python in this phase (no sane NumPy mapping for a per-entity `std::vector`).
- Design note added at `docs/pages/Kratos/For_Developers/Data_Structures/Data_Container.md`.

**Prototype bugs fixed during the port** (the prototype used stub macros that only printed instead of throwing, which hid these):
- `HistoricalDataPolicy::CloneStepIndex` was missing `override`.
- Zero-entity chunks (how sparse chunks legitimately start) would have thrown in FullDebug builds due to overly strict `N > 0` debug checks — relaxed and regression-tested.
- `DataChunk::ResizeDataContainer(0)` left a dangling pointer, causing a double delete in the destructor — fixed and regression-tested.
- The resize copy/zero-fill was computed from the *total* size but applied per step slot, reading out of bounds for any chunk with more than one history step — fixed to a per-step `min(old, new)` copy and regression-tested.
- `DataContainer::Initialize` validated the wrong variable (a member instead of its own argument) and never stored the requested chunk size — fixed and regression-tested.
- Two `throw std::runtime_error` sites converted to `KRATOS_ERROR`.
- `NumberOfEntitiePerStep()` typo renamed to `NumberOfEntitiesPerStep()` (no existing callers outside this PR).

### **Validation**

- Full rebuild of `KratosCore`, `KratosCoreTest` and the `Kratos` Python module (Release, gcc 13.3) with zero warnings/errors introduced.
- `KratosCoreTest --gtest_filter='*DataContainer*:*DataChunk*:*DataAccessor*:*DataValuePolicy*:*DataHistoryPolicy*:*HistoricalDataPolicy*:*NonHistoricalDataPolicy*:*SparseDataValuePolicy*'` → **31/31 passed**, covering type/equality comparisons, variable compatibility, raw type-erased operations, sparse growth (`UpdateSparseStorage`/`AddToSparseStorage` reproducing the original voxel-mesh scenarios directly on a 125-entity `DataContainer`), step-history cycling/cloning, accessor mismatch handling, shallow-copy semantics, and variable-lifetime independence from the `Registry`.
- `kratos/tests/test_data_container.py` (registered in `test_KratosCore.py`'s small suite) → **10/10 passed**, mirroring the C++ scenarios through the pybind11 bindings (NumPy view semantics, custom zero values, `array_1d` shape, sparse workflow, error paths).
- Full `KratosCoreTest` regression run (1609 tests) → all green, no pre-existing test broken by the addition.
- Every new header and `.cpp` file compiled **standalone** (its own includes only, outside the aggregated build) to verify the trimmed include lists are actually self-sufficient and not silently relying on include order from other translation units.

## **🆕 Changelog**

- Added `kratos/containers/data_container/` — a chunked, type-erased, variable-keyed data storage module (`DataContainer`, `DataChunk`, `DataValuePolicy`/`LayeredDataValuePolicy`/`SparseDataValuePolicy`, `DataHistoryPolicy`, `DataAccessor`), standalone in this phase (not yet used by `Node`/`Element`/`Condition`/`Geometry`/`MasterSlaveConstraint`)
- Added pybind11 bindings for the new module (`DataContainer`, `StepCategory`, history and value policies) for `double`, `int`, `array_1d<double,3>` and `std::string`, with zero-copy NumPy views for `GetDataSpan`
- Added C++ (`kratos/tests/cpp_tests/containers/data_container/`) and Python (`kratos/tests/test_data_container.py`) test coverage for the new module
- Added a developer design note at `docs/pages/Kratos/For_Developers/Data_Structures/Data_Container.md`
