### PR TITLE
[Core] Refactor `Length` method in `Quadrilateral3D9` to use `array_1d`

### DIFF
--- a/kratos/geometries/quadrilateral_3d_9.h
+++ b/kratos/geometries/quadrilateral_3d_9.h
@@ -424,7 +424,7 @@ public:
      */
     double Length() const override
     {
-        Vector d = this->Points()[2] - this->Points()[0];
+        const array_1d<double, 3> d = this->Points()[2] - this->Points()[0];
         return( std::sqrt( d[0]*d[0] + d[1]*d[1] + d[2]*d[2] ) );
     }
 


### PR DESCRIPTION
---
name: ✨ Feature
about: Refactor `Length` method in `Quadrilateral3D9` to use `array_1d`.
---

## **📝 Description**

Refactor `Length` method in `Quadrilateral3D9` to use `array_1d`, for consistency.

## **🆕 Changelog**

- [Refactor Length method in Quadrilateral3D9 to use array_1d](https://github.com/KratosMultiphysics/Kratos/commit/13a04b172b757bbf2e612fd76b97f2060ec87a5e)
