### PR TITLE
[GeoMechanicsApplication] Removed all seepage related legacy code

### DIFF
--- a/applications/GeoMechanicsApplication/custom_processes/apply_constant_hydrostatic_pressure_process.cpp
+++ b/applications/GeoMechanicsApplication/custom_processes/apply_constant_hydrostatic_pressure_process.cpp
@@ -32,7 +32,6 @@ ApplyConstantHydrostaticPressureProcess::ApplyConstantHydrostaticPressureProcess
             "model_part_name":"PLEASE_CHOOSE_MODEL_PART_NAME",
             "variable_name": "PLEASE_PRESCRIBE_VARIABLE_NAME",
             "is_fixed": false,
-            "is_seepage" : false,
             "gravity_direction" : 2,
             "reference_coordinate" : 0.0,
             "specific_weight" : 10000.0,
@@ -53,7 +52,6 @@ ApplyConstantHydrostaticPressureProcess::ApplyConstantHydrostaticPressureProcess
     mModelPartName         = rParameters["model_part_name"].GetString();
     mVariableName          = rParameters["variable_name"].GetString();
     mIsFixed               = rParameters["is_fixed"].GetBool();
-    mIsSeepage             = rParameters["is_seepage"].GetBool();
     mGravityDirection      = rParameters["gravity_direction"].GetInt();
     mReferenceCoordinate   = rParameters["reference_coordinate"].GetDouble();
     mSpecificWeight        = rParameters["specific_weight"].GetDouble();
@@ -71,19 +69,10 @@ void ApplyConstantHydrostaticPressureProcess::ExecuteInitialize()
         const double pressure = -PORE_PRESSURE_SIGN_FACTOR * mSpecificWeight *
                                 (mReferenceCoordinate - rNode.Coordinates()[mGravityDirection]);
 
-        if (mIsSeepage) {
-            if (pressure < PORE_PRESSURE_SIGN_FACTOR * mPressureTensionCutOff) { // Before 0. was used i.s.o. the tension cut off value -> no effect in any test.
-                rNode.FastGetSolutionStepValue(var) = pressure;
-                if (mIsFixed) rNode.Fix(var);
-            } else {
-                if (mIsFixedProvided) rNode.Free(var);
-            }
-        } else {
-            rNode.FastGetSolutionStepValue(var) =
-                std::min(pressure, PORE_PRESSURE_SIGN_FACTOR * mPressureTensionCutOff);
-            if (mIsFixed) rNode.Fix(var);
-            else if (mIsFixedProvided) rNode.Free(var);
-        }
+        rNode.FastGetSolutionStepValue(var) =
+            std::min(pressure, PORE_PRESSURE_SIGN_FACTOR * mPressureTensionCutOff);
+        if (mIsFixed) rNode.Fix(var);
+        else if (mIsFixedProvided) rNode.Free(var);
     });
 
     KRATOS_CATCH("")

--- a/applications/GeoMechanicsApplication/custom_processes/apply_constant_hydrostatic_pressure_process.h
+++ b/applications/GeoMechanicsApplication/custom_processes/apply_constant_hydrostatic_pressure_process.h
@@ -48,7 +48,6 @@ protected:
     std::string  mVariableName;
     bool         mIsFixed;
     bool         mIsFixedProvided;
-    bool         mIsSeepage;
     unsigned int mGravityDirection;
     double       mReferenceCoordinate;
     double       mSpecificWeight;

--- a/applications/GeoMechanicsApplication/custom_processes/apply_constant_interpolate_line_pressure_process.cpp
+++ b/applications/GeoMechanicsApplication/custom_processes/apply_constant_interpolate_line_pressure_process.cpp
@@ -33,7 +33,6 @@ ApplyConstantInterpolateLinePressureProcess::ApplyConstantInterpolateLinePressur
                 "model_part_name":"PLEASE_CHOOSE_MODEL_PART_NAME",
                 "variable_name": "PLEASE_PRESCRIBE_VARIABLE_NAME",
                 "is_fixed": false,
