### PR TITLE
Controls can be initialized from csv files now. Added test for MaterialPropertiesControl

### DIFF
--- a/applications/SystemIdentificationApplication/python_scripts/controls/data_values_control.py
+++ b/applications/SystemIdentificationApplication/python_scripts/controls/data_values_control.py
@@ -1,5 +1,6 @@
 import math, numpy
 from typing import Optional
+import pandas as pd
 
 import KratosMultiphysics as Kratos
 import KratosMultiphysics.SystemIdentificationApplication as KratosSI
@@ -42,7 +43,12 @@ class DataValuesControl(Control):
                     "primal_model_part_name" : "PLEASE_PROVIDE_MODEL_PART_NAME",
                     "adjoint_model_part_name": "PLEASE_PROVIDE_MODEL_PART_NAME"
                 }
-            ]
+            ],
+            "control_initialization_settings": {
+                "initialize_from_file" : false,
+                "filetype" : "csv",
+                "file_name" : ""
+            }
         }""")
 
         parameters.ValidateAndAssignDefaults(default_settings)
@@ -103,9 +109,30 @@ class DataValuesControl(Control):
         self.interval_bounder = TensorAdaptorBoundingManager(control_variable_bounds)
         self.clamper = KratosSI.SmoothClamper(0, 1)
 
+        # Control initialization settings
+        self.initialization_settings = parameters["control_initialization_settings"]
+        self.initialize_from_file = self.initialization_settings["initialize_from_file"].GetBool()
+        if self.initialize_from_file:
+            if self.initialization_settings["filetype"].GetString() != "csv":
+                raise RuntimeError(f"Only csv file type is supported for control initialization. [ control name = \"{self.GetName()}\"]")
+            self.initialization_file_name = self.initialization_settings["file_name"].GetString()
+
     def Initialize(self) -> None:
         self.primal_model_part = self.primal_model_part_operation.GetModelPart()
         self.adjoint_model_part = self.adjoint_model_part_operation.GetModelPart()
+
+        # initialize the control field if required from a file
+        if self.initialize_from_file:
+            df = pd.read_csv(self.initialization_file_name, header=0, index_col=0)
+
+            # check sizes
+            if len(df) != self.GetEmptyField().Shape()[0]:
+                raise RuntimeError(f"Control initialization file does not have the required number of entries. [ control name = \"{self.GetName()}\", required = {self.GetEmptyField().Shape()[0]}, provided = {len(df)}]")
+
+            # Assign to the specific field
+            ta = GetTensorAdaptor(self.primal_model_part, self.container_type, self.controlled_physical_variable)
+            ta.data[:] = df.to_numpy().flatten()
+            ta.StoreData()
 
         # initialize the filter
         self.filter.SetComponentDataView(ComponentDataView(self, self.optimization_problem))

--- a/applications/SystemIdentificationApplication/python_scripts/controls/data_values_control.py
+++ b/applications/SystemIdentificationApplication/python_scripts/controls/data_values_control.py
@@ -1,6 +1,5 @@
 import math, numpy
 from typing import Optional
-import pandas as pd
 
 import KratosMultiphysics as Kratos
 import KratosMultiphysics.SystemIdentificationApplication as KratosSI
@@ -123,15 +122,17 @@ class DataValuesControl(Control):
 
         # initialize the control field if required from a file
         if self.initialize_from_file:
-            df = pd.read_csv(self.initialization_file_name, header=0, index_col=0)
-
+            df = numpy.loadtxt(self.initialization_file_name, delimiter=',', skiprows=1)
+                            
             # check sizes
+            if df.shape[1] != 2:
+                raise RuntimeError(f"Initialization file for control \"{self.GetName()}\" should have 2 columns (Node/Element/ConditionID, {self.controlled_physical_variable.Name()}) with first row for header. [ provided file: {self.initialization_file_name} ]")
             if len(df) != self.GetEmptyField().Shape()[0]:
                 raise RuntimeError(f"Control initialization file does not have the required number of entries. [ control name = \"{self.GetName()}\", required = {self.GetEmptyField().Shape()[0]}, provided = {len(df)}]")
 
             # Assign to the specific field
             ta = GetTensorAdaptor(self.primal_model_part, self.container_type, self.controlled_physical_variable)
-            ta.data[:] = df.to_numpy().flatten()
+            ta.data[:] = df[:, 1].flatten()
             ta.StoreData()
 
         # initialize the filter

--- a/applications/SystemIdentificationApplication/python_scripts/controls/material_properties_control.py
+++ b/applications/SystemIdentificationApplication/python_scripts/controls/material_properties_control.py
@@ -1,5 +1,6 @@
 import math, numpy
 from typing import Optional
+import pandas as pd
 
 import KratosMultiphysics as Kratos
 import KratosMultiphysics.OptimizationApplication as KratosOA
@@ -42,7 +43,12 @@ class MaterialPropertiesControl(Control):
                     "primal_model_part_name" : "PLEASE_PROVIDE_MODEL_PART_NAME",
                     "adjoint_model_part_name": "PLEASE_PROVIDE_MODEL_PART_NAME"
                 }
-            ]
+            ],
+            "control_initialization_settings": {
+                "initialize_from_file" : false,
+                "filetype" : "csv",
+                "file_name" : ""
+            }
         }""")
         parameters.ValidateAndAssignDefaults(default_settings)
 
