### PR TITLE
Adding database accessor

### DIFF
--- a/applications/StructuralMechanicsApplication/custom_constitutive/flexible_elastic_isotropic_3d.cpp
+++ b/applications/StructuralMechanicsApplication/custom_constitutive/flexible_elastic_isotropic_3d.cpp
@@ -1,0 +1,409 @@
+// KRATOS  ___|  |                   |                   |
+//       \___ \  __|  __| |   |  __| __| |   |  __| _` | |
+//             | |   |    |   | (    |   |   | |   (   | |
+//       _____/ \__|_|   \__,_|\___|\__|\__,_|_|  \__,_|_| MECHANICS
+//
+//  License:         BSD License
+//                   license: StructuralMechanicsApplication/license.txt
+//
+//  Main authors:    Riccardo Rossi
+//
+
+// System includes
+#include <iostream>
+
+// External includes
+
+// Project includes
+#include "custom_constitutive/flexible_elastic_isotropic_3d.h"
+#include "includes/checks.h"
+#include "custom_utilities/constitutive_law_utilities.h"
+#include "structural_mechanics_application_variables.h"
+
+namespace Kratos
+{
+/******************************CONSTRUCTOR******************************************/
+/***********************************************************************************/
+
+FlexibleElasticIsotropic3D::FlexibleElasticIsotropic3D()
+    : ConstitutiveLaw()
+{
+}
+
+/******************************COPY CONSTRUCTOR*************************************/
+/***********************************************************************************/
+
+FlexibleElasticIsotropic3D::FlexibleElasticIsotropic3D(const FlexibleElasticIsotropic3D& rOther)
+    : ConstitutiveLaw(rOther)
+{
+}
+
+/********************************CLONE**********************************************/
+/***********************************************************************************/
+
+ConstitutiveLaw::Pointer FlexibleElasticIsotropic3D::Clone() const
+{
+    return Kratos::make_shared<FlexibleElasticIsotropic3D>(*this);
+}
+
+/*******************************DESTRUCTOR******************************************/
+/***********************************************************************************/
+
+FlexibleElasticIsotropic3D::~FlexibleElasticIsotropic3D()
+{
+}
+
+/***********************************************************************************/
+/***********************************************************************************/
+
+void  FlexibleElasticIsotropic3D::CalculateMaterialResponsePK2(ConstitutiveLaw::Parameters& rValues)
+{
+    KRATOS_TRY;
+
+    Flags &r_constitutive_law_options = rValues.GetOptions();
+    ConstitutiveLaw::StrainVectorType &r_strain_vector = rValues.GetStrainVector();
+
+    if (r_constitutive_law_options.IsNot(ConstitutiveLaw::USE_ELEMENT_PROVIDED_STRAIN)) {
+        // Since we are in small strains, any strain measure works, e.g. CAUCHY_GREEN
+        CalculateCauchyGreenStrain(rValues, r_strain_vector);
+    }
+    AddInitialStrainVectorContribution<StrainVectorType>(r_strain_vector);
+
+    if (r_constitutive_law_options.Is(ConstitutiveLaw::COMPUTE_STRESS)) {
+        ConstitutiveLaw::StressVectorType &r_stress_vector = rValues.GetStressVector();
+        CalculatePK2Stress(r_strain_vector, r_stress_vector, rValues);
+        AddInitialStressVectorContribution<StressVectorType>(r_stress_vector);
+    }
+
+    if (r_constitutive_law_options.Is(ConstitutiveLaw::COMPUTE_CONSTITUTIVE_TENSOR)) {
+        ConstitutiveLaw::VoigtSizeMatrixType &r_constitutive_matrix = rValues.GetConstitutiveMatrix();
+        CalculateElasticMatrix(r_constitutive_matrix, rValues);
+    }
+
+    KRATOS_CATCH("");
+}
+
+/***********************************************************************************/
+/***********************************************************************************/
+
+// NOTE: Since we are in the hypothesis of small strains we can use the same function for everything
+
+void FlexibleElasticIsotropic3D::CalculateMaterialResponsePK1 (ConstitutiveLaw::Parameters& rValues)
+{
+    CalculateMaterialResponsePK2(rValues);
+}
+
+/***********************************************************************************/
+/***********************************************************************************/
+
+void FlexibleElasticIsotropic3D::CalculateMaterialResponseKirchhoff (ConstitutiveLaw::Parameters& rValues)
+{
+    CalculateMaterialResponsePK2(rValues);
+}
+
+/***********************************************************************************/
+/***********************************************************************************/
+
+void FlexibleElasticIsotropic3D::CalculateMaterialResponseCauchy (ConstitutiveLaw::Parameters& rValues)
+{
+    CalculateMaterialResponsePK2(rValues);
+}
+
+/***********************************************************************************/
+/***********************************************************************************/
+
+void FlexibleElasticIsotropic3D::InitializeMaterialResponsePK1(ConstitutiveLaw::Parameters& rValues)
+{
+    // Small deformation so we can call the Cauchy method
+    InitializeMaterialResponseCauchy(rValues);
+}
+
+/***********************************************************************************/
+/***********************************************************************************/
+
+void FlexibleElasticIsotropic3D::InitializeMaterialResponsePK2(ConstitutiveLaw::Parameters& rValues)
+{
+    // Small deformation so we can call the Cauchy method
+    InitializeMaterialResponseCauchy(rValues);
+}
+
+/***********************************************************************************/
+/***********************************************************************************/
+
+void FlexibleElasticIsotropic3D::InitializeMaterialResponseCauchy(ConstitutiveLaw::Parameters& rValues)
+{
+    // TODO: Add if necessary
+}
+
+/***********************************************************************************/
+/***********************************************************************************/
+
+void FlexibleElasticIsotropic3D::InitializeMaterialResponseKirchhoff(ConstitutiveLaw::Parameters& rValues)
+{
+    // Small deformation so we can call the Cauchy method
+    InitializeMaterialResponseCauchy(rValues);
+}
+
+/***********************************************************************************/
+/***********************************************************************************/
+
+void FlexibleElasticIsotropic3D::FinalizeMaterialResponsePK1(ConstitutiveLaw::Parameters& rValues)
+{
+    // Small deformation so we can call the Cauchy method
+    FinalizeMaterialResponseCauchy(rValues);
+}
+
+/***********************************************************************************/
+/***********************************************************************************/
+
+void FlexibleElasticIsotropic3D::FinalizeMaterialResponsePK2(ConstitutiveLaw::Parameters& rValues)
+{
+    // Small deformation so we can call the Cauchy method
+    FinalizeMaterialResponseCauchy(rValues);
+}
+
+/***********************************************************************************/
+/***********************************************************************************/
+
+void FlexibleElasticIsotropic3D::FinalizeMaterialResponseCauchy(ConstitutiveLaw::Parameters& rValues)
+{
+    // TODO: Add if necessary
+}
+
+/***********************************************************************************/
+/***********************************************************************************/
+
+void FlexibleElasticIsotropic3D::FinalizeMaterialResponseKirchhoff(ConstitutiveLaw::Parameters& rValues)
+{
+    // Small deformation so we can call the Cauchy method
+    FinalizeMaterialResponseCauchy(rValues);
+}
+
+/***********************************************************************************/
+/***********************************************************************************/
+
+double& FlexibleElasticIsotropic3D::CalculateValue(ConstitutiveLaw::Parameters& rParameterValues, const Variable<double>& rThisVariable, double& rValue)
+{
+    Flags &r_constitutive_law_options = rParameterValues.GetOptions();
+    ConstitutiveLaw::StrainVectorType &r_strain_vector = rParameterValues.GetStrainVector();
+    ConstitutiveLaw::StressVectorType &r_stress_vector = rParameterValues.GetStressVector();
+
+    if (rThisVariable == STRAIN_ENERGY) {
+        if (r_constitutive_law_options.IsNot(ConstitutiveLaw::USE_ELEMENT_PROVIDED_STRAIN)) {
+            this->CalculateCauchyGreenStrain(rParameterValues, r_strain_vector);
+        }
+        this->CalculatePK2Stress(r_strain_vector, r_stress_vector, rParameterValues);
+        rValue = 0.5 * inner_prod(r_strain_vector, r_stress_vector); // Strain energy = 0.5*E:C:E
+    }
+
+    return rValue;
+}
+
+/***********************************************************************************/
+/***********************************************************************************/
+
+Vector& FlexibleElasticIsotropic3D::CalculateValue(
+    ConstitutiveLaw::Parameters& rParameterValues,
+    const Variable<Vector>& rThisVariable,
+    Vector& rValue
+    )
+{
+    if (rThisVariable == STRAIN ||
+        rThisVariable == GREEN_LAGRANGE_STRAIN_VECTOR ||
+        rThisVariable == ALMANSI_STRAIN_VECTOR) {
+
+        Flags& r_flags = rParameterValues.GetOptions();
+
+        ConstitutiveLaw::StrainVectorType& r_strain_vector = rParameterValues.GetStrainVector();
+
+        if( r_flags.IsNot( ConstitutiveLaw::USE_ELEMENT_PROVIDED_STRAIN )) {
+            //Since we are in small strains, any strain measure works, e.g. CAUCHY_GREEN
+            CalculateCauchyGreenStrain(rParameterValues, r_strain_vector);
+        }
+        AddInitialStrainVectorContribution<StrainVectorType>(r_strain_vector);
+
+        if (rValue.size() != GetStrainSize()) {
+            rValue.resize(GetStrainSize());
+        }
+        noalias(rValue) = r_strain_vector;
+
+    } else if (rThisVariable == STRESSES ||
+        rThisVariable == CAUCHY_STRESS_VECTOR ||
+        rThisVariable == KIRCHHOFF_STRESS_VECTOR ||
+        rThisVariable == PK2_STRESS_VECTOR) {
+
+        Flags& r_flags = rParameterValues.GetOptions();
+
+        // Previous flags saved
+        const bool flag_const_tensor = r_flags.Is( ConstitutiveLaw::COMPUTE_CONSTITUTIVE_TENSOR );
+        const bool flag_stress = r_flags.Is( ConstitutiveLaw::COMPUTE_STRESS );
+
+        // Set flags to only compute the stress
+        r_flags.Set( ConstitutiveLaw::COMPUTE_CONSTITUTIVE_TENSOR, false );
+        r_flags.Set( ConstitutiveLaw::COMPUTE_STRESS, true );
+
+        this->CalculateMaterialResponsePK2(rParameterValues);
+        if (rValue.size() != GetStrainSize()) {
+            rValue.resize(GetStrainSize());
+        }
+        noalias(rValue) = rParameterValues.GetStressVector();
+
+        // Previous flags restored
+        r_flags.Set( ConstitutiveLaw::COMPUTE_CONSTITUTIVE_TENSOR, flag_const_tensor );
+        r_flags.Set( ConstitutiveLaw::COMPUTE_STRESS, flag_stress );
+        return rValue;
+
+    } else if (rThisVariable == INITIAL_STRAIN_VECTOR) {
+        if (this->HasInitialState()) {
+	    if (rValue.size() != GetStrainSize()) {
+	        rValue.resize(GetStrainSize());
+	    }
+	    noalias(rValue) = GetInitialState().GetInitialStrainVector();
+        } else {
+            noalias(rValue) = ZeroVector(0);
+        }
+    }
+
+    return rValue;
+}
+
+/***********************************************************************************/
+/***********************************************************************************/
+
+Matrix& FlexibleElasticIsotropic3D::CalculateValue(
+    ConstitutiveLaw::Parameters& rParameterValues,
+    const Variable<Matrix>& rThisVariable,
+    Matrix& rValue
+    )
+{
+    if (rThisVariable == CONSTITUTIVE_MATRIX ||
+        rThisVariable == CONSTITUTIVE_MATRIX_PK2 ||
+        rThisVariable == CONSTITUTIVE_MATRIX_KIRCHHOFF) {
+        this->CalculateElasticMatrix(rValue, rParameterValues);
+    }
+
+    return( rValue );
+}
+
+//*************************CONSTITUTIVE LAW GENERAL FEATURES *************************
+/***********************************************************************************/
+
+void FlexibleElasticIsotropic3D::GetLawFeatures(Features& rFeatures)
+{
+    //Set the type of law
+    rFeatures.mOptions.Set( THREE_DIMENSIONAL_LAW );
+    rFeatures.mOptions.Set( INFINITESIMAL_STRAINS );
+    rFeatures.mOptions.Set( ISOTROPIC );
+
+    //Set strain measure required by the consitutive law
+    rFeatures.mStrainMeasures.push_back(StrainMeasure_Infinitesimal);
+    rFeatures.mStrainMeasures.push_back(StrainMeasure_Deformation_Gradient);
+
+    //Set the strain size
+    rFeatures.mStrainSize = 6;
+
+    //Set the spacedimension
+    rFeatures.mSpaceDimension = 3;
+}
+
+/***********************************************************************************/
+/***********************************************************************************/
+
+int FlexibleElasticIsotropic3D::Check(
+    const Properties& rMaterialProperties,
+    const GeometryType& rElementGeometry,
+    const ProcessInfo& rCurrentProcessInfo
+    ) const
+{
+    Vector N(rElementGeometry.size(), 1.0/rElementGeometry.size());
+    double E = rMaterialProperties.GetValue(YOUNG_MODULUS, rElementGeometry, N, rCurrentProcessInfo);
+    KRATOS_ERROR_IF(E < 0.0) << "YOUNG_MODULUS is negative." << std::endl;
+
+    const double tolerance = 1.0e-12;
+    const double nu_upper_bound = 0.5;
+    const double nu_lower_bound = -1.0;
+    const double nu = rMaterialProperties.GetValue(POISSON_RATIO, rElementGeometry, N, rCurrentProcessInfo);
+    KRATOS_ERROR_IF((nu_upper_bound - nu) < tolerance) << "POISSON_RATIO is above the upper bound 0.5." << std::endl;
+    KRATOS_ERROR_IF((nu - nu_lower_bound) < tolerance) << "POISSON_RATIO is below the lower bound -1.0." << std::endl;
+
+    KRATOS_ERROR_IF(rMaterialProperties[DENSITY] < 0.0) << "DENSITY is negative." << std::endl;
+
+    return 0;
+}
+
+/***********************************************************************************/
+/***********************************************************************************/
+
+std::string FlexibleElasticIsotropic3D::Info() const
+{
+    return "FlexibleElasticIsotropic3D ConstitutiveLaw instance";
+}
+
+/***********************************************************************************/
+/***********************************************************************************/
+
+void FlexibleElasticIsotropic3D::PrintInfo(std::ostream& rOStream) const
+{
+    rOStream << this->Info() << std::endl;
+}
+
+/***********************************************************************************/
+/***********************************************************************************/
+
+void FlexibleElasticIsotropic3D::CheckClearElasticMatrix(ConstitutiveLaw::VoigtSizeMatrixType& rConstitutiveMatrix)
+{
+    const SizeType size_system = this->GetStrainSize();
+    if (rConstitutiveMatrix.size1() != size_system || rConstitutiveMatrix.size2() != size_system)
+        rConstitutiveMatrix.resize(size_system, size_system, false);
+    rConstitutiveMatrix.clear();
+}
+
+/***********************************************************************************/
+/***********************************************************************************/
+
+void FlexibleElasticIsotropic3D::CalculateElasticMatrix(
+    ConstitutiveLaw::VoigtSizeMatrixType& rConstitutiveMatrix,
+    ConstitutiveLaw::Parameters& rValues
+    )
+{
+    const auto &r_props = rValues.GetMaterialProperties();
+    const auto& N = rValues.GetShapeFunctionsValues();
+    const auto& rCurrentProcessInfo = rValues.GetProcessInfo();
+    const auto& rElementGeometry = rValues.GetElementGeometry();
+    const double E = r_props.GetValue(YOUNG_MODULUS, rElementGeometry, N, rCurrentProcessInfo);
+    const double NU = r_props.GetValue(POISSON_RATIO, rElementGeometry, N, rCurrentProcessInfo);
+    ConstitutiveLawUtilities<6>::CalculateElasticMatrix(rConstitutiveMatrix, E, NU);
+}
+
+/***********************************************************************************/
+/***********************************************************************************/
+
+void FlexibleElasticIsotropic3D::CalculatePK2Stress(
+    const Vector& rStrainVector,
+    ConstitutiveLaw::StressVectorType& rStressVector,
+    ConstitutiveLaw::Parameters& rValues
+    )
+{
+    const auto &r_props = rValues.GetMaterialProperties();
+    const auto& N = rValues.GetShapeFunctionsValues();
+    const auto& rCurrentProcessInfo = rValues.GetProcessInfo();
+    const auto& rElementGeometry = rValues.GetElementGeometry();
+    const double E = r_props.GetValue(YOUNG_MODULUS, rElementGeometry, N, rCurrentProcessInfo);
+    const double NU = r_props.GetValue(POISSON_RATIO, rElementGeometry, N, rCurrentProcessInfo);
+
+
+    ConstitutiveLawUtilities<6>::CalculatePK2StressFromStrain(rStressVector, rStrainVector, E, NU);
+}
+
+/***********************************************************************************/
+/***********************************************************************************/
+
+void FlexibleElasticIsotropic3D::CalculateCauchyGreenStrain(
+    ConstitutiveLaw::Parameters& rValues,
+    ConstitutiveLaw::StrainVectorType& rStrainVector
+    )
+{
+    ConstitutiveLawUtilities<6>::CalculateCauchyGreenStrain(rValues, rStrainVector);
+}
+
+} // Namespace Kratos

