### PR TITLE
[Core] Fix type casting in `KRATOS_EXPECT_VECTOR_NEAR` macro for size comparison

### DIFF
--- a/kratos/includes/expect.h
+++ b/kratos/includes/expect.h
@@ -73,14 +73,14 @@ if(!(std::abs(b) <= std::numeric_limits<double>::epsilon())) {                  
 #define KRATOS_EXPECT_DOUBLE_EQ(a,b) EXPECT_DOUBLE_EQ((a),(b)) << "Check failed because " << #a << " = " << (a) << \
 " is not equal to " << #b << " = " << (b)
 
-#define KRATOS_EXPECT_VECTOR_NEAR(a,b,tolerance) {                                                                  \
+#define KRATOS_EXPECT_VECTOR_NEAR(a,b,tolerance) {                                         \
     EXPECT_TRUE(static_cast<std::size_t>(a.size()) == static_cast<std::size_t>(b.size()))  \
-    << "Check failed because vector arguments do not have the same size:"       \
-    << std::endl                                                                \
-    << "First argument has size " << a.size() << ", "                           \
-    << "second argument has size " << b.size() << "." << std::endl;             \
-                                                                                \
-    EXPECT_THAT(a, Pointwise(DoubleNear(tolerance), b));                        \
+    << "Check failed because vector arguments do not have the same size:"                  \
+    << std::endl                                                                           \
+    << "First argument has size " << a.size() << ", "                                      \
+    << "second argument has size " << b.size() << "." << std::endl;                        \
+                                                                                           \
+    EXPECT_THAT(a, Pointwise(DoubleNear(tolerance), b));                                   \
 }
 
 // TODO: I don't know how to represent the relative error test in terms of Gtest

--- a/kratos/includes/expect.h
+++ b/kratos/includes/expect.h
@@ -73,8 +73,8 @@ if(!(std::abs(b) <= std::numeric_limits<double>::epsilon())) {                  
 #define KRATOS_EXPECT_DOUBLE_EQ(a,b) EXPECT_DOUBLE_EQ((a),(b)) << "Check failed because " << #a << " = " << (a) << \
 " is not equal to " << #b << " = " << (b)
 
-#define KRATOS_EXPECT_VECTOR_NEAR(a,b,tolerance) {                              \
-    EXPECT_TRUE(a.size() == b.size())                                           \
+#define KRATOS_EXPECT_VECTOR_NEAR(a,b,tolerance) {                                                                  \
+    EXPECT_TRUE(static_cast<std::size_t>(a.size()) == static_cast<std::size_t>(b.size()))  \
     << "Check failed because vector arguments do not have the same size:"       \
     << std::endl                                                                \
     << "First argument has size " << a.size() << ", "                           \


### PR DESCRIPTION
---
name: ✨ Feature
about: Fix type casting in `KRATOS_EXPECT_VECTOR_NEAR` macro for size comparison

---

## **📝 Description**

Fix type casting in `KRATOS_EXPECT_VECTOR_NEAR` macro for size comparison.

## **🆕 Changelog**

- [Fix type casting in  `KRATOS_EXPECT_VECTOR_NEAR` macro for size comparison](https://github.com/KratosMultiphysics/Kratos/commit/3a35e301d2fee61c57a63bd1aa4583bf3af45e38)