### PR TITLE
[GeoMechanicsApplication] Use unique materials for the CROW case

### DIFF
--- a/applications/GeoMechanicsApplication/tests/crow_validation/common/initial_materials.json
+++ b/applications/GeoMechanicsApplication/tests/crow_validation/common/initial_materials.json
@@ -34,7 +34,10 @@
             }
         },
         {
-            "model_part_name_list": ["PorousDomain.Soil_Bottom_Left", "PorousDomain.Soil_Bottom_Right"],
+            "model_part_name_list": [
+                "PorousDomain.Soil_Bottom_Left",
+                "PorousDomain.Soil_Bottom_Right"
+            ],
             "properties_id": 2,
             "Material": {
                 "constitutive_law": {

--- a/applications/GeoMechanicsApplication/tests/crow_validation/common/initial_materials.json
+++ b/applications/GeoMechanicsApplication/tests/crow_validation/common/initial_materials.json
@@ -1,7 +1,14 @@
 {
     "properties": [
         {
-            "model_part_name": "PorousDomain.Excavated_Soil_1",
+            "model_part_name_list": [
+                "PorousDomain.Excavated_Soil_1",
+                "PorousDomain.Excavated_Soil_2",
+                "PorousDomain.Excavated_Soil_3",
+                "PorousDomain.Soil_Below_Pit",
+                "PorousDomain.Soil_Top_Right",
+                "PorousDomain.Soil_Middle_Right"
+            ],
             "properties_id": 1,
             "Material": {
                 "constitutive_law": {
@@ -27,7 +34,7 @@
             }
         },
         {
-            "model_part_name": "PorousDomain.Excavated_Soil_2",
+            "model_part_name_list": ["PorousDomain.Soil_Bottom_Left", "PorousDomain.Soil_Bottom_Right"],
             "properties_id": 2,
             "Material": {
                 "constitutive_law": {
@@ -35,315 +42,55 @@
                 },
                 "Variables": {
                     "GEO_DRAINAGE_TYPE": "CONSTANT_PW_FIELD",
-                    "DENSITY_SOLID": 1.83486e+03,
+                    "DENSITY_SOLID": 2.03874e+03,
                     "DENSITY_WATER": 1.01937e+03,
                     "POROSITY": 0.0,
                     "BULK_MODULUS_SOLID": 1.0e+10,
                     "BULK_MODULUS_FLUID": 2.2e+09,
-                    "YOUNG_MODULUS": 9.0e+05,
-                    "POISSON_RATIO": 0.2,
+                    "YOUNG_MODULUS": 7.4286e+06,
+                    "POISSON_RATIO": 0.3,
                     "BIOT_COEFFICIENT": 1.0,
                     "RETENTION_LAW": "SaturatedBelowPhreaticLevelLaw",
                     "SATURATED_SATURATION": 1.0,
                     "RESIDUAL_SATURATION": 1.0e-10,
                     "MINIMUM_RELATIVE_PERMEABILITY": 1.0e-04,
                     "K0_MAIN_DIRECTION": 1,
-                    "K0_NC": 0.62
+                    "K0_NC": 0.46
                 }
             }
         },
         {
-            "model_part_name": "PorousDomain.Excavated_Soil_3",
+            "model_part_name_list": [
+                "PorousDomain.Interface_Excavated_Soil_1",
+                "PorousDomain.Interface_Excavated_Soil_2",
+                "PorousDomain.Interface_Excavated_Soil_3",
+                "PorousDomain.Interface_Middle_Left",
+                "PorousDomain.Interface_Top_Right",
+                "PorousDomain.Interface_Middle_Right"
+            ],
             "properties_id": 3,
             "Material": {
                 "constitutive_law": {
-                    "name": "GeoLinearElasticPlaneStrain2DLaw"
+                    "name": "GeoIncrementalLinearElasticInterfaceLaw"
                 },
                 "Variables": {
                     "GEO_DRAINAGE_TYPE": "CONSTANT_PW_FIELD",
-                    "DENSITY_SOLID": 1.83486e+03,
-                    "DENSITY_WATER": 1.01937e+03,
-                    "POROSITY": 0.0,
-                    "BULK_MODULUS_SOLID": 1.0e+10,
-                    "BULK_MODULUS_FLUID": 2.2e+09,
-                    "YOUNG_MODULUS": 9.0e+05,
-                    "POISSON_RATIO": 0.2,
+                    "INTERFACE_NORMAL_STIFFNESS": 3.75e+06,
+                    "INTERFACE_SHEAR_STIFFNESS": 3.75e+05,
                     "BIOT_COEFFICIENT": 1.0,
                     "RETENTION_LAW": "SaturatedBelowPhreaticLevelLaw",
                     "SATURATED_SATURATION": 1.0,
                     "RESIDUAL_SATURATION": 1.0e-10,
-                    "MINIMUM_RELATIVE_PERMEABILITY": 1.0e-04,
-                    "K0_MAIN_DIRECTION": 1,
-                    "K0_NC": 0.62
+                    "MINIMUM_RELATIVE_PERMEABILITY": 1.0e-04
                 }
             }
         },
         {
-            "model_part_name": "PorousDomain.Soil_Below_Pit",
+            "model_part_name_list": [
+                "PorousDomain.Interface_Bottom_Left",
+                "PorousDomain.Interface_Bottom_Right"
+            ],
             "properties_id": 4,
-            "Material": {
-                "constitutive_law": {
-                    "name": "GeoLinearElasticPlaneStrain2DLaw"
-                },
-                "Variables": {
-                    "GEO_DRAINAGE_TYPE": "CONSTANT_PW_FIELD",
-                    "DENSITY_SOLID": 1.83486e+03,
-                    "DENSITY_WATER": 1.01937e+03,
-                    "POROSITY": 0.0,
-                    "BULK_MODULUS_SOLID": 1.0e+10,
-                    "BULK_MODULUS_FLUID": 2.2e+09,
-                    "YOUNG_MODULUS": 9.0e+05,
-                    "POISSON_RATIO": 0.2,
-                    "BIOT_COEFFICIENT": 1.0,
-                    "RETENTION_LAW": "SaturatedBelowPhreaticLevelLaw",
-                    "SATURATED_SATURATION": 1.0,
-                    "RESIDUAL_SATURATION": 1.0e-10,
-                    "MINIMUM_RELATIVE_PERMEABILITY": 1.0e-04,
-                    "K0_MAIN_DIRECTION": 1,
-                    "K0_NC": 0.62
-                }
-            }
-        },
-        {
-            "model_part_name": "PorousDomain.Soil_Bottom_Left",
-            "properties_id": 5,
-            "Material": {
-                "constitutive_law": {
-                    "name": "GeoLinearElasticPlaneStrain2DLaw"
-                },
-                "Variables": {
-                    "GEO_DRAINAGE_TYPE": "CONSTANT_PW_FIELD",
-                    "DENSITY_SOLID": 2.03874e+03,
-                    "DENSITY_WATER": 1.01937e+03,
-                    "POROSITY": 0.0,
-                    "BULK_MODULUS_SOLID": 1.0e+10,
-                    "BULK_MODULUS_FLUID": 2.2e+09,
-                    "YOUNG_MODULUS": 7.4286e+06,
-                    "POISSON_RATIO": 0.3,
-                    "BIOT_COEFFICIENT": 1.0,
-                    "RETENTION_LAW": "SaturatedBelowPhreaticLevelLaw",
-                    "SATURATED_SATURATION": 1.0,
-                    "RESIDUAL_SATURATION": 1.0e-10,
-                    "MINIMUM_RELATIVE_PERMEABILITY": 1.0e-04,
-                    "K0_MAIN_DIRECTION": 1,
-                    "K0_NC": 0.46
-                }
-            }
-        },
-        {
-            "model_part_name": "PorousDomain.Soil_Bottom_Right",
-            "properties_id": 6,
-            "Material": {
-                "constitutive_law": {
-                    "name": "GeoLinearElasticPlaneStrain2DLaw"
-                },
-                "Variables": {
-                    "GEO_DRAINAGE_TYPE": "CONSTANT_PW_FIELD",
-                    "DENSITY_SOLID": 2.03874e+03,
-                    "DENSITY_WATER": 1.01937e+03,
-                    "POROSITY": 0.0,
-                    "BULK_MODULUS_SOLID": 1.0e+10,
-                    "BULK_MODULUS_FLUID": 2.2e+09,
-                    "YOUNG_MODULUS": 7.4286e+06,
-                    "POISSON_RATIO": 0.3,
-                    "BIOT_COEFFICIENT": 1.0,
-                    "RETENTION_LAW": "SaturatedBelowPhreaticLevelLaw",
-                    "SATURATED_SATURATION": 1.0,
-                    "RESIDUAL_SATURATION": 1.0e-10,
-                    "MINIMUM_RELATIVE_PERMEABILITY": 1.0e-04,
-                    "K0_MAIN_DIRECTION": 1,
-                    "K0_NC": 0.46
-                }
-            }
-        },
-        {
-            "model_part_name": "PorousDomain.Soil_Middle_Right",
-            "properties_id": 7,
-            "Material": {
-                "constitutive_law": {
-                    "name": "GeoLinearElasticPlaneStrain2DLaw"
-                },
-                "Variables": {
-                    "GEO_DRAINAGE_TYPE": "CONSTANT_PW_FIELD",
-                    "DENSITY_SOLID": 1.83486e+03,
-                    "DENSITY_WATER": 1.01937e+03,
-                    "POROSITY": 0.0,
-                    "BULK_MODULUS_SOLID": 1.0e+10,
-                    "BULK_MODULUS_FLUID": 2.2e+09,
-                    "YOUNG_MODULUS": 9.0e+05,
-                    "POISSON_RATIO": 0.2,
-                    "BIOT_COEFFICIENT": 1.0,
-                    "RETENTION_LAW": "SaturatedBelowPhreaticLevelLaw",
-                    "SATURATED_SATURATION": 1.0,
-                    "RESIDUAL_SATURATION": 1.0e-10,
-                    "MINIMUM_RELATIVE_PERMEABILITY": 1.0e-04,
-                    "K0_MAIN_DIRECTION": 1,
-                    "K0_NC": 0.62
-                }
-            }
-        },
-        {
-            "model_part_name": "PorousDomain.Soil_Top_Right",
-            "properties_id": 8,
-            "Material": {
-                "constitutive_law": {
-                    "name": "GeoLinearElasticPlaneStrain2DLaw"
-                },
-                "Variables": {
-                    "GEO_DRAINAGE_TYPE": "CONSTANT_PW_FIELD",
-                    "DENSITY_SOLID": 1.83486e+03,
-                    "DENSITY_WATER": 1.01937e+03,
-                    "POROSITY": 0.0,
-                    "BULK_MODULUS_SOLID": 1.0e+10,
-                    "BULK_MODULUS_FLUID": 2.2e+09,
-                    "YOUNG_MODULUS": 9.0e+05,
-                    "POISSON_RATIO": 0.2,
-                    "BIOT_COEFFICIENT": 1.0,
-                    "RETENTION_LAW": "SaturatedBelowPhreaticLevelLaw",
-                    "SATURATED_SATURATION": 1.0,
-                    "RESIDUAL_SATURATION": 1.0e-10,
-                    "MINIMUM_RELATIVE_PERMEABILITY": 1.0e-04,
-                    "K0_MAIN_DIRECTION": 1,
-                    "K0_NC": 0.62
-                }
-            }
-        },
-        {
-            "model_part_name": "PorousDomain.Interface_Top_Right",
-            "properties_id": 9,
-            "Material": {
-                "constitutive_law": {
-                    "name": "GeoIncrementalLinearElasticInterfaceLaw"
-                },
-                "Variables": {
-                    "GEO_DRAINAGE_TYPE": "CONSTANT_PW_FIELD",
-                    "INTERFACE_NORMAL_STIFFNESS": 3.75e+06,
-                    "INTERFACE_SHEAR_STIFFNESS": 3.75e+05,
-                    "BIOT_COEFFICIENT": 1.0,
-                    "RETENTION_LAW": "SaturatedBelowPhreaticLevelLaw",
-                    "SATURATED_SATURATION": 1.0,
-                    "RESIDUAL_SATURATION": 1.0e-10,
-                    "MINIMUM_RELATIVE_PERMEABILITY": 1.0e-04
-                }
-            }
-        },
-        {
-            "model_part_name": "PorousDomain.Interface_Middle_Right",
-            "properties_id": 10,
-            "Material": {
-                "constitutive_law": {
-                    "name": "GeoIncrementalLinearElasticInterfaceLaw"
-                },
-                "Variables": {
-                    "GEO_DRAINAGE_TYPE": "CONSTANT_PW_FIELD",
-                    "INTERFACE_NORMAL_STIFFNESS": 3.75e+06,
-                    "INTERFACE_SHEAR_STIFFNESS": 3.75e+05,
-                    "BIOT_COEFFICIENT": 1.0,
-                    "RETENTION_LAW": "SaturatedBelowPhreaticLevelLaw",
-                    "SATURATED_SATURATION": 1.0,
-                    "RESIDUAL_SATURATION": 1.0e-10,
-                    "MINIMUM_RELATIVE_PERMEABILITY": 1.0e-04
-                }
-            }
-        },
-        {
-            "model_part_name": "PorousDomain.Interface_Bottom_Right",
-            "properties_id": 11,
-            "Material": {
-                "constitutive_law": {
-                    "name": "GeoIncrementalLinearElasticInterfaceLaw"
-                },
-                "Variables": {
-                    "GEO_DRAINAGE_TYPE": "CONSTANT_PW_FIELD",
-                    "INTERFACE_NORMAL_STIFFNESS": 2.8571e+07,
-                    "INTERFACE_SHEAR_STIFFNESS": 2.8571e+06,
-                    "BIOT_COEFFICIENT": 1.0,
-                    "RETENTION_LAW": "SaturatedBelowPhreaticLevelLaw",
-                    "SATURATED_SATURATION": 1.0,
-                    "RESIDUAL_SATURATION": 1.0e-10,
-                    "MINIMUM_RELATIVE_PERMEABILITY": 1.0e-04
-                }
-            }
-        },
-        {
-            "model_part_name": "PorousDomain.Interface_Excavated_Soil_1",
-            "properties_id": 12,
-            "Material": {
-                "constitutive_law": {
-                    "name": "GeoIncrementalLinearElasticInterfaceLaw"
-                },
-                "Variables": {
-                    "GEO_DRAINAGE_TYPE": "CONSTANT_PW_FIELD",
-                    "INTERFACE_NORMAL_STIFFNESS": 3.75e+06,
-                    "INTERFACE_SHEAR_STIFFNESS": 3.75e+05,
-                    "BIOT_COEFFICIENT": 1.0,
-                    "RETENTION_LAW": "SaturatedBelowPhreaticLevelLaw",
-                    "SATURATED_SATURATION": 1.0,
-                    "RESIDUAL_SATURATION": 1.0e-10,
-                    "MINIMUM_RELATIVE_PERMEABILITY": 1.0e-04
-                }
-            }
-        },
-        {
-            "model_part_name": "PorousDomain.Interface_Excavated_Soil_2",
-            "properties_id": 13,
-            "Material": {
-                "constitutive_law": {
-                    "name": "GeoIncrementalLinearElasticInterfaceLaw"
-                },
-                "Variables": {
-                    "GEO_DRAINAGE_TYPE": "CONSTANT_PW_FIELD",
-                    "INTERFACE_NORMAL_STIFFNESS": 3.75e+06,
-                    "INTERFACE_SHEAR_STIFFNESS": 3.75e+05,
-                    "BIOT_COEFFICIENT": 1.0,
-                    "RETENTION_LAW": "SaturatedBelowPhreaticLevelLaw",
-                    "SATURATED_SATURATION": 1.0,
-                    "RESIDUAL_SATURATION": 1.0e-10,
-                    "MINIMUM_RELATIVE_PERMEABILITY": 1.0e-04
-                }
-            }
-        },
-        {
-            "model_part_name": "PorousDomain.Interface_Excavated_Soil_3",
-            "properties_id": 14,
-            "Material": {
-                "constitutive_law": {
-                    "name": "GeoIncrementalLinearElasticInterfaceLaw"
-                },
-                "Variables": {
-                    "GEO_DRAINAGE_TYPE": "CONSTANT_PW_FIELD",
-                    "INTERFACE_NORMAL_STIFFNESS": 3.75e+06,
-                    "INTERFACE_SHEAR_STIFFNESS": 3.75e+05,
-                    "BIOT_COEFFICIENT": 1.0,
-                    "RETENTION_LAW": "SaturatedBelowPhreaticLevelLaw",
-                    "SATURATED_SATURATION": 1.0,
-                    "RESIDUAL_SATURATION": 1.0e-10,
-                    "MINIMUM_RELATIVE_PERMEABILITY": 1.0e-04
-                }
-            }
-        },
-        {
-            "model_part_name": "PorousDomain.Interface_Middle_Left",
-            "properties_id": 15,
-            "Material": {
-                "constitutive_law": {
-                    "name": "GeoIncrementalLinearElasticInterfaceLaw"
-                },
-                "Variables": {
-                    "GEO_DRAINAGE_TYPE": "CONSTANT_PW_FIELD",
-                    "INTERFACE_NORMAL_STIFFNESS": 3.75e+06,
-                    "INTERFACE_SHEAR_STIFFNESS": 3.75e+05,
-                    "BIOT_COEFFICIENT": 1.0,
-                    "RETENTION_LAW": "SaturatedBelowPhreaticLevelLaw",
-                    "SATURATED_SATURATION": 1.0,
-                    "RESIDUAL_SATURATION": 1.0e-10,
-                    "MINIMUM_RELATIVE_PERMEABILITY": 1.0e-04
-                }
-            }
-        },
-        {
-            "model_part_name": "PorousDomain.Interface_Bottom_Left",
-            "properties_id": 16,
             "Material": {
                 "constitutive_law": {
                     "name": "GeoIncrementalLinearElasticInterfaceLaw"
@@ -362,7 +109,7 @@
         },
         {
             "model_part_name": "PorousDomain.Sheet_Pile_Wall",
-            "properties_id": 17,
+            "properties_id": 5,
             "Material": {
                 "constitutive_law": {
                     "name": "TimoshenkoBeamPlaneStrainElasticConstitutiveLaw"
@@ -378,7 +125,7 @@
         },
         {
             "model_part_name": "PorousDomain.Anchor",
-            "properties_id": 18,
+            "properties_id": 6,
             "Material": {
                 "constitutive_law": {
                     "name": "TrussConstitutiveLaw"

--- a/applications/GeoMechanicsApplication/tests/crow_validation/linear_elastic/MaterialParameters.json
+++ b/applications/GeoMechanicsApplication/tests/crow_validation/linear_elastic/MaterialParameters.json
@@ -1,7 +1,14 @@
 {
     "properties": [
         {
-            "model_part_name": "PorousDomain.Excavated_Soil_1",
+            "model_part_name_list": [
+                "PorousDomain.Excavated_Soil_1",
+                "PorousDomain.Excavated_Soil_2",
+                "PorousDomain.Excavated_Soil_3",
+                "PorousDomain.Soil_Below_Pit",
+                "PorousDomain.Soil_Top_Right",
+                "PorousDomain.Soil_Middle_Right"
+            ],
             "properties_id": 1,
             "Material": {
                 "constitutive_law": {
@@ -25,7 +32,7 @@
             }
         },
         {
-            "model_part_name": "PorousDomain.Excavated_Soil_2",
+            "model_part_name_list": ["PorousDomain.Soil_Bottom_Left", "PorousDomain.Soil_Bottom_Right"],
             "properties_id": 2,
             "Material": {
                 "constitutive_law": {
@@ -33,13 +40,13 @@
                 },
                 "Variables": {
                     "GEO_DRAINAGE_TYPE": "CONSTANT_PW_FIELD",
-                    "DENSITY_SOLID": 1.83486e+03,
+                    "DENSITY_SOLID": 2.03874e+03,
                     "DENSITY_WATER": 1.01937e+03,
                     "POROSITY": 0.0,
                     "BULK_MODULUS_SOLID": 1.0e+10,
                     "BULK_MODULUS_FLUID": 2.2e+09,
-                    "YOUNG_MODULUS": 9.0e+05,
-                    "POISSON_RATIO": 0.2,
+                    "YOUNG_MODULUS": 7.4286e+06,
+                    "POISSON_RATIO": 0.3,
                     "BIOT_COEFFICIENT": 1.0,
                     "RETENTION_LAW": "SaturatedBelowPhreaticLevelLaw",
                     "SATURATED_SATURATION": 1.0,
@@ -49,21 +56,23 @@
             }
         },
         {
-            "model_part_name": "PorousDomain.Excavated_Soil_3",
+            "model_part_name_list": [
+                "PorousDomain.Interface_Excavated_Soil_1",
+                "PorousDomain.Interface_Excavated_Soil_2",
+                "PorousDomain.Interface_Excavated_Soil_3",
+                "PorousDomain.Interface_Middle_Left",
+                "PorousDomain.Interface_Top_Right",
+                "PorousDomain.Interface_Middle_Right"
+            ],
             "properties_id": 3,
             "Material": {
                 "constitutive_law": {
-                    "name": "GeoLinearElasticPlaneStrain2DLaw"
+                    "name": "GeoIncrementalLinearElasticInterfaceLaw"
                 },
                 "Variables": {
                     "GEO_DRAINAGE_TYPE": "CONSTANT_PW_FIELD",
-                    "DENSITY_SOLID": 1.83486e+03,
-                    "DENSITY_WATER": 1.01937e+03,
-                    "POROSITY": 0.0,
-                    "BULK_MODULUS_SOLID": 1.0e+10,
-                    "BULK_MODULUS_FLUID": 2.2e+09,
-                    "YOUNG_MODULUS": 9.0e+05,
-                    "POISSON_RATIO": 0.2,
+                    "INTERFACE_NORMAL_STIFFNESS": 3.75e+06,
+                    "INTERFACE_SHEAR_STIFFNESS": 3.75e+05,
                     "BIOT_COEFFICIENT": 1.0,
                     "RETENTION_LAW": "SaturatedBelowPhreaticLevelLaw",
                     "SATURATED_SATURATION": 1.0,
@@ -73,261 +82,11 @@
             }
         },
         {
-            "model_part_name": "PorousDomain.Soil_Below_Pit",
+            "model_part_name_list": [
+                "PorousDomain.Interface_Bottom_Left",
+                "PorousDomain.Interface_Bottom_Right"
+            ],
             "properties_id": 4,
-            "Material": {
-                "constitutive_law": {
-                    "name": "GeoLinearElasticPlaneStrain2DLaw"
-                },
-                "Variables": {
-                    "GEO_DRAINAGE_TYPE": "CONSTANT_PW_FIELD",
-                    "DENSITY_SOLID": 1.83486e+03,
-                    "DENSITY_WATER": 1.01937e+03,
-                    "POROSITY": 0.0,
-                    "BULK_MODULUS_SOLID": 1.0e+10,
-                    "BULK_MODULUS_FLUID": 2.2e+09,
-                    "YOUNG_MODULUS": 9.0e+05,
-                    "POISSON_RATIO": 0.2,
-                    "BIOT_COEFFICIENT": 1.0,
-                    "RETENTION_LAW": "SaturatedBelowPhreaticLevelLaw",
-                    "SATURATED_SATURATION": 1.0,
-                    "RESIDUAL_SATURATION": 1.0e-10,
-                    "MINIMUM_RELATIVE_PERMEABILITY": 1.0e-04
-                }
-            }
-        },
-        {
-            "model_part_name": "PorousDomain.Soil_Bottom_Left",
-            "properties_id": 5,
-            "Material": {
-                "constitutive_law": {
-                    "name": "GeoLinearElasticPlaneStrain2DLaw"
-                },
-                "Variables": {
-                    "GEO_DRAINAGE_TYPE": "CONSTANT_PW_FIELD",
-                    "DENSITY_SOLID": 2.03874e+03,
-                    "DENSITY_WATER": 1.01937e+03,
-                    "POROSITY": 0.0,
-                    "BULK_MODULUS_SOLID": 1.0e+10,
-                    "BULK_MODULUS_FLUID": 2.2e+09,
-                    "YOUNG_MODULUS": 7.4286e+06,
-                    "POISSON_RATIO": 0.3,
-                    "BIOT_COEFFICIENT": 1.0,
-                    "RETENTION_LAW": "SaturatedBelowPhreaticLevelLaw",
-                    "SATURATED_SATURATION": 1.0,
-                    "RESIDUAL_SATURATION": 1.0e-10,
-                    "MINIMUM_RELATIVE_PERMEABILITY": 1.0e-04
-                }
-            }
-        },
-        {
-            "model_part_name": "PorousDomain.Soil_Bottom_Right",
-            "properties_id": 6,
-            "Material": {
-                "constitutive_law": {
-                    "name": "GeoLinearElasticPlaneStrain2DLaw"
-                },
-                "Variables": {
-                    "GEO_DRAINAGE_TYPE": "CONSTANT_PW_FIELD",
-                    "DENSITY_SOLID": 2.03874e+03,
-                    "DENSITY_WATER": 1.01937e+03,
-                    "POROSITY": 0.0,
-                    "BULK_MODULUS_SOLID": 1.0e+10,
-                    "BULK_MODULUS_FLUID": 2.2e+09,
-                    "YOUNG_MODULUS": 7.4286e+06,
-                    "POISSON_RATIO": 0.3,
-                    "BIOT_COEFFICIENT": 1.0,
-                    "RETENTION_LAW": "SaturatedBelowPhreaticLevelLaw",
-                    "SATURATED_SATURATION": 1.0,
-                    "RESIDUAL_SATURATION": 1.0e-10,
-                    "MINIMUM_RELATIVE_PERMEABILITY": 1.0e-04
-                }
-            }
-        },
-        {
-            "model_part_name": "PorousDomain.Soil_Middle_Right",
-            "properties_id": 7,
-            "Material": {
-                "constitutive_law": {
-                    "name": "GeoLinearElasticPlaneStrain2DLaw"
-                },
-                "Variables": {
-                    "GEO_DRAINAGE_TYPE": "CONSTANT_PW_FIELD",
-                    "DENSITY_SOLID": 1.83486e+03,
-                    "DENSITY_WATER": 1.01937e+03,
-                    "POROSITY": 0.0,
-                    "BULK_MODULUS_SOLID": 1.0e+10,
-                    "BULK_MODULUS_FLUID": 2.2e+09,
-                    "YOUNG_MODULUS": 9.0e+05,
-                    "POISSON_RATIO": 0.2,
-                    "BIOT_COEFFICIENT": 1.0,
-                    "RETENTION_LAW": "SaturatedBelowPhreaticLevelLaw",
-                    "SATURATED_SATURATION": 1.0,
-                    "RESIDUAL_SATURATION": 1.0e-10,
-                    "MINIMUM_RELATIVE_PERMEABILITY": 1.0e-04
-                }
-            }
-        },
-        {
-            "model_part_name": "PorousDomain.Soil_Top_Right",
-            "properties_id": 8,
-            "Material": {
-                "constitutive_law": {
-                    "name": "GeoLinearElasticPlaneStrain2DLaw"
-                },
-                "Variables": {
-                    "GEO_DRAINAGE_TYPE": "CONSTANT_PW_FIELD",
-                    "DENSITY_SOLID": 1.83486e+03,
-                    "DENSITY_WATER": 1.01937e+03,
-                    "POROSITY": 0.0,
-                    "BULK_MODULUS_SOLID": 1.0e+10,
-                    "BULK_MODULUS_FLUID": 2.2e+09,
-                    "YOUNG_MODULUS": 9.0e+05,
-                    "POISSON_RATIO": 0.2,
-                    "BIOT_COEFFICIENT": 1.0,
-                    "RETENTION_LAW": "SaturatedBelowPhreaticLevelLaw",
-                    "SATURATED_SATURATION": 1.0,
-                    "RESIDUAL_SATURATION": 1.0e-10,
-                    "MINIMUM_RELATIVE_PERMEABILITY": 1.0e-04
-                }
-            }
-        },
-        {
-            "model_part_name": "PorousDomain.Interface_Top_Right",
-            "properties_id": 9,
-            "Material": {
-                "constitutive_law": {
-                    "name": "GeoIncrementalLinearElasticInterfaceLaw"
-                },
-                "Variables": {
-                    "GEO_DRAINAGE_TYPE": "CONSTANT_PW_FIELD",
-                    "INTERFACE_NORMAL_STIFFNESS": 3.75e+06,
-                    "INTERFACE_SHEAR_STIFFNESS": 3.75e+05,
-                    "BIOT_COEFFICIENT": 1.0,
-                    "RETENTION_LAW": "SaturatedBelowPhreaticLevelLaw",
-                    "SATURATED_SATURATION": 1.0,
-                    "RESIDUAL_SATURATION": 1.0e-10,
-                    "MINIMUM_RELATIVE_PERMEABILITY": 1.0e-04
-                }
-            }
-        },
-        {
-            "model_part_name": "PorousDomain.Interface_Middle_Right",
-            "properties_id": 10,
-            "Material": {
-                "constitutive_law": {
-                    "name": "GeoIncrementalLinearElasticInterfaceLaw"
-                },
-                "Variables": {
-                    "GEO_DRAINAGE_TYPE": "CONSTANT_PW_FIELD",
-                    "INTERFACE_NORMAL_STIFFNESS": 3.75e+06,
-                    "INTERFACE_SHEAR_STIFFNESS": 3.75e+05,
-                    "BIOT_COEFFICIENT": 1.0,
-                    "RETENTION_LAW": "SaturatedBelowPhreaticLevelLaw",
-                    "SATURATED_SATURATION": 1.0,
-                    "RESIDUAL_SATURATION": 1.0e-10,
-                    "MINIMUM_RELATIVE_PERMEABILITY": 1.0e-04
-                }
-            }
-        },
-        {
-            "model_part_name": "PorousDomain.Interface_Bottom_Right",
-            "properties_id": 11,
-            "Material": {
-                "constitutive_law": {
-                    "name": "GeoIncrementalLinearElasticInterfaceLaw"
-                },
-                "Variables": {
-                    "GEO_DRAINAGE_TYPE": "CONSTANT_PW_FIELD",
-                    "INTERFACE_NORMAL_STIFFNESS": 2.8571e+07,
-                    "INTERFACE_SHEAR_STIFFNESS": 2.8571e+06,
-                    "BIOT_COEFFICIENT": 1.0,
-                    "RETENTION_LAW": "SaturatedBelowPhreaticLevelLaw",
-                    "SATURATED_SATURATION": 1.0,
-                    "RESIDUAL_SATURATION": 1.0e-10,
-                    "MINIMUM_RELATIVE_PERMEABILITY": 1.0e-04
-                }
-            }
-        },
-        {
-            "model_part_name": "PorousDomain.Interface_Excavated_Soil_1",
-            "properties_id": 12,
-            "Material": {
-                "constitutive_law": {
-                    "name": "GeoIncrementalLinearElasticInterfaceLaw"
-                },
-                "Variables": {
-                    "GEO_DRAINAGE_TYPE": "CONSTANT_PW_FIELD",
-                    "INTERFACE_NORMAL_STIFFNESS": 3.75e+06,
-                    "INTERFACE_SHEAR_STIFFNESS": 3.75e+05,
-                    "BIOT_COEFFICIENT": 1.0,
-                    "RETENTION_LAW": "SaturatedBelowPhreaticLevelLaw",
-                    "SATURATED_SATURATION": 1.0,
-                    "RESIDUAL_SATURATION": 1.0e-10,
-                    "MINIMUM_RELATIVE_PERMEABILITY": 1.0e-04
-                }
-            }
-        },
-        {
-            "model_part_name": "PorousDomain.Interface_Excavated_Soil_2",
-            "properties_id": 13,
-            "Material": {
-                "constitutive_law": {
-                    "name": "GeoIncrementalLinearElasticInterfaceLaw"
-                },
-                "Variables": {
-                    "GEO_DRAINAGE_TYPE": "CONSTANT_PW_FIELD",
-                    "INTERFACE_NORMAL_STIFFNESS": 3.75e+06,
-                    "INTERFACE_SHEAR_STIFFNESS": 3.75e+05,
-                    "BIOT_COEFFICIENT": 1.0,
-                    "RETENTION_LAW": "SaturatedBelowPhreaticLevelLaw",
-                    "SATURATED_SATURATION": 1.0,
-                    "RESIDUAL_SATURATION": 1.0e-10,
-                    "MINIMUM_RELATIVE_PERMEABILITY": 1.0e-04
-                }
-            }
-        },
-        {
-            "model_part_name": "PorousDomain.Interface_Excavated_Soil_3",
-            "properties_id": 14,
-            "Material": {
-                "constitutive_law": {
-                    "name": "GeoIncrementalLinearElasticInterfaceLaw"
-                },
-                "Variables": {
-                    "GEO_DRAINAGE_TYPE": "CONSTANT_PW_FIELD",
-                    "INTERFACE_NORMAL_STIFFNESS": 3.75e+06,
-                    "INTERFACE_SHEAR_STIFFNESS": 3.75e+05,
-                    "BIOT_COEFFICIENT": 1.0,
-                    "RETENTION_LAW": "SaturatedBelowPhreaticLevelLaw",
-                    "SATURATED_SATURATION": 1.0,
-                    "RESIDUAL_SATURATION": 1.0e-10,
-                    "MINIMUM_RELATIVE_PERMEABILITY": 1.0e-04
-                }
-            }
-        },
-        {
-            "model_part_name": "PorousDomain.Interface_Middle_Left",
-            "properties_id": 15,
-            "Material": {
-                "constitutive_law": {
-                    "name": "GeoIncrementalLinearElasticInterfaceLaw"
-                },
-                "Variables": {
-                    "GEO_DRAINAGE_TYPE": "CONSTANT_PW_FIELD",
-                    "INTERFACE_NORMAL_STIFFNESS": 3.75e+06,
-                    "INTERFACE_SHEAR_STIFFNESS": 3.75e+05,
-                    "BIOT_COEFFICIENT": 1.0,
-                    "RETENTION_LAW": "SaturatedBelowPhreaticLevelLaw",
-                    "SATURATED_SATURATION": 1.0,
-                    "RESIDUAL_SATURATION": 1.0e-10,
-                    "MINIMUM_RELATIVE_PERMEABILITY": 1.0e-04
-                }
-            }
-        },
-        {
-            "model_part_name": "PorousDomain.Interface_Bottom_Left",
-            "properties_id": 16,
             "Material": {
                 "constitutive_law": {
                     "name": "GeoIncrementalLinearElasticInterfaceLaw"
@@ -346,7 +105,7 @@
         },
         {
             "model_part_name": "PorousDomain.Sheet_Pile_Wall",
-            "properties_id": 17,
+            "properties_id": 5,
             "Material": {
                 "constitutive_law": {
                     "name": "TimoshenkoBeamPlaneStrainElasticConstitutiveLaw"
@@ -362,7 +121,7 @@
         },
         {
             "model_part_name": "PorousDomain.Anchor",
-            "properties_id": 18,
+            "properties_id": 6,
             "Material": {
                 "constitutive_law": {
                     "name": "TrussConstitutiveLaw"

--- a/applications/GeoMechanicsApplication/tests/crow_validation/linear_elastic/MaterialParameters.json
+++ b/applications/GeoMechanicsApplication/tests/crow_validation/linear_elastic/MaterialParameters.json
@@ -32,7 +32,10 @@
             }
         },
         {
-            "model_part_name_list": ["PorousDomain.Soil_Bottom_Left", "PorousDomain.Soil_Bottom_Right"],
+            "model_part_name_list": [
+                "PorousDomain.Soil_Bottom_Left",
+                "PorousDomain.Soil_Bottom_Right"
+            ],
             "properties_id": 2,
             "Material": {
                 "constitutive_law": {

--- a/applications/GeoMechanicsApplication/tests/crow_validation/mohr_coulomb_clay-sand/MaterialParameters.json
+++ b/applications/GeoMechanicsApplication/tests/crow_validation/mohr_coulomb_clay-sand/MaterialParameters.json
@@ -1,7 +1,14 @@
 {
     "properties": [
         {
-            "model_part_name": "PorousDomain.Excavated_Soil_1",
+            "model_part_name_list": [
+                "PorousDomain.Excavated_Soil_1",
+                "PorousDomain.Excavated_Soil_2",
+                "PorousDomain.Excavated_Soil_3",
+                "PorousDomain.Soil_Below_Pit",
+                "PorousDomain.Soil_Top_Right",
+                "PorousDomain.Soil_Middle_Right"
+            ],
             "properties_id": 1,
             "Material": {
                 "constitutive_law": {
@@ -29,7 +36,7 @@
             }
         },
         {
-            "model_part_name": "PorousDomain.Excavated_Soil_2",
+            "model_part_name_list": ["PorousDomain.Soil_Bottom_Left", "PorousDomain.Soil_Bottom_Right"],
             "properties_id": 2,
             "Material": {
                 "constitutive_law": {
@@ -37,357 +44,61 @@
                 },
                 "Variables": {
                     "GEO_DRAINAGE_TYPE": "CONSTANT_PW_FIELD",
-                    "DENSITY_SOLID": 1.83486e+03,
+                    "DENSITY_SOLID": 2.03874e+03,
                     "DENSITY_WATER": 1.01937e+03,
                     "POROSITY": 0.0,
                     "BULK_MODULUS_SOLID": 1.0e+10,
                     "BULK_MODULUS_FLUID": 2.2e+09,
-                    "YOUNG_MODULUS": 9.0e+05,
-                    "POISSON_RATIO": 0.2,
+                    "YOUNG_MODULUS": 7.4286e+06,
+                    "POISSON_RATIO": 0.3,
                     "BIOT_COEFFICIENT": 1.0,
                     "RETENTION_LAW": "SaturatedBelowPhreaticLevelLaw",
                     "SATURATED_SATURATION": 1.0,
                     "RESIDUAL_SATURATION": 1.0e-10,
                     "MINIMUM_RELATIVE_PERMEABILITY": 1.0e-04,
-                    "GEO_COHESION": 3.0e+03,
-                    "GEO_FRICTION_ANGLE": 22.5,
+                    "GEO_COHESION": 0.0,
+                    "GEO_FRICTION_ANGLE": 32.5,
                     "GEO_ENABLE_TENSION_CUT_OFF": false,
                     "GEO_DILATANCY_ANGLE": 0.0
                 }
             }
         },
         {
-            "model_part_name": "PorousDomain.Excavated_Soil_3",
+            "model_part_name_list": [
+                "PorousDomain.Interface_Excavated_Soil_1",
+                "PorousDomain.Interface_Excavated_Soil_2",
+                "PorousDomain.Interface_Excavated_Soil_3",
+                "PorousDomain.Interface_Middle_Left",
+                "PorousDomain.Interface_Top_Right",
+                "PorousDomain.Interface_Middle_Right"
+            ],
             "properties_id": 3,
             "Material": {
                 "constitutive_law": {
-                    "name": "GeoMohrCoulombLawPlaneStrain"
+                    "name": "GeoInterfaceCoulombLawPlaneStrain"
                 },
                 "Variables": {
                     "GEO_DRAINAGE_TYPE": "CONSTANT_PW_FIELD",
-                    "DENSITY_SOLID": 1.83486e+03,
-                    "DENSITY_WATER": 1.01937e+03,
-                    "POROSITY": 0.0,
-                    "BULK_MODULUS_SOLID": 1.0e+10,
-                    "BULK_MODULUS_FLUID": 2.2e+09,
-                    "YOUNG_MODULUS": 9.0e+05,
-                    "POISSON_RATIO": 0.2,
+                    "INTERFACE_NORMAL_STIFFNESS": 3.75e+06,
+                    "INTERFACE_SHEAR_STIFFNESS": 3.75e+05,
+                    "GEO_COHESION": 1.44065e+03,
+                    "GEO_FRICTION_ANGLE": 11.25,
+                    "GEO_DILATANCY_ANGLE": 0.0,
+                    "GEO_ENABLE_TENSION_CUT_OFF": false,
                     "BIOT_COEFFICIENT": 1.0,
                     "RETENTION_LAW": "SaturatedBelowPhreaticLevelLaw",
                     "SATURATED_SATURATION": 1.0,
                     "RESIDUAL_SATURATION": 1.0e-10,
-                    "MINIMUM_RELATIVE_PERMEABILITY": 1.0e-04,
-                    "GEO_COHESION": 3.0e+03,
-                    "GEO_FRICTION_ANGLE": 22.5,
-                    "GEO_ENABLE_TENSION_CUT_OFF": false,
-                    "GEO_DILATANCY_ANGLE": 0.0
+                    "MINIMUM_RELATIVE_PERMEABILITY": 1.0e-04
                 }
             }
         },
         {
-            "model_part_name": "PorousDomain.Soil_Below_Pit",
+            "model_part_name_list": [
+                "PorousDomain.Interface_Bottom_Left",
+                "PorousDomain.Interface_Bottom_Right"
+            ],
             "properties_id": 4,
-            "Material": {
-                "constitutive_law": {
-                    "name": "GeoMohrCoulombLawPlaneStrain"
-                },
-                "Variables": {
-                    "GEO_DRAINAGE_TYPE": "CONSTANT_PW_FIELD",
-                    "DENSITY_SOLID": 1.83486e+03,
-                    "DENSITY_WATER": 1.01937e+03,
-                    "POROSITY": 0.0,
-                    "BULK_MODULUS_SOLID": 1.0e+10,
-                    "BULK_MODULUS_FLUID": 2.2e+09,
-                    "YOUNG_MODULUS": 9.0e+05,
-                    "POISSON_RATIO": 0.2,
-                    "BIOT_COEFFICIENT": 1.0,
-                    "RETENTION_LAW": "SaturatedBelowPhreaticLevelLaw",
-                    "SATURATED_SATURATION": 1.0,
-                    "RESIDUAL_SATURATION": 1.0e-10,
-                    "MINIMUM_RELATIVE_PERMEABILITY": 1.0e-04,
-                    "GEO_COHESION": 3.0e+03,
-                    "GEO_FRICTION_ANGLE": 22.5,
-                    "GEO_ENABLE_TENSION_CUT_OFF": false,
-                    "GEO_DILATANCY_ANGLE": 0.0
-                }
-            }
-        },
-        {
-            "model_part_name": "PorousDomain.Soil_Bottom_Left",
-            "properties_id": 5,
-            "Material": {
-                "constitutive_law": {
-                    "name": "GeoMohrCoulombLawPlaneStrain"
-                },
-                "Variables": {
-                    "GEO_DRAINAGE_TYPE": "CONSTANT_PW_FIELD",
-                    "DENSITY_SOLID": 2.03874e+03,
-                    "DENSITY_WATER": 1.01937e+03,
-                    "POROSITY": 0.0,
-                    "BULK_MODULUS_SOLID": 1.0e+10,
-                    "BULK_MODULUS_FLUID": 2.2e+09,
-                    "YOUNG_MODULUS": 7.4286e+06,
-                    "POISSON_RATIO": 0.3,
-                    "BIOT_COEFFICIENT": 1.0,
-                    "RETENTION_LAW": "SaturatedBelowPhreaticLevelLaw",
-                    "SATURATED_SATURATION": 1.0,
-                    "RESIDUAL_SATURATION": 1.0e-10,
-                    "MINIMUM_RELATIVE_PERMEABILITY": 1.0e-04,
-                    "GEO_COHESION": 0.0,
-                    "GEO_FRICTION_ANGLE": 32.5,
-                    "GEO_ENABLE_TENSION_CUT_OFF": false,
-                    "GEO_DILATANCY_ANGLE": 0.0
-                }
-            }
-        },
-        {
-            "model_part_name": "PorousDomain.Soil_Bottom_Right",
-            "properties_id": 6,
-            "Material": {
-                "constitutive_law": {
-                    "name": "GeoMohrCoulombLawPlaneStrain"
-                },
-                "Variables": {
-                    "GEO_DRAINAGE_TYPE": "CONSTANT_PW_FIELD",
-                    "DENSITY_SOLID": 2.03874e+03,
-                    "DENSITY_WATER": 1.01937e+03,
-                    "POROSITY": 0.0,
-                    "BULK_MODULUS_SOLID": 1.0e+10,
-                    "BULK_MODULUS_FLUID": 2.2e+09,
-                    "YOUNG_MODULUS": 7.4286e+06,
-                    "POISSON_RATIO": 0.3,
-                    "BIOT_COEFFICIENT": 1.0,
-                    "RETENTION_LAW": "SaturatedBelowPhreaticLevelLaw",
-                    "SATURATED_SATURATION": 1.0,
-                    "RESIDUAL_SATURATION": 1.0e-10,
-                    "MINIMUM_RELATIVE_PERMEABILITY": 1.0e-04,
-                    "GEO_COHESION": 0.0,
-                    "GEO_FRICTION_ANGLE": 32.5,
-                    "GEO_ENABLE_TENSION_CUT_OFF": false,
-                    "GEO_DILATANCY_ANGLE": 0.0
-                }
-            }
-        },
-        {
-            "model_part_name": "PorousDomain.Soil_Middle_Right",
-            "properties_id": 7,
-            "Material": {
-                "constitutive_law": {
-                    "name": "GeoMohrCoulombLawPlaneStrain"
-                },
-                "Variables": {
-                    "GEO_DRAINAGE_TYPE": "CONSTANT_PW_FIELD",
-                    "DENSITY_SOLID": 1.83486e+03,
-                    "DENSITY_WATER": 1.01937e+03,
-                    "POROSITY": 0.0,
-                    "BULK_MODULUS_SOLID": 1.0e+10,
-                    "BULK_MODULUS_FLUID": 2.2e+09,
-                    "YOUNG_MODULUS": 9.0e+05,
-                    "POISSON_RATIO": 0.2,
-                    "BIOT_COEFFICIENT": 1.0,
-                    "RETENTION_LAW": "SaturatedBelowPhreaticLevelLaw",
-                    "SATURATED_SATURATION": 1.0,
-                    "RESIDUAL_SATURATION": 1.0e-10,
-                    "MINIMUM_RELATIVE_PERMEABILITY": 1.0e-04,
-                    "GEO_COHESION": 3.0e+03,
-                    "GEO_FRICTION_ANGLE": 22.5,
-                    "GEO_ENABLE_TENSION_CUT_OFF": false,
-                    "GEO_DILATANCY_ANGLE": 0.0
-                }
-            }
-        },
-        {
-            "model_part_name": "PorousDomain.Soil_Top_Right",
-            "properties_id": 8,
-            "Material": {
-                "constitutive_law": {
-                    "name": "GeoMohrCoulombLawPlaneStrain"
-                },
-                "Variables": {
-                    "GEO_DRAINAGE_TYPE": "CONSTANT_PW_FIELD",
-                    "DENSITY_SOLID": 1.83486e+03,
-                    "DENSITY_WATER": 1.01937e+03,
-                    "POROSITY": 0.0,
-                    "BULK_MODULUS_SOLID": 1.0e+10,
-                    "BULK_MODULUS_FLUID": 2.2e+09,
-                    "YOUNG_MODULUS": 9.0e+05,
-                    "POISSON_RATIO": 0.2,
-                    "BIOT_COEFFICIENT": 1.0,
-                    "RETENTION_LAW": "SaturatedBelowPhreaticLevelLaw",
-                    "SATURATED_SATURATION": 1.0,
-                    "RESIDUAL_SATURATION": 1.0e-10,
-                    "MINIMUM_RELATIVE_PERMEABILITY": 1.0e-04,
-                    "GEO_COHESION": 3.0e+03,
-                    "GEO_FRICTION_ANGLE": 22.5,
-                    "GEO_ENABLE_TENSION_CUT_OFF": false,
-                    "GEO_DILATANCY_ANGLE": 0.0
-                }
-            }
-        },
-        {
-            "model_part_name": "PorousDomain.Interface_Top_Right",
-            "properties_id": 9,
-            "Material": {
-                "constitutive_law": {
-                    "name": "GeoInterfaceCoulombLawPlaneStrain"
-                },
-                "Variables": {
-                    "GEO_DRAINAGE_TYPE": "CONSTANT_PW_FIELD",
-                    "INTERFACE_NORMAL_STIFFNESS": 3.75e+06,
-                    "INTERFACE_SHEAR_STIFFNESS": 3.75e+05,
-                    "GEO_COHESION": 1.44065e+03,
-                    "GEO_FRICTION_ANGLE": 11.25,
-                    "GEO_DILATANCY_ANGLE": 0.0,
-                    "GEO_ENABLE_TENSION_CUT_OFF": false,
-                    "BIOT_COEFFICIENT": 1.0,
-                    "RETENTION_LAW": "SaturatedBelowPhreaticLevelLaw",
-                    "SATURATED_SATURATION": 1.0,
-                    "RESIDUAL_SATURATION": 1.0e-10,
-                    "MINIMUM_RELATIVE_PERMEABILITY": 1.0e-04
-                }
-            }
-        },
-        {
-            "model_part_name": "PorousDomain.Interface_Middle_Right",
-            "properties_id": 10,
-            "Material": {
-                "constitutive_law": {
-                    "name": "GeoInterfaceCoulombLawPlaneStrain"
-                },
-                "Variables": {
-                    "GEO_DRAINAGE_TYPE": "CONSTANT_PW_FIELD",
-                    "INTERFACE_NORMAL_STIFFNESS": 3.75e+06,
-                    "INTERFACE_SHEAR_STIFFNESS": 3.75e+05,
-                    "GEO_COHESION": 1.44065e+03,
-                    "GEO_FRICTION_ANGLE": 11.25,
-                    "GEO_DILATANCY_ANGLE": 0.0,
-                    "GEO_ENABLE_TENSION_CUT_OFF": false,
-                    "BIOT_COEFFICIENT": 1.0,
-                    "RETENTION_LAW": "SaturatedBelowPhreaticLevelLaw",
-                    "SATURATED_SATURATION": 1.0,
-                    "RESIDUAL_SATURATION": 1.0e-10,
-                    "MINIMUM_RELATIVE_PERMEABILITY": 1.0e-04
-                }
-            }
-        },
-        {
-            "model_part_name": "PorousDomain.Interface_Bottom_Right",
-            "properties_id": 11,
-            "Material": {
-                "constitutive_law": {
-                    "name": "GeoInterfaceCoulombLawPlaneStrain"
-                },
-                "Variables": {
-                    "GEO_DRAINAGE_TYPE": "CONSTANT_PW_FIELD",
-                    "INTERFACE_NORMAL_STIFFNESS": 2.8571e+07,
-                    "INTERFACE_SHEAR_STIFFNESS": 2.8571e+06,
-                    "GEO_COHESION": 0.0,
-                    "GEO_FRICTION_ANGLE": 20.0,
-                    "GEO_DILATANCY_ANGLE": 0.0,
-                    "GEO_ENABLE_TENSION_CUT_OFF": false,
-                    "BIOT_COEFFICIENT": 1.0,
-                    "RETENTION_LAW": "SaturatedBelowPhreaticLevelLaw",
-                    "SATURATED_SATURATION": 1.0,
-                    "RESIDUAL_SATURATION": 1.0e-10,
-                    "MINIMUM_RELATIVE_PERMEABILITY": 1.0e-04
-                }
-            }
-        },
-        {
-            "model_part_name": "PorousDomain.Interface_Excavated_Soil_1",
-            "properties_id": 12,
-            "Material": {
-                "constitutive_law": {
-                    "name": "GeoInterfaceCoulombLawPlaneStrain"
-                },
-                "Variables": {
-                    "GEO_DRAINAGE_TYPE": "CONSTANT_PW_FIELD",
-                    "INTERFACE_NORMAL_STIFFNESS": 3.75e+06,
-                    "INTERFACE_SHEAR_STIFFNESS": 3.75e+05,
-                    "GEO_COHESION": 1.44065e+03,
-                    "GEO_FRICTION_ANGLE": 11.25,
-                    "GEO_DILATANCY_ANGLE": 0.0,
-                    "GEO_ENABLE_TENSION_CUT_OFF": false,
-                    "BIOT_COEFFICIENT": 1.0,
-                    "RETENTION_LAW": "SaturatedBelowPhreaticLevelLaw",
-                    "SATURATED_SATURATION": 1.0,
-                    "RESIDUAL_SATURATION": 1.0e-10,
-                    "MINIMUM_RELATIVE_PERMEABILITY": 1.0e-04
-                }
-            }
-        },
-        {
-            "model_part_name": "PorousDomain.Interface_Excavated_Soil_2",
-            "properties_id": 13,
-            "Material": {
-                "constitutive_law": {
-                    "name": "GeoInterfaceCoulombLawPlaneStrain"
-                },
-                "Variables": {
-                    "GEO_DRAINAGE_TYPE": "CONSTANT_PW_FIELD",
-                    "INTERFACE_NORMAL_STIFFNESS": 3.75e+06,
-                    "INTERFACE_SHEAR_STIFFNESS": 3.75e+05,
-                    "GEO_COHESION": 1.44065e+03,
-                    "GEO_FRICTION_ANGLE": 11.25,
-                    "GEO_DILATANCY_ANGLE": 0.0,
-                    "GEO_ENABLE_TENSION_CUT_OFF": false,
-                    "BIOT_COEFFICIENT": 1.0,
-                    "RETENTION_LAW": "SaturatedBelowPhreaticLevelLaw",
-                    "SATURATED_SATURATION": 1.0,
-                    "RESIDUAL_SATURATION": 1.0e-10,
-                    "MINIMUM_RELATIVE_PERMEABILITY": 1.0e-04
-                }
-            }
-        },
-        {
-            "model_part_name": "PorousDomain.Interface_Excavated_Soil_3",
-            "properties_id": 14,
-            "Material": {
-                "constitutive_law": {
-                    "name": "GeoInterfaceCoulombLawPlaneStrain"
-                },
-                "Variables": {
-                    "GEO_DRAINAGE_TYPE": "CONSTANT_PW_FIELD",
-                    "INTERFACE_NORMAL_STIFFNESS": 3.75e+06,
-                    "INTERFACE_SHEAR_STIFFNESS": 3.75e+05,
-                    "GEO_COHESION": 1.44065e+03,
-                    "GEO_FRICTION_ANGLE": 11.25,
-                    "GEO_DILATANCY_ANGLE": 0.0,
-                    "GEO_ENABLE_TENSION_CUT_OFF": false,
-                    "BIOT_COEFFICIENT": 1.0,
-                    "RETENTION_LAW": "SaturatedBelowPhreaticLevelLaw",
-                    "SATURATED_SATURATION": 1.0,
-                    "RESIDUAL_SATURATION": 1.0e-10,
-                    "MINIMUM_RELATIVE_PERMEABILITY": 1.0e-04
-                }
-            }
-        },
-        {
-            "model_part_name": "PorousDomain.Interface_Middle_Left",
-            "properties_id": 15,
-            "Material": {
-                "constitutive_law": {
-                    "name": "GeoInterfaceCoulombLawPlaneStrain"
-                },
-                "Variables": {
-                    "GEO_DRAINAGE_TYPE": "CONSTANT_PW_FIELD",
-                    "INTERFACE_NORMAL_STIFFNESS": 3.75e+06,
-                    "INTERFACE_SHEAR_STIFFNESS": 3.75e+05,
-                    "GEO_COHESION": 1.44065e+03,
-                    "GEO_FRICTION_ANGLE": 11.25,
-                    "GEO_DILATANCY_ANGLE": 0.0,
-                    "GEO_ENABLE_TENSION_CUT_OFF": false,
-                    "BIOT_COEFFICIENT": 1.0,
-                    "RETENTION_LAW": "SaturatedBelowPhreaticLevelLaw",
-                    "SATURATED_SATURATION": 1.0,
-                    "RESIDUAL_SATURATION": 1.0e-10,
-                    "MINIMUM_RELATIVE_PERMEABILITY": 1.0e-04
-                }
-            }
-        },
-        {
-            "model_part_name": "PorousDomain.Interface_Bottom_Left",
-            "properties_id": 16,
             "Material": {
                 "constitutive_law": {
                     "name": "GeoInterfaceCoulombLawPlaneStrain"
@@ -410,7 +121,7 @@
         },
         {
             "model_part_name": "PorousDomain.Sheet_Pile_Wall",
-            "properties_id": 17,
+            "properties_id": 5,
             "Material": {
                 "constitutive_law": {
                     "name": "TimoshenkoBeamPlaneStrainElasticConstitutiveLaw"
@@ -426,7 +137,7 @@
         },
         {
             "model_part_name": "PorousDomain.Anchor",
-            "properties_id": 18,
+            "properties_id": 6,
             "Material": {
                 "constitutive_law": {
                     "name": "TrussConstitutiveLaw"

--- a/applications/GeoMechanicsApplication/tests/crow_validation/mohr_coulomb_clay-sand/MaterialParameters.json
+++ b/applications/GeoMechanicsApplication/tests/crow_validation/mohr_coulomb_clay-sand/MaterialParameters.json
@@ -36,7 +36,10 @@
             }
         },
         {
-            "model_part_name_list": ["PorousDomain.Soil_Bottom_Left", "PorousDomain.Soil_Bottom_Right"],
+            "model_part_name_list": [
+                "PorousDomain.Soil_Bottom_Left",
+                "PorousDomain.Soil_Bottom_Right"
+            ],
             "properties_id": 2,
             "Material": {
                 "constitutive_law": {

--- a/applications/GeoMechanicsApplication/tests/crow_validation/mohr_coulomb_clay-sand/MaterialParametersWithSubstepping.json
+++ b/applications/GeoMechanicsApplication/tests/crow_validation/mohr_coulomb_clay-sand/MaterialParametersWithSubstepping.json
@@ -1,7 +1,14 @@
 {
     "properties": [
         {
-            "model_part_name": "PorousDomain.Excavated_Soil_1",
+            "model_part_name_list": [
+                "PorousDomain.Excavated_Soil_1",
+                "PorousDomain.Excavated_Soil_2",
+                "PorousDomain.Excavated_Soil_3",
+                "PorousDomain.Soil_Below_Pit",
+                "PorousDomain.Soil_Top_Right",
+                "PorousDomain.Soil_Middle_Right"
+            ],
             "properties_id": 1,
             "Material": {
                 "constitutive_law": {
@@ -31,7 +38,10 @@
             }
         },
         {
-            "model_part_name": "PorousDomain.Excavated_Soil_2",
+            "model_part_name_list": [
+                "PorousDomain.Soil_Bottom_Left",
+                "PorousDomain.Soil_Bottom_Right"
+            ],
             "properties_id": 2,
             "Material": {
                 "constitutive_law": {
@@ -39,20 +49,20 @@
                 },
                 "Variables": {
                     "GEO_DRAINAGE_TYPE": "CONSTANT_PW_FIELD",
-                    "DENSITY_SOLID": 1.83486e+03,
+                    "DENSITY_SOLID": 2.03874e+03,
                     "DENSITY_WATER": 1.01937e+03,
                     "POROSITY": 0.0,
                     "BULK_MODULUS_SOLID": 1.0e+10,
                     "BULK_MODULUS_FLUID": 2.2e+09,
-                    "YOUNG_MODULUS": 9.0e+05,
-                    "POISSON_RATIO": 0.2,
+                    "YOUNG_MODULUS": 7.4286e+06,
+                    "POISSON_RATIO": 0.3,
                     "BIOT_COEFFICIENT": 1.0,
                     "RETENTION_LAW": "SaturatedBelowPhreaticLevelLaw",
                     "SATURATED_SATURATION": 1.0,
                     "RESIDUAL_SATURATION": 1.0e-10,
                     "MINIMUM_RELATIVE_PERMEABILITY": 1.0e-04,
-                    "GEO_COHESION": 3.0e+03,
-                    "GEO_FRICTION_ANGLE": 22.5,
+                    "GEO_COHESION": 0.0,
+                    "GEO_FRICTION_ANGLE": 32.5,
                     "GEO_ENABLE_TENSION_CUT_OFF": false,
                     "GEO_DILATANCY_ANGLE": 0.0,
                     "GEO_MAX_RELATIVE_OVERSHOOT": 0.1,
@@ -61,363 +71,43 @@
             }
         },
         {
-            "model_part_name": "PorousDomain.Excavated_Soil_3",
+            "model_part_name_list": [
+                "PorousDomain.Interface_Excavated_Soil_1",
+                "PorousDomain.Interface_Excavated_Soil_2",
+                "PorousDomain.Interface_Excavated_Soil_3",
+                "PorousDomain.Interface_Middle_Left",
+                "PorousDomain.Interface_Top_Right",
+                "PorousDomain.Interface_Middle_Right"
+            ],
             "properties_id": 3,
             "Material": {
                 "constitutive_law": {
-                    "name": "GeoMohrCoulombLawPlaneStrain"
+                    "name": "GeoInterfaceCoulombLawPlaneStrain"
                 },
                 "Variables": {
                     "GEO_DRAINAGE_TYPE": "CONSTANT_PW_FIELD",
-                    "DENSITY_SOLID": 1.83486e+03,
-                    "DENSITY_WATER": 1.01937e+03,
-                    "POROSITY": 0.0,
-                    "BULK_MODULUS_SOLID": 1.0e+10,
-                    "BULK_MODULUS_FLUID": 2.2e+09,
-                    "YOUNG_MODULUS": 9.0e+05,
-                    "POISSON_RATIO": 0.2,
+                    "INTERFACE_NORMAL_STIFFNESS": 3.75e+06,
+                    "INTERFACE_SHEAR_STIFFNESS": 3.75e+05,
+                    "GEO_COHESION": 1.44065e+03,
+                    "GEO_FRICTION_ANGLE": 11.25,
+                    "GEO_DILATANCY_ANGLE": 0.0,
+                    "GEO_ENABLE_TENSION_CUT_OFF": false,
                     "BIOT_COEFFICIENT": 1.0,
                     "RETENTION_LAW": "SaturatedBelowPhreaticLevelLaw",
                     "SATURATED_SATURATION": 1.0,
                     "RESIDUAL_SATURATION": 1.0e-10,
                     "MINIMUM_RELATIVE_PERMEABILITY": 1.0e-04,
-                    "GEO_COHESION": 3.0e+03,
-                    "GEO_FRICTION_ANGLE": 22.5,
-                    "GEO_ENABLE_TENSION_CUT_OFF": false,
-                    "GEO_DILATANCY_ANGLE": 0.0,
                     "GEO_MAX_RELATIVE_OVERSHOOT": 0.1,
                     "GEO_MAX_NUMBER_OF_SUB_STEPS": 100
                 }
             }
         },
         {
-            "model_part_name": "PorousDomain.Soil_Below_Pit",
+            "model_part_name_list": [
+                "PorousDomain.Interface_Bottom_Left",
+                "PorousDomain.Interface_Bottom_Right"
+            ],
             "properties_id": 4,
-            "Material": {
-                "constitutive_law": {
-                    "name": "GeoMohrCoulombLawPlaneStrain"
-                },
-                "Variables": {
-                    "GEO_DRAINAGE_TYPE": "CONSTANT_PW_FIELD",
-                    "DENSITY_SOLID": 1.83486e+03,
-                    "DENSITY_WATER": 1.01937e+03,
-                    "POROSITY": 0.0,
-                    "BULK_MODULUS_SOLID": 1.0e+10,
-                    "BULK_MODULUS_FLUID": 2.2e+09,
-                    "YOUNG_MODULUS": 9.0e+05,
-                    "POISSON_RATIO": 0.2,
-                    "BIOT_COEFFICIENT": 1.0,
-                    "RETENTION_LAW": "SaturatedBelowPhreaticLevelLaw",
-                    "SATURATED_SATURATION": 1.0,
-                    "RESIDUAL_SATURATION": 1.0e-10,
-                    "MINIMUM_RELATIVE_PERMEABILITY": 1.0e-04,
-                    "GEO_COHESION": 3.0e+03,
-                    "GEO_FRICTION_ANGLE": 22.5,
-                    "GEO_ENABLE_TENSION_CUT_OFF": false,
-                    "GEO_DILATANCY_ANGLE": 0.0,
-                    "GEO_MAX_RELATIVE_OVERSHOOT": 0.1,
-                    "GEO_MAX_NUMBER_OF_SUB_STEPS": 100
-                }
-            }
-        },
-        {
-            "model_part_name": "PorousDomain.Soil_Bottom_Left",
-            "properties_id": 5,
-            "Material": {
-                "constitutive_law": {
-                    "name": "GeoMohrCoulombLawPlaneStrain"
-                },
-                "Variables": {
-                    "GEO_DRAINAGE_TYPE": "CONSTANT_PW_FIELD",
-                    "DENSITY_SOLID": 2.03874e+03,
-                    "DENSITY_WATER": 1.01937e+03,
-                    "POROSITY": 0.0,
-                    "BULK_MODULUS_SOLID": 1.0e+10,
-                    "BULK_MODULUS_FLUID": 2.2e+09,
-                    "YOUNG_MODULUS": 7.4286e+06,
-                    "POISSON_RATIO": 0.3,
-                    "BIOT_COEFFICIENT": 1.0,
-                    "RETENTION_LAW": "SaturatedBelowPhreaticLevelLaw",
-                    "SATURATED_SATURATION": 1.0,
-                    "RESIDUAL_SATURATION": 1.0e-10,
-                    "MINIMUM_RELATIVE_PERMEABILITY": 1.0e-04,
-                    "GEO_COHESION": 0.0,
-                    "GEO_FRICTION_ANGLE": 32.5,
-                    "GEO_ENABLE_TENSION_CUT_OFF": false,
-                    "GEO_DILATANCY_ANGLE": 0.0,
-                    "GEO_MAX_RELATIVE_OVERSHOOT": 0.1,
-                    "GEO_MAX_NUMBER_OF_SUB_STEPS": 100
-                }
-            }
-        },
-        {
-            "model_part_name": "PorousDomain.Soil_Bottom_Right",
-            "properties_id": 6,
-            "Material": {
-                "constitutive_law": {
-                    "name": "GeoMohrCoulombLawPlaneStrain"
-                },
-                "Variables": {
-                    "GEO_DRAINAGE_TYPE": "CONSTANT_PW_FIELD",
-                    "DENSITY_SOLID": 2.03874e+03,
-                    "DENSITY_WATER": 1.01937e+03,
-                    "POROSITY": 0.0,
-                    "BULK_MODULUS_SOLID": 1.0e+10,
-                    "BULK_MODULUS_FLUID": 2.2e+09,
-                    "YOUNG_MODULUS": 7.4286e+06,
-                    "POISSON_RATIO": 0.3,
-                    "BIOT_COEFFICIENT": 1.0,
-                    "RETENTION_LAW": "SaturatedBelowPhreaticLevelLaw",
-                    "SATURATED_SATURATION": 1.0,
-                    "RESIDUAL_SATURATION": 1.0e-10,
-                    "MINIMUM_RELATIVE_PERMEABILITY": 1.0e-04,
-                    "GEO_COHESION": 0.0,
-                    "GEO_FRICTION_ANGLE": 32.5,
-                    "GEO_ENABLE_TENSION_CUT_OFF": false,
-                    "GEO_DILATANCY_ANGLE": 0.0,
-                    "GEO_MAX_RELATIVE_OVERSHOOT": 0.1,
-                    "GEO_MAX_NUMBER_OF_SUB_STEPS": 100
-                }
-            }
-        },
-        {
-            "model_part_name": "PorousDomain.Soil_Middle_Right",
-            "properties_id": 7,
-            "Material": {
-                "constitutive_law": {
-                    "name": "GeoMohrCoulombLawPlaneStrain"
-                },
-                "Variables": {
-                    "GEO_DRAINAGE_TYPE": "CONSTANT_PW_FIELD",
-                    "DENSITY_SOLID": 1.83486e+03,
-                    "DENSITY_WATER": 1.01937e+03,
-                    "POROSITY": 0.0,
-                    "BULK_MODULUS_SOLID": 1.0e+10,
-                    "BULK_MODULUS_FLUID": 2.2e+09,
-                    "YOUNG_MODULUS": 9.0e+05,
-                    "POISSON_RATIO": 0.2,
-                    "BIOT_COEFFICIENT": 1.0,
-                    "RETENTION_LAW": "SaturatedBelowPhreaticLevelLaw",
-                    "SATURATED_SATURATION": 1.0,
-                    "RESIDUAL_SATURATION": 1.0e-10,
-                    "MINIMUM_RELATIVE_PERMEABILITY": 1.0e-04,
-                    "GEO_COHESION": 3.0e+03,
-                    "GEO_FRICTION_ANGLE": 22.5,
-                    "GEO_ENABLE_TENSION_CUT_OFF": false,
-                    "GEO_DILATANCY_ANGLE": 0.0,
-                    "GEO_MAX_RELATIVE_OVERSHOOT": 0.1,
-                    "GEO_MAX_NUMBER_OF_SUB_STEPS": 100
-                }
-            }
-        },
-        {
-            "model_part_name": "PorousDomain.Soil_Top_Right",
-            "properties_id": 8,
-            "Material": {
-                "constitutive_law": {
-                    "name": "GeoMohrCoulombLawPlaneStrain"
-                },
-                "Variables": {
-                    "GEO_DRAINAGE_TYPE": "CONSTANT_PW_FIELD",
-                    "DENSITY_SOLID": 1.83486e+03,
-                    "DENSITY_WATER": 1.01937e+03,
-                    "POROSITY": 0.0,
-                    "BULK_MODULUS_SOLID": 1.0e+10,
-                    "BULK_MODULUS_FLUID": 2.2e+09,
-                    "YOUNG_MODULUS": 9.0e+05,
-                    "POISSON_RATIO": 0.2,
-                    "BIOT_COEFFICIENT": 1.0,
-                    "RETENTION_LAW": "SaturatedBelowPhreaticLevelLaw",
-                    "SATURATED_SATURATION": 1.0,
-                    "RESIDUAL_SATURATION": 1.0e-10,
-                    "MINIMUM_RELATIVE_PERMEABILITY": 1.0e-04,
-                    "GEO_COHESION": 3.0e+03,
-                    "GEO_FRICTION_ANGLE": 22.5,
-                    "GEO_ENABLE_TENSION_CUT_OFF": false,
-                    "GEO_DILATANCY_ANGLE": 0.0,
-                    "GEO_MAX_RELATIVE_OVERSHOOT": 0.1,
-                    "GEO_MAX_NUMBER_OF_SUB_STEPS": 100
-                }
-            }
-        },
-        {
-            "model_part_name": "PorousDomain.Interface_Top_Right",
-            "properties_id": 9,
-            "Material": {
-                "constitutive_law": {
-                    "name": "GeoInterfaceCoulombLawPlaneStrain"
-                },
-                "Variables": {
-                    "GEO_DRAINAGE_TYPE": "CONSTANT_PW_FIELD",
-                    "INTERFACE_NORMAL_STIFFNESS": 3.75e+06,
-                    "INTERFACE_SHEAR_STIFFNESS": 3.75e+05,
-                    "GEO_COHESION": 1.44065e+03,
-                    "GEO_FRICTION_ANGLE": 11.25,
-                    "GEO_DILATANCY_ANGLE": 0.0,
-                    "GEO_ENABLE_TENSION_CUT_OFF": false,
-                    "BIOT_COEFFICIENT": 1.0,
-                    "RETENTION_LAW": "SaturatedBelowPhreaticLevelLaw",
-                    "SATURATED_SATURATION": 1.0,
-                    "RESIDUAL_SATURATION": 1.0e-10,
-                    "MINIMUM_RELATIVE_PERMEABILITY": 1.0e-04,
-                    "GEO_MAX_RELATIVE_OVERSHOOT": 0.1,
-                    "GEO_MAX_NUMBER_OF_SUB_STEPS": 100
-                }
-            }
-        },
-        {
-            "model_part_name": "PorousDomain.Interface_Middle_Right",
-            "properties_id": 10,
-            "Material": {
-                "constitutive_law": {
-                    "name": "GeoInterfaceCoulombLawPlaneStrain"
-                },
-                "Variables": {
-                    "GEO_DRAINAGE_TYPE": "CONSTANT_PW_FIELD",
-                    "INTERFACE_NORMAL_STIFFNESS": 3.75e+06,
-                    "INTERFACE_SHEAR_STIFFNESS": 3.75e+05,
-                    "GEO_COHESION": 1.44065e+03,
-                    "GEO_FRICTION_ANGLE": 11.25,
-                    "GEO_DILATANCY_ANGLE": 0.0,
-                    "GEO_ENABLE_TENSION_CUT_OFF": false,
-                    "BIOT_COEFFICIENT": 1.0,
-                    "RETENTION_LAW": "SaturatedBelowPhreaticLevelLaw",
-                    "SATURATED_SATURATION": 1.0,
-                    "RESIDUAL_SATURATION": 1.0e-10,
-                    "MINIMUM_RELATIVE_PERMEABILITY": 1.0e-04,
-                    "GEO_MAX_RELATIVE_OVERSHOOT": 0.1,
-                    "GEO_MAX_NUMBER_OF_SUB_STEPS": 100
-                }
-            }
-        },
-        {
-            "model_part_name": "PorousDomain.Interface_Bottom_Right",
-            "properties_id": 11,
-            "Material": {
-                "constitutive_law": {
-                    "name": "GeoInterfaceCoulombLawPlaneStrain"
-                },
-                "Variables": {
-                    "GEO_DRAINAGE_TYPE": "CONSTANT_PW_FIELD",
-                    "INTERFACE_NORMAL_STIFFNESS": 2.8571e+07,
-                    "INTERFACE_SHEAR_STIFFNESS": 2.8571e+06,
-                    "GEO_COHESION": 0.0,
-                    "GEO_FRICTION_ANGLE": 20.0,
-                    "GEO_DILATANCY_ANGLE": 0.0,
-                    "GEO_ENABLE_TENSION_CUT_OFF": false,
-                    "BIOT_COEFFICIENT": 1.0,
-                    "RETENTION_LAW": "SaturatedBelowPhreaticLevelLaw",
-                    "SATURATED_SATURATION": 1.0,
-                    "RESIDUAL_SATURATION": 1.0e-10,
-                    "MINIMUM_RELATIVE_PERMEABILITY": 1.0e-04,
-                    "GEO_MAX_RELATIVE_OVERSHOOT": 0.1,
-                    "GEO_MAX_NUMBER_OF_SUB_STEPS": 100
-                }
-            }
-        },
-        {
-            "model_part_name": "PorousDomain.Interface_Excavated_Soil_1",
-            "properties_id": 12,
-            "Material": {
-                "constitutive_law": {
-                    "name": "GeoInterfaceCoulombLawPlaneStrain"
-                },
-                "Variables": {
-                    "GEO_DRAINAGE_TYPE": "CONSTANT_PW_FIELD",
-                    "INTERFACE_NORMAL_STIFFNESS": 3.75e+06,
-                    "INTERFACE_SHEAR_STIFFNESS": 3.75e+05,
-                    "GEO_COHESION": 1.44065e+03,
-                    "GEO_FRICTION_ANGLE": 11.25,
-                    "GEO_DILATANCY_ANGLE": 0.0,
-                    "GEO_ENABLE_TENSION_CUT_OFF": false,
-                    "BIOT_COEFFICIENT": 1.0,
-                    "RETENTION_LAW": "SaturatedBelowPhreaticLevelLaw",
-                    "SATURATED_SATURATION": 1.0,
-                    "RESIDUAL_SATURATION": 1.0e-10,
-                    "MINIMUM_RELATIVE_PERMEABILITY": 1.0e-04,
-                    "GEO_MAX_RELATIVE_OVERSHOOT": 0.1,
-                    "GEO_MAX_NUMBER_OF_SUB_STEPS": 100
-                }
-            }
-        },
-        {
-            "model_part_name": "PorousDomain.Interface_Excavated_Soil_2",
-            "properties_id": 13,
-            "Material": {
-                "constitutive_law": {
-                    "name": "GeoInterfaceCoulombLawPlaneStrain"
-                },
-                "Variables": {
-                    "GEO_DRAINAGE_TYPE": "CONSTANT_PW_FIELD",
-                    "INTERFACE_NORMAL_STIFFNESS": 3.75e+06,
-                    "INTERFACE_SHEAR_STIFFNESS": 3.75e+05,
-                    "GEO_COHESION": 1.44065e+03,
-                    "GEO_FRICTION_ANGLE": 11.25,
-                    "GEO_DILATANCY_ANGLE": 0.0,
-                    "GEO_ENABLE_TENSION_CUT_OFF": false,
-                    "BIOT_COEFFICIENT": 1.0,
-                    "RETENTION_LAW": "SaturatedBelowPhreaticLevelLaw",
-                    "SATURATED_SATURATION": 1.0,
-                    "RESIDUAL_SATURATION": 1.0e-10,
-                    "MINIMUM_RELATIVE_PERMEABILITY": 1.0e-04,
-                    "GEO_MAX_RELATIVE_OVERSHOOT": 0.1,
-                    "GEO_MAX_NUMBER_OF_SUB_STEPS": 100
-                }
-            }
-        },
-        {
-            "model_part_name": "PorousDomain.Interface_Excavated_Soil_3",
-            "properties_id": 14,
-            "Material": {
-                "constitutive_law": {
-                    "name": "GeoInterfaceCoulombLawPlaneStrain"
-                },
-                "Variables": {
-                    "GEO_DRAINAGE_TYPE": "CONSTANT_PW_FIELD",
-                    "INTERFACE_NORMAL_STIFFNESS": 3.75e+06,
-                    "INTERFACE_SHEAR_STIFFNESS": 3.75e+05,
-                    "GEO_COHESION": 1.44065e+03,
-                    "GEO_FRICTION_ANGLE": 11.25,
-                    "GEO_DILATANCY_ANGLE": 0.0,
-                    "GEO_ENABLE_TENSION_CUT_OFF": false,
-                    "BIOT_COEFFICIENT": 1.0,
-                    "RETENTION_LAW": "SaturatedBelowPhreaticLevelLaw",
-                    "SATURATED_SATURATION": 1.0,
-                    "RESIDUAL_SATURATION": 1.0e-10,
-                    "MINIMUM_RELATIVE_PERMEABILITY": 1.0e-04,
-                    "GEO_MAX_RELATIVE_OVERSHOOT": 0.1,
-                    "GEO_MAX_NUMBER_OF_SUB_STEPS": 100
-                }
-            }
-        },
-        {
-            "model_part_name": "PorousDomain.Interface_Middle_Left",
-            "properties_id": 15,
-            "Material": {
-                "constitutive_law": {
-                    "name": "GeoInterfaceCoulombLawPlaneStrain"
-                },
-                "Variables": {
-                    "GEO_DRAINAGE_TYPE": "CONSTANT_PW_FIELD",
-                    "INTERFACE_NORMAL_STIFFNESS": 3.75e+06,
-                    "INTERFACE_SHEAR_STIFFNESS": 3.75e+05,
-                    "GEO_COHESION": 1.44065e+03,
-                    "GEO_FRICTION_ANGLE": 11.25,
-                    "GEO_DILATANCY_ANGLE": 0.0,
-                    "GEO_ENABLE_TENSION_CUT_OFF": false,
-                    "BIOT_COEFFICIENT": 1.0,
-                    "RETENTION_LAW": "SaturatedBelowPhreaticLevelLaw",
-                    "SATURATED_SATURATION": 1.0,
-                    "RESIDUAL_SATURATION": 1.0e-10,
-                    "MINIMUM_RELATIVE_PERMEABILITY": 1.0e-04,
-                    "GEO_MAX_RELATIVE_OVERSHOOT": 0.1,
-                    "GEO_MAX_NUMBER_OF_SUB_STEPS": 100
-                }
-            }
-        },
-        {
-            "model_part_name": "PorousDomain.Interface_Bottom_Left",
-            "properties_id": 16,
             "Material": {
                 "constitutive_law": {
                     "name": "GeoInterfaceCoulombLawPlaneStrain"
@@ -442,7 +132,7 @@
         },
         {
             "model_part_name": "PorousDomain.Sheet_Pile_Wall",
-            "properties_id": 17,
+            "properties_id": 5,
             "Material": {
                 "constitutive_law": {
                     "name": "TimoshenkoBeamPlaneStrainElasticConstitutiveLaw"
@@ -458,7 +148,7 @@
         },
         {
             "model_part_name": "PorousDomain.Anchor",
-            "properties_id": 18,
+            "properties_id": 6,
             "Material": {
                 "constitutive_law": {
                     "name": "TrussConstitutiveLaw"


### PR DESCRIPTION
Now that materials can be assigned to multiple model parts, the material input files of the CROW case can be simplified significantly by removing the duplicated materials.