### PR TITLE
[Core] Fix some inconsistent matrices sizes

### DIFF
--- a/kratos/utilities/discont_utils.h
+++ b/kratos/utilities/discont_utils.h
@@ -962,7 +962,7 @@ private:
         rShapeFunctionValues(Volume2Id, i) -= delta2;
     }
 
-    static double ComputeSubTetraVolumeAndCenter(const BoundedMatrix<double, 3, 8 > & rAuxCoordinates,
+    static double ComputeSubTetraVolumeAndCenter(const BoundedMatrix<double, 8, 3 > & rAuxCoordinates,
                                                  array_1d<double, 3 > & rCenterPosition,
                                                  const int i0, const int i1, const int i2, const int i3)
     {

--- a/kratos/utilities/enrichment_utilities.h
+++ b/kratos/utilities/enrichment_utilities.h
@@ -2497,9 +2497,9 @@ private:
     }
 
     //2d
-    template<class TCoordinatesType>
+    template<class TCoordinateContainerType>
     static inline void CalculateGeometryData(
-        const TCoordinatesType& coordinates,
+        const TCoordinateContainerType& coordinates,
         BoundedMatrix<double,3,2>& DN_DX,
         array_1d<double,3>& N,
         double& Area)
@@ -2534,9 +2534,9 @@ private:
     }
 
     //template<class TMatrixType, class TVectorType, class TGradientType>
-    template<class TCoordinatesType>
+    template<class TCoordinateContainerType>
     static inline double CalculateVolume2D(
-        const TCoordinatesType& coordinates)
+        const TCoordinateContainerType& coordinates)
     {
         double x10 = coordinates(1,0) - coordinates(0,0);
         double y10 = coordinates(1,1) - coordinates(0,1);
@@ -2547,8 +2547,8 @@ private:
         return 0.5*detJ;
     }
 
-    template<class TCoordinatesType>
-    static inline bool CalculatePosition(const TCoordinatesType& coordinates,
+    template<class TCoordinateContainerType>
+    static inline bool CalculatePosition(const TCoordinateContainerType& coordinates,
                                          const double xc, const double yc, const double zc,
                                          array_1d<double, 3 > & N
                                         )
@@ -2591,9 +2591,9 @@ private:
         return 0.5 * ((x1 - x0)*(y2 - y0)- (y1 - y0)*(x2 - x0));
     }
 
-    template<class TCoordinatesType>
+    template<class TCoordinateContainerType>
     static inline void CalculateGeometryData(
-        const TCoordinatesType& coordinates,
+        const TCoordinateContainerType& coordinates,
         BoundedMatrix<double,3,2>& DN_DX,
         double& Area)
     {

--- a/kratos/utilities/enrichment_utilities.h
+++ b/kratos/utilities/enrichment_utilities.h
@@ -2414,7 +2414,7 @@ private:
         //            rShapeFunctionValues(Volume2Id, j) = division_j * 0.25;
     }
 
-    static double ComputeSubTetraVolumeAndCenter(const BoundedMatrix<double, 3, 8 > & aux_coordinates,
+    static double ComputeSubTetraVolumeAndCenter(const BoundedMatrix<double, 8, 3 > & aux_coordinates,
             array_1d<double, 3 > & center_position,
             const int i0, const int i1, const int i2, const int i3)
     {
@@ -2497,8 +2497,9 @@ private:
     }
 
     //2d
+    template<class TCoordinatesType>
     static inline void CalculateGeometryData(
-        const BoundedMatrix<double, 3, 3 > & coordinates,
+        const TCoordinatesType& coordinates,
         BoundedMatrix<double,3,2>& DN_DX,
         array_1d<double,3>& N,
         double& Area)
@@ -2533,8 +2534,9 @@ private:
     }
 
     //template<class TMatrixType, class TVectorType, class TGradientType>
+    template<class TCoordinatesType>
     static inline double CalculateVolume2D(
-        const BoundedMatrix<double, 3, 3 > & coordinates)
+        const TCoordinatesType& coordinates)
     {
         double x10 = coordinates(1,0) - coordinates(0,0);
         double y10 = coordinates(1,1) - coordinates(0,1);
@@ -2545,7 +2547,8 @@ private:
         return 0.5*detJ;
     }
 