@@ -93,6 +99,14 @@ class MaterialPropertiesControl(Control):
         self.interval_bounder = TensorAdaptorBoundingManager(control_variable_bounds)
         self.clamper = KratosSI.SmoothClamper(0, 1)
 
+        # Control initialization settings
+        self.initialization_settings = parameters["control_initialization_settings"]
+        self.initialize_from_file = self.initialization_settings["initialize_from_file"].GetBool()
+        if self.initialize_from_file:
+            if self.initialization_settings["filetype"].GetString() != "csv":
+                raise RuntimeError(f"Only csv file type is supported for control initialization. [ control name = \"{self.GetName()}\"]")
+            self.initialization_file_name = self.initialization_settings["file_name"].GetString()
+
     def Initialize(self) -> None:
         self.primal_model_part = self.primal_model_part_operation.GetModelPart()
         self.adjoint_model_part = self.adjoint_model_part_operation.GetModelPart()
@@ -100,6 +114,18 @@ class MaterialPropertiesControl(Control):
         if not KratosOA.OptAppModelPartUtils.CheckModelPartStatus(self.primal_model_part, "element_specific_properties_created"):
             KratosOA.OptimizationUtils.CreateEntitySpecificPropertiesForContainer(self.primal_model_part, self.primal_model_part.Elements, self.consider_recursive_property_update)
             KratosOA.OptAppModelPartUtils.LogModelPartStatus(self.primal_model_part, "element_specific_properties_created")
+
+            if self.initialize_from_file:
+                df = pd.read_csv(self.initialization_file_name, header=0, index_col=0)
+
+                # check sizes
+                if len(df) != self.primal_model_part.NumberOfElements():
+                    raise RuntimeError(f"Number of elements in the primal model part ({self.primal_model_part.NumberOfElements()}) does not match the number of rows in the initialization file ({len(df)}). [ control name = \"{self.GetName()}\"]")
+
+                # Assign values to properties
+                ta = KratosOA.TensorAdaptors.PropertiesVariableTensorAdaptor(self.primal_model_part.Elements, self.controlled_physical_variable)
+                ta.data[:] = df.to_numpy().flatten()
+                ta.StoreData()
 
             if self.primal_model_part != self.adjoint_model_part:
                 if KratosOA.OptAppModelPartUtils.CheckModelPartStatus(self.adjoint_model_part, "element_specific_properties_created"):

--- a/applications/SystemIdentificationApplication/python_scripts/controls/material_properties_control.py
+++ b/applications/SystemIdentificationApplication/python_scripts/controls/material_properties_control.py
@@ -1,6 +1,5 @@
 import math, numpy
 from typing import Optional
-import pandas as pd
 
 import KratosMultiphysics as Kratos
 import KratosMultiphysics.OptimizationApplication as KratosOA
@@ -116,15 +115,17 @@ class MaterialPropertiesControl(Control):
             KratosOA.OptAppModelPartUtils.LogModelPartStatus(self.primal_model_part, "element_specific_properties_created")
 
             if self.initialize_from_file:
