### PR TITLE
[FastPR][IGA] Fix incorrect assignment of int_point in the inner loop

### DIFF
--- a/kratos/utilities/geometry_utilities/brep_trimming_utilities.cpp
+++ b/kratos/utilities/geometry_utilities/brep_trimming_utilities.cpp
@@ -62,7 +62,7 @@ namespace Kratos
                         if (!(int_point.x == new_int_point.x && int_point.y == new_int_point.y)) {
                             all_loops[i_inner_loops + 1].push_back(new_int_point);
                             int_point.x = new_int_point.x;
-                            int_point.y = new_int_point.x;
+                            int_point.y = new_int_point.y;
                         }
                     }
                 }


### PR DESCRIPTION
Fix a small bug in the Brep trimming utilities. The bug affects cases where the surface is trimmed by a straight line (which is very uncommon), in which the last point of the line is neglected. However, this does not affect trimming by an enclosed loop of lines. Nevertheless, the correction is necessary to ensure correctness and consistency.

Thanks, @juancamarotti, for noticing it.