--- a/applications/StructuralMechanicsApplication/custom_constitutive/flexible_elastic_isotropic_3d.h
+++ b/applications/StructuralMechanicsApplication/custom_constitutive/flexible_elastic_isotropic_3d.h
@@ -1,0 +1,468 @@
+// KRATOS  ___|  |                   |                   |
+//       \___ \  __|  __| |   |  __| __| |   |  __| _` | |
+//             | |   |    |   | (    |   |   | |   (   | |
+//       _____/ \__|_|   \__,_|\___|\__|\__,_|_|  \__,_|_| MECHANICS
+//
+//  License:         BSD License
+//                   license: StructuralMechanicsApplication/license.txt
+//
+//  Main authors:    Riccardo Rossi
+//                   Vicente Mataix Ferrandiz
+//
+
+#pragma once
+
+// System includes
+
+// External includes
+
+// Project includes
+#include "includes/constitutive_law.h"
+
+namespace Kratos
+{
+///@name Kratos Globals
+///@{
+
+///@}
+///@name Type Definitions
+///@{
+
+///@}
+///@name  Enum's
+///@{
+
+///@}
+///@name  Functions
+///@{
+
+///@}
+///@name Kratos Classes
+///@{
+
+/**
+ * @class LinearPlaneStrain
+ * @ingroup StructuralMechanicsApplication
+ * @brief This class defines a small deformation linear elastic constitutive model for 3D cases
+ * @details This class derives from the base constitutive law
+ * @author Riccardo Rossi
+ * @author Vicente Mataix Ferrandiz
+ */
+class KRATOS_API(STRUCTURAL_MECHANICS_APPLICATION) FlexibleElasticIsotropic3D
+    : public ConstitutiveLaw
+{
+public:
+
+    ///@name Type Definitions
+    ///@{
+
+    /// The process info type definition
+    typedef ProcessInfo      ProcessInfoType;
+
+    /// The base class ConstitutiveLaw type definition
+    typedef ConstitutiveLaw         BaseType;
+
+    /// The size type definition
+    typedef std::size_t             SizeType;
+
+    /// Static definition of the dimension
+    static constexpr SizeType Dimension = 3;
+
+    /// Static definition of the VoigtSize
+    static constexpr SizeType VoigtSize = 6;
+
+    // Adding the respective using to avoid overload conflicts
+    using BaseType::Has;
+    using BaseType::GetValue;
+
+    /// Counted pointer of FlexibleElasticIsotropic3D
+    KRATOS_CLASS_POINTER_DEFINITION( FlexibleElasticIsotropic3D );
+
+    ///@}
+    ///@name Lyfe Cycle
+    ///@{
+
+    /**
+     * @brief Default constructor.
+     */
+    FlexibleElasticIsotropic3D();
+
+    /**
+     * @brief Clone method
+     */
+    ConstitutiveLaw::Pointer Clone() const override;
+
+    /**
+     * Copy constructor.
+     */
+    FlexibleElasticIsotropic3D (const FlexibleElasticIsotropic3D& rOther);
+
+    /**
+     * @brief Destructor.
+     */
+    ~FlexibleElasticIsotropic3D() override;
+
+    ///@}
+    ///@name Operators
+    ///@{
+
+    ///@}
+    ///@name Operations
+    ///@{
+
+    /**
+     * @brief This function is designed to be called once to check compatibility with element
+     * @param rFeatures The Features of the law
+     */
+    void GetLawFeatures(Features& rFeatures) override;
+
+    /**
+    * @brief Dimension of the law:
+    */
+    SizeType WorkingSpaceDimension() override
+    {
+        return Dimension;
+    };
+
+    /**
+     * @brief Voigt tensor size:
+     */
+    SizeType GetStrainSize() const override
+    {
+        return VoigtSize;
+    };
+
+    /**
+     * @brief Returns the expected strain measure of this constitutive law (by default Green-Lagrange)
+     * @return the expected strain measure
+     */
+    StrainMeasure GetStrainMeasure() override
+    {
+        return StrainMeasure_Infinitesimal;
+    }
+
+    /**
+     * @brief Returns the stress measure of this constitutive law (by default 2nd Piola-Kirchhoff stress in voigt notation)
+     * @return the expected stress measure
+     */
+    StressMeasure GetStressMeasure() override
+    {
+        return StressMeasure_Cauchy;
+    }
+
+    /**
+     * @brief Computes the material response:
+     * @details PK1 stresses and algorithmic ConstitutiveMatrix
+     * @param rValues The internal values of the law
+     * @see   Parameters
+     */
+    void CalculateMaterialResponsePK1 (ConstitutiveLaw::Parameters & rValues) override;
+
+    /**
+     * @brief Computes the material response:
+     * @details PK2 stresses and algorithmic ConstitutiveMatrix
+     * @param rValues The internal values of the law
+     * @see   Parameters
+     */
+    void CalculateMaterialResponsePK2 (ConstitutiveLaw::Parameters & rValues) override;
+
+    /**
+     * @brief Computes the material response:
+     * @details Kirchhoff stresses and algorithmic ConstitutiveMatrix
+     * @param rValues The internal values of the law
+     * @see   Parameters
+     */
+    void CalculateMaterialResponseKirchhoff (ConstitutiveLaw::Parameters & rValues) override;
+
+    /**
+     * @brief Computes the material response:
+     * @details Cauchy stresses and algorithmic ConstitutiveMatrix
+     * @param rValues The internal values of the law
+     * @see   Parameters
+     */
+    void CalculateMaterialResponseCauchy (ConstitutiveLaw::Parameters & rValues) override;
+
+    /**
+     * @brief Initialize the material response in terms of 1st Piola-Kirchhoff stresses
+     * @see Parameters
+     */
+    void InitializeMaterialResponsePK1 (ConstitutiveLaw::Parameters& rValues) override;
+
+    /**
+     * @brief Initialize the material response in terms of 2nd Piola-Kirchhoff stresses
+     * @see Parameters
+     */
+    void InitializeMaterialResponsePK2 (ConstitutiveLaw::Parameters& rValues) override;
+
+    /**
+     * @brief Initialize the material response in terms of Kirchhoff stresses
+     * @see Parameters
+     */
+    void InitializeMaterialResponseKirchhoff (ConstitutiveLaw::Parameters& rValues) override;
+
+    /**
+     * @brief Initialize the material response in terms of Cauchy stresses
+     * @see Parameters
+     */
+    void InitializeMaterialResponseCauchy (ConstitutiveLaw::Parameters& rValues) override;
+
+    /**
+      * @brief Updates the material response:
+      * @details Cauchy stresses and Internal Variables
+      * @param rValues The internal values of the law
+      * @see   Parameters
+      */
+    void FinalizeMaterialResponsePK1 (ConstitutiveLaw::Parameters & rValues) override;
+
+    /**
+     * @brief Updates the material response:
+     * Cauchy stresses and Internal Variables
+     * @param rValues The internal values of the law
+     * @see   Parameters
+     */
+    void FinalizeMaterialResponsePK2 (ConstitutiveLaw::Parameters & rValues) override;
+
+    /**
+     * @brief Updates the material response:
+     * @details Cauchy stresses and Internal Variables
+     * @param rValues The internal values of the law
+     * @see   Parameters
+     */
+    void FinalizeMaterialResponseKirchhoff (ConstitutiveLaw::Parameters & rValues)  override;
+
+    /**
+     * @brief Updates the material response:
+     * @details Cauchy stresses and Internal Variables
+     * @param rValues The internal values of the law
+     * @see   Parameters
+     */
+    void FinalizeMaterialResponseCauchy (ConstitutiveLaw::Parameters & rValues) override;
+
+    /**
+     * @brief If the CL requires to initialize the material response, called by the element in InitializeSolutionStep.
+     */
+    bool RequiresInitializeMaterialResponse() override
+    {
+        return false;
+    }
+
+    /**
+     * @brief If the CL requires to finalize the material response, called by the element in FinalizeSolutionStep.
+     */
+    bool RequiresFinalizeMaterialResponse() override
+    {
+        return false;
+    }
+
+    /**
+     * @brief It calculates the value of a specified variable (double case)
+     * @param rParameterValues the needed parameters for the CL calculation
+     * @param rThisVariable the variable to be returned
+     * @param rValue a reference to the returned value
+     * @return rValue output: the value of the specified variable
+     */
+    double& CalculateValue(
+        ConstitutiveLaw::Parameters& rParameterValues,
+        const Variable<double>& rThisVariable,
+        double& rValue
+        ) override;
+
+    /**
+     * @brief It calculates the value of a specified variable (Vector case)
+     * @param rParameterValues the needed parameters for the CL calculation
+     * @param rThisVariable the variable to be returned
+     * @param rValue a reference to the returned value
+     * @return rValue output: the value of the specified variable
+     */
+    Vector& CalculateValue(
+        ConstitutiveLaw::Parameters& rParameterValues,
+        const Variable<Vector>& rThisVariable,
+        Vector& rValue
+        ) override;
+
+    // /**
+    //  * @brief It calculates the value of a specified variable (StrainVectorType case)
+    //  * @param rParameterValues the needed parameters for the CL calculation
+    //  * @param rThisVariable the variable to be returned
+    //  * @param rValue a reference to the returned value
+    //  * @return rValue output: the value of the specified variable
+    //  */
+    // ConstitutiveLaw::StrainVectorType& CalculateValue(
+    //     ConstitutiveLaw::Parameters& rParameterValues,
+    //     const Variable<StrainVectorType>& rThisVariable,
+    //     ConstitutiveLaw::StrainVectorType& rValue
+    //     ) override;
+
+    // /**
+    //  * @brief It calculates the value of a specified variable (StressVectorType case)
+    //  * @param rParameterValues the needed parameters for the CL calculation
+    //  * @param rThisVariable the variable to be returned
+    //  * @param rValue a reference to the returned value
+    //  * @return rValue output: the value of the specified variable
+    //  */
+    // ConstitutiveLaw::StressVectorType& CalculateValue(
+    //     ConstitutiveLaw::Parameters& rParameterValues,
+    //     const Variable<StressVectorType>& rThisVariable,
+    //     ConstitutiveLaw::StressVectorType& rValue
+    //     ) override;
+
+    /**
+     * @brief It calculates the value of a specified variable (Matrix case)
+     * @param rParameterValues the needed parameters for the CL calculation
+     * @param rThisVariable the variable to be returned
+     * @param rValue a reference to the returned value
+     * @return rValue output: the value of the specified variable
+     */
+    Matrix& CalculateValue(
+        ConstitutiveLaw::Parameters& rParameterValues,
+        const Variable<Matrix>& rThisVariable,
+        Matrix& rValue
+        ) override;
+
+    // /**
+    //  * @brief It calculates the value of a specified variable (VoigtSizeMatrixType case)
+    //  * @param rParameterValues the needed parameters for the CL calculation
+    //  * @param rThisVariable the variable to be returned
+    //  * @param rValue a reference to the returned value
+    //  * @return rValue output: the value of the specified variable
+    //  */
+    // ConstitutiveLaw::VoigtSizeMatrixType& CalculateValue(
+    //     ConstitutiveLaw::Parameters& rParameterValues,
+    //     const Variable<VoigtSizeMatrixType>& rThisVariable,
+    //     ConstitutiveLaw::VoigtSizeMatrixType& rValue
+    //     ) override;
+
+    // /**
+    //  * @brief It calculates the value of a specified variable (DeformationGradientMatrixType case)
+    //  * @param rParameterValues the needed parameters for the CL calculation
+    //  * @param rThisVariable the variable to be returned
+    //  * @param rValue a reference to the returned value
+    //  * @return rValue output: the value of the specified variable
+    //  */
+    // ConstitutiveLaw::DeformationGradientMatrixType& CalculateValue(
+    //     ConstitutiveLaw::Parameters& rParameterValues,
+    //     const Variable<DeformationGradientMatrixType>& rThisVariable,
+    //     ConstitutiveLaw::DeformationGradientMatrixType& rValue
+    //     ) override;
+
+    /**
+     * @brief This function provides the place to perform checks on the completeness of the input.
+     * @details It is designed to be called only once (or anyway, not often) typically at the beginning of the calculations, so to verify that nothing is missing from the input or that no common error is found.
+     * @param rMaterialProperties The properties of the material
+     * @param rElementGeometry The geometry of the element
+     * @param rCurrentProcessInfo The current process info instance
+     * @return 0 if OK, 1 otherwise
+     */
+    int Check(
+        const Properties& rMaterialProperties,
+        const GeometryType& rElementGeometry,
+        const ProcessInfo& rCurrentProcessInfo
+        ) const override;
+
+
+    /** @brief General information identifying this instance. */
+    std::string Info() const override;
+
+    /**
+     * @brief General information identifying this instance.
+     * @param rOstream The stream where the info will be printed.
+     */
+    void PrintInfo(std::ostream& rOStream) const override;
+
+protected:
+
+    ///@name Protected static Member Variables
+    ///@{
+
+    ///@}
+    ///@name Protected member Variables
+    ///@{
+
+    ///@}
+    ///@name Protected Operators
+    ///@{
+
+    ///@}
+    ///@name Protected Operations
+    ///@{
+
+    /**
+    * @brief It checks the size of the constitutive matrix rConstitutiveMatrix and resize it if necessary
+    * @param rConstitutiveMatrix The constitutive matrix
+    */
+    void CheckClearElasticMatrix(VoigtSizeMatrixType& rConstitutiveMatrix);
+
+    /**
+    * @brief It calculates the constitutive matrix rConstitutiveMatrix
+    * @param rConstitutiveMatrix The constitutive matrix
+    * @param rValues Parameters of the constitutive law
+    */
+    virtual void CalculateElasticMatrix(
+        ConstitutiveLaw::VoigtSizeMatrixType& rConstitutiveMatrix,
+        ConstitutiveLaw::Parameters& rValues
+        );
+
+    /**
+     * @brief It calculates the stress vector
+     * @param rStrainVector The strain vector in Voigt notation
+     * @param rStressVector The stress vector in Voigt notation
+     * @param rValues Parameters of the constitutive law
+     */
+    virtual void CalculatePK2Stress(
+        const ConstitutiveLaw::StrainVectorType& rStrainVector,
+        ConstitutiveLaw::StressVectorType& rStressVector,
+        ConstitutiveLaw::Parameters& rValues
+        );
+
+    /**
+     * @brief It calculates the strain vector
+     * @param rValues The internal values of the law
+     * @param rStrainVector The strain vector in Voigt notation
+     */
+    virtual void CalculateCauchyGreenStrain(
+        ConstitutiveLaw::Parameters& rValues,
+        ConstitutiveLaw::StrainVectorType& rStrainVector
+        );
+
+    ///@}
+
+private:
+
+    ///@name Static Member Variables
+    ///@{
+
+    ///@}
+    ///@name Member Variables
+    ///@{
+
+    ///@}
+    ///@name Private Operators
+    ///@{
+
+    ///@}
+    ///@name Private Operations
+    ///@{
+
+    ///@}
+    ///@name Private  Access
+    ///@{
+    ///@}
+
+    ///@}
+    ///@name Serialization
+    ///@{
+    friend class Serializer;
+
+    void save(Serializer& rSerializer) const override
+    {
+        KRATOS_SERIALIZE_SAVE_BASE_CLASS( rSerializer, ConstitutiveLaw )
+    }
+
+    void load(Serializer& rSerializer) override
+    {
+        KRATOS_SERIALIZE_LOAD_BASE_CLASS( rSerializer, ConstitutiveLaw)
+    }
+
+
+}; // Class FlexibleElasticIsotropic3D
+}  // namespace Kratos.