-                df = pd.read_csv(self.initialization_file_name, header=0, index_col=0)
-
+                df = numpy.loadtxt(self.initialization_file_name, delimiter=',', skiprows=1)
+                
                 # check sizes
+                if df.shape[1] != 2:
+                    raise RuntimeError(f"Initialization file for control \"{self.GetName()}\" should have 2 columns (Node/Element/ConditionID, {self.controlled_physical_variable.Name()}) with first row for header. [ provided file: {self.initialization_file_name} ]")
                 if len(df) != self.primal_model_part.NumberOfElements():
                     raise RuntimeError(f"Number of elements in the primal model part ({self.primal_model_part.NumberOfElements()}) does not match the number of rows in the initialization file ({len(df)}). [ control name = \"{self.GetName()}\"]")
 
                 # Assign values to properties
                 ta = KratosOA.TensorAdaptors.PropertiesVariableTensorAdaptor(self.primal_model_part.Elements, self.controlled_physical_variable)
-                ta.data[:] = df.to_numpy().flatten()
+                ta.data[:] = df[:, 1].flatten()
                 ta.StoreData()
 
             if self.primal_model_part != self.adjoint_model_part:

--- a/applications/SystemIdentificationApplication/tests/controls/test_data_values_control.py
+++ b/applications/SystemIdentificationApplication/tests/controls/test_data_values_control.py
@@ -82,6 +82,8 @@ class TestDataValuesControl_nodal_historical(kratos_unittest.TestCase):
     def tearDownClass(cls):
         with kratos_unittest.WorkFolderScope(".", __file__):
             DeleteFileIfExisting("Structure.time")
+            DeleteFileIfExisting("initial_nodal_historical_control_values.csv")
+            DeleteFileIfExisting("../initial_nodal_historical_control_values.csv")
 
     def test_GetPhysicalKratosVariables(self):
         control_var = self.temperature_control.GetPhysicalKratosVariables()
@@ -122,11 +124,95 @@ class TestDataValuesControl_nodal_historical(kratos_unittest.TestCase):
         self.assertAlmostEqual(np.linalg.norm(control_field.data, ord=np.inf), 0.25, 4)
         # ForwardFilter: control_update -> phi_update (Here, filter radius ~ 0. Therefore, both are the same = 0.25)
         # physical = -2.5
-        # phi = 0.5 - sin(asin(1-2*(physical - min)/delta)/3) = 0.3263518223
+        # IntervalBounder: min = -5, max = 5, delta = 10: GetBoundedTensorAdaptor: phi_b = (physical - min)/delta = 0.25
+        # phi = 0.25 - sin(asin(1-2*(phi_b - min_clamper)/delta_clamper)/3) = 0.3263518223
         # phi_updated = phi_current + phi_update = 0.3263518223 + 0.25 = 0.5763518223
         # ProjectForward: phi_updated -> physical_updated
