### PR TITLE
[DamApplication] Prevent vector load processes from fixing DOFs

### DIFF
--- a/applications/DamApplication/python_scripts/apply_load_vector_dam_process.py
+++ b/applications/DamApplication/python_scripts/apply_load_vector_dam_process.py
@@ -1,45 +1,69 @@
 import KratosMultiphysics
-from KratosMultiphysics.assign_scalar_variable_process import AssignScalarVariableProcess
+from KratosMultiphysics.assign_scalar_variable_process import (
+    AssignScalarVariableProcess,
+)
+
 
 def Factory(settings, Model):
     if not isinstance(settings, KratosMultiphysics.Parameters):
-        raise Exception("expected input shall be a Parameters object, encapsulating a json string")
+        raise Exception(
+            "expected input shall be a Parameters object, encapsulating a json string"
+        )
     return ApplyLoadVectorDamProcess(Model, settings["Parameters"])
+
 
 ## All the processes python should be derived from "Process"
 
+
 class ApplyLoadVectorDamProcess(KratosMultiphysics.Process):
-    def __init__(self, Model, settings ):
+    def __init__(self, Model, settings):
         KratosMultiphysics.Process.__init__(self)
 
         variable_name = settings["variable_name"].GetString()
 
         self.components_process_list = []
 
-        self.factor = settings["modulus"].GetDouble();
-        self.direction = [settings["direction"][0].GetDouble(),settings["direction"][1].GetDouble(),settings["direction"][2].GetDouble()]
-        self.value = [self.direction[0]*self.factor,self.direction[1]*self.factor,self.direction[2]*self.factor]
+        self.factor = settings["modulus"].GetDouble()
+        self.direction = [
+            settings["direction"][0].GetDouble(),
+            settings["direction"][1].GetDouble(),
+            settings["direction"][2].GetDouble(),
+        ]
+        self.value = [
+            self.direction[0] * self.factor,
+            self.direction[1] * self.factor,
+            self.direction[2] * self.factor,
+        ]
 
-        if abs(self.value[0])>1.0e-15:
+        if abs(self.value[0]) > 1.0e-15:
             x_params = KratosMultiphysics.Parameters("{}")
-            x_params.AddValue("model_part_name",settings["model_part_name"])
+            x_params.AddValue("model_part_name", settings["model_part_name"])
+            x_params.AddEmptyValue("constrained").SetBool(False)
             x_params.AddEmptyValue("value").SetDouble(self.value[0])
-            x_params.AddEmptyValue("variable_name").SetString(variable_name+"_X")
-            self.components_process_list.append(AssignScalarVariableProcess(Model, x_params))
+            x_params.AddEmptyValue("variable_name").SetString(variable_name + "_X")
+            self.components_process_list.append(
+                AssignScalarVariableProcess(Model, x_params)
+            )
 
-        if abs(self.value[1])>1.0e-15:
+        if abs(self.value[1]) > 1.0e-15:
             y_params = KratosMultiphysics.Parameters("{}")
-            y_params.AddValue("model_part_name",settings["model_part_name"])
+            y_params.AddValue("model_part_name", settings["model_part_name"])
+            y_params.AddEmptyValue("constrained").SetBool(False)
             y_params.AddEmptyValue("value").SetDouble(self.value[1])
-            y_params.AddEmptyValue("variable_name").SetString(variable_name+"_Y")
-            self.components_process_list.append(AssignScalarVariableProcess(Model, y_params))
+            y_params.AddEmptyValue("variable_name").SetString(variable_name + "_Y")
+            self.components_process_list.append(
+                AssignScalarVariableProcess(Model, y_params)
+            )
 
-        if abs(self.value[2])>1.0e-15:
+        if abs(self.value[2]) > 1.0e-15:
             z_params = KratosMultiphysics.Parameters("{}")
-            z_params.AddValue("model_part_name",settings["model_part_name"])
+            z_params.AddValue("model_part_name", settings["model_part_name"])
+            z_params.AddEmptyValue("constrained").SetBool(False)
             z_params.AddEmptyValue("value").SetDouble(self.value[2])
-            z_params.AddEmptyValue("variable_name").SetString(variable_name+"_Z")
-            self.components_process_list.append(AssignScalarVariableProcess(Model, z_params))
+            z_params.AddEmptyValue("variable_name").SetString(variable_name + "_Z")
+            self.components_process_list.append(
+                AssignScalarVariableProcess(Model, z_params)
+            )
 
     def ExecuteBeforeSolutionLoop(self):
 

