### PR TITLE
[IGA] Add VTK output support for BRep curves

### DIFF
--- a/applications/IgaApplication/python_scripts/iga_vtk_output_process.py
+++ b/applications/IgaApplication/python_scripts/iga_vtk_output_process.py
@@ -92,8 +92,9 @@ class IgaVTKOutputProcess(KM.OutputProcess):
                     f"Make sure to call AddNodalSolutionStepVariable."
                 )
 
-        # Cached parametric sampling (shared across time steps)
+        # Cached parametric sampling and shape function data
         self.cached_uv = None
+        self.cached_shape_function_data = None
 
         KM.Logger.PrintWarning(
             "IgaVTKOutputProcess",
@@ -122,6 +123,7 @@ class IgaVTKOutputProcess(KM.OutputProcess):
             # Rebuild parametric sampling if needed when reopening the file
             if self.cached_uv is None and "Points" in root:
                 all_local_coordinates = []
+                all_shape_function_data = []
                 self.cached_uv_sizes = []
 
                 # BRep surfaces
@@ -133,6 +135,7 @@ class IgaVTKOutputProcess(KM.OutputProcess):
                     )
 
                     all_local_coordinates.extend(uv)
+                    all_shape_function_data.extend(self.__compute_shape_function_data(brep_surface, uv))
                     self.cached_uv_sizes.append(len(uv))
 
                 # IGA beam curves
@@ -144,12 +147,13 @@ class IgaVTKOutputProcess(KM.OutputProcess):
                     )
 
                     # Store curve coordinates in the same format as surface coordinates
-                    all_local_coordinates.extend(
-                        [(u, 0.0) for u in u_coordinates]
-                    )
+                    curve_uv = [(u, 0.0) for u in u_coordinates]
+                    all_local_coordinates.extend(curve_uv)
+                    all_shape_function_data.extend(self.__compute_shape_function_data(curve, curve_uv))
                     self.cached_uv_sizes.append(len(u_coordinates))
 
                 self.cached_uv = all_local_coordinates
+                self.cached_shape_function_data = all_shape_function_data
 
             # Geometry is written only once
             if "Points" not in root:
@@ -160,6 +164,7 @@ class IgaVTKOutputProcess(KM.OutputProcess):
                 all_offsets = []
                 all_types = []
                 all_uv = []
+                all_shape_function_data = []
 
                 point_shift = 0
                 conn_shift = 0
@@ -191,6 +196,7 @@ class IgaVTKOutputProcess(KM.OutputProcess):
 
                     # Surface local coordinates: (u, v)
                     all_uv.extend(uv)
+                    all_shape_function_data.extend(self.__compute_shape_function_data(brep_surface, uv))
 
                     point_shift += len(pts)
                     conn_shift += len(conn)
@@ -221,9 +227,9 @@ class IgaVTKOutputProcess(KM.OutputProcess):
                     all_types.append(types)
 
                     # Store curve coordinates using the same (u, v) format
-                    all_uv.extend(
-                        [(u, 0.0) for u in u_coordinates]
-                    )
+                    curve_uv = [(u, 0.0) for u in u_coordinates]
+                    all_uv.extend(curve_uv)
+                    all_shape_function_data.extend(self.__compute_shape_function_data(curve, curve_uv))
 
                     point_shift += len(pts)
                     conn_shift += len(conn)
@@ -243,6 +249,7 @@ class IgaVTKOutputProcess(KM.OutputProcess):
                 types = np.concatenate(all_types)
 
                 self.cached_uv = all_uv
+                self.cached_shape_function_data = all_shape_function_data
 
                 # Write geometry
                 root.create_dataset("Points", data=points)
@@ -259,51 +266,37 @@ class IgaVTKOutputProcess(KM.OutputProcess):
                 # Initial write of nodal variables
                 for var in self.nodal_variables:
                     data = []
-                    uv_counter = 0
+                    shape_function_data_counter = 0
                     patch_index = 0
 
                     # Evaluate variables on BRep surfaces
                     for brep_id in self.brep_surface_ids:
-                        brep_surface = self.model_part.GetGeometry(brep_id)
-
                         n_local = self.cached_uv_sizes[patch_index]
 