--- a/applications/StructuralMechanicsApplication/custom_python/add_custom_constitutive_laws_to_python.cpp
+++ b/applications/StructuralMechanicsApplication/custom_python/add_custom_constitutive_laws_to_python.cpp
@@ -21,6 +21,7 @@
 #include "custom_constitutive/truss_constitutive_law.h"
 #include "custom_constitutive/beam_constitutive_law.h"
 #include "custom_constitutive/elastic_isotropic_3d.h"
+#include "custom_constitutive/flexible_elastic_isotropic_3d.h"
 #include "custom_constitutive/axisym_elastic_isotropic.h"
 #include "custom_constitutive/linear_plane_stress.h"
 #include "custom_constitutive/linear_plane_strain.h"
@@ -54,6 +55,10 @@ void  AddCustomConstitutiveLawsToPython(pybind11::module& m)
 
     py::class_< ElasticIsotropic3D, typename ElasticIsotropic3D::Pointer, ConstitutiveLaw >
     (m, "LinearElastic3DLaw").def(py::init<>() )
+    ;
+
+    py::class_< FlexibleElasticIsotropic3D, typename FlexibleElasticIsotropic3D::Pointer, ConstitutiveLaw >
+    (m, "FlexibleLinearElastic3DLaw").def(py::init<>() )
     ;
 
     py::class_< AxisymElasticIsotropic, typename AxisymElasticIsotropic::Pointer, ConstitutiveLaw >

