### PR TITLE
[Core] Refactor octree bounding box setting to use pointer arithmetic for improved clarity

### DIFF
--- a/kratos/processes/find_intersected_geometrical_objects_process.cpp
+++ b/kratos/processes/find_intersected_geometrical_objects_process.cpp
@@ -245,7 +245,7 @@ void FindIntersectedGeometricalObjectsProcess::GenerateOctree()
 
     // Adding mrModelPart2 to the octree
     for (auto it_node = mrModelPartIntersecting.NodesBegin(); it_node != mrModelPartIntersecting.NodesEnd(); it_node++) {
-        mpOctree->Insert(it_node->Coordinates().data().data());
+        mpOctree->Insert(&(it_node->Coordinates()[0]));
     }
 
     // Add entities
@@ -309,7 +309,7 @@ void  FindIntersectedGeometricalObjectsProcess::SetOctreeBoundingBox()
     }
 
     // TODO: Octree needs refactoring to work with BoundingBox. Pooyan.
-    mpOctree->SetBoundingBox(low.data().data(), high.data().data());
+    mpOctree->SetBoundingBox(&low[0], &high[0]);
 }
 
 /***********************************************************************************/

--- a/kratos/processes/find_intersected_geometrical_objects_with_obb_process.cpp
+++ b/kratos/processes/find_intersected_geometrical_objects_with_obb_process.cpp
@@ -165,7 +165,7 @@ void FindIntersectedGeometricalObjectsWithOBBProcess::SetOctreeBoundingBox()
     }
 
     // TODO: Octree needs refactoring to work with BoundingBox. Pooyan.
-    GetOctreePointer()->SetBoundingBox(low.data().data(), high.data().data());
+    GetOctreePointer()->SetBoundingBox(&low[0], &high[0]);
 }
 
 /***********************************************************************************/


### PR DESCRIPTION
---
name: ✨ Feature
about: Refactor octree bounding box setting to use pointer arithmetic for improved clarity
---

## **📝 Description**

Refactor octree bounding box setting to use pointer arithmetic for improved clarity.

## **🆕 Changelog**

- [Refactor octree bounding box setting to use pointer arithmetic for im…](https://github.com/KratosMultiphysics/Kratos/commit/58494f4c418e63187a48fa374f7f667e57743311)
