### PR TITLE
Refactor DamNodalYoungModulusProcess: Remove fixed constraint and upd…

### DIFF
--- a/applications/DamApplication/custom_processes/dam_nodal_young_modulus_process.hpp
+++ b/applications/DamApplication/custom_processes/dam_nodal_young_modulus_process.hpp
@@ -67,7 +67,6 @@ class DamNodalYoungModulusProcess : public Process
         rParameters.ValidateAndAssignDefaults(default_parameters);
 
         mVariableName = rParameters["variable_name"].GetString();
-        mIsFixed = rParameters["constrained"].GetBool();
         mYoung1 = rParameters["Young_Modulus_1"].GetDouble();
         mYoung2 = rParameters["Young_Modulus_2"].GetDouble();
         mYoung3 = rParameters["Young_Modulus_3"].GetDouble();
@@ -106,11 +105,6 @@ class DamNodalYoungModulusProcess : public Process
             {
                 ModelPart::NodesContainerType::iterator it = it_begin + i;
 
-                if (mIsFixed)
-                {
-                    it->Fix(var);
-                }
-
                 double Young = mYoung1 + (mYoung2 * it->X()) + (mYoung3 * it->Y()) + (mYoung4 * it->Z());
 
                 if (Young <= 0.0)
@@ -143,11 +137,6 @@ class DamNodalYoungModulusProcess : public Process
             for (int i = 0; i < nnodes; i++)
             {
                 ModelPart::NodesContainerType::iterator it = it_begin + i;
-
-                if (mIsFixed)
-                {
-                    it->Fix(var);
-                }
 
                 double Young = mYoung1 + (mYoung2 * it->X()) + (mYoung3 * it->Y()) + (mYoung4 * it->Z());
 
@@ -187,7 +176,6 @@ class DamNodalYoungModulusProcess : public Process
 
     ModelPart &mrModelPart;
     std::string mVariableName;
-    bool mIsFixed;
     double mYoung1;
     double mYoung2;
     double mYoung3;

--- a/applications/DamApplication/python_scripts/impose_nodal_young_modulus_process.py
+++ b/applications/DamApplication/python_scripts/impose_nodal_young_modulus_process.py
@@ -1,7 +1,8 @@
 import KratosMultiphysics
 import KratosMultiphysics.DamApplication as KratosDam
 
-## In this case, the scalar value is automatically fixed.
+## In this case, the nodal value is assigned as a prescribed material field.
+## It is not a degree of freedom, so it is not fixed.
 
 def Factory(settings, Model):
     if not isinstance(settings, KratosMultiphysics.Parameters):
@@ -14,7 +15,6 @@ class ImposeNodalYoungModulusProcess(KratosMultiphysics.Process):
 
         KratosMultiphysics.Process.__init__(self)
         model_part = Model[settings["model_part_name"].GetString()]
-        settings.AddEmptyValue("constrained").SetBool(True)
 
         self.process = KratosDam.DamNodalYoungModulusProcess(model_part, settings)
 

--- a/applications/DamApplication/tests/test_DamApplication.py
+++ b/applications/DamApplication/tests/test_DamApplication.py
@@ -8,6 +8,7 @@ import KratosMultiphysics.KratosUnittest as KratosUnittest
 # Import the tests o test_classes to create the suits
 from generalTests import KratosDamGeneralTests
 from test_apply_load_vector_dam_processes import TestApplyLoadVectorDamProcesses
+from test_dam_nodal_young_modulus_process import TestImposeNodalYoungModulusProcess
 from test_dam_process_lifecycle import TestDamProcessLifetime
 
 def AssembleTestSuites():
@@ -40,7 +41,8 @@ def AssembleTestSuites():
     smallSuite.addTest(KratosDamGeneralTests('test_construction'))
     smallSuite.addTests(
         KratosUnittest.TestLoader().loadTestsFromTestCases([
-            TestApplyLoadVectorDamProcesses
+            TestApplyLoadVectorDamProcesses,
+            TestImposeNodalYoungModulusProcess
         ])
     )
     smallSuite.addTests(
@@ -64,6 +66,7 @@ def AssembleTestSuites():
         KratosUnittest.TestLoader().loadTestsFromTestCases([
             KratosDamGeneralTests,
             TestApplyLoadVectorDamProcesses,
+            TestImposeNodalYoungModulusProcess
             TestDamProcessLifetime
         ])
     )

--- a/applications/DamApplication/tests/test_DamApplication.py
+++ b/applications/DamApplication/tests/test_DamApplication.py
@@ -1,6 +1,4 @@
 # import Kratos
-import KratosMultiphysics
-import KratosMultiphysics.DamApplication
 
 # Import Kratos "wrapper" for unittests
 import KratosMultiphysics.KratosUnittest as KratosUnittest
@@ -11,8 +9,9 @@ from test_apply_load_vector_dam_processes import TestApplyLoadVectorDamProcesses
 from test_dam_nodal_young_modulus_process import TestImposeNodalYoungModulusProcess
 from test_dam_process_lifecycle import TestDamProcessLifetime
 
+
 def AssembleTestSuites():
-    ''' Populates the test suites to run.
+    """Populates the test suites to run.
 
     Populates the test suites to run. At least, it should populate the suites:
     "small", "nightly" and "all"
@@ -22,33 +21,38 @@ def AssembleTestSuites():
 
     suites: A dictionary of suites
         The set of suites with its test_cases added.
-    '''
+    """
 
     suites = KratosUnittest.KratosSuites
 
     # Create a test suit with the selected tests (Small tests):
     # smallSuite will contain the following tests:
     # - testSmallExample
-    smallSuite = suites['small']
-    smallSuite.addTest(KratosDamGeneralTests('test_joint_elastic_cohesive_2d_normal'))
-    smallSuite.addTest(KratosDamGeneralTests('test_joint_elastic_cohesive_2d_shear'))
-    smallSuite.addTest(KratosDamGeneralTests('test_joint_isotropic_damage_cohesive_2d_normal'))
-    smallSuite.addTest(KratosDamGeneralTests('test_joint_isotropic_damage_cohesive_2d_shear'))
-    smallSuite.addTest(KratosDamGeneralTests('test_joint_elastic_cohesive_3d_normal'))
-    smallSuite.addTest(KratosDamGeneralTests('test_joint_elastic_cohesive_3d_shear'))
-    smallSuite.addTest(KratosDamGeneralTests('test_joint_isotropic_damage_cohesive_3d_normal'))
-    smallSuite.addTest(KratosDamGeneralTests('test_joint_isotropic_damage_cohesive_3d_shear'))
-    smallSuite.addTest(KratosDamGeneralTests('test_construction'))
+    smallSuite = suites["small"]
+    smallSuite.addTest(KratosDamGeneralTests("test_joint_elastic_cohesive_2d_normal"))
+    smallSuite.addTest(KratosDamGeneralTests("test_joint_elastic_cohesive_2d_shear"))
+    smallSuite.addTest(
+        KratosDamGeneralTests("test_joint_isotropic_damage_cohesive_2d_normal")
+    )
+    smallSuite.addTest(
+        KratosDamGeneralTests("test_joint_isotropic_damage_cohesive_2d_shear")
+    )
+    smallSuite.addTest(KratosDamGeneralTests("test_joint_elastic_cohesive_3d_normal"))
+    smallSuite.addTest(KratosDamGeneralTests("test_joint_elastic_cohesive_3d_shear"))
+    smallSuite.addTest(
+        KratosDamGeneralTests("test_joint_isotropic_damage_cohesive_3d_normal")
+    )
+    smallSuite.addTest(
+        KratosDamGeneralTests("test_joint_isotropic_damage_cohesive_3d_shear")
+    )
+    smallSuite.addTest(KratosDamGeneralTests("test_construction"))
     smallSuite.addTests(
-        KratosUnittest.TestLoader().loadTestsFromTestCases([
-            TestApplyLoadVectorDamProcesses,
-            TestImposeNodalYoungModulusProcess
-        ])
+        KratosUnittest.TestLoader().loadTestsFromTestCases(
+            [TestApplyLoadVectorDamProcesses, TestImposeNodalYoungModulusProcess]
+        )
     )
     smallSuite.addTests(
-        KratosUnittest.TestLoader().loadTestsFromTestCases([
-            TestDamProcessLifetime
-        ])
+        KratosUnittest.TestLoader().loadTestsFromTestCases([TestDamProcessLifetime])
     )
 
     # Create a test suit with the selected tests
@@ -56,22 +60,25 @@ def AssembleTestSuites():
     # - testSmallExample
     # - testNightlyFirstExample
     # - testNightlySecondExample
-    nightSuite = suites['nightly']
+    nightSuite = suites["nightly"]
     nightSuite.addTests(smallSuite)
 
     # Create a test suit that contains all the tests from every testCase
     # in the list:
-    allSuite = suites['all']
+    allSuite = suites["all"]
     allSuite.addTests(
-        KratosUnittest.TestLoader().loadTestsFromTestCases([
-            KratosDamGeneralTests,
-            TestApplyLoadVectorDamProcesses,
-            TestImposeNodalYoungModulusProcess
-            TestDamProcessLifetime
-        ])
+        KratosUnittest.TestLoader().loadTestsFromTestCases(
+            [
+                KratosDamGeneralTests,
+                TestApplyLoadVectorDamProcesses,
+                TestImposeNodalYoungModulusProcess,
+                TestDamProcessLifetime,
+            ]
+        )
     )
 
     return suites
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     KratosUnittest.runTests(AssembleTestSuites())

--- a/applications/DamApplication/tests/test_dam_nodal_young_modulus_process.py
+++ b/applications/DamApplication/tests/test_dam_nodal_young_modulus_process.py
@@ -1,0 +1,204 @@
+import KratosMultiphysics
+import KratosMultiphysics.DamApplication as KratosDam
+import KratosMultiphysics.KratosUnittest as KratosUnittest
+
+from KratosMultiphysics.DamApplication.impose_nodal_young_modulus_process import (
+    Factory,
+)
+
+
+class TestImposeNodalYoungModulusProcess(KratosUnittest.TestCase):
+
+    def setUp(self):
+        self.previous_threads = KratosMultiphysics.ParallelUtilities.GetNumThreads()
+
+    def tearDown(self):
+        KratosMultiphysics.ParallelUtilities.SetNumThreads(self.previous_threads)
+
+    @staticmethod
+    def _CreateModelPart(num_nodes):
+        model = KratosMultiphysics.Model()
+        model_part = model.CreateModelPart("main")
+        model_part.AddNodalSolutionStepVariable(KratosDam.NODAL_YOUNG_MODULUS)
+        for i in range(num_nodes):
+            model_part.CreateNewNode(i + 1, float(i), float(i % 3), 0.25 * i)
+        return model, model_part
+
+    @staticmethod
+    def _CreateSettings():
+        return KratosMultiphysics.Parameters(
+            """
+            {
+                "Parameters" : {
+                    "model_part_name" : "main",
+                    "variable_name"   : "NODAL_YOUNG_MODULUS",
+                    "Young_Modulus_1" : 1.0,
+                    "Young_Modulus_2" : 2.0,
+                    "Young_Modulus_3" : 3.0,
+                    "Young_Modulus_4" : 4.0
+                }
+            }
+            """
+        )
+
+    @staticmethod
+    def _ExpectedValue(node):
+        return 1.0 + 2.0 * node.X + 3.0 * node.Y + 4.0 * node.Z
+
+    @staticmethod
+    def _NodalValues(model_part):
+        return [
+            node.GetSolutionStepValue(KratosDam.NODAL_YOUNG_MODULUS)
+            for node in model_part.Nodes
+        ]
+
+    def test_factory_returns_valid_process(self):
+        model, _ = self._CreateModelPart(4)
+        process = Factory(self._CreateSettings(), model)
+        self.assertTrue(isinstance(process, KratosMultiphysics.Process))
+
+    def test_execution_assigns_values_and_does_not_create_dof(self):
+        model, model_part = self._CreateModelPart(8)
+        process = Factory(self._CreateSettings(), model)
+
+        process.ExecuteBeforeSolutionLoop()
+
+        for node in model_part.Nodes:
+            self.assertAlmostEqual(
+                node.GetSolutionStepValue(KratosDam.NODAL_YOUNG_MODULUS),
+                self._ExpectedValue(node),
+            )
+            # NODAL_YOUNG_MODULUS is a prescribed nodal material field, not a
+            # degree of freedom; no DOF may be created by the process.
+            self.assertFalse(node.HasDofFor(KratosDam.NODAL_YOUNG_MODULUS))
+
+    def test_multithreaded_execution_matches_single_thread(self):
+        # Single-threaded reference
+        KratosMultiphysics.ParallelUtilities.SetNumThreads(1)
+        model_ref, model_part_ref = self._CreateModelPart(64)
+        Factory(self._CreateSettings(), model_ref).ExecuteBeforeSolutionLoop()
+        reference_values = self._NodalValues(model_part_ref)
+
+        # Multi-threaded run of the same production callback
+        for threads in (2, 4):
+            KratosMultiphysics.ParallelUtilities.SetNumThreads(threads)
+            model, model_part = self._CreateModelPart(64)
+            Factory(self._CreateSettings(), model).ExecuteBeforeSolutionLoop()
+            values = self._NodalValues(model_part)
+            self.assertEqual(len(values), len(reference_values))
+            for value, reference_value in zip(values, reference_values):
+                self.assertAlmostEqual(value, reference_value)
+
+    def test_initialize_solution_step_multithreaded(self):
+        KratosMultiphysics.ParallelUtilities.SetNumThreads(4)
+        model, model_part = self._CreateModelPart(64)
+        process = Factory(self._CreateSettings(), model)
+
+        process.ExecuteInitializeSolutionStep()
+
+        for node in model_part.Nodes:
+            self.assertAlmostEqual(
+                node.GetSolutionStepValue(KratosDam.NODAL_YOUNG_MODULUS),
+                self._ExpectedValue(node),
+            )
+            self.assertFalse(node.HasDofFor(KratosDam.NODAL_YOUNG_MODULUS))
+
+    def _NodalYoungTetraModel(self, nodal_young):
+        """Build a single-tetra model with the given nodal NODAL_YOUNG_MODULUS."""
+        model, model_part = self._CreateModelPart(4)
+        nodes = list(model_part.Nodes)
+        coordinates = [(0.0, 0.0, 0.0), (1.0, 0.0, 0.0), (0.0, 1.0, 0.0), (0.0, 0.0, 1.0)]
+        for node, coords in zip(nodes, coordinates):
+            node.X = coords[0]
+            node.Y = coords[1]
+            node.Z = coords[2]
+        for node, young in zip(nodes, nodal_young):
+            node.SetSolutionStepValue(KratosDam.NODAL_YOUNG_MODULUS, 0, young)
+        properties = model_part.GetProperties()[1]
+        properties.SetValue(KratosMultiphysics.POISSON_RATIO, 0.3)
+        law = KratosDam.LinearElastic3DLawNodal()
+        geometry = KratosMultiphysics.Tetrahedra3D4(*nodes)
+        return model_part, properties, law, geometry
+
+    def _ConstitutiveResponse(self, model_part, properties, law, geometry):
+        """Evaluate the law at the tetra centroid for a fixed strain state."""
+        shape = KratosMultiphysics.Vector([0.25, 0.25, 0.25, 0.25])
+        law.InitializeMaterial(properties, geometry, shape)
+
+        strain_size = law.GetStrainSize()
+        strain_vector = KratosMultiphysics.Vector(strain_size)
+        stress_vector = KratosMultiphysics.Vector(strain_size)
+        constitutive_matrix = KratosMultiphysics.Matrix(strain_size, strain_size)
+        for i in range(strain_size):
+            strain_vector[i] = 0.0
+            stress_vector[i] = 0.0
+        strain_vector[0] = 1.0e-3  # uniaxial strain along x
+
+        options = KratosMultiphysics.Flags()
+        options.Set(KratosMultiphysics.ConstitutiveLaw.COMPUTE_CONSTITUTIVE_TENSOR, True)
+        options.Set(KratosMultiphysics.ConstitutiveLaw.COMPUTE_STRESS, True)
+
+        params = KratosMultiphysics.ConstitutiveLawParameters()
+        params.SetOptions(options)
+        params.SetDeterminantF(1.0)
+        params.SetStrainVector(strain_vector)
+        params.SetStressVector(stress_vector)
+        params.SetConstitutiveMatrix(constitutive_matrix)
+        params.SetShapeFunctionsValues(shape)
+        params.SetProcessInfo(model_part.ProcessInfo)
+        params.SetMaterialProperties(properties)
+        params.SetElementGeometry(geometry)
+        law.CalculateMaterialResponseCauchy(params)
+        return params.GetStressVector()[0], params.GetConstitutiveMatrix()[0, 0]
+
+    def test_constitutive_response_uses_interpolated_young_modulus(self):
+        # The constitutive response must be linear in the interpolated nodal
+        # Young modulus: rescaling all nodal values by a factor rescales the
+        # response by the same factor (the nodal field drives the material).
+        model_part_a, props_a, law_a, geom_a = self._NodalYoungTetraModel(
+            [10.0, 20.0, 30.0, 40.0]
+        )
+        model_part_b, props_b, law_b, geom_b = self._NodalYoungTetraModel(
+            [20.0, 40.0, 60.0, 80.0]
+        )
+
+        stress_a, c00_a = self._ConstitutiveResponse(model_part_a, props_a, law_a, geom_a)
+        stress_b, c00_b = self._ConstitutiveResponse(model_part_b, props_b, law_b, geom_b)
+
+        # Doubling every nodal value doubles the interpolated E, hence doubles
+        # the linear-elastic stress and constitutive matrix.
+        self.assertAlmostEqual(stress_b, 2.0 * stress_a, 12)
+        self.assertAlmostEqual(c00_b, 2.0 * c00_a, 12)
+
+        # The response is deterministic (repeated evaluation is identical).
+        stress_a2, c00_a2 = self._ConstitutiveResponse(model_part_a, props_a, law_a, geom_a)
+        self.assertAlmostEqual(stress_a2, stress_a, 12)
+        self.assertAlmostEqual(c00_a2, c00_a, 12)
+
+    def test_constitutive_response_matches_nodal_interpolation_change(self):
+        # A non-uniform nodal field produces the expected interpolated value:
+        # changing only some nodal values must change the response, i.e. the
+        # response follows the nodal interpolation, not a single material
+        # constant.
+        model_part_a, props_a, law_a, geom_a = self._NodalYoungTetraModel(
+            [10.0, 20.0, 30.0, 40.0]
+        )
+        model_part_b, props_b, law_b, geom_b = self._NodalYoungTetraModel(
+            [10.0, 20.0, 30.0, 80.0]  # only the 4th node doubled
+        )
+
+        stress_a, c00_a = self._ConstitutiveResponse(model_part_a, props_a, law_a, geom_a)
+        stress_b, c00_b = self._ConstitutiveResponse(model_part_b, props_b, law_b, geom_b)
+
+        # Changing a single nodal value changes the interpolated response.
+        self.assertNotEqual(stress_b, stress_a)
+        self.assertNotEqual(c00_b, c00_a)
+
+        # With N_i = 1/4, the interpolated E increases from (10+20+30+40)/4=25
+        # to (10+20+30+80)/4=35, a factor 35/25 = 1.4 for the elastic response.
+        self.assertAlmostEqual(c00_b, (35.0 / 25.0) * c00_a, 12)
+        self.assertAlmostEqual(stress_b, (35.0 / 25.0) * stress_a, 12)
+
+
+if __name__ == "__main__":
+    KratosUnittest.main()

--- a/applications/DamApplication/tests/test_dam_process_lifecycle.py
+++ b/applications/DamApplication/tests/test_dam_process_lifecycle.py
@@ -185,29 +185,6 @@ class TestDamProcessLifetime(KratosUnittest.TestCase):
             msg="uniform face heat flux was re-applied in a later step",
         )
 
-    def test_nodal_young_modulus_process_factory(self):
-        """The nodal Young modulus production wrapper is importable and
-        instantiates a valid process that assigns NODAL_YOUNG_MODULUS."""
-        from KratosMultiphysics.DamApplication.impose_nodal_young_modulus_process import (
-            Factory as NodalYoungFactory,
-        )
-
-        model, mp = self._make_model([KratosDam.NODAL_YOUNG_MODULUS])
-        settings = self._make_wrapper_settings(
-            "main.target",
-            r"""
-            {
-                "model_part_name": "",
-                "variable_name": "NODAL_YOUNG_MODULUS",
-                "Young_Modulus_1": 20.0,
-                "Young_Modulus_2": 30.0,
-                "Young_Modulus_3": 40.0,
-                "Young_Modulus_4": 50.0
-            }""",
-        )
-        process = NodalYoungFactory(settings, model)
-        self.assertIsInstance(process, KratosMultiphysics.Process)
-
 
 if __name__ == "__main__":
     KratosUnittest.main()


### PR DESCRIPTION
## **📝 Description**
DamNodalYoungModulusProcess was fixing NODAL_YOUNG_MODULUS inside a parallel loop. Since the corresponding DOF did not exist, Fix() attempted to create it inside the parallel region, causing an exception in multithreaded execution.

NODAL_YOUNG_MODULUS is used as a nodal material field by the constitutive law and is not a system DOF. This PR removes the unnecessary fixity and also fixes the Python process inheritance.

### **Key changes**

- Remove unnecessary NODAL_YOUNG_MODULUS fixity/DOF handling.
- Fix ImposeNodalYoungModulusProcess inheritance.
- Add regression tests for process execution and constitutive response.

### **Validation**

- Process tested with 1, 2 and 4 threads with identical results.
- Constitutive response verified after proper material initialization.
- No NODAL_YOUNG_MODULUS DOF is created.

## **🆕 Changelog**
- Fix parallel execution of the DamApplication nodal Young modulus process.