--- a/applications/DamApplication/python_scripts/apply_load_vector_dam_table_process.py
+++ b/applications/DamApplication/python_scripts/apply_load_vector_dam_table_process.py
@@ -25,6 +25,7 @@ class ApplyLoadVectorDamTableProcess(KratosMultiphysics.Process):
         if abs(self.value[0])>1.0e-15:
             x_params = KratosMultiphysics.Parameters("{}")
             x_params.AddValue("model_part_name",settings["model_part_name"])
+            x_params.AddEmptyValue("constrained").SetBool(False)
             x_params.AddEmptyValue("value").SetDouble(self.value[0])
             x_params.AddEmptyValue("variable_name").SetString(variable_name+"_X")
             if settings["table"].GetInt() == 0:
@@ -36,6 +37,7 @@ class ApplyLoadVectorDamTableProcess(KratosMultiphysics.Process):
         if abs(self.value[1])>1.0e-15:
             y_params = KratosMultiphysics.Parameters("{}")
             y_params.AddValue("model_part_name",settings["model_part_name"])
+            y_params.AddEmptyValue("constrained").SetBool(False)
             y_params.AddEmptyValue("value").SetDouble(self.value[1])
             y_params.AddEmptyValue("variable_name").SetString(variable_name+"_Y")
             if settings["table"].GetInt() == 0:
@@ -47,6 +49,7 @@ class ApplyLoadVectorDamTableProcess(KratosMultiphysics.Process):
         if abs(self.value[2])>1.0e-15:
             z_params = KratosMultiphysics.Parameters("{}")
             z_params.AddValue("model_part_name",settings["model_part_name"])
+            z_params.AddEmptyValue("constrained").SetBool(False)
             z_params.AddEmptyValue("value").SetDouble(self.value[2])
             z_params.AddEmptyValue("variable_name").SetString(variable_name+"_Z")
             if settings["table"].GetInt() == 0:

--- a/applications/DamApplication/tests/test_DamApplication.py
+++ b/applications/DamApplication/tests/test_DamApplication.py
@@ -7,6 +7,7 @@ import KratosMultiphysics.KratosUnittest as KratosUnittest
 
 # Import the tests o test_classes to create the suits
 from generalTests import KratosDamGeneralTests
