### PR TITLE
[GeoMechanicsApplication] Modification of KratosGeoUnittest

### DIFF
--- a/applications/GeoMechanicsApplication/tests/KratosGeoUnittest.py
+++ b/applications/GeoMechanicsApplication/tests/KratosGeoUnittest.py
@@ -2,19 +2,24 @@ from KratosMultiphysics.GeoMechanicsApplication.gid_output_file_reader import Gi
 from KratosMultiphysics import KratosUnittest
 
 class TestCase(KratosUnittest.TestCase):
-	def assert_y_displacements_at_time(self, result, node_ids, expected_y, time, places=None, delta=None):
-		displacements = GiDOutputFileReader.nodal_values_at_time("DISPLACEMENT", time, result, node_ids=node_ids)
-		for displacement in displacements:
-			self.assertAlmostEqual(expected_y, displacement[1], places, delta = delta)
+    def assert_y_displacements_at_time(self, result, node_ids, expected_y, time, places=None, delta=None):
+        displacements = GiDOutputFileReader.nodal_values_at_time("DISPLACEMENT", time, result, node_ids=node_ids)
+        for displacement in displacements:
+            self.assertAlmostEqual(expected_y, displacement[1], places, delta = delta)
 
-	def assert_nodal_values_at_time(self, result, variable_name, node_ids, expected_values, time, places=None, delta=None):
-		for node_id, expected_node_values in zip(node_ids, expected_values):
-			result_values = GiDOutputFileReader.nodal_values_at_time(variable_name, time, result, [node_id])[0]
-			self.assertAlmostEqual(expected_node_values, result_values, places, delta = delta,
-						  	msg = f"There is a difference in the {variable_name} components for node {node_id}")
+    def assert_nodal_values_at_time(self, result, variable_name, node_ids, expected_values, time, places=None, delta=None):
+        def _ensure_list(value):
+            if isinstance(value, (list, tuple)):
+                return value
+            return [value]
 
-	def assert_integration_point_tensors(self, result, variable_name, expected_tensors, time, places=None, delta=None):
-		for (element_id, ip_index), expected_tensor in expected_tensors.items():
-			tensor = GiDOutputFileReader.element_integration_point_values_at_time(variable_name, time, result, [element_id], [ip_index])[0][0]
-			self.assertVectorAlmostEqual(expected_tensor, tensor, places, delta = delta, 
-							msg = f"There is a difference in the {variable_name} components for element {element_id}, integration point {ip_index}")
+        for node_id, expected_node_values in zip(node_ids, expected_values):
+            result_values = GiDOutputFileReader.nodal_values_at_time(variable_name, time, result, [node_id])[0]
+            self.assertVectorAlmostEqual(_ensure_list(expected_node_values), _ensure_list(result_values), places, delta=delta,
+                            msg=f"There is a difference in the {variable_name} components for node {node_id}")
+
+    def assert_integration_point_tensors(self, result, variable_name, expected_tensors, time, places=None, delta=None):
+        for (element_id, ip_index), expected_tensor in expected_tensors.items():
+            tensor = GiDOutputFileReader.element_integration_point_values_at_time(variable_name, time, result, [element_id], [ip_index])[0][0]
+            self.assertVectorAlmostEqual(expected_tensor, tensor, places, delta = delta, 
+                            msg = f"There is a difference in the {variable_name} components for element {element_id}, integration point {ip_index}")

--- a/applications/GeoMechanicsApplication/tests/KratosGeoUnittest.py
+++ b/applications/GeoMechanicsApplication/tests/KratosGeoUnittest.py
@@ -2,7 +2,7 @@ from KratosMultiphysics.GeoMechanicsApplication.gid_output_file_reader import Gi
 from KratosMultiphysics import KratosUnittest
 
 class TestCase(KratosUnittest.TestCase):
-    def assert_y_displacements_at_time(self, result, node_ids, expected_y, time, places=None, delta=None):
+    def assert_uniform_y_displacement_at_time(self, result, node_ids, expected_y, time, places=None, delta=None):
         displacements = GiDOutputFileReader.nodal_values_at_time("DISPLACEMENT", time, result, node_ids=node_ids)
         for displacement in displacements:
             self.assertAlmostEqual(expected_y, displacement[1], places, delta = delta)
@@ -13,8 +13,8 @@ class TestCase(KratosUnittest.TestCase):
                 return value
             return [value]
 
-        for node_id, expected_node_values in zip(node_ids, expected_values):
-            result_values = GiDOutputFileReader.nodal_values_at_time(variable_name, time, result, [node_id])[0]
+        result_values_at_nodes = GiDOutputFileReader.nodal_values_at_time(variable_name, time, result, node_ids)
+        for node_id, expected_node_values, result_values in zip(node_ids, expected_values, result_values_at_nodes):
             self.assertVectorAlmostEqual(_ensure_list(expected_node_values), _ensure_list(result_values), places, delta=delta,
                             msg=f"There is a difference in the {variable_name} components for node {node_id}")
 

--- a/applications/GeoMechanicsApplication/tests/test_element_lab.py
+++ b/applications/GeoMechanicsApplication/tests/test_element_lab.py
@@ -86,7 +86,7 @@ class KratosGeoMechanicsLabElementTests(KratosGeoUnittest.TestCase):
             1.0, precision_places_stress)
 
         for time, expected_y in zip(displacement_times, expected_y_displacements):
-            self.assert_y_displacements_at_time(result, top_nodes, expected_y, time, precision_places_displacement)
+            self.assert_uniform_y_displacement_at_time(result, top_nodes, expected_y, time, precision_places_displacement)
 
     def test_dss_drained(self):
         """Regression test for the direct simple shear experiment with constant pore water pressure."""
@@ -210,9 +210,9 @@ class KratosGeoMechanicsLabElementTests(KratosGeoUnittest.TestCase):
         reader = GiDOutputFileReader()
         result = reader.read_output_from(output_file)
 
-        self.assert_y_displacements_at_time(result, top_node_nbrs, -0.0099, 0.1, 4)
-        self.assert_y_displacements_at_time(result, top_node_nbrs, -0.0654, 0.7, 4)
-        self.assert_y_displacements_at_time(result, top_node_nbrs, -0.0909, 1.0, 4)
+        self.assert_uniform_y_displacement_at_time(result, top_node_nbrs, -0.0099, 0.1, 4)
+        self.assert_uniform_y_displacement_at_time(result, top_node_nbrs, -0.0654, 0.7, 4)
+        self.assert_uniform_y_displacement_at_time(result, top_node_nbrs, -0.0909, 1.0, 4)
 
     def test_oedometer_ULFEM_diff_order(self):
         """
@@ -228,7 +228,7 @@ class KratosGeoMechanicsLabElementTests(KratosGeoUnittest.TestCase):
         reader = GiDOutputFileReader()
         result = reader.read_output_from(output_file)
         top_node_nbrs = [1]
-        self.assert_y_displacements_at_time(result, top_node_nbrs, -1e-4, 1.0, 6)
+        self.assert_uniform_y_displacement_at_time(result, top_node_nbrs, -1e-4, 1.0, 6)
 
     def _assert_oedometer_effective_stresses(self, effective_stresses, expected_yy, places_yy):
         for element in effective_stresses:


### PR DESCRIPTION
- used `assertVectorAlmostEqual `instead of `assertAlmostEqual`
- added `_ensure_list` to insure that inputs are lists
- replaced tabs with white spaces