### PR TITLE
[GeoMechanicsApplication][Core] Enable Variable<std::vector<Vector>> support in ReadMaterialsUtility

### DIFF
--- a/kratos/includes/kratos_components.h
+++ b/kratos/includes/kratos_components.h
@@ -490,6 +490,7 @@ KRATOS_API_EXTERN template class KRATOS_API(KRATOS_CORE) KratosComponents<Variab
 KRATOS_API_EXTERN template class KRATOS_API(KRATOS_CORE) KratosComponents<Variable<Vector>>;
 KRATOS_API_EXTERN template class KRATOS_API(KRATOS_CORE) KratosComponents<Variable<Matrix>>;
 KRATOS_API_EXTERN template class KRATOS_API(KRATOS_CORE) KratosComponents<Variable<std::string>>;
+KRATOS_API_EXTERN template class KRATOS_API(KRATOS_CORE) KratosComponents<Variable<std::vector<Vector>>>;
 KRATOS_API_EXTERN template class KRATOS_API(KRATOS_CORE) KratosComponents<Variable<Flags>>;
 KRATOS_API_EXTERN template class KRATOS_API(KRATOS_CORE) KratosComponents<Flags>;
 KRATOS_API_EXTERN template class KRATOS_API(KRATOS_CORE) KratosComponents<DataCommunicator>;
@@ -522,6 +523,7 @@ void KRATOS_API(KRATOS_CORE) AddKratosComponent(const std::string& rName, const 
 void KRATOS_API(KRATOS_CORE) AddKratosComponent(const std::string& rName, const Variable<Vector>& rComponent);
 void KRATOS_API(KRATOS_CORE) AddKratosComponent(const std::string& rName, const Variable<Matrix>& rComponent);
 void KRATOS_API(KRATOS_CORE) AddKratosComponent(const std::string& rName, const Variable<std::string>& rComponent);
+void KRATOS_API(KRATOS_CORE) AddKratosComponent(const std::string& rName, const Variable<std::vector<Vector>>& rComponent);
 void KRATOS_API(KRATOS_CORE) AddKratosComponent(const std::string& rName, const Flags& rComponent);
 void KRATOS_API(KRATOS_CORE) AddKratosComponent(const std::string& rName, const Variable<Flags>& rComponent);
 

--- a/kratos/sources/kratos_components.cpp
+++ b/kratos/sources/kratos_components.cpp
@@ -93,6 +93,11 @@ void AddKratosComponent(const std::string& rName, const Variable<std::string>& r
     KratosComponents<Variable<std::string>>::Add(rName, rComponent);
 }
 
+void AddKratosComponent(const std::string& rName, const Variable<std::vector<Vector>>& rComponent)
+{
+    KratosComponents<Variable<std::vector<Vector>>>::Add(rName, rComponent);
+}
+
 void AddKratosComponent(const std::string& rName, const Variable<Flags>& rComponent)
 {
     KratosComponents<Variable<Flags>>::Add(rName, rComponent);
@@ -140,6 +145,7 @@ template class KratosComponents<Variable<Quaternion<double>>>;
 template class KratosComponents<Variable<Vector>>;
 template class KratosComponents<Variable<Matrix>>;
 template class KratosComponents<Variable<std::string>>;
+template class KratosComponents<Variable<std::vector<Vector>>>;
 template class KratosComponents<Variable<Flags>>;
 template class KratosComponents<Flags>;
 template class KratosComponents<DataCommunicator>;

--- a/kratos/utilities/read_materials_utility.cpp
+++ b/kratos/utilities/read_materials_utility.cpp
@@ -298,8 +298,9 @@ void ReadMaterialsUtility::AssignVariablesToProperty(
                 rProperty.SetValue(r_variable, value.GetString());
             } else if(KratosComponents<Variable<std::vector<Vector>> >::Has(variable_name)) {
                 const Variable<std::vector<Vector>>& r_variable = KratosComponents<Variable<std::vector<Vector>>>().Get(variable_name);
-                CheckIfOverwritingValue(rProperty, r_variable, value.GetVectorArray());
-                rProperty.SetValue(r_variable, value.GetVectorArray());
+                const auto vector_array = value.GetVectorArray();
+                CheckIfOverwritingValue(rProperty, r_variable, vector_array);
+                rProperty.SetValue(r_variable, vector_array);
             } else {
                 KRATOS_ERROR << "Value type for \"" << variable_name << "\" not defined";
             }

--- a/kratos/utilities/read_materials_utility.cpp
+++ b/kratos/utilities/read_materials_utility.cpp
@@ -253,7 +253,7 @@ void ReadMaterialsUtility::AssignVariablesToProperty(
             std::string variable_name = iter.name();
             TrimComponentName(variable_name);
 
-            // We don't just copy the values, we do some tyransformation depending of the destination variable
+            // We don't just copy the values, we do some transformation depending of the destination variable
             if (KratosComponents<Variable<double> >::Has(variable_name)) {
                 const Variable<double>& r_variable = KratosComponents<Variable<double>>().Get(variable_name);
                 CheckIfOverwritingValue(rProperty, r_variable, value.GetDouble());
@@ -296,6 +296,10 @@ void ReadMaterialsUtility::AssignVariablesToProperty(
                 const Variable<std::string>& r_variable = KratosComponents<Variable<std::string>>().Get(variable_name);
                 CheckIfOverwritingValue(rProperty, r_variable, value.GetString());
                 rProperty.SetValue(r_variable, value.GetString());
+            } else if(KratosComponents<Variable<std::vector<Vector>> >::Has(variable_name)) {
+                const Variable<std::vector<Vector>>& r_variable = KratosComponents<Variable<std::vector<Vector>>>().Get(variable_name);
+                CheckIfOverwritingValue(rProperty, r_variable, value.GetVectorArray());
+                rProperty.SetValue(r_variable, value.GetVectorArray());
             } else {
                 KRATOS_ERROR << "Value type for \"" << variable_name << "\" not defined";
             }


### PR DESCRIPTION
To enable support without refactoring the core architecture:

- Explicit Instantiation: Added explicit instantiation directives (`KRATOS_API_EXTERN`) for `KratosComponents<Variable<std::vector<Vector>>>` in` kratos_component.h`.
- Definition Stub: Provided the missing function definition for `AddKratosComponent(..., const Variable<std::vector<Vector>>&)` in `kratos_component.cpp` to satisfy the MSVC linker.
- Logic Update: Updated `AssignVariablesToProperty `in `ReadMaterialsUtility `to check for `Variable<std::vector<Vector>>` and correctly bind the data using` value.GetVectorArray().`
