### PR TITLE
[GeoMechanicsApplication] Fix code smells 'avoid explicitly specifying template arguments'

### DIFF
--- a/applications/GeoMechanicsApplication/custom_processes/geo_extrapolate_integration_point_values_to_nodes_process.cpp
+++ b/applications/GeoMechanicsApplication/custom_processes/geo_extrapolate_integration_point_values_to_nodes_process.cpp
@@ -23,7 +23,7 @@ namespace
 
 using namespace Kratos;
 
-void CheckElement(Element& rElement, const std::string& rModelPartName, const ProcessInfo& rProcessInfo)
+void CheckElement(const Element& rElement, const std::string& rModelPartName, const ProcessInfo& rProcessInfo)
 {
     int check_result = 0;
     try {

--- a/applications/GeoMechanicsApplication/custom_strategies/builder_and_solvers/residualbased_block_builder_and_solver_with_mass_and_damping.hpp
+++ b/applications/GeoMechanicsApplication/custom_strategies/builder_and_solvers/residualbased_block_builder_and_solver_with_mass_and_damping.hpp
@@ -465,7 +465,7 @@ protected:
                 GetDerivativesForVariable(DISPLACEMENT_X, rNode, rFirstDerivativeVector, rSecondDerivativeVector);
                 GetDerivativesForVariable(DISPLACEMENT_Y, rNode, rFirstDerivativeVector, rSecondDerivativeVector);
 
-                const std::vector<const Variable<double>*> optional_variables = {
+                const auto optional_variables = std::vector<const Variable<double>*>{
                     &ROTATION_X, &ROTATION_Y, &ROTATION_Z, &DISPLACEMENT_Z};
 
                 for (const auto p_variable : optional_variables) {

--- a/applications/GeoMechanicsApplication/python_scripts/validation_helpers.py
+++ b/applications/GeoMechanicsApplication/python_scripts/validation_helpers.py
@@ -50,7 +50,7 @@ def validated_stage_file_paths(
 def validated_parameter_path(filename):
     """
     Validates that 'filename' resolves within the current working directory 
-    and has a .json extension.
+    and has a .json extension. If this is the case, the full file path is returned.
     """
     safe_base = Path.cwd().resolve()
     candidate = _resolve_safe_path(filename, base_dir=safe_base, strict=False)

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_conditions/test_t_normal_flux_condition.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_conditions/test_t_normal_flux_condition.cpp
@@ -93,7 +93,7 @@ KRATOS_TEST_CASE_IN_SUITE(GeoTNormalFluxCondition2D2N, KratosGeoMechanicsFastSui
 
     GenerateGeoTnormalFluxCondition2D2N(model_part);
 
-    const std::vector<double> expected_right_hand_side{5.0, 5.0};
+    const auto expected_right_hand_side = std::vector{5.0, 5.0};
     TestGeoTnormalFluxCondition(model_part, expected_right_hand_side);
 }
 
@@ -122,7 +122,7 @@ KRATOS_TEST_CASE_IN_SUITE(GeoTNormalFluxCondition2D3N, KratosGeoMechanicsFastSui
 
     GenerateGeoTnormalFluxCondition2D3N(model_part);
 
-    const std::vector<double> expected_right_hand_side{5.77898, 3.3428, 18.24365};
+    const auto expected_right_hand_side = std::vector{5.77898, 3.3428, 18.24365};
     TestGeoTnormalFluxCondition(model_part, expected_right_hand_side);
 }
 
@@ -152,7 +152,7 @@ KRATOS_TEST_CASE_IN_SUITE(GeoTNormalFluxCondition2D4N, KratosGeoMechanicsFastSui
 
     GenerateGeoTnormalFluxCondition2D4N(model_part);
 
-    const std::vector<double> expected_right_hand_side{7.33331, 2.60131, 16.89195, 5.27702};
+    const auto expected_right_hand_side = std::vector{7.33331, 2.60131, 16.89195, 5.27702};
     TestGeoTnormalFluxCondition(model_part, expected_right_hand_side);
 }
 
@@ -183,7 +183,7 @@ KRATOS_TEST_CASE_IN_SUITE(GeoTNormalFluxCondition2D5N, KratosGeoMechanicsFastSui
 
     GenerateGeoTnormalFluxCondition2D5N(model_part);
 
-    const std::vector<double> expected_right_hand_side{9.11795, 3.92042, 27.99155, 1.3485, 18.8636};
+    const auto expected_right_hand_side = std::vector{9.11795, 3.92042, 27.99155, 1.3485, 18.8636};
     TestGeoTnormalFluxCondition(model_part, expected_right_hand_side);
 }
 
@@ -213,7 +213,7 @@ KRATOS_TEST_CASE_IN_SUITE(GeoTNormalFluxCondition3D4N, KratosGeoMechanicsFastSui
 
     GenerateGeoTnormalFluxCondition3D4N(model_part);
 
-    const std::vector<double> expected_right_hand_side{0.569177, 1.29087, 0.985844, 0.569177};
+    const auto expected_right_hand_side = std::vector{0.569177, 1.29087, 0.985844, 0.569177};
     TestGeoTnormalFluxCondition(model_part, expected_right_hand_side);
 }
 
@@ -245,8 +245,8 @@ KRATOS_TEST_CASE_IN_SUITE(GeoTNormalFluxCondition3D6N, KratosGeoMechanicsFastSui
 
     GenerateGeoTnormalFluxCondition3D6N(model_part);
 
-    const std::vector<double> expected_right_hand_side{3.60822e-16, -2.77556e-16, -1.66533e-16,
-                                                       1.66667,     1.66667,      1.66667};
+    const auto expected_right_hand_side =
+        std::vector{3.60822e-16, -2.77556e-16, -1.66533e-16, 1.66667, 1.66667, 1.66667};
     TestGeoTnormalFluxCondition(model_part, expected_right_hand_side);
 }
 
@@ -280,8 +280,8 @@ KRATOS_TEST_CASE_IN_SUITE(GeoTNormalFluxCondition3D8N, KratosGeoMechanicsFastSui
 
     GenerateGeoTnormalFluxCondition3D8N(model_part);
 
-    const std::vector<double> expected_right_hand_side{0.133919, 0.635973, -0.403995, -0.117107,
-                                                       1.86947,  1.53697,  0.721923,  1.09723};
+    const auto expected_right_hand_side =
+        std::vector{0.133919, 0.635973, -0.403995, -0.117107, 1.86947, 1.53697, 0.721923, 1.09723};
     TestGeoTnormalFluxCondition(model_part, expected_right_hand_side);
 }
 
@@ -316,7 +316,7 @@ KRATOS_TEST_CASE_IN_SUITE(GeoTNormalFluxCondition3D9N, KratosGeoMechanicsFastSui
 
     GenerateGeoTnormalFluxCondition3D9N(model_part);
 
-    const std::vector<double> expected_right_hand_side{
+    const auto expected_right_hand_side = std::vector{
         0.325617, 0.741605, -0.0401643, 0.160657, 0.785555, 0.467627, 0.228477, 0.324183, 0.676021};
     TestGeoTnormalFluxCondition(model_part, expected_right_hand_side);
 }

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_elements/test_integration_schemes.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_elements/test_integration_schemes.cpp
@@ -238,8 +238,8 @@ KRATOS_TEST_CASE_IN_SUITE(PointsOfAllSupportedTriangleLumpedSchemesMustBeInRange
 
 KRATOS_TEST_CASE_IN_SUITE(CorrectWeightsFromTriangle6LumpedSchemes, KratosGeoMechanicsFastSuiteWithoutKernel)
 {
-    std::vector<double> expected_weights{0.0328638, 0.0328638, 0.0328638, 0.300469,
-                                         0.300469,  0.300469}; // regression values see core test test_triangle_2d_6
+    auto expected_weights = std::vector{0.0328638, 0.0328638, 0.0328638, 0.300469,
+                                        0.300469,  0.300469}; // regression values see core test test_triangle_2d_6
     std::transform(expected_weights.begin(), expected_weights.end(), expected_weights.begin(),
                    [](const auto& rWeight) {
         return rWeight * 0.5; // Adjust weights for the area of the triangle
@@ -251,7 +251,7 @@ KRATOS_TEST_CASE_IN_SUITE(CorrectWeightsFromTriangle6LumpedSchemes, KratosGeoMec
 
 KRATOS_TEST_CASE_IN_SUITE(CorrectWeightsFromTriangle3LumpedSchemes, KratosGeoMechanicsFastSuiteWithoutKernel)
 {
-    std::vector<double> expected_weights{1.0 / 3.0, 1.0 / 3.0, 1.0 / 3.0};
+    auto expected_weights = std::vector{1.0 / 3.0, 1.0 / 3.0, 1.0 / 3.0};
     std::transform(expected_weights.begin(), expected_weights.end(), expected_weights.begin(),
                    [](const auto& rWeight) {
         return rWeight * 0.5; // Adjust weights for the area of the triangle
@@ -263,7 +263,7 @@ KRATOS_TEST_CASE_IN_SUITE(CorrectWeightsFromTriangle3LumpedSchemes, KratosGeoMec
 
 KRATOS_TEST_CASE_IN_SUITE(CorrectWeightsFromQuadrilateral4LumpedSchemes, KratosGeoMechanicsFastSuiteWithoutKernel)
 {
-    std::vector<double> expected_weights{1.0 / 4.0, 1.0 / 4.0, 1.0 / 4.0, 1.0 / 4.0};
+    auto expected_weights = std::vector{1.0 / 4.0, 1.0 / 4.0, 1.0 / 4.0, 1.0 / 4.0};
     std::transform(expected_weights.begin(), expected_weights.end(), expected_weights.begin(),
                    [](const auto& rWeight) {
         return rWeight * 4.0; // Adjust weights for the area of the quadrilateral
@@ -275,7 +275,7 @@ KRATOS_TEST_CASE_IN_SUITE(CorrectWeightsFromQuadrilateral4LumpedSchemes, KratosG
 
 KRATOS_TEST_CASE_IN_SUITE(CorrectWeightsFromQuadrilateral8LumpedSchemes, KratosGeoMechanicsFastSuiteWithoutKernel)
 {
-    std::vector<double> expected_weights{
+    auto expected_weights = std::vector{
         0.0394737, 0.0394737, 0.0394737, 0.0394737, 0.210526,
         0.210526,  0.210526,  0.210526}; // regression lumping values see core test test_quadrilateral_2d_8
     std::transform(expected_weights.begin(), expected_weights.end(), expected_weights.begin(),

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_processes/test_apply_initial_uniform_stress_field.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_processes/test_apply_initial_uniform_stress_field.cpp
@@ -42,7 +42,7 @@ KRATOS_TEST_CASE_IN_SUITE(ApplyInitialUniformStressFieldProcessAppliesStressesTo
                                                             r_model_part.GetProcessInfo());
     KRATOS_EXPECT_EQ(actual_stresses.size(), 3);
 
-    const std::vector<double> expected_stress = {1.0, 2.0, 3.0, 4.0};
+    const auto expected_stress = std::vector{1.0, 2.0, 3.0, 4.0};
     for (const auto& stress : actual_stresses) {
         KRATOS_EXPECT_VECTOR_NEAR(stress, expected_stress, Defaults::absolute_tolerance);
     }
@@ -68,7 +68,7 @@ KRATOS_TEST_CASE_IN_SUITE(ApplyInitialUniformStressFieldProcessAppliesStressesTo
                                                             r_model_part.GetProcessInfo());
     KRATOS_EXPECT_EQ(actual_stresses.size(), 4);
 
-    const std::vector<double> expected_stress = {1.0, 2.0, 3.0, 4.0, 5.0, 6.0};
+    const auto expected_stress = std::vector{1.0, 2.0, 3.0, 4.0, 5.0, 6.0};
     for (const auto& stress : actual_stresses) {
         KRATOS_EXPECT_VECTOR_NEAR(stress, expected_stress, Defaults::absolute_tolerance);
     }
@@ -94,7 +94,7 @@ KRATOS_TEST_CASE_IN_SUITE(ApplyInitialUniformStressFieldProcessAppliesStressesTo
                                                             r_model_part.GetProcessInfo());
     KRATOS_EXPECT_EQ(actual_stresses.size(), 3);
 
-    const std::vector<double> expected_stress = {1.0, 2.0, 3.0, 4.0};
+    const auto expected_stress = std::vector{1.0, 2.0, 3.0, 4.0};
     for (const auto& stress : actual_stresses) {
         KRATOS_EXPECT_VECTOR_NEAR(stress, expected_stress, Defaults::absolute_tolerance);
     }

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_utilities/test_equation_of_motion.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_utilities/test_equation_of_motion.cpp
@@ -172,7 +172,7 @@ KRATOS_TEST_CASE_IN_SUITE(CalculateStiffnessMatrixGivesCorrectResults, KratosGeo
     constitutive_matrices.push_back(constitutive);
     constitutive_matrices.push_back(constitutive);
 
-    std::vector<double> integration_coefficients{1.0, 2.0};
+    auto integration_coefficients = std::vector{1.0, 2.0};
 
     auto stiffness_matrix = GeoEquationOfMotionUtilities::CalculateStiffnessMatrix(
         b_matrices, constitutive_matrices, integration_coefficients);

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_utilities/test_math_utilities.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_utilities/test_math_utilities.cpp
@@ -23,17 +23,15 @@ KRATOS_TEST_CASE_IN_SUITE(CalculateDeterminants_ReturnsCorrectResults, KratosGeo
 {
     const std::vector<Matrix> matrices = {ScalarMatrix(1, 1, 3.0), ZeroMatrix(3, 3), IdentityMatrix(3) * 2.0};
 
-    const std::vector<double> results = GeoMechanicsMathUtilities::CalculateDeterminants(matrices);
-
+    const auto results          = GeoMechanicsMathUtilities::CalculateDeterminants(matrices);
     const auto expected_results = std::vector{3.0, 0.0, 8.0};
     KRATOS_CHECK_VECTOR_NEAR(results, expected_results, 1.0e-12)
 }
 
 KRATOS_TEST_CASE_IN_SUITE(CalculateDeterminants_ReturnsEmptyVectorForEmptyInput, KratosGeoMechanicsFastSuiteWithoutKernel)
 {
-    const std::vector<Matrix> matrices = {};
-
-    const std::vector<double> results = GeoMechanicsMathUtilities::CalculateDeterminants(matrices);
+    const auto matrices = std::vector<Matrix>{};
+    const auto results  = GeoMechanicsMathUtilities::CalculateDeterminants(matrices);
 
     KRATOS_EXPECT_TRUE(results.empty())
 }

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_utilities/test_math_utilities.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_utilities/test_math_utilities.cpp
@@ -25,7 +25,7 @@ KRATOS_TEST_CASE_IN_SUITE(CalculateDeterminants_ReturnsCorrectResults, KratosGeo
 
     const std::vector<double> results = GeoMechanicsMathUtilities::CalculateDeterminants(matrices);
 
-    const std::vector<double> expected_results = {3.0, 0.0, 8.0};
+    const auto expected_results = std::vector{3.0, 0.0, 8.0};
     KRATOS_CHECK_VECTOR_NEAR(results, expected_results, 1.0e-12)
 }
 

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_utilities/test_process_info_parser.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_utilities/test_process_info_parser.cpp
@@ -75,13 +75,13 @@ KRATOS_TEST_CASE_IN_SUITE(GetProcessList_ReturnsExpectedProcesses_ForAllListType
     const auto            actual_result = parser.GetProcessList(process_list);
 
     // Then
-    const std::vector<ProcessParameters> expected_result = {
-        ProcessParameters{"ConstraintProcess1", Parameters{parameterString}},
-        ProcessParameters{"ConstraintProcess2", Parameters{parameterString}},
-        ProcessParameters{"LoadProcess1", Parameters{parameterString}},
-        ProcessParameters{"LoadProcess2", Parameters{parameterString}},
-        ProcessParameters{"AuxiliaryProcess1", Parameters{parameterString}},
-        ProcessParameters{"AuxiliaryProcess2", Parameters{parameterString}}};
+    const auto expected_result =
+        std::vector{ProcessParameters{"ConstraintProcess1", Parameters{parameterString}},
+                    ProcessParameters{"ConstraintProcess2", Parameters{parameterString}},
+                    ProcessParameters{"LoadProcess1", Parameters{parameterString}},
+                    ProcessParameters{"LoadProcess2", Parameters{parameterString}},
+                    ProcessParameters{"AuxiliaryProcess1", Parameters{parameterString}},
+                    ProcessParameters{"AuxiliaryProcess2", Parameters{parameterString}}};
 
     KRATOS_EXPECT_EQ(expected_result, actual_result);
 }
@@ -111,7 +111,7 @@ KRATOS_TEST_CASE_IN_SUITE(GetProcessList_GivesDuplicates_ForProcessesWithIdentic
     const auto            actual_result = parser.GetProcessList(process_list_with_duplicate_names);
 
     // Then
-    const std::vector<ProcessParameters> expected_result = {
+    const auto expected_result = std::vector{
         ProcessParameters{"ApplyVectorConstraintTableProcess", Parameters{parameterString}},
         ProcessParameters{"ApplyVectorConstraintTableProcess", Parameters{parameterString}}};
 

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/stub_process_info_parser.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/stub_process_info_parser.cpp
@@ -44,7 +44,7 @@ const std::string k0_string =
     "variable_name": "CAUCHY_STRESS_TENSOR"
 })";
 
-const std::vector<ProcessParameters> process_list = {
+const auto process_list = std::vector{
     ProcessParameters{"ApplyVectorConstraintTableProcess", Parameters{vector_parameter_string}},
     ProcessParameters{"SetParameterFieldProcess", Parameters{parameter_field_string}},
     ProcessParameters{"ApplyExcavationProcess", Parameters{excavation_string}},


### PR DESCRIPTION
- Modernized ` std::vector` initialization in GeoMechanics code using auto and class template argument deduction without changing behavior.
- Extended comment in` validation_helper.py` from the previous PR.
- Added `const `in `CheckElement `function