--- a/applications/StructuralMechanicsApplication/structural_mechanics_application.cpp
+++ b/applications/StructuralMechanicsApplication/structural_mechanics_application.cpp
@@ -845,6 +845,7 @@ void KratosStructuralMechanicsApplication::Register() {
     KRATOS_REGISTER_CONSTITUTIVE_LAW("TrussConstitutiveLaw", mTrussConstitutiveLaw);
     KRATOS_REGISTER_CONSTITUTIVE_LAW("BeamConstitutiveLaw", mBeamConstitutiveLaw);
     KRATOS_REGISTER_CONSTITUTIVE_LAW("LinearElastic3DLaw", mElasticIsotropic3D);
+    KRATOS_REGISTER_CONSTITUTIVE_LAW("FlexibleLinearElastic3DLaw", mFlexibleElasticIsotropic3D);
     KRATOS_REGISTER_CONSTITUTIVE_LAW("LinearElasticPlaneStrain2DLaw", mLinearPlaneStrain);
     KRATOS_REGISTER_CONSTITUTIVE_LAW("LinearElasticPlaneStress2DLaw", mLinearPlaneStress);
     KRATOS_REGISTER_CONSTITUTIVE_LAW("LinearElasticAxisym2DLaw", mAxisymElasticIsotropic);

--- a/applications/StructuralMechanicsApplication/structural_mechanics_application.h
+++ b/applications/StructuralMechanicsApplication/structural_mechanics_application.h
@@ -122,6 +122,7 @@
 #include "custom_constitutive/truss_constitutive_law.h"
 #include "custom_constitutive/beam_constitutive_law.h"
 #include "custom_constitutive/elastic_isotropic_3d.h"
+#include "custom_constitutive/flexible_elastic_isotropic_3d.h"
 #include "custom_constitutive/axisym_elastic_isotropic.h"
 #include "custom_constitutive/linear_plane_strain.h"
 #include "custom_constitutive/linear_plane_stress.h"
@@ -549,6 +550,7 @@ private:
     const TrussConstitutiveLaw mTrussConstitutiveLaw;
     const BeamConstitutiveLaw mBeamConstitutiveLaw;
     const ElasticIsotropic3D mElasticIsotropic3D;
+    const FlexibleElasticIsotropic3D mFlexibleElasticIsotropic3D;
     const AxisymElasticIsotropic mAxisymElasticIsotropic;
     const LinearPlaneStrain  mLinearPlaneStrain;
     const LinearPlaneStress  mLinearPlaneStress;

--- a/kratos/includes/database_accessor.h
+++ b/kratos/includes/database_accessor.h
@@ -1,0 +1,167 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
+//
+//  Main authors:    Alejandro Cornejo
+//                   Riccardo Rossi
+//                   Carlos Roig
+//                   Ruben Zorrilla
+//
+
+#pragma once
+
+// System includes
+
+// External includes
+
+// Project includes
+#include "includes/accessor.h"
+
+namespace Kratos
+{
+///@addtogroup KratosCore
+///@{
+
+///@name Kratos Classes
+///@{
+
+/**
+ * @class DatabaseAccessor
+ * @ingroup Kratos Core
+ * @brief This class defines the way a certain property is accessed according to a table.
+ * @brief The tables are supposed to relate double <-> double type entities.
+ * @brief The input variable is suposed to be a nodally accesible one (either historical or not)
+ * @author Alejandro Cornejo, Riccardo Rossi, Carlos Roig and Ruben Zorrilla
+ */
+class KRATOS_API(KRATOS_CORE) DatabaseAccessor : public Accessor
+{
+public:
+    ///@name Type Definitions
+    ///@{
+
+    /// Geometry type definition
+    using GeometryType = Geometry<Node>;
+
+    /// Variable type
+    using VariableType = Variable<double>;
+
+    /// BaseType
+    using BaseType = Accessor;
+
+    using DataLocation = Globals::DataLocation;
+
+    using SizeType = std::size_t;
+
+    /// Pointer definition of DatabaseAccessor
+    KRATOS_CLASS_POINTER_DEFINITION(DatabaseAccessor);
+
+    ///@}
+    ///@name Life Cycle
+    ///@{
+    DatabaseAccessor()
+    {}
+
+    /// Custom constructor
+    DatabaseAccessor(const std::string& rInputVariableType = "node_historical")
+    {
+        // We initialize the variable type only once
+        if (rInputVariableType == "node_historical") {
+            mInputVariableType = Globals::DataLocation::NodeHistorical;
+        } else if (rInputVariableType == "node_non_historical") {
+            mInputVariableType = Globals::DataLocation::NodeNonHistorical;
+        } else if (rInputVariableType == "element") {
+            mInputVariableType = Globals::DataLocation::Element;
+        } else if (rInputVariableType == "process_info") {
+            mInputVariableType = Globals::DataLocation::ProcessInfo;
+        } else {
+            KRATOS_ERROR << "The input_variable_type is incorrect or not supported. Types available are : 'node_historical', 'node_non_historical', 'element' (which gets it from the geometry) and 'process_info'" << std::endl;
+        }
+    }
+
+    /// Copy constructor
+    DatabaseAccessor(const DatabaseAccessor& rOther)
+    : BaseType(rOther),
+        mInputVariableType(rOther.mInputVariableType)
+    {}
+
+    ///@}
+    ///@name Operations
+    ///@{
+
+    /**
+     * @brief Custom method to retrieve double type properties
+     * @param rVariable The variable considered (double type properties)
+     * @param rProperties The properties considered
+     * @param rGeometry The geometry considered
+     * @param rShapeFunctionVector The shape function of the GP considered
+     * @param rProcessInfo The process info considered
+     * @return The double type properties
+     */
+    double GetValue(
+        const Variable<double>& rVariable,
+        const Properties& rProperties,
+        const GeometryType& rGeometry,
+        const Vector& rShapeFunctionVector,
+        const ProcessInfo& rProcessInfo
+        ) const override;
+
+    /**
+     * @brief This computes a material property according to a certain
+     * nodal Variable<double> table
+     */
+    double GetValueFromDatabase(
+        const Variable<double>& rVariable,
+        const Properties& rProperties,
+        const GeometryType& rGeometry,
+        const Vector& rShapeFunctionVector,
+        const ProcessInfo& rProcessInfo) const;
+
+
+    // Getting a pointer to the class
+    Accessor::UniquePointer Clone() const override;
+
+    ///@}
+    ///@name Input and output
+    ///@{
+
+    /// Turn back information as a string.
+    std::string Info() const override
+    {
+        std::stringstream buffer;
+        buffer << "DatabaseAccessor" ;
+
+        return buffer.str();
+    }
+
+    /// Print information about this object.
+    void PrintInfo(std::ostream& rOStream) const override {rOStream << "DatabaseAccessor";}
+
+    /// Print object's data.
+    void PrintData(std::ostream& rOStream) const override {rOStream << "DatabaseAccessor class";}
+
+    ///@}
+
+private:
+
+    ///@name Member Variables
+    ///@{
+
+    Globals::DataLocation mInputVariableType = Globals::DataLocation::NodeHistorical; // NodalHistorical by default
+
+    friend class Serializer;
+
+    void save(Serializer &rSerializer) const override;
+
+    void load(Serializer &rSerializer) override;
+
+}; // class
+///@}
+
+///@} addtogroup block
+
+} // namespace Kratos

--- a/kratos/includes/database_accessor.h
+++ b/kratos/includes/database_accessor.h
@@ -63,8 +63,6 @@ public:
     ///@}
     ///@name Life Cycle
     ///@{
-    DatabaseAccessor()
-    {}
 
     /// Custom constructor
     DatabaseAccessor(const std::string& rInputVariableType = "node_historical")

--- a/kratos/python/add_accessors_to_python.cpp
+++ b/kratos/python/add_accessors_to_python.cpp
@@ -20,6 +20,9 @@
 #include "add_accessors_to_python.h"
 #include "includes/define_python.h"
 #include "includes/accessor.h"
+#include "includes/database_accessor.h"
+#include "includes/table_accessor.h"
+
 #include "includes/properties.h"
 
 using AccessorBindType = std::unique_ptr<Kratos::Accessor>;
@@ -34,6 +37,21 @@ namespace py = pybind11;
 void AddAccessorsToPython(py::module& m)
 {
     py::class_<AccessorBindType>(m, "Accessor")
+        .def_static("Create", []() { 
+            return std::make_unique<Accessor>();
+        })
+        ;
+
+        py::class_<DatabaseAccessor>(m, "DatabaseAccessor")
+        .def(py::init<const std::string&>(), py::arg("database_type"))
+        .def_static("Create", []() { 
+            return std::make_unique<Accessor>();
+        })
+        ;
+
+
+        py::class_<TableAccessor>(m, "TableAccessor")
+        .def(py::init<const Variable<double>&, const std::string&>(), py::arg("r_variable"), py::arg("database_type"))
         .def_static("Create", []() { 
             return std::make_unique<Accessor>();
         })

--- a/kratos/sources/database_accessor.cpp
+++ b/kratos/sources/database_accessor.cpp
@@ -1,0 +1,102 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
+//
+//  Main authors:    Alejandro Cornejo
+//                   Riccardo Rossi
+//                   Carlos Roig
+//
+//
+
+// System includes
+
+// External includes
+
+// Project includes
+#include "includes/database_accessor.h"
+#include "includes/properties.h"
+
+namespace Kratos
+{
+
+/***********************************************************************************/
+/***********************************************************************************/
+
+double DatabaseAccessor::GetValue(
+    const Variable<double>& rVariable,
+    const Properties& rProperties,
+    const GeometryType& rGeometry,
+    const Vector& rShapeFunctionVector,
+    const ProcessInfo& rProcessInfo
+    ) const
+{
+    return GetValueFromDatabase(rVariable, rProperties, rGeometry, rShapeFunctionVector, rProcessInfo);
+}
+
+/***********************************************************************************/
+/***********************************************************************************/
+
+double DatabaseAccessor::GetValueFromDatabase(
+        const Variable<double> &rVariable,
+        const Properties& rProperties,
+        const GeometryType& rGeometry,
+        const Vector& rShapeFunctionVector,
+        const ProcessInfo& rProcessInfo) const
+{
+    double value = 0.0;
+    if (mInputVariableType == Globals::DataLocation::NodeHistorical) {
+        for (SizeType i = 0; i < rShapeFunctionVector.size(); ++i) {
+            KRATOS_DEBUG_ERROR_IF_NOT(rGeometry[i].SolutionStepsDataHas(rVariable)) << "The Variable " << rVariable.Name() << " is not available at the nodes of the Geometry to retrieve Table values." << std::endl;
+            const double nodal_value = rGeometry[i].FastGetSolutionStepValue(rVariable);
+            value += nodal_value * rShapeFunctionVector[i];
+        }
+    } else if (mInputVariableType == Globals::DataLocation::NodeNonHistorical) {
+        for (SizeType i = 0; i < rShapeFunctionVector.size(); ++i) {
+            KRATOS_DEBUG_ERROR_IF_NOT(rGeometry[i].Has(rVariable)) << "The Variable " << rVariable.Name() << " is not available at the nodes of the Geometry to retrieve Table values." << std::endl;
+            const double nodal_value = rGeometry[i].GetValue(rVariable);
+            value += nodal_value * rShapeFunctionVector[i];
+        }
+    } else if (mInputVariableType == Globals::DataLocation::Element) {
+        KRATOS_DEBUG_ERROR_IF_NOT(rGeometry.Has(rVariable)) << "The Variable " << rVariable.Name() << " is not available at the Geometry to retrieve Table values." << std::endl;
+        value = rGeometry.GetValue(rVariable);
+    } else if (mInputVariableType == Globals::DataLocation::ProcessInfo) {
+        KRATOS_DEBUG_ERROR_IF_NOT(rProcessInfo.Has(rVariable)) << "The Variable " << rVariable.Name() << " is not available at the rProcessInfo to retrieve Table values." << std::endl;
+        value = rProcessInfo.GetValue(rVariable);
+    } else {
+        KRATOS_ERROR << "The table_input_variable_type is incorrect or not supported. Types available are : nodal_historical, nodal_non_historical and elemental_non_historical" << std::endl;
+    }
+
+    // Retrieve the dependent variable from the table
+    return value;
+}
+
+/***********************************************************************************/
+/***********************************************************************************/
+
+void DatabaseAccessor::save(Serializer& rSerializer) const
+{
+    // we must do the int cast to be able to compile
+    rSerializer.save("InputVariableType", static_cast<int>(mInputVariableType));
+}
+void DatabaseAccessor::load(Serializer& rSerializer)
+{
+    // we must do the int cast to be able to compile
+    int enum_value;
+    rSerializer.load("InputVariableType", enum_value);
+    mInputVariableType = static_cast<Globals::DataLocation>(enum_value);
+}
+
+/***********************************************************************************/
+/***********************************************************************************/
+
+Accessor::UniquePointer DatabaseAccessor::Clone() const
+{
+    return Kratos::make_unique<DatabaseAccessor>(*this);
+}
+
+} // namespace Kratos

--- a/kratos/tests/auxiliar_files_for_python_unittest/materials_files/material_with_accessor.json
+++ b/kratos/tests/auxiliar_files_for_python_unittest/materials_files/material_with_accessor.json
@@ -1,0 +1,67 @@
+{
+	"properties": [{
+		"model_part_name": "Main",
+		"properties_id": 1,
+		"Material": {
+			"name": "steel",
+			"constitutive_law": {
+				"name": "FlexibleLinearElastic3DLaw"
+			},
+			"Tables"           : {
+                "TEMPERATURE_vs_E" : {
+                        "input_variable"  : "TEMPERATURE",
+                        "output_variable" : "YOUNG_MODULUS",
+                        "data"            : [[0.0,   30e9],
+                                             [1100,  2.0e10]]
+                },                
+				"TEMPERATURE_vs_yield" : {
+                        "input_variable"  : "TEMPERATURE",
+                        "output_variable" : "YIELD_STRESS",
+                        "data"            : [[0.0,   1.0E6],
+                                             [1100,  7.5E5]]
+                },
+				"TEMPERATURE_vs_G" : {
+                        "input_variable"  : "TEMPERATURE",
+                        "output_variable" : "FRACTURE_ENERGY",
+                        "data"            : [[0.0,   0.1],
+                                             [1100,  0.07]]
+                }
+            },
+			"accessors"        : {
+				"accessor_table_T_E" : {
+					"accessor_type"  : "table_accessor",
+					"properties" : {
+						"table_input_variable"      : "TEMPERATURE",
+						"table_output_variable"     : "YOUNG_MODULUS",
+						"table_input_variable_type" : "node_historical"
+					}
+				},
+				"accessor_table_T_YIELD" : {
+					"accessor_type"  : "table_accessor",
+					"properties" : {
+						"table_input_variable"      : "TEMPERATURE",
+						"table_output_variable"     : "YIELD_STRESS",
+						"table_input_variable_type" : "node_historical"
+					}
+				},
+				"accessor_table_T_G" : {
+					"accessor_type"  : "table_accessor",
+					"properties" : {
+						"table_input_variable"      : "TEMPERATURE",
+						"table_output_variable"     : "FRACTURE_ENERGY",
+						"table_input_variable_type" : "node_historical"
+					}
+				},
+				"accessor_database_YOUNG_MODULUS" : {
+					"accessor_type"  : "database_accessor",
+					"properties" : {
+						"variable"      : "VISCOSITY",
+						"input_variable_type" : "node_historical"
+					}
+				}
+			}
+
+		}
+	}
+	]
+}

--- a/kratos/tests/cpp_tests/includes/test_property_accessor.cpp
+++ b/kratos/tests/cpp_tests/includes/test_property_accessor.cpp
@@ -295,7 +295,7 @@ KRATOS_TEST_CASE_IN_SUITE(DatabaseAccessorSimplePropertiesProcessInfo, KratosCor
 
         //check interpolation of non-historical database
         auto non_historical_accessor = DatabaseAccessor("node_non_historical");
-        //p_elem_prop->SetAccessor(YOUNG_MODULUS, non_historical_accessor.Clone());
+        //p_elem_prop->SetAccessor(YOUNG_MODULUS, non_historical_accessor.Clone()); //NOTE: this does nothing as an emplace is used inside
         p_elem_prop->pGetAccessor(YOUNG_MODULUS) = non_historical_accessor.Clone();
         KRATOS_EXPECT_EQ(true, (*p_elem_prop).HasAccessor(YOUNG_MODULUS));
         KRATOS_EXPECT_EQ(35.0, (*p_elem_prop).GetValue(YOUNG_MODULUS, *p_geom, N, r_model_part.GetProcessInfo()));

--- a/kratos/tests/cpp_tests/includes/test_property_accessor.cpp
+++ b/kratos/tests/cpp_tests/includes/test_property_accessor.cpp
@@ -19,6 +19,7 @@
 #include "testing/testing.h"
 #include "includes/properties.h"
 #include "includes/table_accessor.h"
+#include "includes/database_accessor.h"
 #include "geometries/quadrilateral_2d_4.h"
 #include "tests/test_utilities/test_element.h"
 #include "tests/test_utilities/test_constitutive_law.h"
@@ -235,6 +236,69 @@ KRATOS_TEST_CASE_IN_SUITE(TableTableAccessorSerialization, KratosCoreFastSuite)
     serializer.load("table_accessor_info", table_accessor_loaded);
 
     KRATOS_EXPECT_EQ(TEMPERATURE.Key(), table_accessor_loaded.GetInputVariable().Key());
+}
+
+/**
+* checks the database accessor
+*/
+KRATOS_TEST_CASE_IN_SUITE(DatabaseAccessorSimplePropertiesProcessInfo, KratosCoreFastSuite)
+{
+        Model current_model;
+        auto &r_model_part = current_model.CreateModelPart("ModelPart",1);
+        r_model_part.AddNodalSolutionStepVariable(YOUNG_MODULUS);
+
+        r_model_part.GetProcessInfo().SetValue(DOMAIN_SIZE, 2);
+        r_model_part.GetProcessInfo().SetValue(TIME, 0.0);
+
+        // Set the element properties
+        auto p_elem_prop = r_model_part.CreateNewProperties(0);
+        p_elem_prop->SetValue(YOUNG_MODULUS, 2.0);
+
+        auto p_node_1 = r_model_part.CreateNewNode(1, 0.0 , 0.0 , 0.0);
+        auto p_node_2 = r_model_part.CreateNewNode(2, 1.0 , 0.0 , 0.0);
+        auto p_node_3 = r_model_part.CreateNewNode(3, 1.0 , 1.0 , 0.0);
+        auto p_node_4 = r_model_part.CreateNewNode(4, 0.0 , 1.0 , 0.0);
+
+        p_node_1->GetSolutionStepValue(YOUNG_MODULUS) = 25.0e1;
+        p_node_2->GetSolutionStepValue(YOUNG_MODULUS) = 30.0e1;
+        p_node_3->GetSolutionStepValue(YOUNG_MODULUS) = 35.0e1;
+        p_node_4->GetSolutionStepValue(YOUNG_MODULUS) = 40.0e1;
+    
+        p_node_1->GetValue(YOUNG_MODULUS) = 25.0;
+        p_node_2->GetValue(YOUNG_MODULUS) = 30.0;
+        p_node_3->GetValue(YOUNG_MODULUS) = 35.0;
+        p_node_4->GetValue(YOUNG_MODULUS) = 40.0;
+
+        std::vector<Node::Pointer> geom(4);
+        geom[0] = p_node_1;
+        geom[1] = p_node_2;
+        geom[2] = p_node_3;
+        geom[3] = p_node_4;
+
+        auto p_geom = Kratos::make_shared<Quadrilateral2D4<Node>>(PointerVector<Node>{geom});
+        Vector N = ZeroVector(4);
+        N[0] = 0.1;
+        N[1] = 0.2;
+        N[2] = 0.3;
+        N[3] = 0.4;
+
+        KRATOS_EXPECT_EQ(2.0, (*p_elem_prop)[YOUNG_MODULUS]);
+        KRATOS_EXPECT_EQ(2.0, (*p_elem_prop).GetValue(YOUNG_MODULUS));
+        KRATOS_EXPECT_EQ(2.0, (*p_elem_prop).GetValue(YOUNG_MODULUS, *p_geom, N, r_model_part.GetProcessInfo()));
+        KRATOS_EXPECT_EQ(false, (*p_elem_prop).HasAccessor(YOUNG_MODULUS));
+
+        //check interpolation of historical database
+        auto historical_accessor = DatabaseAccessor("node_historical");
+        p_elem_prop->SetAccessor(YOUNG_MODULUS, historical_accessor.Clone());
+        KRATOS_EXPECT_EQ(true, (*p_elem_prop).HasAccessor(YOUNG_MODULUS));
+        KRATOS_EXPECT_EQ(350.0, (*p_elem_prop).GetValue(YOUNG_MODULUS, *p_geom, N, r_model_part.GetProcessInfo()));
+
+        //check interpolation of non-historical database
+        auto non_historical_accessor = DatabaseAccessor("node_non_historical");
+        //p_elem_prop->SetAccessor(YOUNG_MODULUS, non_historical_accessor.Clone());
+        p_elem_prop->pGetAccessor(YOUNG_MODULUS) = non_historical_accessor.Clone();
+        KRATOS_EXPECT_EQ(true, (*p_elem_prop).HasAccessor(YOUNG_MODULUS));
+        KRATOS_EXPECT_EQ(35.0, (*p_elem_prop).GetValue(YOUNG_MODULUS, *p_geom, N, r_model_part.GetProcessInfo()));
 }
 
 }  // namespace Kratos::Testing.

--- a/kratos/tests/test_KratosCore.py
+++ b/kratos/tests/test_KratosCore.py
@@ -108,6 +108,7 @@ import test_connectivity_ids_tensor_adaptor
 import test_constraint_restart
 import test_vtu_output
 import test_ensight_output_process
+import test_materials_input_with_accessors
 
 # Import modules required for sequential orchestrator test
 from test_sequential_orchestrator import EmptyAnalysisStage
@@ -241,6 +242,7 @@ def AssembleTestSuites():
     smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([test_vtu_output.TestVtuOutput2D]))
     smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([test_vtu_output.TestVtuOutput3D]))
     smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([test_ensight_output_process.TestEnsightOutputProcess]))