-                        local_uv = self.cached_uv[
-                            uv_counter:uv_counter + n_local
+                        local_shape_function_data = self.cached_shape_function_data[
+                            shape_function_data_counter:shape_function_data_counter + n_local
                         ]
 
-                        for u, v in local_uv:
-                            val = self.__eval_variable(
-                                brep_surface,
-                                u,
-                                v,
-                                var
-                            )
+                        for nodes, N in local_shape_function_data:
+                            val = self.__eval_variable(nodes, N, var)
                             data.append(val)
 
-                        uv_counter += n_local
+                        shape_function_data_counter += n_local
                         patch_index += 1
 
                     # Evaluate variables on IGA curves / beams
                     for curve_id in self.brep_curve_ids:
-                        curve = self.model_part.GetGeometry(curve_id)
-
                         n_local = self.cached_uv_sizes[patch_index]
 
-                        local_uv = self.cached_uv[
-                            uv_counter:uv_counter + n_local
+                        local_shape_function_data = self.cached_shape_function_data[
+                            shape_function_data_counter:shape_function_data_counter + n_local
                         ]
 
-                        for u, _ in local_uv:
-                            val = self.__eval_variable(
-                                curve,
-                                u,
-                                0.0,
-                                var
-                            )
+                        for nodes, N in local_shape_function_data:
+                            val = self.__eval_variable(nodes, N, var)
                             data.append(val)
 
-                        uv_counter += n_local
+                        shape_function_data_counter += n_local
                         patch_index += 1
 
                     data = np.array(data)
@@ -327,51 +320,37 @@ class IgaVTKOutputProcess(KM.OutputProcess):
 
                 for var in self.nodal_variables:
                     data = []
-                    uv_counter = 0
+                    shape_function_data_counter = 0
                     patch_index = 0
 
                     # Evaluate variables on BRep surfaces
                     for brep_id in self.brep_surface_ids:
-                        brep_surface = self.model_part.GetGeometry(brep_id)
-
                         n_local = self.cached_uv_sizes[patch_index]
 
-                        local_uv = self.cached_uv[
-                            uv_counter:uv_counter + n_local
+                        local_shape_function_data = self.cached_shape_function_data[
+                            shape_function_data_counter:shape_function_data_counter + n_local
                         ]
 
-                        for u, v in local_uv:
-                            val = self.__eval_variable(
-                                brep_surface,
-                                u,
-                                v,
-                                var
-                            )
+                        for nodes, N in local_shape_function_data:
+                            val = self.__eval_variable(nodes, N, var)
                             data.append(val)
 
-                        uv_counter += n_local
+                        shape_function_data_counter += n_local
                         patch_index += 1
 
                     # Evaluate variables on IGA curves / beams
                     for curve_id in self.brep_curve_ids:
-                        curve = self.model_part.GetGeometry(curve_id)
-
                         n_local = self.cached_uv_sizes[patch_index]
 
-                        local_uv = self.cached_uv[
-                            uv_counter:uv_counter + n_local
+                        local_shape_function_data = self.cached_shape_function_data[
+                            shape_function_data_counter:shape_function_data_counter + n_local
                         ]
 
-                        for u, _ in local_uv:
-                            val = self.__eval_variable(
-                                curve,
-                                u,
-                                0.0,
-                                var
-                            )
+                        for nodes, N in local_shape_function_data:
+                            val = self.__eval_variable(nodes, N, var)
                             data.append(val)
 
-                        uv_counter += n_local
+                        shape_function_data_counter += n_local
                         patch_index += 1
 
                     data = np.array(data)
@@ -662,30 +641,38 @@ class IgaVTKOutputProcess(KM.OutputProcess):
             u_coordinates,
         )
 
-    # Evaluate the desired variable at a local coordinate position
-    def __eval_variable(self, brep, u, v, variable):
-        lc = KM.Array3()
-        lc[0] = u
-        lc[1] = v
-        lc[2] = 0.0
+    # Evaluate the active control points and shape function values at a local coordinate position
+    def __compute_shape_function_data(self, brep, local_coords):
+        shape_function_data = []
 
-        ids, N = brep.EvaluateShapeFunctionsAtLocalCoordinates(lc, 0)
+        for u, v in local_coords:
+            lc = KM.Array3()
+            lc[0] = u
+            lc[1] = v
+            lc[2] = 0.0
 
-        if len(ids) == 0:
-            raise RuntimeError(
-                f"No active control points found for geometry {brep.Id} "
-                f"at local coordinates ({u}, {v})."
-            )
+            ids, N = brep.EvaluateShapeFunctionsAtLocalCoordinates(lc, 0)
 
-        sample_node = self.model_part.GetNode(ids[0])
-        value = sample_node.GetSolutionStepValue(variable)
+            if len(ids) == 0:
+                raise RuntimeError(
+                    f"No active control points found for geometry {brep.Id} "
+                    f"at local coordinates ({u}, {v})."
+                )
+
+            nodes = [self.model_part.GetNode(node_id) for node_id in ids]
+            shape_function_data.append((nodes, N))
+
+        return shape_function_data
+
+    # Evaluate the desired variable from cached shape function data
+    def __eval_variable(self, nodes, N, variable):
+        value = nodes[0].GetSolutionStepValue(variable)
 
         if hasattr(value, "__len__"):
             size = len(value)
             result = [0.0] * size
 
-            for i, node_id in enumerate(ids):
-                node = self.model_part.GetNode(node_id)
+            for i, node in enumerate(nodes):
                 node_value = node.GetSolutionStepValue(variable)
                 weight = N[i]
                 for k in range(size):
@@ -693,8 +680,7 @@ class IgaVTKOutputProcess(KM.OutputProcess):
         else:
             result = 0.0
 
-            for i, node_id in enumerate(ids):
-                node = self.model_part.GetNode(node_id)
+            for i, node in enumerate(nodes):
                 result += N[i] * node.GetSolutionStepValue(variable)
 
         return result

--- a/applications/IgaApplication/python_scripts/iga_vtk_output_process.py
+++ b/applications/IgaApplication/python_scripts/iga_vtk_output_process.py
@@ -685,13 +685,15 @@ class IgaVTKOutputProcess(KM.OutputProcess):
         value = sample_node.GetSolutionStepValue(variable)
 
         if hasattr(value, "__len__"):
-            result = np.zeros(len(value))
+            size = len(value)
+            result = [0.0] * size
 
             for i, node_id in enumerate(ids):
                 node = self.model_part.GetNode(node_id)
-                result += N[i] * np.asarray(
-                    node.GetSolutionStepValue(variable)
-                )
+                v = node.GetSolutionStepValue(variable)
+                weight = N[i]
+                for k in range(size):
+                    result[k] += weight * v[k]
         else:
             result = 0.0
 

--- a/applications/IgaApplication/python_scripts/iga_vtk_output_process.py
+++ b/applications/IgaApplication/python_scripts/iga_vtk_output_process.py
@@ -39,11 +39,9 @@ class IgaVTKOutputProcess(KM.OutputProcess):
         }""")
 
         params.ValidateAndAssignDefaults(default_parameters)
-        self.interval_utility = KM.IntervalUtility(params)
 
         self.model = model
-        self.model_part_name = params["model_part_name"].GetString()
-        self.model_part = model[self.model_part_name]
+        self.model_part = model[params["model_part_name"].GetString()]
         self.output_file_name = Path(params["output_file_name"].GetString())
 
         self.settings = params
@@ -86,7 +84,7 @@ class IgaVTKOutputProcess(KM.OutputProcess):
         for i in range(params["nodal_solution_step_data_variables"].size()):
             var_name = params["nodal_solution_step_data_variables"][i].GetString()
             self.nodal_variables.append(KM.KratosGlobals.GetVariable(var_name))
-        
+
         for var in self.nodal_variables:
             if not self.model_part.HasNodalSolutionStepVariable(var):
                 raise Exception(
@@ -332,9 +330,7 @@ class IgaVTKOutputProcess(KM.OutputProcess):
                     uv_counter = 0
                     patch_index = 0
 
-                    # --------------------------------------------------
                     # Evaluate variables on BRep surfaces
-                    # --------------------------------------------------
                     for brep_id in self.brep_surface_ids:
                         brep_surface = self.model_part.GetGeometry(brep_id)
 
@@ -461,7 +457,7 @@ class IgaVTKOutputProcess(KM.OutputProcess):
 
             self.printed_step_count += 1
             steps.attrs["NSteps"] = self.printed_step_count
-        
+
         self.__controller.Update()
 
     # Compute the visualization grid for brep surfaces
@@ -568,7 +564,7 @@ class IgaVTKOutputProcess(KM.OutputProcess):
             np.array(types,np.uint8),
             uv_coords
         )
-    
+
     # Compute the visualization grid for a BRep curve
     def __compute_full_grid_brep_curve(self, brep_curve):
         knots = brep_curve.Knots()
@@ -579,7 +575,7 @@ class IgaVTKOutputProcess(KM.OutputProcess):
             )
 
         u_min = knots[0]
-        u_max = u_max = knots[len(knots) - 1]
+        u_max = knots[len(knots) - 1]
 
         if len(self.output_refinement_curve) == 0:
             refinement = 0
@@ -666,7 +662,7 @@ class IgaVTKOutputProcess(KM.OutputProcess):
             u_coordinates,
         )
 
-    # Evaluate the desired variable at a local coordinate position  
+    # Evaluate the desired variable at a local coordinate position
     def __eval_variable(self, brep, u, v, variable):
         lc = KM.Array3()
         lc[0] = u
@@ -690,10 +686,10 @@ class IgaVTKOutputProcess(KM.OutputProcess):
 
             for i, node_id in enumerate(ids):
                 node = self.model_part.GetNode(node_id)
-                v = node.GetSolutionStepValue(variable)
+                node_value = node.GetSolutionStepValue(variable)
                 weight = N[i]
                 for k in range(size):
-                    result[k] += weight * v[k]
+                    result[k] += weight * node_value[k]
         else:
             result = 0.0
 

--- a/applications/IgaApplication/python_scripts/iga_vtk_output_process.py
+++ b/applications/IgaApplication/python_scripts/iga_vtk_output_process.py
@@ -298,9 +298,7 @@ class IgaVTKOutputProcess(KM.OutputProcess):
                     uv_counter = 0
                     patch_index = 0
 
-                    # --------------------------------------------------
                     # Evaluate variables on BRep surfaces
-                    # --------------------------------------------------
                     for brep_id in self.brep_surface_ids:
                         brep_surface = self.model_part.GetGeometry(brep_id)
 
@@ -322,9 +320,7 @@ class IgaVTKOutputProcess(KM.OutputProcess):
                         uv_counter += n_local
                         patch_index += 1
 
-                    # --------------------------------------------------
                     # Evaluate variables on IGA curves / beams
-                    # --------------------------------------------------
                     for curve_id in self.brep_curve_ids:
                         curve = self.model_part.GetGeometry(curve_id)
 
@@ -394,9 +390,7 @@ class IgaVTKOutputProcess(KM.OutputProcess):
                         uv_counter += n_local
                         patch_index += 1
 
-                    # --------------------------------------------------
                     # Evaluate variables on IGA curves / beams
-                    # --------------------------------------------------
                     for curve_id in self.brep_curve_ids:
                         curve = self.model_part.GetGeometry(curve_id)
 

--- a/applications/IgaApplication/python_scripts/iga_vtk_output_process.py
+++ b/applications/IgaApplication/python_scripts/iga_vtk_output_process.py
@@ -32,7 +32,7 @@ class IgaVTKOutputProcess(KM.OutputProcess):
             "nodal_solution_step_data_variables" : [],
             "output_refinement_surface"    : [],
             "output_refinement_curve"    : [],
-            "output_control_type"  : "none",
+            "output_control_type"  : "step",
             "output_frequency"     : 1,
             "output_interval"      : 0.0,
             "interval"               : [0.0, "End"]
@@ -41,8 +41,12 @@ class IgaVTKOutputProcess(KM.OutputProcess):
         params.ValidateAndAssignDefaults(default_parameters)
         self.interval_utility = KM.IntervalUtility(params)
 
-        self.model_part = model[params["model_part_name"].GetString()]
+        self.model = model
+        self.model_part_name = params["model_part_name"].GetString()
+        self.model_part = model[self.model_part_name]
         self.output_file_name = Path(params["output_file_name"].GetString())
+
+        self.settings = params
 
         # Ensure correct file extension
         self.output_file_name = self.output_file_name.with_suffix(".vtkhdf")
@@ -90,27 +94,6 @@ class IgaVTKOutputProcess(KM.OutputProcess):
                     f"Make sure to call AddNodalSolutionStepVariable."
                 )
 
-        # Output control settings
-        self.output_control_type = params["output_control_type"].GetString()
-
-        if self.output_control_type == "none":
-            pass
-
-        elif self.output_control_type == "step":
-            self.output_frequency = params["output_frequency"].GetInt()
-            self.step_counter = -1  # ensures first output at step 0
-
-        elif self.output_control_type == "time":
-            self.output_interval = params["output_interval"].GetDouble()
-            if self.output_interval <= 0.0:
-                raise Exception('"output_interval" must be > 0.0 for "time" control.')
-            self.next_output_time = self.interval_utility.GetIntervalBegin()
-
-        else:
-            err_msg  = 'The requested "output_control_type" "' + self.output_control_type
-            err_msg += '" is not available!\nAvailable options are: "time", "step"'
-            raise Exception(err_msg)
-
         # Cached parametric sampling (shared across time steps)
         self.cached_uv = None
 
@@ -119,28 +102,11 @@ class IgaVTKOutputProcess(KM.OutputProcess):
             "VTKHDF requires ParaView 5.11 or newer. Older versions may not support it reliably."
         )
 
-    # Decide whether to output or not a time
+    def ExecuteBeforeSolutionLoop(self):
+        self.__controller = KM.OutputController(self.model, self.settings)
+
     def IsOutputStep(self):
-        if self.output_control_type == "none":
-            return self.printed_step_count == 0
-
-        elif self.output_control_type == "step":
-            return (self.step_counter % int(self.output_frequency)) == 0
-
-        elif self.output_control_type == "time":
-            current_time = self.model_part.ProcessInfo[KM.TIME]
-
-            if not self.interval_utility.IsInInterval(current_time):
-                return False
-
-            if current_time >= self.next_output_time:
-                while current_time >= self.next_output_time:
-                    self.next_output_time += self.output_interval
-                return True
-
-            return False
-
-        return False
+        return self.__controller.Evaluate()
 
     # Print the output in the HDFVTK file
     def PrintOutput(self):
@@ -495,10 +461,8 @@ class IgaVTKOutputProcess(KM.OutputProcess):
 
             self.printed_step_count += 1
             steps.attrs["NSteps"] = self.printed_step_count
-
-    def ExecuteFinalizeSolutionStep(self):
-        if self.output_control_type == "step":
-            self.step_counter += 1
+        
+        self.__controller.Update()
 
     # Compute the visualization grid for brep surfaces
     def __compute_full_grid_brep_surface(self, brep_surface):

--- a/applications/IgaApplication/python_scripts/iga_vtk_output_process.py
+++ b/applications/IgaApplication/python_scripts/iga_vtk_output_process.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 VTK_QUAD = 9
 VTK_TRIANGLE = 5
+VTK_LINE = 3
 VERSION = (2, 4)
 GLOBAL_TYPE = 'UnstructuredGrid'
 
@@ -26,9 +27,11 @@ class IgaVTKOutputProcess(KM.OutputProcess):
         default_parameters = KM.Parameters("""{
             "output_file_name"     : "",
             "brep_surface_ids"     : [],
+            "brep_curve_ids": [],
             "model_part_name"      : "",
             "nodal_solution_step_data_variables" : [],
-            "output_refinement"    : [],
+            "output_refinement_surface"    : [],
+            "output_refinement_curve"    : [],
             "output_control_type"  : "none",
             "output_frequency"     : 1,
             "output_interval"      : 0.0,
@@ -54,10 +57,22 @@ class IgaVTKOutputProcess(KM.OutputProcess):
             for i in range(params["brep_surface_ids"].size())
         ]
 
+        # IDs of Brep curves to be exported
+        self.brep_curve_ids = [
+            params["brep_curve_ids"][i].GetInt()
+            for i in range(params["brep_curve_ids"].size())
+        ]
+
         # Refinement level per parametric direction
-        self.output_refinement = [
-            params["output_refinement"][i].GetInt()
-            for i in range(params["output_refinement"].size())
+        self.output_refinement_surface = [
+            params["output_refinement_surface"][i].GetInt()
+            for i in range(params["output_refinement_surface"].size())
+        ]
+
+        # Refinement level per parametric direction
+        self.output_refinement_curve = [
+            params["output_refinement_curve"][i].GetInt()
+            for i in range(params["output_refinement_curve"].size())
         ]
 
         self.printed_step_count = 0
@@ -140,22 +155,42 @@ class IgaVTKOutputProcess(KM.OutputProcess):
             else:
                 root = file["VTKHDF"]
 
-            # Rebuild UV sampling if needed (when reopening file)
+            # Rebuild parametric sampling if needed when reopening the file
             if self.cached_uv is None and "Points" in root:
-                all_uv = []
+                all_local_coordinates = []
                 self.cached_uv_sizes = []
 
+                # BRep surfaces
                 for brep_id in self.brep_surface_ids:
                     brep_surface = self.model_part.GetGeometry(brep_id)
-                    _, _, _, _, uv = self.__compute_full_grid(brep_surface)
-                    all_uv.extend(uv)
+
+                    _, _, _, _, uv = self.__compute_full_grid_brep_surface(
+                        brep_surface
+                    )
+
+                    all_local_coordinates.extend(uv)
                     self.cached_uv_sizes.append(len(uv))
 
-                self.cached_uv = all_uv
+                # IGA beam curves
+                for curve_id in self.brep_curve_ids:
+                    curve = self.model_part.GetGeometry(curve_id)
+
+                    _, _, _, _, u_coordinates = self.__compute_full_grid_brep_curve(
+                        curve
+                    )
+
+                    # Store curve coordinates in the same format as surface coordinates
+                    all_local_coordinates.extend(
+                        [(u, 0.0) for u in u_coordinates]
+                    )
+                    self.cached_uv_sizes.append(len(u_coordinates))
+
+                self.cached_uv = all_local_coordinates
 
             # Geometry is written only once
             if "Points" not in root:
                 self.cached_uv_sizes = []
+
                 all_pts = []
                 all_conn = []
                 all_offsets = []
@@ -165,10 +200,19 @@ class IgaVTKOutputProcess(KM.OutputProcess):
                 point_shift = 0
                 conn_shift = 0
 
+                # BRep surfaces
                 for brep_id in self.brep_surface_ids:
                     brep_surface = self.model_part.GetGeometry(brep_id)
 
-                    pts, conn, offs, types, uv = self.__compute_full_grid(brep_surface)
+                    pts, conn, offs, types, uv = (
+                        self.__compute_full_grid_brep_surface(brep_surface)
+                    )
+
+                    if len(pts) == 0:
+                        raise RuntimeError(
+                            f"No visualization points were generated for "
+                            f"BRep surface {brep_id}."
+                        )
 
                     self.cached_uv_sizes.append(len(uv))
 
@@ -180,10 +224,52 @@ class IgaVTKOutputProcess(KM.OutputProcess):
                     all_conn.append(conn_shifted)
                     all_offsets.append(offs_shifted)
                     all_types.append(types)
+
+                    # Surface local coordinates: (u, v)
                     all_uv.extend(uv)
 
                     point_shift += len(pts)
                     conn_shift += len(conn)
+
+                # IGA curves / beams
+                for curve_id in self.brep_curve_ids:
+                    curve = self.model_part.GetGeometry(curve_id)
+
+                    pts, conn, offs, types, u_coordinates = (
+                        self.__compute_full_grid_brep_curve(curve)
+                    )
+
+                    if len(pts) == 0:
+                        raise RuntimeError(
+                            f"No visualization points were generated for "
+                            f"IGA curve {curve_id}."
+                        )
+
+                    self.cached_uv_sizes.append(len(u_coordinates))
+
+                    # Shift indices for global assembly
+                    conn_shifted = conn + point_shift
+                    offs_shifted = offs[:-1] + conn_shift
+
+                    all_pts.append(pts)
+                    all_conn.append(conn_shifted)
+                    all_offsets.append(offs_shifted)
+                    all_types.append(types)
+
+                    # Store curve coordinates using the same (u, v) format
+                    all_uv.extend(
+                        [(u, 0.0) for u in u_coordinates]
+                    )
+
+                    point_shift += len(pts)
+                    conn_shift += len(conn)
+
+                if len(all_pts) == 0:
+                    raise RuntimeError(
+                        "No geometry was provided for VTK output. "
+                        f"brep_surface_ids={self.brep_surface_ids}, "
+                        f"brep_curve_ids={self.brep_curve_ids}"
+                    )
 
                 # Assemble global arrays
                 points = np.vstack(all_pts)
@@ -210,50 +296,127 @@ class IgaVTKOutputProcess(KM.OutputProcess):
                 for var in self.nodal_variables:
                     data = []
                     uv_counter = 0
+                    patch_index = 0
 
-                    for patch_index, brep_id in enumerate(self.brep_surface_ids):
+                    # --------------------------------------------------
+                    # Evaluate variables on BRep surfaces
+                    # --------------------------------------------------
+                    for brep_id in self.brep_surface_ids:
                         brep_surface = self.model_part.GetGeometry(brep_id)
+
                         n_local = self.cached_uv_sizes[patch_index]
 
-                        local_uv = self.cached_uv[uv_counter:uv_counter + n_local]
+                        local_uv = self.cached_uv[
+                            uv_counter:uv_counter + n_local
+                        ]
 
                         for u, v in local_uv:
-                            val = self.__eval_variable(brep_surface, u, v, var)
+                            val = self.__eval_variable(
+                                brep_surface,
+                                u,
+                                v,
+                                var
+                            )
                             data.append(val)
 
                         uv_counter += n_local
+                        patch_index += 1
+
+                    # --------------------------------------------------
+                    # Evaluate variables on IGA curves / beams
+                    # --------------------------------------------------
+                    for curve_id in self.brep_curve_ids:
+                        curve = self.model_part.GetGeometry(curve_id)
+
+                        n_local = self.cached_uv_sizes[patch_index]
+
+                        local_uv = self.cached_uv[
+                            uv_counter:uv_counter + n_local
+                        ]
+
+                        for u, _ in local_uv:
+                            val = self.__eval_variable(
+                                curve,
+                                u,
+                                0.0,
+                                var
+                            )
+                            data.append(val)
+
+                        uv_counter += n_local
+                        patch_index += 1
 
                     data = np.array(data)
 
-                    # Ensure 2D array (scalar → (n,1))
+                    # Ensure 2D array: scalar -> (n, 1)
                     if data.ndim == 1:
                         data = data[:, np.newaxis]
 
-                    pd.create_dataset(var.Name(), data=data, maxshape=(None, data.shape[1]))
+                    pd.create_dataset(
+                        var.Name(),
+                        data=data,
+                        maxshape=(None, data.shape[1])
+                    )
 
                 n_pts = len(points)
 
             else:
-                # Append new time step data
+                # Append new time-step data
                 pd = root["PointData"]
                 n_pts = int(root["NumberOfPoints"][0])
 
                 for var in self.nodal_variables:
-
                     data = []
                     uv_counter = 0
+                    patch_index = 0
 
-                    for patch_index, brep_id in enumerate(self.brep_surface_ids):
+                    # --------------------------------------------------
+                    # Evaluate variables on BRep surfaces
+                    # --------------------------------------------------
+                    for brep_id in self.brep_surface_ids:
                         brep_surface = self.model_part.GetGeometry(brep_id)
+
                         n_local = self.cached_uv_sizes[patch_index]
 
-                        local_uv = self.cached_uv[uv_counter:uv_counter + n_local]
+                        local_uv = self.cached_uv[
+                            uv_counter:uv_counter + n_local
+                        ]
 
                         for u, v in local_uv:
-                            val = self.__eval_variable(brep_surface, u, v, var)
+                            val = self.__eval_variable(
+                                brep_surface,
+                                u,
+                                v,
+                                var
+                            )
                             data.append(val)
 
                         uv_counter += n_local
+                        patch_index += 1
+
+                    # --------------------------------------------------
+                    # Evaluate variables on IGA curves / beams
+                    # --------------------------------------------------
+                    for curve_id in self.brep_curve_ids:
+                        curve = self.model_part.GetGeometry(curve_id)
+
+                        n_local = self.cached_uv_sizes[patch_index]
+
+                        local_uv = self.cached_uv[
+                            uv_counter:uv_counter + n_local
+                        ]
+
+                        for u, _ in local_uv:
+                            val = self.__eval_variable(
+                                curve,
+                                u,
+                                0.0,
+                                var
+                            )
+                            data.append(val)
+
+                        uv_counter += n_local
+                        patch_index += 1
 
                     data = np.array(data)
 
@@ -261,7 +424,10 @@ class IgaVTKOutputProcess(KM.OutputProcess):
                         data = data[:, np.newaxis]
 
                     if data.shape[0] != n_pts:
-                        raise RuntimeError("Non-constant number of points across time steps!")
+                        raise RuntimeError(
+                            "Non-constant number of points across time steps! "
+                            f"Expected {n_pts}, obtained {data.shape[0]}."
+                        )
 
                     ds = pd[var.Name()]
 
@@ -340,16 +506,16 @@ class IgaVTKOutputProcess(KM.OutputProcess):
         if self.output_control_type == "step":
             self.step_counter += 1
 
-    # Compute the visualization grid 
-    def __compute_full_grid(self, brep_surface):
+    # Compute the visualization grid for brep surfaces
+    def __compute_full_grid_brep_surface(self, brep_surface):
         knots_u = brep_surface.KnotsU()
         knots_v = brep_surface.KnotsV()
 
         u_min, u_max = knots_u[0], knots_u[-1]
         v_min, v_max = knots_v[0], knots_v[-1]
 
-        ku = self.__refine(knots_u, self.output_refinement[0])
-        kv = self.__refine(knots_v, self.output_refinement[1])
+        ku = self.__refine(knots_u, self.output_refinement_surface[0])
+        kv = self.__refine(knots_v, self.output_refinement_surface[1])
 
         pts, conn, offs, types = [], [], [], []
         uv_coords = []
@@ -444,26 +610,135 @@ class IgaVTKOutputProcess(KM.OutputProcess):
             np.array(types,np.uint8),
             uv_coords
         )
+    
+    # Compute the visualization grid for a BRep curve
+    def __compute_full_grid_brep_curve(self, brep_curve):
+        knots = brep_curve.Knots()
 
-    # Evaluate the desired variable at a local coordinate position (u, v, 0)
+        if len(knots) < 2:
+            raise RuntimeError(
+                f"BRep curve {brep_curve.Id} has fewer than two knots."
+            )
+
+        u_min = knots[0]
+        u_max = u_max = knots[len(knots) - 1]
+
+        if len(self.output_refinement_curve) == 0:
+            refinement = 0
+        else:
+            refinement = self.output_refinement_curve[0]
+
+        refined_knots = self.__refine(knots, refinement)
+
+        pts = []
+        conn = []
+        offs = []
+        types = []
+        u_coordinates = []
+
+        point_id = 0
+        connectivity_counter = 0
+
+        # Loop over the refined knot spans
+        for i in range(len(refined_knots) - 1):
+            u0 = refined_knots[i]
+            u1 = refined_knots[i + 1]
+
+            # Skip zero-length knot spans
+            if abs(u1 - u0) < 1e-12:
+                continue
+
+            local_point_ids = []
+
+            # Create both endpoints of the VTK line
+            for u in (u0, u1):
+                u = max(u_min, min(u_max, u))
+
+                if not np.isfinite(u):
+                    raise RuntimeError(
+                        f"Non-finite local coordinate u={u} encountered "
+                        f"for BRep curve {brep_curve.Id}."
+                    )
+
+                local_coordinates = KM.Array3()
+                local_coordinates[0] = u
+                local_coordinates[1] = 0.0
+                local_coordinates[2] = 0.0
+
+                try:
+                    global_coordinates = brep_curve.GlobalCoordinates(
+                        local_coordinates
+                    )
+                except Exception as exception:
+                    raise RuntimeError(
+                        f"Failed to compute global coordinates for "
+                        f"BRep curve {brep_curve.Id} at u={u}."
+                    ) from exception
+
+                pts.append([
+                    global_coordinates[0],
+                    global_coordinates[1],
+                    global_coordinates[2],
+                ])
+
+                u_coordinates.append(u)
+                local_point_ids.append(point_id)
+                point_id += 1
+
+            offs.append(connectivity_counter)
+            conn.extend(local_point_ids)
+
+            connectivity_counter += 2
+            types.append(VTK_LINE)
+
+        offs.append(connectivity_counter)
+
+        if len(pts) == 0:
+            raise RuntimeError(
+                f"No visualization points were generated for "
+                f"BRep curve {brep_curve.Id}. "
+                f"Knots: {list(knots)}"
+            )
+
+        return (
+            np.array(pts, dtype=float),
+            np.array(conn, dtype=np.int64),
+            np.array(offs, dtype=np.int64),
+            np.array(types, dtype=np.uint8),
+            u_coordinates,
+        )
+
+    # Evaluate the desired variable at a local coordinate position  
     def __eval_variable(self, brep, u, v, variable):
         lc = KM.Array3()
-        lc[0], lc[1], lc[2] = u, v, 0.0
+        lc[0] = u
+        lc[1] = v
+        lc[2] = 0.0
 
         ids, N = brep.EvaluateShapeFunctionsAtLocalCoordinates(lc, 0)
+
+        if len(ids) == 0:
+            raise RuntimeError(
+                f"No active control points found for geometry {brep.Id} "
+                f"at local coordinates ({u}, {v})."
+            )
 
         sample_node = self.model_part.GetNode(ids[0])
         value = sample_node.GetSolutionStepValue(variable)
 
         if hasattr(value, "__len__"):
             result = np.zeros(len(value))
-            for i, id in enumerate(ids):
-                node = self.model_part.GetNode(id)
-                result += N[i] * np.array(node.GetSolutionStepValue(variable))
+
+            for i, node_id in enumerate(ids):
+                node = self.model_part.GetNode(node_id)
+                result += N[i] * np.asarray(
+                    node.GetSolutionStepValue(variable)
+                )
         else:
             result = 0.0
-            for i, id in enumerate(ids):
-                node = self.model_part.GetNode(id)
+
+            for i, node_id in enumerate(ids):
+                node = self.model_part.GetNode(node_id)
                 result += N[i] * node.GetSolutionStepValue(variable)
 
         return result
@@ -481,5 +756,5 @@ class IgaVTKOutputProcess(KM.OutputProcess):
                 t = j/(n+1)
                 out.append((1-t)*a + t*b)
 
-        out.append(knots[-1])
+        out.append(knots[len(knots) - 1])
         return out

--- a/applications/IgaApplication/tests/test_iga_vtk_output_process.py
+++ b/applications/IgaApplication/tests/test_iga_vtk_output_process.py
@@ -72,7 +72,7 @@ class TestIgaVTKHDFOutputProcess(KratosUnittest.TestCase):
             "output_file_name" : "{self.out_file}",
             "brep_surface_ids" : [{self.brep_id}],
             "nodal_solution_step_data_variables" : ["DISPLACEMENT"],
-            "output_refinement" : [3,3],
+            "output_refinement_surface" : [3,3],
             "output_control_type" : "step",
             "output_frequency" : 1
         }}

