### PR TITLE
[GeoMechanicsApplication] Made throw in stub-element more consistent with code base

### DIFF
--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_processes/test_geo_extrapolate_integration_point_values_to_nodes_process.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_processes/test_geo_extrapolate_integration_point_values_to_nodes_process.cpp
@@ -113,10 +113,7 @@ public:
 
     using StubElementForNodalExtrapolationTest::StubElementForNodalExtrapolationTest;
 
-    int Check(const ProcessInfo&) const override
-    {
-        throw std::runtime_error("Synthetic check failure");
-    }
+    int Check(const ProcessInfo&) const override { KRATOS_ERROR << "Check failure"; }
 };
 
 class StubElementWithUnknownThrowingCheckForNodalExtrapolationTest : public StubElementForNodalExtrapolationTest


### PR DESCRIPTION
Fixes a code smell, which complains about the exception thrown being too generic