### PR TITLE
[GeoMechanicsApplication] Fixed SQ issue and be a bit stricter with the test include

### DIFF
--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_retention/test_van_genuchten_law.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_retention/test_van_genuchten_law.cpp
@@ -39,8 +39,8 @@ class VanGenuchtenCalculateValuesSuite : public testing::TestWithParam<TestData>
 
 TEST_P(VanGenuchtenCalculateValuesSuite, TestValuesAreCalculatedCorrectly)
 {
-    const auto& test_data = GetParam();
-    auto        law       = VanGenuchtenLaw();
+    const auto& r_test_data = GetParam();
+    auto        law         = VanGenuchtenLaw();
     Properties  properties;
     properties.SetValue(SATURATED_SATURATION, 0.9);
     properties.SetValue(RESIDUAL_SATURATION, 0.1);
@@ -50,12 +50,12 @@ TEST_P(VanGenuchtenCalculateValuesSuite, TestValuesAreCalculatedCorrectly)
     properties.SetValue(VAN_GENUCHTEN_GL, 1.5);
     auto retention_law_parameters = RetentionLaw::Parameters{properties};
 
-    retention_law_parameters.SetFluidPressure(test_data.input_pressure);
+    retention_law_parameters.SetFluidPressure(r_test_data.input_pressure);
     double value = 0.0;
-    EXPECT_DOUBLE_EQ(law.CalculateValue(retention_law_parameters, test_data.variable, value),
-                     test_data.expected_value)
-        << "Incorrect value for variable = " << test_data.variable.Name()
-        << " and input pressure = " << test_data.input_pressure;
+    EXPECT_DOUBLE_EQ(law.CalculateValue(retention_law_parameters, r_test_data.variable, value),
+                     r_test_data.expected_value)
+        << "Incorrect value for variable = " << r_test_data.variable.Name()
+        << " and input pressure = " << r_test_data.input_pressure;
 }
 
 INSTANTIATE_TEST_SUITE_P(

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_retention/test_van_genuchten_law.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_retention/test_van_genuchten_law.cpp
@@ -12,13 +12,14 @@
 
 #include "custom_retention/van_genuchten_law.h"
 #include "geo_mechanics_application_variables.h"
-#include "tests/cpp_tests/geo_mechanics_fast_suite.h"
+#include "includes/expect.h"
+#include "tests/cpp_tests/geo_mechanics_fast_suite_without_kernel.h"
 #include "gtest/gtest.h"
 
 namespace Kratos::Testing
 {
 
-KRATOS_TEST_CASE_IN_SUITE(VanGenuchtenLawReturnsCloneOfCorrectType, KratosGeoMechanicsFastSuiteWithoutKernel)
+TEST_F(KratosGeoMechanicsFastSuiteWithoutKernel, VanGenuchtenLawReturnsCloneOfCorrectType)
 {
     const auto law         = VanGenuchtenLaw();
     const auto p_law_clone = law.Clone();
@@ -38,9 +39,9 @@ class VanGenuchtenCalculateValuesSuite : public testing::TestWithParam<TestData>
 
 TEST_P(VanGenuchtenCalculateValuesSuite, TestValuesAreCalculatedCorrectly)
 {
-    const auto test_data = GetParam();
-    auto       law       = VanGenuchtenLaw();
-    Properties properties;
+    const auto& test_data = GetParam();
+    auto        law       = VanGenuchtenLaw();
+    Properties  properties;
     properties.SetValue(SATURATED_SATURATION, 0.9);
     properties.SetValue(RESIDUAL_SATURATION, 0.1);
     properties.SetValue(MINIMUM_RELATIVE_PERMEABILITY, 0.05);
@@ -72,7 +73,7 @@ INSTANTIATE_TEST_SUITE_P(
         TestData{.variable = DERIVATIVE_OF_SATURATION, .expected_value = -0.15050611026881838, .input_pressure = 1.5},
         TestData{.variable = RELATIVE_PERMEABILITY, .expected_value = 0.28755984470352691, .input_pressure = 1.5}));
 
-KRATOS_TEST_CASE_IN_SUITE(VanGenuchtenLawChecksInputParameters, KratosGeoMechanicsFastSuiteWithoutKernel)
+TEST_F(KratosGeoMechanicsFastSuiteWithoutKernel, VanGenuchtenLawChecksInputParameters)
 {
     Properties properties;
     properties.SetId(1);


### PR DESCRIPTION
Changes:
- Fixed a SonarCloud issue -> forgotten `&` leading to redundant copy
- Used a lighter include in the test file (the 'without_kernel' version of the suite) to improve compilation time (this does mean we use TEST_F instead of KRATOS_TEST_CASE_IN_SUITE)