### PR TITLE
[Several] More unused definitions removal

### DIFF
--- a/applications/CompressiblePotentialFlowApplication/custom_elements/adjoint_analytical_incompressible_potential_flow_element.cpp
+++ b/applications/CompressiblePotentialFlowApplication/custom_elements/adjoint_analytical_incompressible_potential_flow_element.cpp
@@ -66,7 +66,6 @@ namespace Kratos
                     x( i_node , 1 ) = pPrimalElement->GetGeometry()[i_node].Y();
             }
             auto p = PotentialFlowUtilities::GetPotentialOnNormalElement<2,3>(*pPrimalElement);
-            BoundedMatrix<double, Dim*NumNodes, NumNodes> test = ZeroMatrix(Dim*NumNodes, NumNodes);
 
             const double crOutput0 =             x(0,0) - x(1,0);
             const double crOutput1 =             -x(2,1);

--- a/applications/ConstitutiveLawsApplication/custom_constitutive/small_strains/damage/d_plus_d_minus_damage_masonry_3d.cpp
+++ b/applications/ConstitutiveLawsApplication/custom_constitutive/small_strains/damage/d_plus_d_minus_damage_masonry_3d.cpp
@@ -57,7 +57,6 @@ void DamageDPlusDMinusMasonry3DLaw::CalculateMaterialResponseCauchy(Constitutive
 
     // Integrate Stress Damage
     Vector& integrated_stress_vector = rValues.GetStressVector();
-    array_1d<double, VoigtSize> auxiliary_integrated_stress_vector = integrated_stress_vector;
     Matrix& r_tangent_tensor = rValues.GetConstitutiveMatrix(); // todo modify after integration
     const Flags& r_constitutive_law_options = rValues.GetOptions();
 

--- a/applications/ConstitutiveLawsApplication/custom_constitutive/small_strains/damage/generic_small_strain_d_plus_d_minus_damage.cpp
+++ b/applications/ConstitutiveLawsApplication/custom_constitutive/small_strains/damage/generic_small_strain_d_plus_d_minus_damage.cpp
@@ -81,7 +81,6 @@ void GenericSmallStrainDplusDminusDamage<TConstLawIntegratorTensionType, TConstL
 
     // Integrate Stress Damage
     Vector& integrated_stress_vector = rValues.GetStressVector();
-    array_1d<double, VoigtSize> auxiliary_integrated_stress_vector = integrated_stress_vector;
     Matrix& r_tangent_tensor = rValues.GetConstitutiveMatrix(); // todo modify after integration
     const Flags& r_constitutive_law_options = rValues.GetOptions();
 

--- a/applications/ConstitutiveLawsApplication/custom_constitutive/small_strains/plastic_damage/generic_small_strain_plastic_damage_model.cpp
+++ b/applications/ConstitutiveLawsApplication/custom_constitutive/small_strains/plastic_damage/generic_small_strain_plastic_damage_model.cpp
@@ -668,7 +668,6 @@ CalculateDamageParameters(
 )
 {
     array_1d<double, VoigtSize> deviator = ZeroVector(6);
-    array_1d<double, VoigtSize> h_capa = ZeroVector(6);
     double J2, tensile_indicator_factor, compression_indicator_factor, suma = 0.0;
     array_1d<double, Dimension> principal_stresses;
 

--- a/applications/FluidDynamicsApplication/custom_processes/two_fluid_navier_stokes_fractional_convection_process.h
+++ b/applications/FluidDynamicsApplication/custom_processes/two_fluid_navier_stokes_fractional_convection_process.h
@@ -345,7 +345,6 @@ namespace Kratos
         void InitializeFractionalVelocityModelPartDatabases()
         {
             if (mElementTauNodal) {
-                const array_1d<double, 3> aux_zero_vector = ZeroVector(3);
                 block_for_each(mpFractionalVelocityModelPart->Nodes(), [&](Node &rNode){
                     rNode.SetValue(TAU, 0.0);
                 });

--- a/applications/StructuralMechanicsApplication/custom_elements/truss_elements/total_lagrangian_truss_element.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/truss_elements/total_lagrangian_truss_element.cpp
@@ -457,7 +457,6 @@ void TotalLagrangianTrussElement<TDimension>::CalculateOnIntegrationPoints(
         const array_3 curr_axis = r_geometry[1].Coordinates() - r_geometry[0].Coordinates();
         const double ref_length = norm_2(ref_axis);
         const double curr_length = norm_2(curr_axis);
-        const array_3 current_unit_dir = curr_axis / curr_length;
         const double Fxx = curr_length / ref_length; // Deformation gradient in the axial direction
         const double ref_area = r_props[CROSS_AREA];
         const double green_lagrange_strain = 0.5 * (Fxx * Fxx - 1.0);

--- a/applications/StructuralMechanicsApplication/custom_strategies/custom_strategies/mechanical_explicit_strategy.hpp
+++ b/applications/StructuralMechanicsApplication/custom_strategies/custom_strategies/mechanical_explicit_strategy.hpp
@@ -505,9 +505,6 @@ private:
             // If we consider rotation dofs
             const bool has_dof_for_rot_z = (r_nodes.begin())->HasDofFor(ROTATION_Z);
 
-            // Auxiliary values
-            const array_1d<double,3> zero_array = ZeroVector(3);
-
             // Getting
             const auto it_node_begin = r_nodes.begin();
             const IndexType disppos = it_node_begin->GetDofPosition(DISPLACEMENT_X);


### PR DESCRIPTION
---
name: ✨ Feature
about: More unused definitions removal.

---

## **📝 Description**

More unused definitions removal.

## **🆕 Changelog**

- [Remove unused calculation of current unit direction in TotalLagrangia…](https://github.com/KratosMultiphysics/Kratos/commit/64053e84b08803b21847395a6c1969ec297dabd1)
- [Remove unused auxiliary values in MechanicalExplicitStrategy](https://github.com/KratosMultiphysics/Kratos/commit/f5a3642e815eb1376f692a55113ab989853567f8)
- [Remove unused auxiliary zero vector in InitializeFractionalVelocityMo…](https://github.com/KratosMultiphysics/Kratos/commit/3bab3a3c38b5a3a8dd303f73d066eb9339a18bc5)
- [Remove unused auxiliary stress vector in damage models](https://github.com/KratosMultiphysics/Kratos/commit/ced950567862894b4b85cf2bca3e9be2ad2b0fd6)
- [Remove unused test matrix in AdjointAnalyticalIncompressiblePotential…](https://github.com/KratosMultiphysics/Kratos/commit/b12a7c1c730c81e6689ce85e048490f1c7aecd7a)