+from test_apply_load_vector_dam_processes import TestApplyLoadVectorDamProcesses
 
 def AssembleTestSuites():
     ''' Populates the test suites to run.
@@ -36,6 +37,11 @@ def AssembleTestSuites():
     smallSuite.addTest(KratosDamGeneralTests('test_joint_isotropic_damage_cohesive_3d_normal'))
     smallSuite.addTest(KratosDamGeneralTests('test_joint_isotropic_damage_cohesive_3d_shear'))
     smallSuite.addTest(KratosDamGeneralTests('test_construction'))
+    smallSuite.addTests(
+        KratosUnittest.TestLoader().loadTestsFromTestCases([
+            TestApplyLoadVectorDamProcesses
+        ])
+    )
 
     # Create a test suit with the selected tests
     # nightSuite will contain the following tests:
@@ -50,7 +56,8 @@ def AssembleTestSuites():
     allSuite = suites['all']
     allSuite.addTests(
         KratosUnittest.TestLoader().loadTestsFromTestCases([
-            KratosDamGeneralTests
+            KratosDamGeneralTests,
+            TestApplyLoadVectorDamProcesses
         ])
     )
 

--- a/applications/DamApplication/tests/test_apply_load_vector_dam_processes.py
+++ b/applications/DamApplication/tests/test_apply_load_vector_dam_processes.py
@@ -1,0 +1,117 @@
+import KratosMultiphysics
+import KratosMultiphysics.DamApplication as KratosDam
+import KratosMultiphysics.KratosUnittest as KratosUnittest
+
+from KratosMultiphysics.DamApplication.apply_load_vector_dam_table_process import (
+    ApplyLoadVectorDamTableProcess,
+)
+from KratosMultiphysics.DamApplication.apply_load_vector_dam_process import (
+    ApplyLoadVectorDamProcess,
+)
+
+
+class TestApplyLoadVectorDamProcesses(KratosUnittest.TestCase):
+
+    def test_load_does_not_fix_components(self):
+        model, model_part = self._CreateModelPart()
+        process = ApplyLoadVectorDamProcess(model, self._CreateSettings())
+
+        process.ExecuteBeforeSolutionLoop()
+
+        self._CheckNodalValues(model_part, [3.0, -6.0, 1.5])
+        self._CheckComponentsAreFree(model_part)
+
+    def test_constant_table_load_does_not_fix_components(self):
+        model, model_part = self._CreateModelPart()
+        settings = self._CreateSettings()
+        settings.AddEmptyValue("table").SetInt(0)
+        process = ApplyLoadVectorDamTableProcess(
+            model,
+            settings,
+        )
+
+        process.ExecuteBeforeSolutionLoop()
+
+        self._CheckNodalValues(model_part, [3.0, -6.0, 1.5])
+        self._CheckComponentsAreFree(model_part)
+
+    def test_table_load_does_not_fix_components(self):
+        model, model_part = self._CreateModelPart()
+        table = KratosMultiphysics.PiecewiseLinearTable()
+        table.AddRow(0.0, 2.0)
+        table.AddRow(1.0, 4.0)
+        model_part.AddTable(1, table)
+
+        settings = self._CreateSettings()
+        settings.AddEmptyValue("table").SetInt(1)
+        process = ApplyLoadVectorDamTableProcess(
+            model,
+            settings,
+        )
+
+        process.ExecuteBeforeSolutionLoop()
+        self._CheckComponentsAreFree(model_part)
+
+        model_part.CloneTimeStep(1.0)
+        process.ExecuteInitializeSolutionStep()
+
+        self._CheckNodalValues(model_part, [4.0, 4.0, 4.0])
+        self._CheckComponentsAreFree(model_part)
+
+    @staticmethod
+    def _CreateModelPart():
+        model = KratosMultiphysics.Model()
+        model_part = model.CreateModelPart("main")
+        model_part.AddNodalSolutionStepVariable(KratosMultiphysics.DISPLACEMENT)
+        model_part.ProcessInfo[KratosDam.TIME_UNIT_CONVERTER] = 1.0
+
+        for node_id, coordinates in enumerate(
+            ((0.0, 0.0, 0.0), (1.0, 2.0, 3.0)),
+            start=1,
+        ):
+            node = model_part.CreateNewNode(node_id, *coordinates)
+            node.AddDof(KratosMultiphysics.DISPLACEMENT_X)
+            node.AddDof(KratosMultiphysics.DISPLACEMENT_Y)
+            node.AddDof(KratosMultiphysics.DISPLACEMENT_Z)
+
+        return model, model_part
+
+    @staticmethod
+    def _CreateSettings():
+        return KratosMultiphysics.Parameters(
+            """
+            {
+                "model_part_name" : "main",
+                "variable_name"   : "DISPLACEMENT",
+                "modulus"         : 3.0,
+                "direction"       : [1.0, -2.0, 0.5]
+            }
+            """
+        )
+
+    def _CheckNodalValues(self, model_part, expected_values):
+        variables = (
+            KratosMultiphysics.DISPLACEMENT_X,
+            KratosMultiphysics.DISPLACEMENT_Y,
+            KratosMultiphysics.DISPLACEMENT_Z,
+        )
+        for node in model_part.Nodes:
+            for variable, expected_value in zip(variables, expected_values):
+                self.assertAlmostEqual(
+                    node.GetSolutionStepValue(variable),
+                    expected_value,
+                )
+
+    def _CheckComponentsAreFree(self, model_part):
+        variables = (
+            KratosMultiphysics.DISPLACEMENT_X,
+            KratosMultiphysics.DISPLACEMENT_Y,
+            KratosMultiphysics.DISPLACEMENT_Z,
+        )
+        for node in model_part.Nodes:
+            for variable in variables:
+                self.assertFalse(node.IsFixed(variable))
+
+
+if __name__ == "__main__":
+    KratosUnittest.main()

--- a/applications/DamApplication/tests/test_apply_load_vector_dam_processes.py
+++ b/applications/DamApplication/tests/test_apply_load_vector_dam_processes.py
@@ -1,6 +1,7 @@
 import KratosMultiphysics
 import KratosMultiphysics.DamApplication as KratosDam
 import KratosMultiphysics.KratosUnittest as KratosUnittest
+import KratosMultiphysics.StructuralMechanicsApplication as KratosStructural
 
 from KratosMultiphysics.DamApplication.apply_load_vector_dam_table_process import (
     ApplyLoadVectorDamTableProcess,
@@ -19,7 +20,7 @@ class TestApplyLoadVectorDamProcesses(KratosUnittest.TestCase):
         process.ExecuteBeforeSolutionLoop()
 
         self._CheckNodalValues(model_part, [3.0, -6.0, 1.5])
-        self._CheckComponentsAreFree(model_part)
+        self._CheckLoadComponentsAreNotDofs(model_part)
 
     def test_constant_table_load_does_not_fix_components(self):
         model, model_part = self._CreateModelPart()
@@ -33,7 +34,7 @@ class TestApplyLoadVectorDamProcesses(KratosUnittest.TestCase):
         process.ExecuteBeforeSolutionLoop()
 
         self._CheckNodalValues(model_part, [3.0, -6.0, 1.5])
-        self._CheckComponentsAreFree(model_part)
+        self._CheckLoadComponentsAreNotDofs(model_part)
 
     def test_table_load_does_not_fix_components(self):
         model, model_part = self._CreateModelPart()
@@ -50,29 +51,26 @@ class TestApplyLoadVectorDamProcesses(KratosUnittest.TestCase):
         )
 
         process.ExecuteBeforeSolutionLoop()
-        self._CheckComponentsAreFree(model_part)
+        self._CheckLoadComponentsAreNotDofs(model_part)
 
         model_part.CloneTimeStep(1.0)
         process.ExecuteInitializeSolutionStep()
 
         self._CheckNodalValues(model_part, [4.0, 4.0, 4.0])
-        self._CheckComponentsAreFree(model_part)
+        self._CheckLoadComponentsAreNotDofs(model_part)
 
     @staticmethod
     def _CreateModelPart():
         model = KratosMultiphysics.Model()
         model_part = model.CreateModelPart("main")
-        model_part.AddNodalSolutionStepVariable(KratosMultiphysics.DISPLACEMENT)
+        model_part.AddNodalSolutionStepVariable(KratosStructural.POINT_LOAD)
         model_part.ProcessInfo[KratosDam.TIME_UNIT_CONVERTER] = 1.0
 
         for node_id, coordinates in enumerate(
             ((0.0, 0.0, 0.0), (1.0, 2.0, 3.0)),
             start=1,
         ):
-            node = model_part.CreateNewNode(node_id, *coordinates)
-            node.AddDof(KratosMultiphysics.DISPLACEMENT_X)
-            node.AddDof(KratosMultiphysics.DISPLACEMENT_Y)
-            node.AddDof(KratosMultiphysics.DISPLACEMENT_Z)
+            model_part.CreateNewNode(node_id, *coordinates)
 
         return model, model_part
 
@@ -82,7 +80,7 @@ class TestApplyLoadVectorDamProcesses(KratosUnittest.TestCase):
             """
             {
                 "model_part_name" : "main",
-                "variable_name"   : "DISPLACEMENT",
+                "variable_name"   : "POINT_LOAD",
                 "modulus"         : 3.0,
                 "direction"       : [1.0, -2.0, 0.5]
             }
@@ -91,9 +89,9 @@ class TestApplyLoadVectorDamProcesses(KratosUnittest.TestCase):
 
     def _CheckNodalValues(self, model_part, expected_values):
         variables = (
-            KratosMultiphysics.DISPLACEMENT_X,
-            KratosMultiphysics.DISPLACEMENT_Y,
-            KratosMultiphysics.DISPLACEMENT_Z,
+            KratosStructural.POINT_LOAD_X,
+            KratosStructural.POINT_LOAD_Y,
+            KratosStructural.POINT_LOAD_Z,
         )
         for node in model_part.Nodes:
             for variable, expected_value in zip(variables, expected_values):
@@ -102,15 +100,15 @@ class TestApplyLoadVectorDamProcesses(KratosUnittest.TestCase):
                     expected_value,
                 )
 
-    def _CheckComponentsAreFree(self, model_part):
+    def _CheckLoadComponentsAreNotDofs(self, model_part):
         variables = (
-            KratosMultiphysics.DISPLACEMENT_X,
-            KratosMultiphysics.DISPLACEMENT_Y,
-            KratosMultiphysics.DISPLACEMENT_Z,
+            KratosStructural.POINT_LOAD_X,
+            KratosStructural.POINT_LOAD_Y,
+            KratosStructural.POINT_LOAD_Z,
         )
         for node in model_part.Nodes:
             for variable in variables:
-                self.assertFalse(node.IsFixed(variable))
+                self.assertFalse(node.HasDofFor(variable))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## **📝 Description**
Dam vector load processes used `AssignScalarVariableProcess` with its default `"constrained": true`, causing load components to be treated as fixed DOFs.

### **Key changes**

- Explicitly set `"constrained": false` in the Dam vector load processes.
- Add tests for constant and table-based `POINT_LOAD` assignments.

### **Validation**

Three unit tests verify the assigned values and ensure load components are not
created as DOFs.

## **🆕 Changelog**

- Fixed Dam vector load processes incorrectly constraining load components.