-                "is_seepage": false,
                 "gravity_direction": 1,
                 "out_of_plane_direction": 2,
                 "pressure_tension_cut_off" : 0.0,
@@ -55,7 +54,6 @@ ApplyConstantInterpolateLinePressureProcess::ApplyConstantInterpolateLinePressur
     FindBoundaryNodes();
 
     mIsFixed             = rParameters["is_fixed"].GetBool();
-    mIsSeepage           = rParameters["is_seepage"].GetBool();
     mGravityDirection    = rParameters["gravity_direction"].GetInt();
     mOutOfPlaneDirection = rParameters["out_of_plane_direction"].GetInt();
     if (mGravityDirection == mOutOfPlaneDirection)
@@ -79,19 +77,10 @@ void ApplyConstantInterpolateLinePressureProcess::ExecuteInitializeSolutionStep(
 
     block_for_each(mrModelPart.Nodes(), [&var, this](Node& rNode) {
         const double pressure = CalculatePressure(rNode);
-        if (mIsSeepage) {
-            if (pressure < PORE_PRESSURE_SIGN_FACTOR * mPressureTensionCutOff) {
-                rNode.FastGetSolutionStepValue(var) = pressure;
-                if (mIsFixed) rNode.Fix(var);
-            } else {
-                rNode.Free(var);
-            }
-        } else {
-            rNode.FastGetSolutionStepValue(var) =
-                std::min(pressure, PORE_PRESSURE_SIGN_FACTOR * mPressureTensionCutOff);
-            if (mIsFixed) rNode.Fix(var);
-            else if (mIsFixedProvided) rNode.Free(var);
-        }
+        rNode.FastGetSolutionStepValue(var) =
+            std::min(pressure, PORE_PRESSURE_SIGN_FACTOR * mPressureTensionCutOff);
+        if (mIsFixed) rNode.Fix(var);
+        else if (mIsFixedProvided) rNode.Free(var);
     });
     mIsInitialized = true;
     KRATOS_CATCH("")

--- a/applications/GeoMechanicsApplication/custom_processes/apply_constant_interpolate_line_pressure_process.h
+++ b/applications/GeoMechanicsApplication/custom_processes/apply_constant_interpolate_line_pressure_process.h
@@ -48,7 +48,6 @@ private:
     std::string        mVariableName;
     bool               mIsFixed;
     bool               mIsFixedProvided;
-    bool               mIsSeepage;
     bool               mIsInitialized = false;
     unsigned int       mGravityDirection;
     unsigned int       mOutOfPlaneDirection;

--- a/applications/GeoMechanicsApplication/custom_processes/apply_constant_phreatic_line_pressure_process.cpp
+++ b/applications/GeoMechanicsApplication/custom_processes/apply_constant_phreatic_line_pressure_process.cpp
@@ -33,7 +33,6 @@ ApplyConstantPhreaticLinePressureProcess::ApplyConstantPhreaticLinePressureProce
                 "model_part_name":"PLEASE_CHOOSE_MODEL_PART_NAME",
                 "variable_name": "PLEASE_PRESCRIBE_VARIABLE_NAME",
                 "is_fixed": false,
-                "is_seepage": false,
                 "gravity_direction": 1,
                 "out_of_plane_direction": 2,
                 "first_reference_coordinate":           [0.0,1.0,0.0],
@@ -57,7 +56,6 @@ ApplyConstantPhreaticLinePressureProcess::ApplyConstantPhreaticLinePressureProce
 
     mVariableName        = rParameters["variable_name"].GetString();
     mIsFixed             = rParameters["is_fixed"].GetBool();
-    mIsSeepage           = rParameters["is_seepage"].GetBool();
     mGravityDirection    = rParameters["gravity_direction"].GetInt();
     mOutOfPlaneDirection = rParameters["out_of_plane_direction"].GetInt();
     if (mGravityDirection == mOutOfPlaneDirection)
@@ -100,19 +98,10 @@ void ApplyConstantPhreaticLinePressureProcess::ExecuteInitialize()
     block_for_each(mrModelPart.Nodes(), [&var, this](Node& rNode) {
         const double pressure = PORE_PRESSURE_SIGN_FACTOR * CalculatePressure(rNode);
 
-        if (mIsSeepage) {
-            if (pressure < PORE_PRESSURE_SIGN_FACTOR * mPressureTensionCutOff) { // Before 0. was used i.s.o. the tension cut off value -> no effect in any test.
-                rNode.FastGetSolutionStepValue(var) = pressure;
-                if (mIsFixed) rNode.Fix(var);
-            } else {
-                if (mIsFixedProvided) rNode.Free(var);
-            }
-        } else {
-            rNode.FastGetSolutionStepValue(var) =
-                std::min(pressure, PORE_PRESSURE_SIGN_FACTOR * mPressureTensionCutOff);
-            if (mIsFixed) rNode.Fix(var);
-            else if (mIsFixedProvided) rNode.Free(var);
-        }
+        rNode.FastGetSolutionStepValue(var) =
+            std::min(pressure, PORE_PRESSURE_SIGN_FACTOR * mPressureTensionCutOff);
+        if (mIsFixed) rNode.Fix(var);
+        else if (mIsFixedProvided) rNode.Free(var);
     });
 
     KRATOS_CATCH("")

--- a/applications/GeoMechanicsApplication/custom_processes/apply_constant_phreatic_line_pressure_process.h
+++ b/applications/GeoMechanicsApplication/custom_processes/apply_constant_phreatic_line_pressure_process.h
@@ -47,7 +47,6 @@ protected:
     std::string  mVariableName;
     bool         mIsFixed;
     bool         mIsFixedProvided;
-    bool         mIsSeepage;
     unsigned int mGravityDirection;
     double       mSpecificWeight;
     unsigned int mOutOfPlaneDirection;

--- a/applications/GeoMechanicsApplication/custom_processes/apply_constant_phreatic_multi_line_pressure_process.cpp
+++ b/applications/GeoMechanicsApplication/custom_processes/apply_constant_phreatic_multi_line_pressure_process.cpp
@@ -30,7 +30,6 @@ ApplyConstantPhreaticMultiLinePressureProcess::ApplyConstantPhreaticMultiLinePre
     mVariableName          = rParameters["variable_name"].GetString();
     mIsFixed               = rParameters["is_fixed"].GetBool();
     mIsFixedProvided       = rParameters.Has("is_fixed");
-    mIsSeepage             = rParameters["is_seepage"].GetBool();
     mSpecificWeight        = rParameters["specific_weight"].GetDouble();
     mPressureTensionCutOff = rParameters["pressure_tension_cut_off"].GetDouble();
     mOutOfPlaneDirection   = rParameters["out_of_plane_direction"].GetInt();
@@ -51,7 +50,6 @@ void ApplyConstantPhreaticMultiLinePressureProcess::InitializeParameters(Paramet
                 "model_part_name":"PLEASE_CHOOSE_MODEL_PART_NAME",
                 "variable_name": "PLEASE_PRESCRIBE_VARIABLE_NAME",
                 "is_fixed": false,
-                "is_seepage": false,
                 "gravity_direction": 1,
                 "out_of_plane_direction": 2,
                 "x_coordinates":           [0.0, 1.0],
@@ -150,19 +148,10 @@ void ApplyConstantPhreaticMultiLinePressureProcess::ExecuteInitialize()
 
     block_for_each(mrModelPart.Nodes(), [&var, this](Node& rNode) {
         const double pressure = CalculatePressure(rNode);
-        if (IsSeepage()) {
-            if (pressure < PORE_PRESSURE_SIGN_FACTOR * PressureTensionCutOff()) {
-                rNode.FastGetSolutionStepValue(var) = pressure;
-                if (IsFixed()) rNode.Fix(var);
-            } else {
-                if (IsFixedProvided()) rNode.Free(var);
-            }
-        } else {
-            if (IsFixed()) rNode.Fix(var);
-            else if (IsFixedProvided()) rNode.Free(var);
-            rNode.FastGetSolutionStepValue(var) =
-                std::min(pressure, PORE_PRESSURE_SIGN_FACTOR * PressureTensionCutOff());
-        }
+        if (IsFixed()) rNode.Fix(var);
+        else if (IsFixedProvided()) rNode.Free(var);
+        rNode.FastGetSolutionStepValue(var) =
+            std::min(pressure, PORE_PRESSURE_SIGN_FACTOR * PressureTensionCutOff());
     });
 
     KRATOS_CATCH("")
@@ -189,8 +178,6 @@ bool ApplyConstantPhreaticMultiLinePressureProcess::IsFixedProvided() const
 {
     return mIsFixedProvided;
 }
-
-bool ApplyConstantPhreaticMultiLinePressureProcess::IsSeepage() const { return mIsSeepage; }
 
 unsigned int ApplyConstantPhreaticMultiLinePressureProcess::GravityDirection() const
 {

--- a/applications/GeoMechanicsApplication/custom_processes/apply_constant_phreatic_multi_line_pressure_process.h
+++ b/applications/GeoMechanicsApplication/custom_processes/apply_constant_phreatic_multi_line_pressure_process.h
@@ -41,7 +41,6 @@ public:
     void               PrintInfo(std::ostream& rOStream) const override;
     const std::string& VariableName() const;
     bool               IsFixed() const;
-    bool               IsSeepage() const;
     unsigned int       GravityDirection() const;
     double             SpecificWeight() const;
     unsigned int       OutOfPlaneDirection() const;
@@ -63,7 +62,6 @@ private:
     std::string  mVariableName;
     bool         mIsFixed;
     bool         mIsFixedProvided;
-    bool         mIsSeepage;
     unsigned int mGravityDirection = 0;
     double       mSpecificWeight;
     unsigned int mOutOfPlaneDirection;

--- a/applications/GeoMechanicsApplication/custom_processes/apply_constant_phreatic_surface_pressure_process.cpp
+++ b/applications/GeoMechanicsApplication/custom_processes/apply_constant_phreatic_surface_pressure_process.cpp
@@ -32,7 +32,6 @@ ApplyConstantPhreaticSurfacePressureProcess::ApplyConstantPhreaticSurfacePressur
                 "model_part_name":"PLEASE_CHOOSE_MODEL_PART_NAME",
                 "variable_name": "PLEASE_PRESCRIBE_VARIABLE_NAME",
                 "is_fixed": false,
-                "is_seepage": false,
                 "gravity_direction": 1,
                 "first_reference_coordinate":          [0.0,1.0,0.0],
                 "second_reference_coordinate":         [1.0,0.5,0.0],
@@ -58,7 +57,6 @@ ApplyConstantPhreaticSurfacePressureProcess::ApplyConstantPhreaticSurfacePressur
 
     mVariableName              = rParameters["variable_name"].GetString();
     mIsFixed                   = rParameters["is_fixed"].GetBool();
-    mIsSeepage                 = rParameters["is_seepage"].GetBool();
     mGravityDirection          = rParameters["gravity_direction"].GetInt();
     mFirstReferenceCoordinate  = rParameters["first_reference_coordinate"].GetVector();
     mSecondReferenceCoordinate = rParameters["second_reference_coordinate"].GetVector();
@@ -85,19 +83,10 @@ void ApplyConstantPhreaticSurfacePressureProcess::ExecuteInitialize()
         const double d        = inner_prod(mNormalVector, direction);
         distance              = -(distance - mEqRHS) / d;
         const double pressure = -PORE_PRESSURE_SIGN_FACTOR * mSpecificWeight * distance;
-        if (mIsSeepage) {
-            if (pressure < PORE_PRESSURE_SIGN_FACTOR * mPressureTensionCutOff) {
-                rNode.FastGetSolutionStepValue(var) = pressure;
-                if (mIsFixed) rNode.Fix(var);
-            } else {
-                if (mIsFixedProvided) rNode.Free(var);
-            }
-        } else {
-            if (mIsFixed) rNode.Fix(var);
-            else if (mIsFixedProvided) rNode.Free(var);
-            rNode.FastGetSolutionStepValue(var) =
-                std::min(pressure, PORE_PRESSURE_SIGN_FACTOR * mPressureTensionCutOff);
-        }
+        if (mIsFixed) rNode.Fix(var);
+        else if (mIsFixedProvided) rNode.Free(var);
+        rNode.FastGetSolutionStepValue(var) =
+            std::min(pressure, PORE_PRESSURE_SIGN_FACTOR * mPressureTensionCutOff);
     });
 
     KRATOS_CATCH("")

--- a/applications/GeoMechanicsApplication/custom_processes/apply_constant_phreatic_surface_pressure_process.h
+++ b/applications/GeoMechanicsApplication/custom_processes/apply_constant_phreatic_surface_pressure_process.h
@@ -48,7 +48,6 @@ protected:
     std::string  mVariableName;
     bool         mIsFixed;
     bool         mIsFixedProvided;
-    bool         mIsSeepage;
     unsigned int mGravityDirection;
     double       mSpecificWeight;
     Vector3      mFirstReferenceCoordinate;

--- a/applications/GeoMechanicsApplication/custom_processes/apply_hydrostatic_pressure_table_process.cpp
+++ b/applications/GeoMechanicsApplication/custom_processes/apply_hydrostatic_pressure_table_process.cpp
@@ -42,17 +42,8 @@ void ApplyHydrostaticPressureTableProcess::ExecuteInitializeSolutionStep()
     block_for_each(mrModelPart.Nodes(), [&var, &deltaH, this](Node& rNode) {
         const double distance = mReferenceCoordinate - rNode.Coordinates()[mGravityDirection];
         const double pressure = -PORE_PRESSURE_SIGN_FACTOR * mSpecificWeight * (distance + deltaH);
-        if (mIsSeepage) {
-            if (pressure < PORE_PRESSURE_SIGN_FACTOR * mPressureTensionCutOff) { // Before 0. was used i.s.o. the tension cut off value -> no effect in any test.
-                rNode.FastGetSolutionStepValue(var) = pressure;
-                if (mIsFixed) rNode.Fix(var);
-            } else {
-                if (mIsFixedProvided) rNode.Free(var);
-            }
-        } else {
-            rNode.FastGetSolutionStepValue(var) =
-                std::min(pressure, PORE_PRESSURE_SIGN_FACTOR * mPressureTensionCutOff);
-        }
+        rNode.FastGetSolutionStepValue(var) =
+            std::min(pressure, PORE_PRESSURE_SIGN_FACTOR * mPressureTensionCutOff);
     });
 
     KRATOS_CATCH("")

--- a/applications/GeoMechanicsApplication/custom_processes/apply_phreatic_line_pressure_table_process.cpp
+++ b/applications/GeoMechanicsApplication/custom_processes/apply_phreatic_line_pressure_table_process.cpp
@@ -63,17 +63,8 @@ void ApplyPhreaticLinePressureTableProcess::ExecuteInitializeSolutionStep()
 
     block_for_each(mrModelPart.Nodes(), [&var, &y, this](Node& rNode) {
         const double pressure = PORE_PRESSURE_SIGN_FACTOR * CalculatePressurewithTable(rNode, y);
-        if (mIsSeepage) {
-            if (pressure < PORE_PRESSURE_SIGN_FACTOR * mPressureTensionCutOff) { // Before 0. was used i.s.o. the tension cut off value -> no effect in any test.
-                rNode.FastGetSolutionStepValue(var) = pressure;
-                if (mIsFixed) rNode.Fix(var);
-            } else {
-                if (mIsFixedProvided) rNode.Free(var);
-            }
-        } else {
-            rNode.FastGetSolutionStepValue(var) =
-                std::min(pressure, PORE_PRESSURE_SIGN_FACTOR * mPressureTensionCutOff);
-        }
+        rNode.FastGetSolutionStepValue(var) =
+            std::min(pressure, PORE_PRESSURE_SIGN_FACTOR * mPressureTensionCutOff);
     });
 
     KRATOS_CATCH("")

--- a/applications/GeoMechanicsApplication/custom_processes/apply_phreatic_multi_line_pressure_table_process.cpp
+++ b/applications/GeoMechanicsApplication/custom_processes/apply_phreatic_multi_line_pressure_table_process.cpp
@@ -62,19 +62,10 @@ void ApplyPhreaticMultiLinePressureTableProcess::ExecuteInitializeSolutionStep()
 
     block_for_each(mrModelPart.Nodes(), [&var, &deltaH, this](Node& rNode) {
         const double pressure = CalculatePressure(rNode, deltaH);
-        if (IsSeepage()) {
-            if (pressure < PORE_PRESSURE_SIGN_FACTOR * PressureTensionCutOff()) {
-                rNode.FastGetSolutionStepValue(var) = pressure;
-                if (IsFixed()) rNode.Fix(var);
-            } else {
-                if (IsFixedProvided()) rNode.Free(var);
-            }
-        } else {
-            if (IsFixed()) rNode.Fix(var);
-            else if (IsFixedProvided()) rNode.Free(var);
-            rNode.FastGetSolutionStepValue(var) =
-                std::min(pressure, PORE_PRESSURE_SIGN_FACTOR * PressureTensionCutOff());
-        }
+        if (IsFixed()) rNode.Fix(var);
+        else if (IsFixedProvided()) rNode.Free(var);
+        rNode.FastGetSolutionStepValue(var) =
+            std::min(pressure, PORE_PRESSURE_SIGN_FACTOR * PressureTensionCutOff());
     });
 
     KRATOS_CATCH("")

--- a/applications/GeoMechanicsApplication/custom_processes/apply_phreatic_surface_pressure_table_process.cpp
+++ b/applications/GeoMechanicsApplication/custom_processes/apply_phreatic_surface_pressure_table_process.cpp
@@ -48,17 +48,8 @@ void ApplyPhreaticSurfacePressureTableProcess::ExecuteInitializeSolutionStep()
         distance              = -(distance - mEqRHS) / d;
         distance += deltaH;
         const double pressure = -PORE_PRESSURE_SIGN_FACTOR * mSpecificWeight * distance;
-        if (mIsSeepage) {
-            if (pressure < PORE_PRESSURE_SIGN_FACTOR * mPressureTensionCutOff) { // Before 0. was used i.s.o. the tension cut off value -> no effect in any test.
-                rNode.FastGetSolutionStepValue(var) = pressure;
-                if (mIsFixed) rNode.Fix(var);
-            } else {
-                if (mIsFixedProvided) rNode.Free(var);
-            }
-        } else {
-            rNode.FastGetSolutionStepValue(var) =
-                std::min(pressure, PORE_PRESSURE_SIGN_FACTOR * mPressureTensionCutOff);
-        }
+        rNode.FastGetSolutionStepValue(var) =
+            std::min(pressure, PORE_PRESSURE_SIGN_FACTOR * mPressureTensionCutOff);
     });
 
     KRATOS_CATCH("")

