### PR TITLE
[GeoMechanicsApplication] Fix clang-tidy issues

### DIFF
--- a/applications/GeoMechanicsApplication/custom_constitutive/interface_coulomb_law.cpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/interface_coulomb_law.cpp
@@ -243,8 +243,8 @@ std::size_t InterfaceCoulombLaw::CalculateAdaptiveNumberOfSubSteps(const Geo::Si
         rTrialTraction, rElasticMatrix, Geo::PrincipalStresses::AveragingType::NO_AVERAGING);
     mpCoulombImpl->RestoreKappaOfCoulombYieldSurface();
 
-    const Vector trial_values  = rTrialTraction.CopyTo<Vector>();
-    const Vector mapped_values = mapped_sigma_tau.CopyTo<Vector>();
+    const auto trial_values  = rTrialTraction.CopyTo<Vector>();
+    const auto mapped_values = mapped_sigma_tau.CopyTo<Vector>();
 
     const auto overshoot          = norm_2(trial_values - mapped_values);
     const auto stress_scale       = std::max(norm_2(trial_values), 1.0e-12);

--- a/applications/GeoMechanicsApplication/custom_constitutive/mohr_coulomb_law.cpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/mohr_coulomb_law.cpp
@@ -310,8 +310,8 @@ std::size_t MohrCoulombLaw::CalculateAdaptiveNumberOfSubSteps(const Geo::Princip
         rTrialPrincipalStresses, rElasticMatrix, Geo::PrincipalStresses::AveragingType::NO_AVERAGING);
     mpCoulombImpl->RestoreKappaOfCoulombYieldSurface();
 
-    const Vector trial_values  = rTrialPrincipalStresses.CopyTo<Vector>();
-    const Vector mapped_values = mapped_principal_stresses.CopyTo<Vector>();
+    const auto trial_values  = rTrialPrincipalStresses.CopyTo<Vector>();
+    const auto mapped_values = mapped_principal_stresses.CopyTo<Vector>();
 
     const auto overshoot          = norm_2(trial_values - mapped_values);
     const auto stress_scale       = std::max(norm_2(trial_values), 1.0e-12);

--- a/applications/GeoMechanicsApplication/custom_processes/apply_scalar_constraint_table_process.cpp
+++ b/applications/GeoMechanicsApplication/custom_processes/apply_scalar_constraint_table_process.cpp
@@ -30,12 +30,6 @@ namespace
 using namespace Kratos;
 using namespace std::string_literals;
 
-void AppendOptionalFluidParameters(const Parameters& rProcessSettings, std::vector<std::string>& rNamesOfSettingsToCopy)
-{
-    ParametersUtilities::AppendParameterNameIfExists("pressure_tension_cut_off", rProcessSettings,
-                                                     rNamesOfSettingsToCopy);
-}
-
 Parameters PrepareProcessParameters(const ModelPart&                rModelPart,
                                     const Parameters&               rProcessSettings,
                                     const std::vector<std::string>& rNamesOfSettingsToCopy)
@@ -113,7 +107,9 @@ void ApplyScalarConstraintTableProcess::MakeProcessForHydrostaticFluidPressure(
 {
     NamesOfSettingsToCopy.insert(NamesOfSettingsToCopy.end(),
                                  {"gravity_direction", "reference_coordinate", "specific_weight"});
-    AppendOptionalFluidParameters(rProcessSettings, NamesOfSettingsToCopy);
+
+    ParametersUtilities::AppendParameterNameIfExists("pressure_tension_cut_off", rProcessSettings,
+                                                     NamesOfSettingsToCopy);
 
     InstantiateProcessByTablePresence<ApplyHydrostaticPressureTableProcess, ApplyConstantHydrostaticPressureProcess>(
         rModelPart, rProcessSettings, std::move(NamesOfSettingsToCopy));
@@ -127,8 +123,9 @@ void ApplyScalarConstraintTableProcess::MakeProcessForPhreaticLine(ModelPart& rM
                                  {"gravity_direction", "out_of_plane_direction", "first_reference_coordinate",
                                   "second_reference_coordinate", "specific_weight"});
 
-    AppendOptionalFluidParameters(rProcessSettings, NamesOfSettingsToCopy);
-
+    ParametersUtilities::AppendParameterNameIfExists("pressure_tension_cut_off", rProcessSettings,
+                                                     NamesOfSettingsToCopy);
+ 
     InstantiateProcessByTablePresence<ApplyPhreaticLinePressureTableProcess, ApplyConstantPhreaticLinePressureProcess>(
         rModelPart, rProcessSettings, std::move(NamesOfSettingsToCopy));
 }
@@ -141,8 +138,9 @@ void ApplyScalarConstraintTableProcess::MakeProcessForPhreaticMultiLine(ModelPar
                                  {"gravity_direction", "out_of_plane_direction", "x_coordinates",
                                   "y_coordinates", "z_coordinates", "specific_weight"});
 
-    AppendOptionalFluidParameters(rProcessSettings, NamesOfSettingsToCopy);
-
+    ParametersUtilities::AppendParameterNameIfExists("pressure_tension_cut_off", rProcessSettings,
+                                                     NamesOfSettingsToCopy);
+ 
     InstantiateProcessByTablePresence<ApplyPhreaticMultiLinePressureTableProcess, ApplyConstantPhreaticMultiLinePressureProcess>(
         rModelPart, rProcessSettings, std::move(NamesOfSettingsToCopy));
 }