--- a/kratos/geometries/brep_curve.h
+++ b/kratos/geometries/brep_curve.h
@@ -373,6 +373,26 @@ public:
         return rResult;
     }
 
+    ///@}
+    ///@name Shape Function values and CP indices
+    ///@{
+    
+    void ShapeFunctionsValuesAndCPIndices(
+        const CoordinatesArrayType& rCoordinates,
+        std::vector<IndexType>& rControlPointIndices,
+        Vector& rShapeFunctionsValues,
+        const IndexType DerivativeOrder = 0,
+        DenseVector<Matrix>* pShapeFunctionDerivatives = nullptr
+    ) const
+    {
+        mpNurbsCurve->ShapeFunctionsValuesAndCPIndices(
+            rCoordinates,
+            rControlPointIndices,
+            rShapeFunctionsValues,
+            DerivativeOrder,
+            pShapeFunctionDerivatives);
+    }
+
     Matrix& ShapeFunctionsLocalGradients(
         Matrix& rResult,
         const CoordinatesArrayType& rCoordinates) const override

--- a/kratos/geometries/nurbs_curve_geometry.h
+++ b/kratos/geometries/nurbs_curve_geometry.h
@@ -698,6 +698,115 @@ public:
         return rResult;
     }
 
+    /**
+    * @brief Returns the nonzero shape-function values, derivatives, and active
+    * control-point IDs at a position in the curve parameter space.
+    *
+    * @param rCoordinates Parameter-space coordinates. Only rCoordinates[0] is used.
+    * @param rControlPointIndices IDs of the active control points.
+    * @param rShapeFunctionsValues Values of the active shape functions.
+    * @param DerivativeOrder Highest requested derivative order.
+    * @param pShapeFunctionDerivatives Optional derivative matrices.
+    */
+    void ShapeFunctionsValuesAndCPIndices(
+        const CoordinatesArrayType& rCoordinates,
+        std::vector<IndexType>& rControlPointIndices,
+        Vector& rShapeFunctionsValues,
+        const IndexType DerivativeOrder = 0,
+        DenseVector<Matrix>* pShapeFunctionDerivatives = nullptr
+    ) const
+    {
+        const double u = rCoordinates[0];
+
+        KRATOS_WARNING_IF(
+            "ShapeFunctionsValuesAndCPIndices",
+            DerivativeOrder > mPolynomialDegree)
+            << "Requested derivative order (" << DerivativeOrder
+            << ") exceeds the polynomial degree (" << mPolynomialDegree
+            << "). Higher derivatives may be zero or undefined."
+            << std::endl;
+
+        NurbsCurveShapeFunction shape_function_container(
+            mPolynomialDegree,
+            DerivativeOrder + 1);
+
+        if (IsRational()) {
+            shape_function_container.ComputeNurbsShapeFunctionValues(
+                mKnots,
+                mWeights,
+                u);
+        } else {
+            shape_function_container.ComputeBSplineShapeFunctionValues(
+                mKnots,
+                u);
+        }
+
+        const SizeType number_of_nonzero_control_points =
+            shape_function_container.NumberOfNonzeroControlPoints();
+
+        // Active control-point indices in the complete control-point array.
+        const auto control_point_indices =
+            shape_function_container.GetNonzeroControlPointIndices();
+
+        // Return the Kratos IDs of the active control points.
+        rControlPointIndices.resize(control_point_indices.size());
+
+        for (IndexType i = 0; i < control_point_indices.size(); ++i) {
+            rControlPointIndices[i] =
+                this->pGetPoint(control_point_indices[i])->Id();
+        }
+
+        // Shape-function values.
+        if (rShapeFunctionsValues.size() !=
+            number_of_nonzero_control_points) {
+            rShapeFunctionsValues.resize(
+                number_of_nonzero_control_points,
+                false);
+        }
+
+        for (IndexType i = 0;
+            i < number_of_nonzero_control_points;
+            ++i) {
+            rShapeFunctionsValues[i] =
+                shape_function_container(i, 0);
+        }
+
+        // Shape-function derivatives.
+        if (pShapeFunctionDerivatives == nullptr ||
+            DerivativeOrder == 0) {
+            return;
+        }
+
+        pShapeFunctionDerivatives->resize(DerivativeOrder);
+
+        for (IndexType derivative_order = 0;
+            derivative_order < DerivativeOrder;
+            ++derivative_order) {
+            Matrix& r_derivatives =
+                (*pShapeFunctionDerivatives)[derivative_order];
+
+            r_derivatives.resize(
+                number_of_nonzero_control_points,
+                1,
+                false);
+
+            // Column zero contains the derivative with respect to u.
+            // derivative_order = 0 corresponds to dN/du and is stored
+            // in column 1 of the shape-function container.
+            const IndexType container_derivative_index =
+                derivative_order + 1;
+
+            for (IndexType i = 0;
+                i < number_of_nonzero_control_points;
+                ++i) {
+                r_derivatives(i, 0) =
+                    shape_function_container(
+                        i,
+                        container_derivative_index);
+            }
+        }
+    }
+
     /*
     * @brief This function computes the first derivatives at a certain point.
     * From Piegl and Tiller, The NURBS Book, Algorithm A3.2/ A4.2

--- a/kratos/python/add_geometries_to_python.cpp
+++ b/kratos/python/add_geometries_to_python.cpp
@@ -51,6 +51,7 @@
 #include "geometries/nurbs_curve_on_surface_geometry.h"
 #include "geometries/surface_in_nurbs_volume_geometry.h"
 #include "geometries/brep_surface.h" 
+#include "geometries/brep_curve.h" 
 
 namespace Kratos::Python
 {
@@ -499,6 +500,48 @@ void  AddGeometriesToPython(pybind11::module& m)
             py::arg("u1"),
             py::arg("v0"),
             py::arg("v1")
+        );
+
+    // BrepCurve
+    using ContainerNodeType = PointerVector<Node>;
+    using ContainerEmbeddedNodeType = PointerVector<Point>;
+    using BrepCurveType = BrepCurve<ContainerNodeType, ContainerEmbeddedNodeType>;
+    py::class_<BrepCurveType, typename BrepCurveType::Pointer, GeometryType>(m, "BrepCurve")
+        .def(
+            py::init<
+                typename BrepCurveType::NurbsCurveType::Pointer
+            >(),
+            py::arg("nurbs_curve")
+        )
+        .def(
+            "Knots",
+            [](const BrepCurveType& self)
+            {
+                return self.Knots();
+            }
+        )
+        .def(
+            "EvaluateShapeFunctionsAtLocalCoordinates",
+            [](const BrepCurveType& self,
+            const BrepCurveType::CoordinatesArrayType& rLocalCoordinates,
+            const BrepCurveType::IndexType DerivativeOrder)
+            {
+                std::vector<BrepCurveType::IndexType> control_point_ids;
+                Vector shape_function_values;
+
+                self.ShapeFunctionsValuesAndCPIndices(
+                    rLocalCoordinates,
+                    control_point_ids,
+                    shape_function_values,
+                    DerivativeOrder,
+                    nullptr);
+
+                return py::make_tuple(
+                    control_point_ids,
+                    shape_function_values);
+            },
+            py::arg("local_coordinates"),
+            py::arg("derivative_order") = 0
         );
 
     py::class_<SurfaceInNurbsVolumeGeometry<3, NodeContainerType>, SurfaceInNurbsVolumeGeometry<3, NodeContainerType>::Pointer, GeometryType>(m, "SurfaceInNurbsVolumeGeometry")


### PR DESCRIPTION
## Description

This PR extends the IGA VTK output process to support `BrepCurve` geometries.

### Main changes

- Added `ShapeFunctionsValuesAndCPIndices()` to `NurbsCurveGeometry`.
- Exposed curve shape-function evaluation to Python through `BrepCurve`.
- Added support for exporting `BrepCurve` geometries as VTK line elements.
- Added interpolation of nodal solution-step variables on curve visualization points.
- Introduced `brep_curve_ids` and `output_refinement_curve` settings in the VTK output process.

This enables visualization of beam/curve deformations and solution variables (e.g. displacements, rotations) directly on `BrepCurve` geometries, while also supporting simultaneous export of BRep surfaces and curves in the same VTKHDF output.

**Example:** Simply supported beam with line load

<img width="1958" height="575" alt="beam" src="https://github.com/user-attachments/assets/a219f2f5-820a-4763-b77e-e2d53c481c39" />