-        # physical_updated = physical_min + phi_updated²*(3 - 2*phi_updated)* delta = 1.136375322
-        self.assertAlmostEqual(np.linalg.norm(temperature_field.data, ord=np.inf), 1.136375322, 6)
+        # Clamper: physical_updated = min + phi_updated²*(3 - 2*phi_updated)* delta = 0.6136375322
+        # GetUnboundedTensorAdaptor: physical_updated_unbounded = physical_min + physical_updated * delta = -5 + 0.6136375322 * 10 = 1.13637532
+        self.assertAlmostEqual(np.linalg.norm(temperature_field.data, ord=np.inf), 1.13637532, 6)
+
+class TestDataValuesControl_nodal_historical_with_initialization(TestDataValuesControl_nodal_historical):
+    @classmethod
+    def setUpClass(cls):
+        cls.model = Kratos.Model()
+        cls.model_part = cls.model.CreateModelPart("Structure")
+        cls.model_part.ProcessInfo[Kratos.DOMAIN_SIZE] = 3
+        cls.model_part.AddNodalSolutionStepVariable(Kratos.TEMPERATURE)
+
+        parameters = Kratos.Parameters("""{
+            "control_variable_name"             : "TEMPERATURE",
+            "control_variable_bounds"           : [-5.0, 5.0],
+            "output_all_fields"                 : false,
+            "container_type"                    : "nodal_historical",
+            "filter_settings"                   : {
+                    "filter_type": "explicit_filter",
+                    "filter_function_type": "linear",
+                    "max_items_in_bucket": 10,
+                    "echo_level": 4,
+                    "filter_radius_settings": {
+                        "filter_radius_type": "constant",
+                        "filter_radius": 1e-10
+                    }
+            },
+            "model_part_names": [
+                {
+                    "primal_model_part_name" : "Structure",
+                    "adjoint_model_part_name": "Structure"
+                }
+            ],
+            "control_initialization_settings": {
+                "initialize_from_file" : true,
+                "filetype" : "csv",
+                "file_name" : "initial_nodal_historical_control_values.csv"
+            }
+        }""")
+
+        cls.optimization_problem = OptimizationProblem()
+        cls.temperature_control = DataValuesControl("test", cls.model, parameters, cls.optimization_problem)
+        cls.optimization_problem.AddComponent(cls.temperature_control)
+
+        with kratos_unittest.WorkFolderScope(".", __file__):
+            Kratos.ModelPartIO("../responses/auxiliary_files_3/Structure", Kratos.ModelPartIO.READ | Kratos.ModelPartIO.MESH_ONLY).ReadModelPart(cls.model_part)
+        material_params = Kratos.Parameters("""{
+            "properties": [
+                {
+                    "model_part_name": "Structure.Parts_Solid_full",
+                    "properties_id": 1,
+                    "Material": {
+                        "constitutive_law" : {
+                            "name" : "ConstitutiveLawsApplication.ThermalLinearPlaneStress"
+                            },
+                        "Variables"        : {
+                            "THICKNESS"     : 0.02,
+                            "DENSITY"       : 7850.0,
+                            "YOUNG_MODULUS" : 2e6,
+                            "POISSON_RATIO" : 0.29,
+                            "THERMAL_EXPANSION_COEFFICIENT": 1e-5,
+                            "REFERENCE_TEMPERATURE": 0.0
+                        },
+                        "Tables"           : null
+                    }
+                }
+            ]
+        }""")
+        Kratos.ReadMaterialsUtility(cls.model).ReadMaterials(material_params)
+
+        for node in cls.model_part.Nodes:
+            node: Kratos.Node
+            node.SetSolutionStepValue(Kratos.TEMPERATURE, 5.0)
+
+        # Create a CSV file with initial control values
+        initial_control_values = np.ones(len(cls.model_part.Nodes))
+        initial_control_values[:] = -2.5  # Set all initial control values to -2.5
+        with open("initial_nodal_historical_control_values.csv", "w") as f:
+            f.write("NodeId,TEMPERATURE\n")
+            for idx, node in enumerate(cls.model_part.Nodes):
+                f.write(f"{node.Id},{initial_control_values[idx]}\n")
+
+        cls.temperature_control.Initialize()
+        cls.initial_temperature = Kratos.TensorAdaptors.HistoricalVariableTensorAdaptor(cls.model_part.Nodes, Kratos.TEMPERATURE)
+        cls.initial_temperature.CollectData()
 
 class TestDataValuesControl_condition(kratos_unittest.TestCase):
     @classmethod
@@ -200,6 +286,8 @@ class TestDataValuesControl_condition(kratos_unittest.TestCase):
     def tearDownClass(cls):
         with kratos_unittest.WorkFolderScope(".", __file__):
             DeleteFileIfExisting("Structure.time")
+            DeleteFileIfExisting("initial_condition_control_values.csv")
+            DeleteFileIfExisting("../initial_condition_control_values.csv")
 
     def test_GetPhysicalKratosVariables(self):
         control_var = self.pressure_control.GetPhysicalKratosVariables()
@@ -244,6 +332,84 @@ class TestDataValuesControl_condition(kratos_unittest.TestCase):
         # ProjectForward: phi_updated -> physical_updated
         # physical_updated = physical_min + phi_updated²*(3 - 2*phi_updated)* delta = 1.136375322
         self.assertAlmostEqual(np.linalg.norm(pressure_field.data, ord=np.inf), 1.136375322, 6)
