### PR TITLE
[FluidApp] Fixing the equation_ids retrieval of the FSGeneralizedWallLaw

### DIFF
--- a/applications/FluidDynamicsApplication/custom_conditions/fs_generalized_wall_condition.cpp
+++ b/applications/FluidDynamicsApplication/custom_conditions/fs_generalized_wall_condition.cpp
@@ -29,7 +29,7 @@ void FSGeneralizedWallCondition<2, 2>::EquationIdVector(
 					VELOCITY_Y).EquationId();
 		}
 	}
-	else if (this->Is(INTERFACE) && rCurrentProcessInfo[FRACTIONAL_STEP] == 5)
+	else if (rCurrentProcessInfo[FRACTIONAL_STEP] == 5)
 	{
 		const SizeType NumNodes = 2;
 		const SizeType LocalSize = 2;
@@ -76,7 +76,7 @@ void FSGeneralizedWallCondition<3, 3>::EquationIdVector(
 					VELOCITY_Z).EquationId();
 		}
 	}
-	else if (this->Is(INTERFACE) && rCurrentProcessInfo[FRACTIONAL_STEP] == 5)
+	else if (rCurrentProcessInfo[FRACTIONAL_STEP] == 5)
 	{
 		const SizeType NumNodes = 3;
 		const SizeType LocalSize = 3;


### PR DESCRIPTION
As In the title. The LHS and RHS construction returns correctly sized zero matrices and vectors for `FRACTIONAL_STEP` = 5 without checking the `INTERFACE` flag. But when we want to have the `EquationIds`, it checks the flag, if the flag is true only then returns the correctly sized equation ids. This makes the `ResidualBasedBlockBuilderAndSolver` to seg fault.

This fixes this issue making the `EquationIdVector` method consistent with the `CalculateLocalSystem` method.