@@ -155,8 +153,9 @@ void ApplyScalarConstraintTableProcess::MakeProcessForPhreaticSurface(ModelPart&
                                  {"gravity_direction", "first_reference_coordinate", "second_reference_coordinate",
                                   "third_reference_coordinate", "specific_weight"});
 
-    AppendOptionalFluidParameters(rProcessSettings, NamesOfSettingsToCopy);
-
+    ParametersUtilities::AppendParameterNameIfExists("pressure_tension_cut_off", rProcessSettings,
+                                                     NamesOfSettingsToCopy);
+ 
     InstantiateProcessByTablePresence<ApplyPhreaticSurfacePressureTableProcess, ApplyConstantPhreaticSurfacePressureProcess>(
         rModelPart, rProcessSettings, std::move(NamesOfSettingsToCopy));
 }
@@ -171,8 +170,9 @@ void ApplyScalarConstraintTableProcess::MakeProcessForInterpolatedLine(ModelPart
     NamesOfSettingsToCopy.insert(NamesOfSettingsToCopy.end(),
                                  {"gravity_direction", "out_of_plane_direction"});
 
-    AppendOptionalFluidParameters(rProcessSettings, NamesOfSettingsToCopy);
-
+    ParametersUtilities::AppendParameterNameIfExists("pressure_tension_cut_off", rProcessSettings,
+                                                     NamesOfSettingsToCopy);
+ 
     mProcesses.emplace_back(std::make_unique<ApplyConstantInterpolateLinePressureProcess>(
         rModelPart, PrepareProcessParameters(rModelPart, rProcessSettings, NamesOfSettingsToCopy)));
 }

--- a/applications/GeoMechanicsApplication/custom_processes/apply_scalar_constraint_table_process.cpp
+++ b/applications/GeoMechanicsApplication/custom_processes/apply_scalar_constraint_table_process.cpp
@@ -25,6 +25,31 @@
 #include "includes/kratos_parameters.h"
 #include "includes/model_part.h"
 
+namespace
+{
+using namespace Kratos;
+using namespace std::string_literals;
+
+void AppendOptionalFluidParameters(const Parameters& rProcessSettings, std::vector<std::string>& rNamesOfSettingsToCopy)
+{
+    ParametersUtilities::AppendParameterNameIfExists("pressure_tension_cut_off", rProcessSettings,
+                                                     rNamesOfSettingsToCopy);
+    ParametersUtilities::AppendParameterNameIfExists("is_seepage", rProcessSettings, rNamesOfSettingsToCopy);
+}
+
+Parameters PrepareProcessParameters(const ModelPart&                rModelPart,
+                                    const Parameters&               rProcessSettings,
+                                    const std::vector<std::string>& rNamesOfSettingsToCopy)
+{
+    auto result = ParametersUtilities::CopyRequiredParameters(rProcessSettings, rNamesOfSettingsToCopy);
+
+    result.AddString("model_part_name"s, rModelPart.Name());
+
+    return result;
+}
+
+} // namespace
+
 namespace Kratos
 {
 using namespace std::string_literals;
@@ -176,14 +201,6 @@ std::string ApplyScalarConstraintTableProcess::Info() const
     return "ApplyScalarConstraintTableProcess"s;
 }
 
-void ApplyScalarConstraintTableProcess::AppendOptionalFluidParameters(const Parameters& rProcessSettings,
-                                                                      std::vector<std::string>& rNamesOfSettingsToCopy) const
-{
-    ParametersUtilities::AppendParameterNameIfExists("pressure_tension_cut_off", rProcessSettings,
-                                                     rNamesOfSettingsToCopy);
-    ParametersUtilities::AppendParameterNameIfExists("is_seepage", rProcessSettings, rNamesOfSettingsToCopy);
-}
-
 template <typename TableProcessType, typename ConstantProcessType>
 void ApplyScalarConstraintTableProcess::InstantiateProcessByTablePresence(ModelPart& rModelPart,
                                                                           const Parameters& rProcessSettings,
@@ -199,14 +216,4 @@ void ApplyScalarConstraintTableProcess::InstantiateProcessByTablePresence(ModelP
     }
 }
 