+
+class TestDataValuesControl_condition_with_initialization(TestDataValuesControl_condition):
+    @classmethod
+    def setUpClass(cls):
+        cls.model = Kratos.Model()
+        cls.model_part = cls.model.CreateModelPart("Structure")
+        cls.model_part.ProcessInfo[Kratos.DOMAIN_SIZE] = 3
+
+        parameters = Kratos.Parameters("""{
+            "control_variable_name"             : "PRESSURE",
+            "control_variable_bounds"           : [-5.0, 5.0],
+            "output_all_fields"                 : false,
+            "container_type"                    : "condition",
+            "filter_settings"                   : {
+                    "filter_type": "explicit_filter",
+                    "filter_function_type": "linear",
+                    "max_items_in_bucket": 10,
+                    "echo_level": 4,
+                    "filter_radius_settings": {
+                        "filter_radius_type": "constant",
+                        "filter_radius": 1e-10
+                    }
+            },
+            "model_part_names": [
+                {
+                    "primal_model_part_name" : "Structure",
+                    "adjoint_model_part_name": "Structure"
+                }
+            ],
+            "control_initialization_settings": {
+                "initialize_from_file" : true,
+                "filetype" : "csv",
+                "file_name" : "initial_condition_control_values.csv"
+            }
+        }""")
+
+        cls.optimization_problem = OptimizationProblem()
+        cls.pressure_control = DataValuesControl("test", cls.model, parameters, cls.optimization_problem)
+        cls.optimization_problem.AddComponent(cls.pressure_control)
+
+        with kratos_unittest.WorkFolderScope(".", __file__):
+            Kratos.ModelPartIO("../responses/auxiliary_files_5/Structure", Kratos.ModelPartIO.READ | Kratos.ModelPartIO.MESH_ONLY).ReadModelPart(cls.model_part)
+        material_params = Kratos.Parameters("""{
+            "properties": [
+            {
+                "model_part_name": "Structure.Parts_Solid",
+                "properties_id": 1,
+                "Material": {
+                    "constitutive_law": {
+                        "name": "LinearElastic3DLaw"
+                    },
+                    "Variables": {
+                        "DENSITY": 7850.0,
+                        "YOUNG_MODULUS": 20.0,
+                        "POISSON_RATIO": 0.29
+                    },
+                    "Tables": null
+                }
+            }
+    ]
+        }""")
+        Kratos.ReadMaterialsUtility(cls.model).ReadMaterials(material_params)
+
+        for condition in cls.model_part.Conditions:
+            condition: Kratos.Condition
+            condition.SetValue(Kratos.PRESSURE, 10.0)
+
+        # Create a CSV file with initial control values
+        initial_control_values = np.ones(len(cls.model_part.Conditions))
+        initial_control_values[:] = -2.5  # Set all initial control values to -2.5
+        with open("initial_condition_control_values.csv", "w") as f:
+            f.write("ConditionId,PRESSURE\n")
+            for idx, cond in enumerate(cls.model_part.Conditions):
+                f.write(f"{cond.Id},{initial_control_values[idx]}\n")
+
+        cls.pressure_control.Initialize()
+        cls.initial_pressure = Kratos.TensorAdaptors.VariableTensorAdaptor(cls.model_part.Conditions, Kratos.PRESSURE)
+        cls.initial_pressure.CollectData()
 
 if __name__ == "__main__":
     kratos_unittest.main()

