### PR TITLE
[TrilinosApplication] Extend support of communicator to `Teuchos`

### DIFF
--- a/applications/TrilinosApplication/custom_python/add_trilinos_space_experimental_to_python.cpp
+++ b/applications/TrilinosApplication/custom_python/add_trilinos_space_experimental_to_python.cpp
@@ -478,6 +478,15 @@ void WriteMatrixMarketVector(
     rDummy.WriteMatrixMarketVector(pFileName, rV);
 }
 
+// --- Communicator factory ---
+
+Teuchos::MpiComm<int> CreateTeuchosCommunicator(const DataCommunicator& rDataCommunicator)
+{
+    KRATOS_ERROR_IF_NOT(rDataCommunicator.IsDistributed()) << "Only distributed DataCommunicators can be used!" << std::endl;
+    auto raw_mpi_comm = MPIDataCommunicator::GetMPICommunicator(rDataCommunicator);
+    return Teuchos::MpiComm<int>(raw_mpi_comm);
+}
+
 } // anonymous namespace
 
 #endif
@@ -488,6 +497,7 @@ void AddBasicOperationsExperimental(py::module& m)
 
     // Expose underlying Tpetra/Teuchos types so Python can receive or pass them
     py::class_<Teuchos::MpiComm<int>>(m, "Experimental_TeuchosMpiComm");
+    m.def("CreateTeuchosCommunicator", CreateTeuchosCommunicator, py::arg("data_communicator"), "Creates a Teuchos::MpiComm from a distributed Kratos DataCommunicator (Tpetra counterpart of CreateEpetraCommunicator)");
     py::class_<Tpetra::FECrsMatrix<>>(m, "Experimental_FECrsMatrix");
     py::class_<Tpetra::FEMultiVector<>>(m, "Experimental_FEMultiVector");
 

--- a/applications/TrilinosApplication/custom_utilities/trilinos_solver_utilities.cpp
+++ b/applications/TrilinosApplication/custom_utilities/trilinos_solver_utilities.cpp
@@ -12,6 +12,7 @@
 
 // External includes
 #include "Epetra_MpiComm.h"
+#include "Teuchos_DefaultMpiComm.hpp"
 
 // Project includes
 #include "trilinos_solver_utilities.h"
@@ -34,6 +35,12 @@ MPI_Comm GetMPICommFromEpetraComm(const Epetra_Comm& rEpetraComm)
     // see https://github.com/trilinos/Trilinos/issues/10122#issuecomment-1021614956
     const Epetra_MpiComm& r_epetra_mpi_comm = dynamic_cast<const Epetra_MpiComm&>(rEpetraComm); // cannot use static_cast due to virtual inheritance
     return r_epetra_mpi_comm.Comm();
+}
+
+MPI_Comm GetMPICommFromTeuchosComm(const Teuchos::Comm<int>& rTeuchosComm)
+{
+    const auto& r_teuchos_mpi_comm = dynamic_cast<const Teuchos::MpiComm<int>&>(rTeuchosComm);
+    return *(r_teuchos_mpi_comm.getRawMpiComm());
 }
 
 }  // namespace TrilinosSolverUtilities.

--- a/applications/TrilinosApplication/custom_utilities/trilinos_solver_utilities.h
+++ b/applications/TrilinosApplication/custom_utilities/trilinos_solver_utilities.h
@@ -15,6 +15,7 @@
 
 // External includes
 #include "Teuchos_ParameterList.hpp"
+#include "Teuchos_Comm.hpp"
 #include <mpi.h>
 #include "Epetra_Comm.h"
 
@@ -28,6 +29,8 @@ namespace TrilinosSolverUtilities {
 void SetTeuchosParameters(const Parameters rSettings, Teuchos::ParameterList& rParameterlist);
 
 MPI_Comm GetMPICommFromEpetraComm(const Epetra_Comm& rEpetraComm);
+
+MPI_Comm GetMPICommFromTeuchosComm(const Teuchos::Comm<int>& rTeuchosComm);
 
 }  // namespace TrilinosSolverUtilities.
 }  // namespace Kratos.


### PR DESCRIPTION
---
name: ✨ Feature
about: Extend support of communicator to `Teuchos`

---

## **📝 Description**

This PR extends the Trilinos communicator utilities to support the Teuchos communicator types used by Tpetra.

This provides the Tpetra counterpart of `CreateEpetraCommunicator()` and enables the experimental Trilinos/Tpetra interfaces to use communicators created from Kratos.

### **Motivation**

The experimental Tpetra-based Trilinos infrastructure requires interoperability between:

- Kratos `DataCommunicator`
- Teuchos `Comm`
- Native `MPI_Comm`

Providing these conversions avoids directly managing MPI communicators in client code and prepares the Python interface for broader Tpetra support.

### **Key changes**

- Add `TrilinosSolverUtilities::GetMPICommFromTeuchosComm()` to retrieve the underlying `MPI_Comm` from a `Teuchos::Comm<int>`.
- Handle the Teuchos communicator through `Teuchos::MpiComm<int>`, following the existing Epetra communicator utility.
- Expose `CreateTeuchosCommunicator()` to Python when Tpetra is available.
- Allow creating a `Teuchos::MpiComm<int>` from a distributed Kratos `DataCommunicator`.
- Reject non-distributed `DataCommunicator` instances with a clear error message.

### **Validation**

- MPI Trilinos C++ test executable run successfully with two processes:
  `KratosTrilinosCoreTest`
- No dedicated tests are added in this PR.

## **🆕 Changelog**

- [Add Teuchos_Comm support to Trilinos solver utilities](https://github.com/KratosMultiphysics/Kratos/commit/674197e7e6a15480bc3fadbc46af40aa6e8a8472)
- [Add Teuchos_Comm support to retrieve MPI_Comm from Teuchos communication](https://github.com/KratosMultiphysics/Kratos/commit/92de4bf3690726704d9a5e71b51406851e16637f)
- [Add CreateTeuchosCommunicator function to expose Teuchos::MpiComm cre…](https://github.com/KratosMultiphysics/Kratos/commit/d3073e72a8e9651bde3472942c1f9e44036fd168)