+    smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([test_materials_input_with_accessors.TestMaterialsInputWithAccessors]))
 
     if sympy_available:
         smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([test_sympy_fe_utilities.TestSympyFEUtilities]))

--- a/kratos/tests/test_materials_input_with_accessors.py
+++ b/kratos/tests/test_materials_input_with_accessors.py
@@ -1,0 +1,74 @@
+import os
+
+# Importing the Kratos Library
+import KratosMultiphysics
+import KratosMultiphysics.KratosUnittest as KratosUnittest
+import KratosMultiphysics.kratos_utilities as KratosUtils
+
+dependencies_are_available = KratosUtils.CheckIfApplicationsAvailable("StructuralMechanicsApplication")
+if dependencies_are_available:
+    import KratosMultiphysics.StructuralMechanicsApplication
+
+
+def GetFilePath(fileName):
+    return os.path.join(os.path.dirname(os.path.realpath(__file__)), fileName)
+
+class TestMaterialsInputWithAccessors(KratosUnittest.TestCase):
+    def _prepare_test(self, input_file = "material_with_accessor.json"):
+        # Define a Model
+        self.current_model = KratosMultiphysics.Model()
+
+        self.model_part = self.current_model.CreateModelPart("Main")
+
+        self.model_part.AddNodalSolutionStepVariable(KratosMultiphysics.DISPLACEMENT)
+        self.model_part.AddNodalSolutionStepVariable(KratosMultiphysics.TEMPERATURE)
+        self.model_part.AddNodalSolutionStepVariable(KratosMultiphysics.VELOCITY)
+        self.model_part.AddNodalSolutionStepVariable(KratosMultiphysics.VISCOSITY)
+        self.model_part_io = KratosMultiphysics.ModelPartIO(GetFilePath("auxiliar_files_for_python_unittest/mdpa_files/cube_few_elements")) #reusing the file that is already in the directory
+        self.model_part_io.ReadModelPart(self.model_part)
+
+        self.test_settings = KratosMultiphysics.Parameters("""
+        {
+            "Parameters": {
+                    "materials_filename": "material_with_accessor.json"
+            }
+        }
+        """)
+        
+        # Assign the real path
+        self.test_settings["Parameters"]["materials_filename"].SetString(GetFilePath("auxiliar_files_for_python_unittest/materials_files/" + input_file))
+
+    @KratosUnittest.skipUnless(dependencies_are_available,"StructuralMechanicsApplication not available")
+    def test_input_cpp(self):
+        self._prepare_test()
+
+        KratosMultiphysics.ReadMaterialsUtility(self.test_settings, self.current_model)
+
+        for node in self.model_part.Nodes:
+            node.SetSolutionStepValue(KratosMultiphysics.TEMPERATURE, node.Y**2)
+            node.SetSolutionStepValue(KratosMultiphysics.VISCOSITY, node.X + node.Y + node.Z)
+
+        prop = self.model_part.GetProperties()[1]
+        N = KratosMultiphysics.Vector([0.25, 0.25, 0.25, 0.25])
+        for elem in self.model_part.Elements:
+            geom = elem.GetGeometry()
+            reference_temperature = 0.0
+            reference_viscosity = 0.0
+            for i in range(geom.PointsNumber()):
+                reference_temperature += geom[i].Y**2 * N[i]
+                reference_viscosity += (geom[i].X + geom[i].Y + geom[i].Z )* N[i]
+
+            #check database accessor
+            visc = prop.GetValue(KratosMultiphysics.VISCOSITY, geom, N, self.model_part.ProcessInfo)
+            self.assertAlmostEqual(reference_viscosity, visc)
+
+            #check table accessor
+            Eref = prop.GetTable(KratosMultiphysics.TEMPERATURE, KratosMultiphysics.YOUNG_MODULUS).GetValue(reference_temperature)
+            E = prop.GetValue(KratosMultiphysics.YOUNG_MODULUS, geom, N, self.model_part.ProcessInfo)
+            self.assertAlmostEqual(reference_viscosity, visc)
+
+
+
+if __name__ == '__main__':
+    KratosMultiphysics.Logger.GetDefaultOutput().SetSeverity(KratosMultiphysics.Logger.Severity.WARNING)
+    KratosUnittest.main()