--- a/applications/SystemIdentificationApplication/tests/controls/test_material_properties_control.py
+++ b/applications/SystemIdentificationApplication/tests/controls/test_material_properties_control.py
@@ -1,0 +1,204 @@
+import numpy as np
+import KratosMultiphysics as Kratos
+import KratosMultiphysics.StructuralMechanicsApplication as KratosSM
+import KratosMultiphysics.OptimizationApplication as KratosOA
+import KratosMultiphysics.KratosUnittest as kratos_unittest
+from KratosMultiphysics.kratos_utilities import DeleteFileIfExisting
+from KratosMultiphysics.OptimizationApplication.utilities.optimization_problem import OptimizationProblem
+from KratosMultiphysics.SystemIdentificationApplication.controls.material_properties_control import MaterialPropertiesControl
+
+class TestMaterialPropertiesControl(kratos_unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.model = Kratos.Model()
+        cls.model_part = cls.model.CreateModelPart("Structure")
+        cls.model_part.ProcessInfo[Kratos.DOMAIN_SIZE] = 3
+
+        parameters = Kratos.Parameters("""{
+            "control_variable_name"             : "YOUNG_MODULUS",
+            "control_variable_bounds"           : [1e6, 3e6],
+            "output_all_fields"                 : false,
+            "filter_settings"                   : {
+                    "filter_type": "explicit_filter",
+                    "filter_function_type": "linear",
+                    "max_items_in_bucket": 10,
+                    "echo_level": 4,
+                    "filter_radius_settings": {
+                        "filter_radius_type": "constant",
+                        "filter_radius": 1e-10
+                    }
+            },
+            "model_part_names": [
+                {
+                    "primal_model_part_name" : "Structure",
+                    "adjoint_model_part_name": "Structure"
+                }
+            ]
+        }""")
+
+        cls.optimization_problem = OptimizationProblem()
+        cls.young_modulus_control = MaterialPropertiesControl("test", cls.model, parameters, cls.optimization_problem)
+        cls.optimization_problem.AddComponent(cls.young_modulus_control)
+
+        with kratos_unittest.WorkFolderScope(".", __file__):
+            Kratos.ModelPartIO("../responses/auxiliary_files_3/Structure", Kratos.ModelPartIO.READ | Kratos.ModelPartIO.MESH_ONLY).ReadModelPart(cls.model_part)
+        material_params = Kratos.Parameters("""{
+            "properties": [
+                {
+                    "model_part_name": "Structure.Parts_Solid_full",
+                    "properties_id": 1,
+                    "Material": {
+                        "constitutive_law" : {
+                            "name" : "LinearElasticPlaneStress2DLaw"
+                            },
+                        "Variables"        : {
+                            "THICKNESS"     : 0.02,
+                            "DENSITY"       : 7850.0,
+                            "YOUNG_MODULUS" : 2e6,
+                            "POISSON_RATIO" : 0.29
+                        },
+                        "Tables"           : null
+                    }
+                }
+            ]
+        }""")
+        Kratos.ReadMaterialsUtility(cls.model).ReadMaterials(material_params)
+
+        cls.young_modulus_control.Initialize()
+        cls.initial_young_modulus = KratosOA.TensorAdaptors.PropertiesVariableTensorAdaptor(cls.model_part.Elements, Kratos.YOUNG_MODULUS)
+        cls.initial_young_modulus.CollectData()
+
+    def setUp(self) -> None:
+        self.initial_young_modulus.CollectData()
+
+    @classmethod
+    def tearDownClass(cls):
+        with kratos_unittest.WorkFolderScope(".", __file__):
+            DeleteFileIfExisting("Structure.time")
+            DeleteFileIfExisting("initial_material_properties_control_values.csv")
+            DeleteFileIfExisting("../initial_material_properties_control_values.csv")
+
+    def test_GetPhysicalKratosVariables(self):
+        control_var = self.young_modulus_control.GetPhysicalKratosVariables()
+        self.assertEqual(control_var, [Kratos.KratosGlobals.GetVariable("YOUNG_MODULUS")])
+
+    def test_GetControlField(self):
+        control_field = self.young_modulus_control.GetControlField()
+        self.assertAlmostEqual(np.linalg.norm(control_field.data), 0.0, 4)
+
+    def test_GetPhysicalField(self):
+        young_modulus_field = self.young_modulus_control.GetPhysicalField()
+        self.assertAlmostEqual(np.linalg.norm(young_modulus_field.data), 5656854.2494924, 4)
+
+    def test_MapGradient(self):
+        physical_gradient = self.young_modulus_control.GetEmptyField()
+        for element in physical_gradient.GetContainer():
+            element.SetValue(KratosSM.YOUNG_MODULUS_SENSITIVITY, 1)
+        Kratos.TensorAdaptors.VariableTensorAdaptor(physical_gradient, KratosSM.YOUNG_MODULUS_SENSITIVITY, copy=False).CollectData()
+
+        mapped_gradient = self.young_modulus_control.MapGradient({Kratos.YOUNG_MODULUS: physical_gradient})
+        # physical = 2e6
+        # interval bounder: min = 1e6, max = 3e6, delta = 2e6: GetBoundedTensorAdaptor: phi_b = (physical - min)/delta = 0.5
+        # Clamper: ProjectBackward: phi = 0.5 - sin(asin(1-2*(phi_b - min_clamper)/delta_clamper)/3) = 0.5
+        # Clamper: CalculateForwardProjectionGradient: d_physical/d_phi = (6*phi - 6*phi²)*delta_physical = 1.5 * 2e6 = 3e6
+        # d_J/d_physical = 1 (input given above)
+        # BackwardFilterIntegratedField: d_J/d_physical * d_physical/d_phi -> d_J/d_control (mapped gradient)
+        # For Integrated type: domain_size  = element_area  = 0.125
+        # BackwardFilterIntegratedField: (1 * 3e6) / 0.125 = 24000000.0 (mapped gradient)
+        self.assertAlmostEqual(np.linalg.norm(mapped_gradient.data, ord=np.inf), 24000000.0, 4)
+
+    def test_Update(self):
+        update_field = self.young_modulus_control.GetEmptyField()
+        update_field.data[:] = 0.25
+        young_modulus_field = self.young_modulus_control.GetPhysicalField()
+        control_field = self.young_modulus_control.GetControlField()
+        self.young_modulus_control.Update(update_field)
+        control_field = self.young_modulus_control.GetControlField()
+        young_modulus_field = self.young_modulus_control.GetPhysicalField()
+        self.assertAlmostEqual(np.linalg.norm(control_field.data, ord=np.inf), 0.25, 4)
+        # ForwardFilter: control_update -> phi_update (Here, filter radius ~ 0. Therefore, both are the same = 0.25)
+        # physical = 2e6
+        # IntervalBounder: min = 1e6, max = 3e6, delta = 2e6: GetBoundedTensorAdaptor: phi_b = (physical - min)/delta = 0.5
+        # phi = 0.5 - sin(asin(1-2*(phi_b - min_clamper)/delta_clamper)/3) = 0.5
+        # phi_updated = phi_current + phi_update = 0.5 + 0.25 = 0.75
+        # ProjectForward: phi_updated -> physical_updated
+        # Clamper: physical_updated = min + phi_updated²*(3 - 2*phi_updated)* delta = 0.84375
+        # GetUnboundedTensorAdaptor: physical_updated_unbounded = physical_min + physical_updated * delta = 1e6 + 0.84375 * 2e6 = 2.6875e6
+        self.assertAlmostEqual(np.linalg.norm(young_modulus_field.data, ord=np.inf), 2.6875e6, 9)
+
+class TestMaterialPropertiesControl_with_initialization(TestMaterialPropertiesControl):
+    @classmethod
+    def setUpClass(cls):
+        cls.model = Kratos.Model()
+        cls.model_part = cls.model.CreateModelPart("Structure")
+        cls.model_part.ProcessInfo[Kratos.DOMAIN_SIZE] = 3
+
+        parameters = Kratos.Parameters("""{
+            "control_variable_name"             : "YOUNG_MODULUS",
+            "control_variable_bounds"           : [1e6, 3e6],
+            "output_all_fields"                 : false,
+            "filter_settings"                   : {
+                    "filter_type": "explicit_filter",
+                    "filter_function_type": "linear",
+                    "max_items_in_bucket": 10,
+                    "echo_level": 4,
+                    "filter_radius_settings": {
+                        "filter_radius_type": "constant",
+                        "filter_radius": 1e-10
+                    }
+            },
+            "model_part_names": [
+                {
+                    "primal_model_part_name" : "Structure",
+                    "adjoint_model_part_name": "Structure"
+                }
+            ],
+            "control_initialization_settings": {
+                "initialize_from_file" : true,
+                "filetype" : "csv",
+                "file_name" : "initial_material_properties_control_values.csv"
+            }
+        }""")
+
+        cls.optimization_problem = OptimizationProblem()
+        cls.young_modulus_control = MaterialPropertiesControl("test", cls.model, parameters, cls.optimization_problem)
+        cls.optimization_problem.AddComponent(cls.young_modulus_control)
+
+        with kratos_unittest.WorkFolderScope(".", __file__):
+            Kratos.ModelPartIO("../responses/auxiliary_files_3/Structure", Kratos.ModelPartIO.READ | Kratos.ModelPartIO.MESH_ONLY).ReadModelPart(cls.model_part)
+        material_params = Kratos.Parameters("""{
+            "properties": [
+                {
+                    "model_part_name": "Structure.Parts_Solid_full",
+                    "properties_id": 1,
+                    "Material": {
+                        "constitutive_law" : {
+                            "name" : "LinearElasticPlaneStress2DLaw"
+                            },
+                        "Variables"        : {
+                            "THICKNESS"     : 0.02,
+                            "DENSITY"       : 7850.0,
+                            "YOUNG_MODULUS" : 1.1e6,
+                            "POISSON_RATIO" : 0.29
+                        },
+                        "Tables"           : null
+                    }
+                }
+            ]
+        }""")
+        Kratos.ReadMaterialsUtility(cls.model).ReadMaterials(material_params)
+
+        # Create a CSV file with initial control values
+        initial_control_values = np.ones(len(cls.model_part.Elements))
+        initial_control_values[:] = 2e6  # Set all initial control values to 2e6
+        with open("initial_material_properties_control_values.csv", "w") as f:
+            f.write("ElementId,YOUNG_MODULUS\n")
+            for idx, element in enumerate(cls.model_part.Elements):
+                f.write(f"{element.Id},{initial_control_values[idx]}\n")
+
+        cls.young_modulus_control.Initialize()
+        cls.initial_young_modulus = KratosOA.TensorAdaptors.PropertiesVariableTensorAdaptor(cls.model_part.Elements, Kratos.YOUNG_MODULUS)
+        cls.initial_young_modulus.CollectData()
+
+if __name__ == "__main__":
+    kratos_unittest.main()

--- a/applications/SystemIdentificationApplication/tests/test_SystemIdentificationApplication.py
+++ b/applications/SystemIdentificationApplication/tests/test_SystemIdentificationApplication.py
@@ -8,6 +8,7 @@ import responses.test_damage_response
 import responses.test_temperature_response
 import responses.test_pressure_response
 import controls.test_data_values_control
+import controls.test_material_properties_control
 import test_smooth_clamper
 import test_mask_utils
 import test_distance_matrix
@@ -39,7 +40,11 @@ def AssembleTestSuites():
     smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([responses.test_pressure_response.TestPressureDetectionResponse]))
     smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([responses.test_pressure_response.TestPressureDetectionResponseStrainSensor]))
     smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([controls.test_data_values_control.TestDataValuesControl_nodal_historical]))