--- a/applications/GeoMechanicsApplication/custom_processes/apply_scalar_constraint_table_process.cpp
+++ b/applications/GeoMechanicsApplication/custom_processes/apply_scalar_constraint_table_process.cpp
@@ -181,7 +181,6 @@ void ApplyScalarConstraintTableProcess::AppendOptionalFluidParameters(const Para
 {
     ParametersUtilities::AppendParameterNameIfExists("pressure_tension_cut_off", rProcessSettings,
                                                      rNamesOfSettingsToCopy);
-    ParametersUtilities::AppendParameterNameIfExists("is_seepage", rProcessSettings, rNamesOfSettingsToCopy);
 }
 
 template <typename TableProcessType, typename ConstantProcessType>

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_processes/test_apply_constant_interpolate_line_pressure_process.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_processes/test_apply_constant_interpolate_line_pressure_process.cpp
@@ -73,7 +73,6 @@ TEST_F(KratosGeoMechanicsFastSuiteWithoutKernel, ApplyConstantInterpolateLinePre
         "model_part_name": "TestPart",
         "variable_name": "WATER_PRESSURE",
         "is_fixed": true,
-        "is_seepage": false,
         "gravity_direction": 1,
         "out_of_plane_direction": 2,
         "pressure_tension_cut_off": 0.0,
@@ -94,7 +93,6 @@ TEST_F(KratosGeoMechanicsFastSuiteWithoutKernel, ApplyConstantInterpolateLinePre
         "model_part_name": "TestPart",
         "variable_name": "WATER_PRESSURE",
         "is_fixed": true,
-        "is_seepage": false,
         "gravity_direction": 1,
         "out_of_plane_direction": 1,
         "pressure_tension_cut_off": 0.0,
@@ -122,7 +120,6 @@ TEST_F(KratosGeoMechanicsFastSuiteWithoutKernel, ApplyConstantInterpolateLinePre
         "model_part_name": "TestPart",
         "variable_name": "WATER_PRESSURE",
         "is_fixed": true,
-        "is_seepage": false,
         "gravity_direction": 1,
         "out_of_plane_direction": 2,
         "pressure_tension_cut_off": 100.0,
@@ -141,65 +138,6 @@ TEST_F(KratosGeoMechanicsFastSuiteWithoutKernel, ApplyConstantInterpolateLinePre
     }
 }
 
-TEST_F(KratosGeoMechanicsFastSuiteWithoutKernel, ApplyConstantInterpolateLinePressureProcess_SeepageBranch)
-{
-    // Arrange
-    Model model;
-    auto& r_model_part = CreateTestModelPart(model);
-
-    // Set up so that CalculatePressure returns a value less than the cut-off for node 1,
-    // and a value greater than or equal to the cut-off for node 2.
-    // We'll do this by setting the initial WATER_PRESSURE and using a high cut-off.
-
-    for (auto& r_node : r_model_part.Nodes()) {
-        r_node.FastGetSolutionStepValue(WATER_PRESSURE) = 0.0;
-    }
-
-    // Set a high cut-off so all nodes will be below the cut-off
-    const auto params_below = Parameters(R"({
-        "model_part_name": "TestPart",
-        "variable_name": "WATER_PRESSURE",
-        "is_fixed": true,
-        "is_seepage": true,
-        "gravity_direction": 1,
-        "out_of_plane_direction": 2,
-        "pressure_tension_cut_off": 100.0,
-        "table": 1
-    })");
-
-    ApplyConstantInterpolateLinePressureProcess process_below(r_model_part, params_below);
-
-    // Act and Assert
-    process_below.ExecuteInitializeSolutionStep();
-
-    // All nodes should be set and fixed (since pressure < cut-off)
-    for (const auto& r_node : r_model_part.Nodes()) {
-        KRATOS_EXPECT_TRUE(r_node.IsFixed(WATER_PRESSURE))
-        // The value is set by CalculatePressure, which in this test setup is 0.0
-        KRATOS_EXPECT_DOUBLE_EQ(r_node.FastGetSolutionStepValue(WATER_PRESSURE), 0.0);
-    }
-
-    // Now set a low cut-off so all nodes will be above the cut-off
-    const auto params_above = Parameters(R"({
-        "model_part_name": "TestPart",
-        "variable_name": "WATER_PRESSURE",
-        "is_fixed": true,
-        "is_seepage": true,
-        "gravity_direction": 1,
-        "out_of_plane_direction": 2,
-        "pressure_tension_cut_off": -100.0,
-        "table": 1
-    })");
-
-    ApplyConstantInterpolateLinePressureProcess process_above(r_model_part, params_above);
-    process_above.ExecuteInitializeSolutionStep();
-
-    // All nodes should be free (since pressure >= cut-off)
-    for (const auto& r_node : r_model_part.Nodes()) {
-        KRATOS_EXPECT_FALSE(r_node.IsFixed(WATER_PRESSURE))
-    }
-}
-
 TEST_F(KratosGeoMechanicsFastSuiteWithoutKernel, ApplyConstantInterpolateLinePressureProcess_Info)
 {
     // Arrange
@@ -210,7 +148,6 @@ TEST_F(KratosGeoMechanicsFastSuiteWithoutKernel, ApplyConstantInterpolateLinePre
         "model_part_name": "TestPart",
         "variable_name": "WATER_PRESSURE",
         "is_fixed": false,
-        "is_seepage": false,
         "gravity_direction": 1,
         "out_of_plane_direction": 2,
         "pressure_tension_cut_off": 0.0,
@@ -238,7 +175,6 @@ TEST_F(KratosGeoMechanicsFastSuiteWithoutKernel,
     const auto params = Parameters(R"({
         "model_part_name": "TestPart",
         "variable_name": "WATER_PRESSURE",
-        "is_seepage": false,
         "gravity_direction": 1,
         "out_of_plane_direction": 2,
         "pressure_tension_cut_off": 1.0e9,
@@ -271,7 +207,6 @@ TEST_F(KratosGeoMechanicsFastSuiteWithoutKernel, ApplyConstantInterpolateLinePre
         "model_part_name": "TestPart",
         "variable_name": "WATER_PRESSURE",
         "is_fixed": false,
-        "is_seepage": false,
         "gravity_direction": 1,
         "out_of_plane_direction": 2,
         "pressure_tension_cut_off": 1.0e9,
@@ -325,7 +260,6 @@ TEST_F(KratosGeoMechanicsFastSuiteWithoutKernel,
         "model_part_name": "Main",
         "variable_name": "WATER_PRESSURE",
         "is_fixed": true,
-        "is_seepage": false,
         "gravity_direction": 1,
         "out_of_plane_direction": 2,
         "pressure_tension_cut_off": 1.0e9

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_processes/test_apply_scalar_constraint_table_process.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_processes/test_apply_scalar_constraint_table_process.cpp
@@ -253,7 +253,6 @@ KRATOS_TEST_CASE_IN_SUITE(ApplyScalarConstraintTableProcess_HydrostaticBranch_Di
         "fluid_pressure_type": "Hydrostatic",
         "gravity_direction": 1,
         "is_fixed": false,
-        "is_seepage": false,
         "pressure_tension_cut_off": 0.0,
         "reference_coordinate": 0.0,
         "specific_weight": 10000.0,


### PR DESCRIPTION
## **📝 Description**
To start the implementation of a seepage boundary with a clean slate, this PR removes the legacy implementation, which acts on the incorrect level (on a solution/time-step level instead of on an iteration level).

We can still refer to this code later, but it is no longer supported. Since there was no integration test related to this, I didn't add a 'deprecation' warning, but just removed it, meaning using `is_seepage` in one of our pressure processes is no longer supported when this PR merges.

## **🆕 Changelog**
Please summarize the changes in one list to generate the changelog:
E.g.
- The `is_seepage` parameter was removed from the water pressure processes
- The usage of `mIsSeepage` was removed from the water pressure processes
- The unit test which tested the seepage branch for one of the water pressure processes is removed.