### PR TITLE
[Several] Remove unused variables (I)

### DIFF
--- a/applications/ConvectionDiffusionApplication/custom_utilities/move_particle_utility.h
+++ b/applications/ConvectionDiffusionApplication/custom_utilities/move_particle_utility.h
@@ -1363,7 +1363,6 @@ namespace Kratos
 		//bool have_water_node;
 
 		array_1d<double,3> vel;
-		array_1d<double,3> vel_without_other_phase_nodes=ZeroVector(3);
 		array_1d<double,3> position;
 		array_1d<double,3> mid_position;
 		array_1d<double,TDim+1> N;

--- a/applications/FluidDynamicsApplication/custom_elements/alternative_d_vms_dem_coupled.cpp
+++ b/applications/FluidDynamicsApplication/custom_elements/alternative_d_vms_dem_coupled.cpp
@@ -500,7 +500,6 @@ void AlternativeDVMSDEMCoupled<TElementData>::InitializeNonLinearIteration(const
 
     TElementData data;
     data.Initialize(*this,rCurrentProcessInfo);
-    array_1d<double,NumNodes> nodal_reaction_term = ZeroVector(NumNodes);
     for (unsigned int g = 0; g < number_of_integration_points; g++) {
         this->UpdateIntegrationPointDataSecondDerivatives(data, g, gauss_weights[g],row(shape_functions,g),shape_function_derivatives[g],shape_function_second_derivatives[g]);
         mPorosity[g] = this->GetAtCoordinate(data.FluidFraction,row(shape_functions,g));

--- a/applications/FluidDynamicsApplication/custom_elements/alternative_qs_vms_dem_coupled.cpp
+++ b/applications/FluidDynamicsApplication/custom_elements/alternative_qs_vms_dem_coupled.cpp
@@ -425,7 +425,6 @@ void AlternativeQSVMSDEMCoupled<TElementData>::InitializeNonLinearIteration(cons
 
     TElementData data;
     data.Initialize(*this,rCurrentProcessInfo);
-    array_1d<double,NumNodes> nodal_reaction_term = ZeroVector(NumNodes);
     for (unsigned int g = 0; g < number_of_integration_points; g++) {
         this->UpdateIntegrationPointDataSecondDerivatives(data, g, gauss_weights[g],row(shape_functions,g),shape_function_derivatives[g],shape_function_second_derivatives[g]);
         mPorosity[g] = this->GetAtCoordinate(data.FluidFraction,row(shape_functions,g));

--- a/applications/FluidDynamicsApplication/custom_elements/d_vms_dem_coupled.cpp
+++ b/applications/FluidDynamicsApplication/custom_elements/d_vms_dem_coupled.cpp
@@ -613,7 +613,6 @@ void DVMSDEMCoupled<TElementData>::InitializeNonLinearIteration(const ProcessInf
 
     TElementData data;
     data.Initialize(*this,rCurrentProcessInfo);
-    array_1d<double,NumNodes> nodal_reaction_term = ZeroVector(NumNodes);
     for (unsigned int g = 0; g < number_of_integration_points; g++) {
         this->UpdateIntegrationPointDataSecondDerivatives(data, g, gauss_weights[g],row(shape_functions,g),shape_function_derivatives[g],shape_function_second_derivatives[g]);
         mPorosity[g] = this->GetAtCoordinate(data.FluidFraction,row(shape_functions,g));

--- a/applications/FluidDynamicsApplication/custom_elements/dpg_vms.h
+++ b/applications/FluidDynamicsApplication/custom_elements/dpg_vms.h
@@ -574,7 +574,6 @@ public:
 //         Vector enrichment_terms_horizontal = ZeroVector(LocalSize);
 //         double enrichment_diagonal = 0.0;
 //         double enriched_rhs = 0.0;
-        array_1d<double,3> bf = ZeroVector(3);
 
         //double positive_volume = 0.0;
         //double negative_volume = 0.0;

--- a/applications/FluidDynamicsApplication/custom_elements/embedded_ausas_navier_stokes.cpp
+++ b/applications/FluidDynamicsApplication/custom_elements/embedded_ausas_navier_stokes.cpp
@@ -1034,10 +1034,6 @@ void EmbeddedAusasNavierStokes<3>::ComputeGaussPointRHSContribution(
     const array_1d<double,nnodes>& N = data.N;
     const BoundedMatrix<double,nnodes,dim>& DN = data.DN_DX;
 
-    // Auxiliary variables used in the calculation of the RHS
-    const array_1d<double,dim> f_gauss = prod(trans(f), N);
-    const array_1d<double,dim> grad_p = prod(trans(DN), p);
-
     // Stabilization parameters
     constexpr double stab_c1 = 4.0;
     constexpr double stab_c2 = 2.0;
@@ -1138,10 +1134,6 @@ void EmbeddedAusasNavierStokes<2>::ComputeGaussPointRHSContribution(
     // Get shape function values
     const array_1d<double,nnodes>& N = data.N;
     const BoundedMatrix<double,nnodes,dim>& DN = data.DN_DX;
-
-    // Auxiliary variables used in the calculation of the RHS
-    const array_1d<double,dim> f_gauss = prod(trans(f), N);
-    const array_1d<double,dim> grad_p = prod(trans(DN), p);
 
     // Stabilization parameters
     constexpr double stab_c1 = 4.0;

--- a/applications/FluidDynamicsApplication/custom_elements/embedded_ausas_navier_stokes.h
+++ b/applications/FluidDynamicsApplication/custom_elements/embedded_ausas_navier_stokes.h
@@ -773,9 +773,6 @@ protected:
             // Get the positive side shape functions Gauss pt. values
             const array_1d<double, TNumNodes> aux_N = row(rData.N_pos_int, i_gauss);
 
-            // Get the positive side shape functions gradients Gauss pt. values
-            const BoundedMatrix<double, TNumNodes, TDim> aux_DN_DX = rData.DN_DX_pos_int[i_gauss];
-
             // Get the positive side Gauss pt. normal
             const array_1d<double, 3> side_normal = rData.pos_int_unit_normals[i_gauss];
 
@@ -797,9 +794,6 @@ protected:
 
             // Get the negative side shape functions Gauss pt. values
             const array_1d<double, TNumNodes> aux_N = row(rData.N_neg_int, i_gauss);
-
-            // Get the negative side shape functions gradients Gauss pt. values
-            const BoundedMatrix<double, TNumNodes, TDim> aux_DN_DX = rData.DN_DX_neg_int[i_gauss];
 
             // Get the negative side Gauss pt. normal
             const array_1d<double, 3> side_normal = rData.neg_int_unit_normals[i_gauss];
@@ -840,9 +834,6 @@ protected:
         array_1d<double, MatrixSize> prev_sol = ZeroVector(MatrixSize);
         GetPreviousSolutionVector(rData, prev_sol);
 
-        // Declare auxiliar arrays
-        array_1d<double, MatrixSize> auxRightHandSideVector = ZeroVector(MatrixSize);
-
         // Contribution coming from the positive side boundary term
         const unsigned int n_int_pos_gauss = (rData.w_gauss_pos_int).size();
 
@@ -851,9 +842,6 @@ protected:
 
             // Get the positive side shape functions Gauss pt. values
             const array_1d<double, TNumNodes> aux_N = row(rData.N_pos_int, i_gauss);
-
-            // Get the positive side shape functions gradients Gauss pt. values
-            const BoundedMatrix<double, TNumNodes, TDim> aux_DN_DX = rData.DN_DX_pos_int[i_gauss];
 
             // Get the positive side Gauss pt. normal
             const array_1d<double, 3> side_normal = rData.pos_int_unit_normals[i_gauss];
@@ -876,9 +864,6 @@ protected:
 
             // Get the negative side shape functions Gauss pt. values
             const array_1d<double, TNumNodes> aux_N = row(rData.N_neg_int, i_gauss);
-
-            // Get the negative side shape functions gradients Gauss pt. values
-            const BoundedMatrix<double, TNumNodes, TDim> aux_DN_DX = rData.DN_DX_neg_int[i_gauss];
 
             // Get the negative side Gauss pt. normal
             const array_1d<double, 3> side_normal = rData.neg_int_unit_normals[i_gauss];
@@ -914,7 +899,6 @@ protected:
         const double pen_coef = ComputePenaltyCoefficient(rData, rCurrentProcessInfo);
 
         // Compute the LHS and RHS penalty contributions
-        BoundedMatrix<double, MatrixSize, MatrixSize> P_gamma = ZeroMatrix(MatrixSize, MatrixSize);
 
         // Contribution coming from the positive side penalty term
         const unsigned int n_int_pos_gauss = (rData.w_gauss_pos_int).size();

--- a/applications/FluidDynamicsApplication/custom_elements/embedded_ausas_navier_stokes.h
+++ b/applications/FluidDynamicsApplication/custom_elements/embedded_ausas_navier_stokes.h
@@ -893,7 +893,6 @@ protected:
     {
         const auto &r_geom = this->GetGeometry();
         constexpr unsigned int BlockSize = TDim + 1;
-        constexpr unsigned int MatrixSize = TNumNodes * BlockSize;
 
         // Compute the penalty coefficient
         const double pen_coef = ComputePenaltyCoefficient(rData, rCurrentProcessInfo);

--- a/applications/FluidDynamicsApplication/custom_elements/fractional_step.cpp
+++ b/applications/FluidDynamicsApplication/custom_elements/fractional_step.cpp
@@ -360,7 +360,6 @@ void FractionalStep<TDim>::CalculateOnIntegrationPoints(
 
         double Density = 0.0;
         array_1d<double,3> PresProj = ZeroVector(3);
-        array_1d<double,3> BodyForce = ZeroVector(3);
 
         // Loop on integration points
         for (unsigned int g = 0; g < NumGauss; g++)

--- a/applications/FluidDynamicsApplication/custom_elements/navier_stokes.cpp
+++ b/applications/FluidDynamicsApplication/custom_elements/navier_stokes.cpp
@@ -1032,10 +1032,6 @@ void NavierStokes<3>::ComputeGaussPointRHSContribution(
     const array_1d<double,nnodes>& N = data.N;
     const BoundedMatrix<double,nnodes,dim>& DN = data.DN_DX;
 
-    // Auxiliary variables used in the calculation of the RHS
-    const array_1d<double,dim> f_gauss = prod(trans(f), N);
-    const array_1d<double,dim> grad_p = prod(trans(DN), p);
-
     // Stabilization parameters
     constexpr double stab_c1 = 4.0;
     constexpr double stab_c2 = 2.0;
@@ -1135,10 +1131,6 @@ void NavierStokes<2>::ComputeGaussPointRHSContribution(
     const array_1d<double,nnodes>& N = data.N;
     const BoundedMatrix<double,nnodes,dim>& DN = data.DN_DX;
 
-    // Auxiliary variables used in the calculation of the RHS
-    const array_1d<double,dim> f_gauss = prod(trans(f), N);
-    const array_1d<double,dim> grad_p = prod(trans(DN), p);
-
     // Stabilization parameters
     constexpr double stab_c1 = 4.0;
     constexpr double stab_c2 = 2.0;
@@ -1213,8 +1205,6 @@ double NavierStokes<3>::SubscaleErrorEstimate(const ElementDataStruct& data)
     // Auxiliary variables used in the calculation of the error estimator
     array_1d<double,dim> v_s_gauss;
     const array_1d<double,dim> v_gauss = prod(trans(v), N);
-    const array_1d<double,dim> f_gauss = prod(trans(f), N);
-    const array_1d<double,dim> grad_p = prod(trans(DN), p);
 
     // Stabilization parameters
     constexpr double stab_c1 = 4.0;
@@ -1268,8 +1258,6 @@ double NavierStokes<2>::SubscaleErrorEstimate(const ElementDataStruct& data)
     // Auxiliary variables used in the calculation of the error estimator
     array_1d<double,dim> v_s_gauss;
     const array_1d<double,dim> v_gauss = prod(trans(v), N);
-    const array_1d<double,dim> f_gauss = prod(trans(f), N);
-    const array_1d<double,dim> grad_p = prod(trans(DN), p);
 
     // Stabilization parameters
     constexpr double stab_c1 = 4.0;

--- a/applications/FluidDynamicsApplication/custom_elements/qs_vms_dem_coupled.cpp
+++ b/applications/FluidDynamicsApplication/custom_elements/qs_vms_dem_coupled.cpp
@@ -375,7 +375,6 @@ void QSVMSDEMCoupled<TElementData>::InitializeNonLinearIteration(const ProcessIn
 
     TElementData data;
     data.Initialize(*this,rCurrentProcessInfo);
-    array_1d<double,NumNodes> nodal_reaction_term = ZeroVector(NumNodes);
     for (unsigned int g = 0; g < number_of_integration_points; g++) {
         this->UpdateIntegrationPointDataSecondDerivatives(data, g, gauss_weights[g],row(shape_functions,g),shape_function_derivatives[g],shape_function_second_derivatives[g]);
         mPorosity[g] = this->GetAtCoordinate(data.FluidFraction,row(shape_functions,g));
@@ -490,7 +489,6 @@ void QSVMSDEMCoupled<TElementData>::MomentumProjTerm(
 
     const auto r_velocities = rData.Velocity;
     const auto r_pressures = rData.Pressure;
-    const auto velocity = this->GetAtCoordinate(rData.Velocity,rData.N);
     Vector grad_div_u, div_sym_grad_u;
 
     for (unsigned int i = 0; i < NumNodes; i++) {

--- a/applications/FluidDynamicsApplication/custom_elements/stokes_3D_twofluid.cpp
+++ b/applications/FluidDynamicsApplication/custom_elements/stokes_3D_twofluid.cpp
@@ -1239,9 +1239,7 @@ void Stokes3DTwoFluid::ComputeGaussPointEnrichmentContributions(
         const double tau1 = 1.0/(tau_denom*rho);
 
         //auxiliary variables used in the calculation of the RHS
-        const array_1d<double,dim> fgauss = prod(trans(f), N);
         const array_1d<double,dim> vgauss = prod(trans(v), N);
-        const array_1d<double,dim> grad_p = prod(trans(DN), p);
 //         const double pgauss = inner_prod(N,p);
 
         array_1d<double,dim> acch = bdf0*vgauss;

--- a/applications/FluidDynamicsApplication/custom_elements/two_fluid_navier_stokes_alpha_method.cpp
+++ b/applications/FluidDynamicsApplication/custom_elements/two_fluid_navier_stokes_alpha_method.cpp
@@ -1469,7 +1469,6 @@ void TwoFluidNavierStokesAlphaMethod<TwoFluidNavierStokesAlphaMethodData<2, 3>>:
     auto &rhs_ee = rData.rhs_ee;
 
     array_1d<double, NumNodes> penr = ZeroVector(NumNodes); //penriched is considered to be zero as we do not want to store it
-    array_1d<double, NumNodes> penr_cn = ZeroVector(NumNodes); //penriched is considered to be zero as we do not want to store it
 
     const double cV0 = N[0]*vconv(0,0) + N[1]*vconv(1,0) + N[2]*vconv(2,0);
 const double cV1 = N[0]*vconv(0,1) + N[1]*vconv(1,1) + N[2]*vconv(2,1);
@@ -1649,7 +1648,6 @@ void TwoFluidNavierStokesAlphaMethod<TwoFluidNavierStokesAlphaMethodData<3, 4>>:
     auto &rhs_ee = rData.rhs_ee;
 
     array_1d<double, NumNodes> penr = ZeroVector(NumNodes); //penriched is considered to be zero as we do not want to store it
-    array_1d<double, NumNodes> penr_cn = ZeroVector(NumNodes); //penriched is considered to be zero as we do not want to store it
 
     const double cV0 = N[0]*vconv(0,0) + N[1]*vconv(1,0) + N[2]*vconv(2,0) + N[3]*vconv(3,0);
 const double cV1 = N[0]*vconv(0,1) + N[1]*vconv(1,1) + N[2]*vconv(2,1) + N[3]*vconv(3,1);

--- a/applications/FluidDynamicsApplication/custom_elements/two_fluid_navier_stokes_fractional.cpp
+++ b/applications/FluidDynamicsApplication/custom_elements/two_fluid_navier_stokes_fractional.cpp
@@ -346,9 +346,7 @@ void TwoFluidNavierStokesFractional<TwoFluidNavierStokesFractionalData<2, 3>>::C
     const double dt = rData.DeltaTime;
     const double bdf0 = rData.bdf0;
     const double dyn_tau = rData.DynamicTau;
-    const auto vn = rData.VelocityOldStep1;
     const auto vconv = rData.Velocity - rData.MeshVelocity;
-    const auto vfrac = rData.FractionalVelocity;
 
     // Get constitutive matrix
     const Matrix &C = rData.C;
@@ -580,9 +578,7 @@ void TwoFluidNavierStokesFractional<TwoFluidNavierStokesFractionalData<3, 4>>::C
     const double dt = rData.DeltaTime;
     const double bdf0 = rData.bdf0;
     const double dyn_tau = rData.DynamicTau;
-    const auto vn=rData.VelocityOldStep1;
     const auto vconv = rData.Velocity - rData.MeshVelocity;
-    const auto vfrac = rData.FractionalVelocity;
 
     // Get constitutive matrix
     const Matrix &C = rData.C;

--- a/applications/StructuralMechanicsApplication/custom_conditions/moving_load_condition.cpp
+++ b/applications/StructuralMechanicsApplication/custom_conditions/moving_load_condition.cpp
@@ -202,9 +202,6 @@ void MovingLoadCondition< TDim, TNumNodes>::CalculateAll(
 
         }
 
-        array_1d<double, TDim> load_first_node = ZeroVector(TDim);
-        array_1d<double, TDim> load_end_node = ZeroVector(TDim);
-
         BoundedMatrix<double, TDim, TNumNodes> local_load_matrix = ZeroMatrix(TDim, TNumNodes);
         BoundedMatrix<double, TDim, TNumNodes> global_load_matrix = ZeroMatrix(TDim, TNumNodes);
 

--- a/applications/StructuralMechanicsApplication/custom_elements/shell_elements/isotropic_shell_element.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/shell_elements/isotropic_shell_element.cpp
@@ -1090,7 +1090,6 @@ void IsotropicShellElement::CalculateOnIntegrationPoints(const Variable<double >
 
         array_1d<double,9> local_disp;
         array_1d<double,3> local_stress, local_strain, membrane_stress;
-        array_1d<double,6> rotated_stress = ZeroVector(6);
 
         CalculatePureMembraneDisplacement(local_disp,v1,v2,v3);
 

--- a/applications/StructuralMechanicsApplication/custom_elements/truss_elements/linear_truss_element.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/truss_elements/linear_truss_element.cpp
@@ -491,8 +491,6 @@ void LinearTrussElement<TDimension, TNNodes>::CalculateLeftHandSide(
 
     // Loop over the integration points
     for (SizeType IP = 0; IP < integration_points.size(); ++IP) {
-        const auto local_body_forces = GetLocalAxesBodyForce(*this, integration_points, IP);
-
         const double xi     = integration_points[IP].X();
         const double weight = integration_points[IP].Weight();
         const double jacobian_weight = weight * J * area;

--- a/applications/StructuralMechanicsApplication/custom_elements/truss_elements/total_lagrangian_truss_element.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/truss_elements/total_lagrangian_truss_element.cpp
@@ -282,7 +282,6 @@ void TotalLagrangianTrussElement<TDimension>::CalculateLeftHandSide(
 
     mConstitutiveLawVector[0]->CalculateMaterialResponsePK2(cl_values); // fills stress and const. matrix
     const double gen_axial_force = ref_area * (stress_vector[0] + pre_stress);
-    const array_3 axial_force_vector = gen_axial_force * current_unit_dir;
 
     bounded_matrix_3 outer_unit, K_m, K_geo, K_t; // the 3x3 matrices
     noalias(outer_unit) = outer_prod(current_unit_dir, current_unit_dir);
@@ -489,7 +488,6 @@ void TotalLagrangianTrussElement<TDimension>::CalculateOnIntegrationPoints(
         const array_3 curr_axis = r_geometry[1].Coordinates() - r_geometry[0].Coordinates();
         const double ref_length = norm_2(ref_axis);
         const double curr_length = norm_2(curr_axis);
-        const array_3 current_unit_dir = curr_axis / curr_length;
         const double Fxx = curr_length / ref_length; // Deformation gradient in the axial direction
         rOutput[0] = 0.5 * (Fxx * Fxx - 1.0);
     }
@@ -516,7 +514,6 @@ void TotalLagrangianTrussElement<TDimension>::CalculateOnIntegrationPoints(
         const array_3 curr_axis = r_geometry[1].Coordinates() - r_geometry[0].Coordinates();
         const double ref_length = norm_2(ref_axis);
         const double curr_length = norm_2(curr_axis);
-        const array_3 current_unit_dir = curr_axis / curr_length;
         const double Fxx = curr_length / ref_length; // Deformation gradient in the axial direction
         const double green_lagrange_strain = 0.5 * (Fxx * Fxx - 1.0);
         const double pre_stress = r_props.Has(TRUSS_PRESTRESS_PK2) ? r_props[TRUSS_PRESTRESS_PK2] :  0.0;

--- a/applications/StructuralMechanicsApplication/custom_elements/truss_elements/truss_element_3D2N.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/truss_elements/truss_element_3D2N.cpp
@@ -457,7 +457,6 @@ void TrussElement3D2N::CalculateOnIntegrationPoints(
     if ((rVariable == CAUCHY_STRESS_VECTOR) || (rVariable == PK2_STRESS_VECTOR)) {
 
         array_1d<double, 3 > truss_stresses;
-        array_1d<double, msDimension> temp_internal_stresses = ZeroVector(msDimension);
 
         double prestress = 0.00;
         if (GetProperties().Has(TRUSS_PRESTRESS_PK2)) {

--- a/applications/StructuralMechanicsApplication/custom_elements/truss_elements/truss_element_linear_3D2N.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/truss_elements/truss_element_linear_3D2N.cpp
@@ -143,8 +143,6 @@ void TrussElementLinear3D2N::CalculateOnIntegrationPoints(
             prestress = GetProperties()[TRUSS_PRESTRESS_PK2];
         }
 
-        array_1d<double, msDimension> temp_internal_stresses = ZeroVector(msDimension);
-
         const auto stress = CalculateStressFromLinearStrain(rCurrentProcessInfo);
         truss_forces[0] = (stress + prestress) * A;
 

--- a/kratos/utilities/enrichment_utilities.h
+++ b/kratos/utilities/enrichment_utilities.h
@@ -117,7 +117,6 @@ public:
 
         int split_edge[] = {0, 1, 2, 3, -1, -1, -1, -1, -1, -1, -1, -1};
         int new_node_id = 4;
-        BoundedMatrix<double, 4, 4 > length = ZeroMatrix(4, 4);
 
         //int n_zero_distance_nodes = 0;
         int n_negative_distance_nodes = 0;
@@ -560,7 +559,6 @@ public:
 
         int split_edge[] = {0, 1, 2, 3, -1, -1, -1, -1, -1, -1, -1, -1};
         int new_node_id = 4;
-        BoundedMatrix<double, 4, 4 > length = ZeroMatrix(4, 4);
 
         //int n_zero_distance_nodes = 0;
         int n_negative_distance_nodes = 0;

--- a/kratos/utilities/enrichment_utilities_duplicate_dofs.h
+++ b/kratos/utilities/enrichment_utilities_duplicate_dofs.h
@@ -120,7 +120,6 @@ public:
 
         int split_edge[] = {0, 1, 2, 3, -1, -1, -1, -1, -1, -1, -1, -1};
         int new_node_id = 4;
-        BoundedMatrix<double, 4, 4 > length = ZeroMatrix(4, 4);
 
         //int n_zero_distance_nodes = 0;
         int n_negative_distance_nodes = 0;


### PR DESCRIPTION
---
name: ✨ Feature
about: Remove unused variables (I)

---

## **📝 Description**

For some reason compiler complains just randomly, not consistently.

## **🆕 Changelog**

- [Remove unused length matrix in enrichment utilities](https://github.com/KratosMultiphysics/Kratos/commit/182cb900c295aab5e07038e1fc849060cfc48873)
- [Remove unused temporary stress variables in truss element calculations](https://github.com/KratosMultiphysics/Kratos/commit/c6aa7963d4d28950b09c9dd009f5b3015a3af153)
- [Remove unused variables in fluid dynamics and structural mechanics](https://github.com/KratosMultiphysics/Kratos/commit/cca9ca6234521e6db2e9dd0bc80c08e1d380bc24)