-Parameters ApplyScalarConstraintTableProcess::PrepareProcessParameters(const ModelPart& rModelPart,
-                                                                       const Parameters& rProcessSettings,
-                                                                       const std::vector<std::string>& rNamesOfSettingsToCopy) const
-{
-    auto result = ParametersUtilities::CopyRequiredParameters(rProcessSettings, rNamesOfSettingsToCopy);
-
-    result.AddString("model_part_name"s, rModelPart.Name());
-
-    return result;
-}
 } // namespace Kratos

--- a/applications/GeoMechanicsApplication/custom_processes/apply_scalar_constraint_table_process.cpp
+++ b/applications/GeoMechanicsApplication/custom_processes/apply_scalar_constraint_table_process.cpp
@@ -125,7 +125,7 @@ void ApplyScalarConstraintTableProcess::MakeProcessForPhreaticLine(ModelPart& rM
 
     ParametersUtilities::AppendParameterNameIfExists("pressure_tension_cut_off", rProcessSettings,
                                                      NamesOfSettingsToCopy);
- 
+
     InstantiateProcessByTablePresence<ApplyPhreaticLinePressureTableProcess, ApplyConstantPhreaticLinePressureProcess>(
         rModelPart, rProcessSettings, std::move(NamesOfSettingsToCopy));
 }
@@ -140,7 +140,7 @@ void ApplyScalarConstraintTableProcess::MakeProcessForPhreaticMultiLine(ModelPar
 
     ParametersUtilities::AppendParameterNameIfExists("pressure_tension_cut_off", rProcessSettings,
                                                      NamesOfSettingsToCopy);
- 
+
     InstantiateProcessByTablePresence<ApplyPhreaticMultiLinePressureTableProcess, ApplyConstantPhreaticMultiLinePressureProcess>(
         rModelPart, rProcessSettings, std::move(NamesOfSettingsToCopy));
 }
@@ -155,7 +155,7 @@ void ApplyScalarConstraintTableProcess::MakeProcessForPhreaticSurface(ModelPart&
 
     ParametersUtilities::AppendParameterNameIfExists("pressure_tension_cut_off", rProcessSettings,
                                                      NamesOfSettingsToCopy);
- 
+
     InstantiateProcessByTablePresence<ApplyPhreaticSurfacePressureTableProcess, ApplyConstantPhreaticSurfacePressureProcess>(
         rModelPart, rProcessSettings, std::move(NamesOfSettingsToCopy));
 }
@@ -172,7 +172,7 @@ void ApplyScalarConstraintTableProcess::MakeProcessForInterpolatedLine(ModelPart
 
     ParametersUtilities::AppendParameterNameIfExists("pressure_tension_cut_off", rProcessSettings,
                                                      NamesOfSettingsToCopy);
- 
+
     mProcesses.emplace_back(std::make_unique<ApplyConstantInterpolateLinePressureProcess>(
         rModelPart, PrepareProcessParameters(rModelPart, rProcessSettings, NamesOfSettingsToCopy)));
 }

--- a/applications/GeoMechanicsApplication/custom_processes/apply_scalar_constraint_table_process.h
+++ b/applications/GeoMechanicsApplication/custom_processes/apply_scalar_constraint_table_process.h
@@ -64,16 +64,11 @@ private:
     void MakeProcessForInterpolatedLine(ModelPart&               rModelPart,
                                         const Parameters&        rProcessSettings,
                                         std::vector<std::string> NamesOfSettingsToCopy);
-    void AppendOptionalFluidParameters(const Parameters&         rProcessSettings,
-                                       std::vector<std::string>& rNamesOfSettingsToCopy) const;
 
     template <typename TableProcessType, typename ConstantProcessType>
-    void       InstantiateProcessByTablePresence(ModelPart&               rModelPart,
-                                                 const Parameters&        rProcessSettings,
-                                                 std::vector<std::string> NamesOfSettingsToCopy);
-    Parameters PrepareProcessParameters(const ModelPart&  rModelPart,
-                                        const Parameters& rProcessSettings,
-                                        const std::vector<std::string>& rNamesOfSettingsToCopy) const;
+    void InstantiateProcessByTablePresence(ModelPart&               rModelPart,
+                                           const Parameters&        rProcessSettings,
+                                           std::vector<std::string> NamesOfSettingsToCopy);
 
     std::vector<std::unique_ptr<Process>> mProcesses;
 };


### PR DESCRIPTION
Fix clang-tidy issues:
- Some types could be converted to `auto` 
- Some functions could be used to an anonymous namespace