-    static inline bool CalculatePosition(const BoundedMatrix<double, 3, 3 > & coordinates,
+    template<class TCoordinatesType>
+    static inline bool CalculatePosition(const TCoordinatesType& coordinates,
                                          const double xc, const double yc, const double zc,
                                          array_1d<double, 3 > & N
                                         )
@@ -2588,8 +2591,9 @@ private:
         return 0.5 * ((x1 - x0)*(y2 - y0)- (y1 - y0)*(x2 - x0));
     }
 
+    template<class TCoordinatesType>
     static inline void CalculateGeometryData(
-        const BoundedMatrix<double, 3, 3 > & coordinates,
+        const TCoordinatesType& coordinates,
         BoundedMatrix<double,3,2>& DN_DX,
         double& Area)
     {

--- a/kratos/utilities/enrichment_utilities_duplicate_dofs.h
+++ b/kratos/utilities/enrichment_utilities_duplicate_dofs.h
@@ -492,7 +492,7 @@ public:
 private:
 
 
-static double ComputeSubTetraVolumeAndCenter(const BoundedMatrix<double, 3, 8 > & aux_coordinates,
+static double ComputeSubTetraVolumeAndCenter(const BoundedMatrix<double, 8, 3 > & aux_coordinates,
         array_1d<double, 3 > & center_position,
         const int i0, const int i1, const int i2, const int i3)
 {
@@ -521,7 +521,7 @@ static double ComputeSubTetraVolumeAndCenter(const BoundedMatrix<double, 3, 8 > 
 }
 
 //compute 4 gauss point per subtetra
-static void ComputeSubTetraVolumeAndGaussPoints(const BoundedMatrix<double, 3, 8 > & aux_coordinates,
+static void ComputeSubTetraVolumeAndGaussPoints(const BoundedMatrix<double, 8, 3 > & aux_coordinates,
         Vector& volumes,
         std::vector< array_1d<double, 3 > >& center_position,
         const int i0, const int i1, const int i2, const int i3)
@@ -627,8 +627,9 @@ static inline double CalculateVol(const double x0, const double y0, const double
 }
 
 //2d
+template<class TCoordinatesType>
 static inline void CalculateGeometryData(
-    const BoundedMatrix<double, 3, 3 > & coordinates,
+    const TCoordinatesType& coordinates,
     BoundedMatrix<double,3,2>& DN_DX,
     array_1d<double,3>& N,
     double& Area)
@@ -663,8 +664,9 @@ static inline void CalculateGeometryData(
 }
 
 //template<class TMatrixType, class TVectorType, class TGradientType>
+template<class TCoordinatesType>
 static inline double CalculateVolume2D(
-    const BoundedMatrix<double, 3, 3 > & coordinates)
+    const TCoordinatesType& coordinates)
 {
     double x10 = coordinates(1,0) - coordinates(0,0);
     double y10 = coordinates(1,1) - coordinates(0,1);
@@ -675,7 +677,8 @@ static inline double CalculateVolume2D(
     return 0.5*detJ;
 }
 
-static inline bool CalculatePosition(const BoundedMatrix<double, 3, 3 > & coordinates,
+template<class TCoordinatesType>
+    static inline bool CalculatePosition(const TCoordinatesType& coordinates,
                                      const double xc, const double yc, const double zc,
                                      array_1d<double, 3 > & N
                                     )
@@ -718,8 +721,9 @@ static inline double CalculateVol(const double x0, const double y0,
     return 0.5 * ((x1 - x0)*(y2 - y0)- (y1 - y0)*(x2 - x0));
 }
 
+template<class TCoordinatesType>
 static inline void CalculateGeometryData(
-    const BoundedMatrix<double, 3, 3 > & coordinates,
+    const TCoordinatesType& coordinates,
     BoundedMatrix<double,3,2>& DN_DX,
     double& Area)
 {


### PR DESCRIPTION
---
name: ✨ Feature
about: Fix some inconsistent matrices sizes

---

## **📝 Description**

Fix some inconsistent matrices sizes.

## **🆕 Changelog**

- [Fix parameter order in ComputeSubTetraVolumeAndCenter for correct vol…](https://github.com/KratosMultiphysics/Kratos/commit/b7e575728fe579579894c472bef8bc84ebdaf4a9)
- [Refactor ComputeSubTetraVolumeAndCenter and related functions to use …](https://github.com/KratosMultiphysics/Kratos/commit/a70e7f43608de2d9e9e7948fc1b36542bb5e40ee)