### PR TITLE
[GeoMechanicsApplication] Skipped unstable validation tests

### DIFF
--- a/applications/GeoMechanicsApplication/tests/test_partial_saturation.py
+++ b/applications/GeoMechanicsApplication/tests/test_partial_saturation.py
@@ -288,6 +288,9 @@ class KratosGeoMechanicsPartialSaturation(KratosUnittest.TestCase):
             reader, output_data, expected_results_at_times, variable_name
         )
 
+    @KratosUnittest.skip(
+        "This test is very sensitive and gives different results depending on e.g. compiler/os. Therefore it's skipped until the test is stabilized."
+    )
     def test_infiltration_from_top_boundary_B10(self):
         file_path = test_helper.get_file_path(
             os.path.join(
@@ -351,8 +354,6 @@ class KratosGeoMechanicsPartialSaturation(KratosUnittest.TestCase):
         self._validate_outputs_against_expected_results(
             reader, output_data, expected_results_at_times, variable_name
         )
-
-
 
     def test_infiltration_from_top_boundary_O4(self):
         file_path = test_helper.get_file_path(
@@ -419,6 +420,9 @@ class KratosGeoMechanicsPartialSaturation(KratosUnittest.TestCase):
             reader, output_data, expected_results_at_times, variable_name
         )
 
+    @KratosUnittest.skip(
+        "This test is very sensitive and gives different results depending on e.g. compiler/os. Therefore it's skipped until the test is stabilized."
+    )
     def test_infiltration_from_top_boundary_O6(self):
         file_path = test_helper.get_file_path(
             os.path.join(
@@ -486,7 +490,6 @@ class KratosGeoMechanicsPartialSaturation(KratosUnittest.TestCase):
             reader, output_data, expected_results_at_times, variable_name
         )
 
-    
     def _calculate_depth_for_boundary_nodes(self, simulation):
         return {
             node.Id: -1.0 * node.Y


### PR DESCRIPTION
After merging the infiltration tests #14673, it turned out two out of four of these test cases are unstable and give different results in our TeamCity pipelines, compared to local results. Therefore, they are disabled for now, untill they are stabilized.