### PR TITLE
[MPM] Remove option for generating 4 material points per triangular element

### DIFF
--- a/applications/MPMApplication/custom_utilities/material_point_generator_utility.cpp
+++ b/applications/MPMApplication/custom_utilities/material_point_generator_utility.cpp
@@ -626,9 +626,6 @@ namespace Kratos::MaterialPointGeneratorUtility
             case 3:
                 rIntegrationMethod = GeometryData::IntegrationMethod::GI_GAUSS_2;
                 break;
-            case 4:
-                rIntegrationMethod = GeometryData::IntegrationMethod::GI_GAUSS_3;
-                break;
             case 6:
                 rIntegrationMethod = GeometryData::IntegrationMethod::GI_GAUSS_4;
                 break;
@@ -639,7 +636,7 @@ namespace Kratos::MaterialPointGeneratorUtility
                 std::string err_msg = "The input number of MATERIAL_POINTS_PER_ELEMENT ";
                 err_msg += "(" + std::to_string(MaterialPointsPerElement) + ")";
                 err_msg += " is not available for Triangular elements\n";
-                err_msg += "Available options are: 1, 3, 4, 6, 12.\n";
+                err_msg += "Available options are: 1, 3, 6, 12.\n";
                 KRATOS_ERROR <<  err_msg << std::endl;
                 break;
             }

--- a/applications/MPMApplication/tests/test_generate_material_point_element.py
+++ b/applications/MPMApplication/tests/test_generate_material_point_element.py
@@ -168,6 +168,7 @@ class TestGenerateMaterialPointElement(KratosUnittest.TestCase):
         current_model = KratosMultiphysics.Model()
         self._generate_material_point_element_and_check(current_model, geometry_element="Triangle", num_material_points=3, expected_num_material_points=3)
 
+    @KratosUnittest.expectedFailure
     def test_GenerateMaterialPointElementTriangle4P(self):
         current_model = KratosMultiphysics.Model()
         self._generate_material_point_element_and_check(current_model, geometry_element="Triangle", num_material_points=4, expected_num_material_points=4)

--- a/docs/pages/Applications/MPM_Application/Input_Files/json.md
+++ b/docs/pages/Applications/MPM_Application/Input_Files/json.md
@@ -155,9 +155,9 @@ Each json object in the list assigned to the `property` field is defined through
             | :-------: | :--------: | :------------: | :-------: |
             |  1        |  1         |  1             |   1       |
             |  3        |  4         |  4             |   8       |
-            |  4        |  8         |  9             |  27       |
-            |  6        | 14         | 16             |  64       |
-            | 12        | 24         | 25             | 125       |
+            |  6        |  8         |  9             |  27       |
+            | 12        | 14         | 16             |  64       |
+            |           | 24         | 25             | 125       |
 
         * other variables depending on the type of constitutive law that has been chosen.
 


### PR DESCRIPTION
## **📝 Description**
The possibility of having 4 material points per triangular element was introduced by mistake in #14103.
This PR removes this options as it cannot be used to generate material points.