+    smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([controls.test_data_values_control.TestDataValuesControl_nodal_historical_with_initialization]))
     smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([controls.test_data_values_control.TestDataValuesControl_condition]))
+    smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([controls.test_data_values_control.TestDataValuesControl_condition_with_initialization]))
+    smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([controls.test_material_properties_control.TestMaterialPropertiesControl]))
+    smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([controls.test_material_properties_control.TestMaterialPropertiesControl_with_initialization]))
     smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([test_convergence_criterion.TestSensorErrorConvCriterion]))
 
     nightSuite = suites['nightly']


### PR DESCRIPTION
## **📝 Description**
This pull request adds support for initializing control fields from CSV files in both `DataValuesControl` and `MaterialPropertiesControl`, enabling users to specify initial control values via external files. It also introduces comprehensive tests to verify this feature for different container types. 

The most important changes are:
**Feature: Control Field Initialization from CSV Files**
* Added a new `"control_initialization_settings"` parameter to both `DataValuesControl` and `MaterialPropertiesControl`, allowing control fields to be optionally initialized from a CSV file. The code reads the CSV, checks for size consistency, and assigns the values to the appropriate tensor adaptor. Only CSV files are currently supported. 

**Dependency Update**
* Imported `pandas` as a new dependency in both control modules to facilitate reading CSV files. 

**Testing: New and Updated Unit Tests**
* Added and extended test cases to verify initialization from CSV files for both nodal historical and condition container types. The tests create temporary CSV files with initial values, initialize the controls from these files, and check that the data is correctly loaded.