### PR TITLE
[Core][MPI] Fixed MPI communicator buffer sizing for Eigen-backed matrix and vector types

### DIFF
--- a/kratos/mpi/includes/mpi_communicator.h
+++ b/kratos/mpi/includes/mpi_communicator.h
@@ -131,7 +131,10 @@ template<> struct SendTraits< Matrix >
 
     static inline std::size_t GetMessageSize(const Matrix& rValue)
     {
-        return rValue.data().size();
+        // Flat storage size, spelled through the extents: the uBLAS matrix
+        // exposes it as data().size(), but the Eigen-backed Matrix returns a
+        // raw pointer from data().
+        return rValue.size1() * rValue.size2();
     }
 };
 
@@ -201,12 +204,27 @@ template<typename ValueType> struct DynamicArrayTypeTransfer
 
     static inline void WriteBuffer(const ValueType& rValue, SendType* pBuffer)
     {
-        std::memcpy(pBuffer, &(rValue.data()[0]), rValue.data().size()*sizeof(double));
+        std::memcpy(pBuffer, &(rValue.data()[0]), FlatSize(rValue)*sizeof(double));
     }
 
     static inline void ReadBuffer(const SendType* pBuffer, ValueType& rValue)
     {
-        std::memcpy(&(rValue.data()[0]), pBuffer, rValue.data().size()*sizeof(double));
+        std::memcpy(&(rValue.data()[0]), pBuffer, FlatSize(rValue)*sizeof(double));
+    }
+
+private:
+
+    // Number of stored scalars. Both backends store the dynamic vector/matrix
+    // contiguously, but only the uBLAS types expose the flat storage size
+    // through data().size() (the Eigen-backed ones return a raw pointer from
+    // data()), so it is spelled through the extents instead.
+    static inline std::size_t FlatSize(const ValueType& rValue)
+    {
+        if constexpr (requires { rValue.size1(); }) {
+            return rValue.size1() * rValue.size2();
+        } else {
+            return rValue.size();
+        }
     }
 };
 


### PR DESCRIPTION
---
name: ✨ Feature
about: Fixed MPI communicator buffer sizing for Eigen-backed matrix and vector types

---

## **📝 Description**

Replaced data().size() with extent-based flat size computation (size1()*size2() for matrices, size() for vectors) in SendTraits<Matrix> and DynamicArrayTypeTransfer, since Eigen-backed types return a raw pointer from data() rather than a container.

## **🆕 Changelog**

- [Fixed MPI communicator buffer sizing for Eigen-backed matrix and vector types](https://github.com/KratosMultiphysics/Kratos/commit/d01939a6efe75aa4c845c37c53dce50228d06836)