--- a/kratos/utilities/read_and_set_accessors_utilities.cpp
+++ b/kratos/utilities/read_and_set_accessors_utilities.cpp
@@ -51,6 +51,17 @@ void ReadAndSetAccessorsUtilities::ReadAndSetAccessors(
                 KRATOS_ERROR_IF(rProperty.HasAccessor(r_output_var)) << "You are trying to add an TableAccessor between " << input_var_name << " and " << output_var_name << " which already exists..." << std::endl;
 
                 rProperty.SetAccessor(r_output_var, (TableAccessor(*p_input_var, input_var_type)).Clone());
+            } else if (accessor_param["accessor_type"].GetString() == "database_accessor") {
+                // Independent Variable
+                std::string input_var_name = accessor_param["properties"]["variable"].GetString();
+                const Variable<double> *p_input_var = static_cast<const Variable<double> *>(KratosComponents<VariableData>::pGet(input_var_name));
+
+                // We set the variable type of the input variable (node_historical, node_non_historical and element)
+                std::string input_var_type = accessor_param["properties"].Has("table_input_variable_type") ? accessor_param["properties"]["table_input_variable_type"].GetString() : "node_historical";
+
+                KRATOS_ERROR_IF(rProperty.HasAccessor(*p_input_var)) << "You are trying to add an DatabaseAccessor for " << input_var_name << " which already exists..." << std::endl;
+
+                rProperty.SetAccessor(*p_input_var, (DatabaseAccessor(input_var_type)).Clone());
             } else {
                 // No more accessors implemented currently
                 KRATOS_ERROR << "This Accessor type is not available, only TableAccessor is ready for now" << std::endl;

--- a/kratos/utilities/read_and_set_accessors_utilities.cpp
+++ b/kratos/utilities/read_and_set_accessors_utilities.cpp
@@ -57,9 +57,9 @@ void ReadAndSetAccessorsUtilities::ReadAndSetAccessors(
                 const Variable<double> *p_input_var = static_cast<const Variable<double> *>(KratosComponents<VariableData>::pGet(input_var_name));
 
                 // We set the variable type of the input variable (node_historical, node_non_historical and element)
-                std::string input_var_type = accessor_param["properties"].Has("table_input_variable_type") ? accessor_param["properties"]["table_input_variable_type"].GetString() : "node_historical";
+                std::string input_var_type = accessor_param["properties"].Has("input_variable_type") ? accessor_param["properties"]["input_variable_type"].GetString() : "node_historical";
 
-                KRATOS_ERROR_IF(rProperty.HasAccessor(*p_input_var)) << "You are trying to add an DatabaseAccessor for " << input_var_name << " which already exists..." << std::endl;
+                KRATOS_ERROR_IF(rProperty.HasAccessor(*p_input_var)) << "You are trying to add a DatabaseAccessor for " << input_var_name << " which already exists..." << std::endl;
 
                 rProperty.SetAccessor(*p_input_var, (DatabaseAccessor(input_var_type)).Clone());
             } else {

--- a/kratos/utilities/read_and_set_accessors_utilities.h
+++ b/kratos/utilities/read_and_set_accessors_utilities.h
@@ -19,6 +19,7 @@
 
 /* Project includes */
 #include "includes/table_accessor.h"
+#include "includes/database_accessor.h"
 #include "includes/properties.h"
 #include "includes/kratos_parameters.h"
 


### PR DESCRIPTION
---
name: ✨ Feature
adds a DatabaseAccessor, which allows getting (for example YOUNG_MODULUS) from nodes, or from elements instead of from propoerties. this is to be used to provide more flexibility in the input of CL.

also a new very simple CL (identical to the existing Isotropic3D one) is added to permit a benchmarking baseline to assess the impact of using the accessor.
---

## **📝 Description**
A brief description of the PR.

Please mark the PR with appropriate tags: 
- feature

### **Key changes**
addes DatabaseAccessor together with python api and the relevant interfaces



A way to validate the changes do not break the code.

## **🆕 Changelog**
Please summarize the changes in one list to generate the changelog:
E.g.
- Added feature X to Y
- Added Foo Application
- Fixed X (#XXXX Reference to issue if apply) 
- etc...
