### PR TITLE
Add Navier-Stokes element (formulation setup) to monolithic solver

### DIFF
--- a/applications/FluidDynamicsApplication/python_scripts/navier_stokes_monolithic_solver.py
+++ b/applications/FluidDynamicsApplication/python_scripts/navier_stokes_monolithic_solver.py
@@ -36,12 +36,14 @@ class StabilizedFormulation:
                 self._SetUpWeaklyCompressible(settings)
             elif formulation == "weakly_compressible":
                 self._SetUpWeaklyCompressible(settings)
+            elif formulation == "navier_stokes":
+                self._SetUpNavierStokes(settings)
             elif formulation == "axisymmetric_navier_stokes":
                 self._SetUpAxisymmetricNavierStokes(settings)
             elif formulation == "p2p1":
                 self._SetUpP2P1(settings)
             else:
-                formulation_list = ["qsvms", "dvms", "fic", "weakly_compressible", "axisymmetric_navier_stokes", "p2p1"]
+                formulation_list = ["qsvms", "dvms", "fic", "weakly_compressible", "navier_stokes", "axisymmetric_navier_stokes", "p2p1"]
                 err_msg = f"Wrong \'element_type\' : \'{formulation}\' provided. Available options are:\n"
                 for elem in formulation_list:
                     err_msg += f"\t- {elem}\n"
@@ -178,6 +180,26 @@ class StabilizedFormulation:
         #TODO: Remove SOUND_VELOCITY from ProcessInfo. Should be obtained from the properties.
         self.process_data[KratosMultiphysics.SOUND_VELOCITY] = settings["sound_velocity"].GetDouble()
 
+    def _SetUpNavierStokes(self,settings):
+        """
+        Symbolic incompressible Navier-Stokes element (NavierStokes<TDim>).
+        Maps to the registered elements 'NavierStokes2D3N' / 'NavierStokes3D4N'.
+        """
+        default_settings = KratosMultiphysics.Parameters(r"""{
+            "element_type": "navier_stokes",
+            "dynamic_tau": 1.0,
+            "sound_velocity": 1.0e+12
+        }""")
+        settings.ValidateAndAssignDefaults(default_settings)
+
+        self.element_name = "NavierStokes"
+        self.condition_name = "NavierStokesWallCondition"
+        self.element_integrates_in_time = True
+        self.element_has_nodal_properties = False
+
+        self.process_data[KratosMultiphysics.DYNAMIC_TAU] = settings["dynamic_tau"].GetDouble()
+        self.process_data[KratosMultiphysics.SOUND_VELOCITY] = settings["sound_velocity"].GetDouble()
+    
     def _SetUpAxisymmetricNavierStokes(self,settings):
         default_settings = KratosMultiphysics.Parameters(r"""{
             "element_type": "axisymmetric_navier_stokes",

--- a/applications/FluidDynamicsApplication/python_scripts/navier_stokes_monolithic_solver.py
+++ b/applications/FluidDynamicsApplication/python_scripts/navier_stokes_monolithic_solver.py
@@ -43,7 +43,7 @@ class StabilizedFormulation:
             elif formulation == "p2p1":
                 self._SetUpP2P1(settings)
             else:
-                formulation_list = ["qsvms", "dvms", "fic", "weakly_compressible", "navier_stokes", "axisymmetric_navier_stokes", "p2p1"]
+                formulation_list = ["vms", "qsvms", "dvms", "fic", "weakly_compressible", "navier_stokes", "axisymmetric_navier_stokes", "p2p1"]
                 err_msg = f"Wrong \'element_type\' : \'{formulation}\' provided. Available options are:\n"
                 for elem in formulation_list:
                     err_msg += f"\t- {elem}\n"

--- a/applications/FluidDynamicsApplication/python_scripts/navier_stokes_monolithic_solver.py
+++ b/applications/FluidDynamicsApplication/python_scripts/navier_stokes_monolithic_solver.py
@@ -372,7 +372,15 @@ class NavierStokesMonolithicSolver(FluidSolver):
         self.element_has_nodal_properties = self.formulation.element_has_nodal_properties
         self.historical_nodal_variables_list = self.formulation.historical_nodal_variables_list
         self.non_historical_nodal_variables_list = self.formulation.non_historical_nodal_variables_list
-
+        # For NavierStokes elements we require BDF2 coefficients. If the user
+        # left the default time scheme (bossak), switch to bdf2 here.
+        if self.element_name == "NavierStokes" and self.settings["time_scheme"].GetString() == "bossak":
+            self.settings["time_scheme"].SetString("bdf2")
+            KratosMultiphysics.Logger.PrintInfo(
+                self.__class__.__name__,
+                "Element 'NavierStokes' requires BDF coefficients. "
+                "Default 'time_scheme' changed from 'bossak' to 'bdf2'.")
+    
     def _SetTimeSchemeBufferSize(self):
         scheme_type = self.settings["time_scheme"].GetString()
         if scheme_type == "bossak":

--- a/applications/FluidDynamicsApplication/tests/fluid_element_test.py
+++ b/applications/FluidDynamicsApplication/tests/fluid_element_test.py
@@ -69,6 +69,38 @@ class FluidElementTest(UnitTest.TestCase):
         self.is_time_integrated = True
         self.runCavity()
 
+    def testNavierStokesSetup(self):
+        """Verify that solver setup with the navier_stokes formulation works correctly."""
+        with UnitTest.WorkFolderScope(self.work_folder, __file__):
+            self.model = Model()
+
+            with open("solver_settings.json","r") as settings_file:
+                settings = Parameters(settings_file.read())
+
+            settings["solver_settings"]["formulation"]["element_type"].SetString("navier_stokes")
+
+            settings["solver_settings"].AddEmptyValue("time_scheme")
+            settings["solver_settings"]["time_scheme"].SetString("bdf2")
+
+            self.fluid_solver = navier_stokes_solver.CreateSolver(self.model,settings["solver_settings"])
+            self.fluid_solver.AddVariables()
+            self.fluid_solver.ImportModelPart()
+            self.fluid_solver.PrepareModelPart()
+            self.fluid_solver.AddDofs()
+
+            fluid_model_part_name = settings["solver_settings"]["model_part_name"].GetString() + "." + settings["solver_settings"]["volume_model_part_name"].GetString()
+            fluid_model_part = self.model.GetModelPart(fluid_model_part_name)
+
+            # Verify ProcessInfo values are set correctly
+            self.assertEqual(fluid_model_part.ProcessInfo[DYNAMIC_TAU], 1.0)
+            self.assertEqual(fluid_model_part.ProcessInfo[SOUND_VELOCITY], 1.0e+12)
+
+            # Verify that elements are of the expected NavierStokes type
+            for element in fluid_model_part.Elements:
+                element_name = element.Info()
+                self.assertTrue("NavierStokes" in element_name, f"Expected NavierStokes element, got {element_name}")
+                break  # Only need to check one element
+
     def testTimeIntegratedQSVMS(self):
         self.element = "qsvms"
         self.reference_file = "reference10_time_integrated"


### PR DESCRIPTION
---
name: ✨ Feature
about: New applications, new features or wider changes

---

## **📝 Description**
Add Navier-Stokes element (formulation setup) to monolithic solver

Please mark the PR with appropriate tags: 
- navier-stokes, monolithic solver

### **Key changes**
"formulation": {
    "element_type": "navier_stokes",
    "dynamic_tau": 1.0,
    "sound_velocity": 1e12
}

### **Validation**
No new feature!

## **🆕 Changelog**
- applications/FluidDynamicsApplication/python_scripts/navier_stokes_monolithic_solver.py
