### PR TITLE
[MPM] Fix `CalculateDepSurface` method to correct matrix multiplication order

### DIFF
--- a/applications/MPMApplication/custom_constitutive/flow_rules/mc_plastic_flow_rule.cpp
+++ b/applications/MPMApplication/custom_constitutive/flow_rules/mc_plastic_flow_rule.cpp
@@ -476,10 +476,10 @@ void MCPlasticFlowRule::CalculateModificationMatrix(const RadialReturnVariables&
 
 void MCPlasticFlowRule::CalculateDepSurface(BoundedMatrix<double,3,3>& rElasticMatrix, BoundedVector<double,3>& rFNorm, BoundedVector<double,3>& rGNorm, BoundedMatrix<double,3,3>& rAuxDep)
 {
-    BoundedVector<double,3> aux_F = prod(trans(rFNorm), rElasticMatrix);
+    BoundedVector<double,3> aux_F = prod(rFNorm, rElasticMatrix);
 
     BoundedVector<double,3> a = prod(rElasticMatrix, rGNorm);
-    BoundedVector<double,3> b = prod(trans(rFNorm),rElasticMatrix);
+    BoundedVector<double,3> b = prod(rFNorm, rElasticMatrix);
 
     BoundedMatrix<double,3,3> num = ZeroMatrix(3,3);
 


### PR DESCRIPTION
---
name: ✨ Feature
about: New applications, new features or wider changes

---

## **📝 Description**

Fix `CalculateDepSurface` method to correct matrix multiplication order to fix potential memory errors.

## **🆕 Changelog**

- [Fix CalculateDepSurface method to correct matrix multiplication order…](https://github.com/KratosMultiphysics/Kratos/commit/46de50f7c7f49b1fb4de6b673facbf20fa5b6bef)
