### PR TITLE
[Core] Remove bool() operator from flags.

### DIFF
--- a/applications/ContactStructuralMechanicsApplication/custom_processes/mpc_contact_search_process.cpp
+++ b/applications/ContactStructuralMechanicsApplication/custom_processes/mpc_contact_search_process.cpp
@@ -155,7 +155,7 @@ void MPCContactSearchProcess<TDim, TNumNodes, TNumNodesMaster>::CleanModelPart(M
     auto& r_constraints_array = rModelPart.MasterSlaveConstraints();
     VariableUtils().SetFlag(TO_ERASE, true, r_constraints_array);
 
-    BaseType::mrMainModelPart.RemoveMasterSlaveConstraintFromAllLevels(TO_ERASE);
+    BaseType::mrMainModelPart.RemoveMasterSlaveConstraintsFromAllLevels(TO_ERASE);
 }
 
 /***********************************************************************************/

--- a/applications/GeoMechanicsApplication/custom_processes/set_multiple_moving_loads.cpp
+++ b/applications/GeoMechanicsApplication/custom_processes/set_multiple_moving_loads.cpp
@@ -112,7 +112,7 @@ void SetMultipleMovingLoadsProcess::RemoveClonedConditions()
         mrModelPart.GetRootModelPart().GetSubModelPart(mParameters["compute_model_part_name"].GetString());
 
     for (const auto& moving_load_condition : mrModelPart.Conditions()) {
-        if (compute_model_part.HasCondition(moving_load_condition))
+        if (compute_model_part.HasCondition(moving_load_condition.Id()))
             compute_model_part.pGetCondition(moving_load_condition)->Set(TO_ERASE, true);
     }
     // Call method

--- a/applications/GeoMechanicsApplication/custom_processes/set_multiple_moving_loads.cpp
+++ b/applications/GeoMechanicsApplication/custom_processes/set_multiple_moving_loads.cpp
@@ -113,7 +113,7 @@ void SetMultipleMovingLoadsProcess::RemoveClonedConditions()
 
     for (const auto& moving_load_condition : mrModelPart.Conditions()) {
         if (compute_model_part.HasCondition(moving_load_condition.Id()))
-            compute_model_part.pGetCondition(moving_load_condition)->Set(TO_ERASE, true);
+            compute_model_part.pGetCondition(moving_load_condition.Id())->Set(TO_ERASE, true);
     }
     // Call method
     compute_model_part.RemoveConditions(TO_ERASE);

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_elements/test_transient_Pw_element.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_elements/test_transient_Pw_element.cpp
@@ -741,21 +741,21 @@ KRATOS_TEST_CASE_IN_SUITE(TransientPwElement_ZeroReturnFunctions, KratosGeoMecha
 
     // Act
     Vector actual_vector;
-    element.GetValuesVector(actual_vector, dummy_process_info);
+    element.GetValuesVector(actual_vector);
 
     // Assert
     KRATOS_EXPECT_EQ(actual_vector.size(), n_DoF);
     KRATOS_EXPECT_VECTOR_EQ(actual_vector, expected_vector);
 
     // Act
-    element.GetFirstDerivativesVector(actual_vector, dummy_process_info);
+    element.GetFirstDerivativesVector(actual_vector);
 
     // Assert
     KRATOS_EXPECT_EQ(actual_vector.size(), n_DoF);
     KRATOS_EXPECT_VECTOR_EQ(actual_vector, expected_vector);
 
     // Act
-    element.GetSecondDerivativesVector(actual_vector, dummy_process_info);
+    element.GetSecondDerivativesVector(actual_vector);
 
     // Assert
     KRATOS_EXPECT_EQ(actual_vector.size(), n_DoF);

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_elements/test_transient_Pw_element.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_elements/test_transient_Pw_element.cpp
@@ -741,21 +741,21 @@ KRATOS_TEST_CASE_IN_SUITE(TransientPwElement_ZeroReturnFunctions, KratosGeoMecha
 
     // Act
     Vector actual_vector;
-    element.GetValuesVector(actual_vector);
+    element.GetValuesVector(actual_vector, 0);
 
     // Assert
     KRATOS_EXPECT_EQ(actual_vector.size(), n_DoF);
     KRATOS_EXPECT_VECTOR_EQ(actual_vector, expected_vector);
 
     // Act
-    element.GetFirstDerivativesVector(actual_vector);
+    element.GetFirstDerivativesVector(actual_vector, 0);
 
     // Assert
     KRATOS_EXPECT_EQ(actual_vector.size(), n_DoF);
     KRATOS_EXPECT_VECTOR_EQ(actual_vector, expected_vector);
 
     // Act
-    element.GetSecondDerivativesVector(actual_vector);
+    element.GetSecondDerivativesVector(actual_vector, 0);
 
     // Assert
     KRATOS_EXPECT_EQ(actual_vector.size(), n_DoF);

--- a/applications/LinearSolversApplication/custom_utilities/mkl_utilities.cpp
+++ b/applications/LinearSolversApplication/custom_utilities/mkl_utilities.cpp
@@ -110,7 +110,7 @@ std::optional<int> MKLUtilities::ComputeMKLThreadCount(const int NumberOfMKLThre
 {
     // Check first if it is needed to set the number of threads
     if (!CheckThreadNumber(NumberOfMKLThreads)) {
-        int number_of_threads_used;
+        int number_of_threads_used = 0;
         if (NumberOfMKLThreads > 0) {
             number_of_threads_used = NumberOfMKLThreads;
         } else if (static_cast<int>(MKLThreadSetting::Minimal) == NumberOfMKLThreads) {

--- a/applications/RomApplication/tests/cpp_tests/test_pg_rom_builder_and_solver.cpp
+++ b/applications/RomApplication/tests/cpp_tests/test_pg_rom_builder_and_solver.cpp
@@ -153,7 +153,7 @@ ModelPart& FillModel(Model& model)
 
         left_basis(0,0) = phi_1(r_node);
         left_basis(0,1) = phi_2(r_node);
-        left_basis(0,2) = phi_3(r_node);
+        left_basis(0,2) = phi_3(0, r_node.Id() - 1);
         r_node.SetValue(ROM_LEFT_BASIS, left_basis);
     }
 

--- a/applications/StructuralMechanicsApplication/custom_elements/solid_elements/total_lagrangian.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/solid_elements/total_lagrangian.cpp
@@ -420,7 +420,7 @@ void TotalLagrangian::CalculateStress(Matrix const& rF,
 {
     KRATOS_TRY;
     Vector strain(mConstitutiveLawVector[IntegrationPoint]->GetStrainSize());
-    CalculateStrain(rF, *mConstitutiveLawVector[IntegrationPoint], strain, rCurrentProcessInfo);
+    CalculateStrain(rF, IntegrationPoint, strain, rCurrentProcessInfo);
     ConstitutiveLaw::Parameters cl_params(GetGeometry(), GetProperties(), rCurrentProcessInfo);
     cl_params.GetOptions().Set(ConstitutiveLaw::COMPUTE_STRESS | ConstitutiveLaw::USE_ELEMENT_PROVIDED_STRAIN);
     cl_params.SetStrainVector(strain);

--- a/kratos/containers/flags.h
+++ b/kratos/containers/flags.h
@@ -141,15 +141,6 @@ public:
     Flags& operator=(Flags&&) noexcept = default;
 
     /**
-     * @brief Conversion operator to bool.
-     * @return true if any flag is set, false otherwise.
-     */
-    operator bool() const
-    {
-        return mFlags;
-    }
-
-    /**
      * @brief Bitwise NOT operator.
      * @return Flags with each bit inverted.
      */
@@ -157,7 +148,7 @@ public:
     {
         Flags results(*this);
         results.mFlags = ~mFlags;
-        return  results;
+        return results;
     }
 
     /**
@@ -168,7 +159,7 @@ public:
     {
         Flags results(*this);
         results.mFlags = !mFlags;
-        return  results;
+        return static_cast<bool>(results.mFlags);
     }
 
     /**
@@ -197,6 +188,15 @@ public:
      * @param Value The value to set the flag to.
      */
     void Set(const Flags ThisFlag, bool Value);
+
+    /**
+     * @brief Get the raw value of the flags.
+     * @return The raw value of the flags.
+     */
+    BlockType GetRaw() const
+    {
+        return mFlags;
+    }
 
     /**
      * @brief Reset the specified flag.

--- a/kratos/input_output/vtk_output.cpp
+++ b/kratos/input_output/vtk_output.cpp
@@ -734,7 +734,7 @@ void VtkOutput::WriteGeometricalContainerResults(
         WriteScalarContainerVariable(rContainer, var_to_write, rFileStream);
     } else if (KratosComponents<Variable<Flags>>::Has(rVariableName)){
         const auto& var_to_write = KratosComponents<Variable<Flags>>::Get(rVariableName);
-        WriteScalarContainerVariable(rContainer, var_to_write, rFileStream);
+        WriteFlagsContainerVariable(rContainer, var_to_write, rFileStream);
     } else if (KratosComponents<Variable<array_1d<double, 3>>>::Has(rVariableName)){
         const auto& var_to_write = KratosComponents<Variable<array_1d<double, 3>>>::Get(rVariableName);
         WriteVectorContainerVariable(rContainer, var_to_write, rFileStream);
@@ -909,6 +909,26 @@ void VtkOutput::WriteScalarContainerVariable(
         if (InputOutputUtilities::SkippableEntity(r_entity, "VtkOutput")) continue;
         const double result = r_entity.GetValue(rVariable);
         WriteScalarDataToFile((float)result, rFileStream);
+        if (mFileFormat == VtkOutput::FileFormat::VTK_ASCII) rFileStream <<"\n";
+    }
+}
+
+/***********************************************************************************/
+/***********************************************************************************/
+
+template<typename TContainerType>
+void VtkOutput::WriteFlagsContainerVariable(
+    const TContainerType& rContainer,
+    const Variable<Flags>& rVariable,
+    std::ofstream& rFileStream) const
+{
+    rFileStream << rVariable.Name() << " 1 "
+                << DetermineVtkContainerSize(rContainer) << "  float\n";
+
+    for (const auto& r_entity : rContainer) {
+        if (InputOutputUtilities::SkippableEntity(r_entity, "VtkOutput")) continue;
+        const float result = static_cast<float>(r_entity.GetValue(rVariable).GetRaw());
+        WriteScalarDataToFile(result, rFileStream);
         if (mFileFormat == VtkOutput::FileFormat::VTK_ASCII) rFileStream <<"\n";
     }
 }

--- a/kratos/input_output/vtk_output.h
+++ b/kratos/input_output/vtk_output.h
@@ -391,6 +391,20 @@ protected:
         std::ofstream& rFileStream) const;
 
     /**
+     * @brief Write the scalar-nonhistorical variable results of rContainer.
+     * @tparam TContainerType The type of container of the entity on which the results are to be written
+     * @tparam TVarType The type of Variable of the entity on which the results are to be written
+     * @param rContainer the container which is beging output
+     * @param rVariable Variable of the result to be written.
+     * @param rFileStream the file stream to which data is to be written.
+     */
+    template<typename TContainerType>
+    void WriteFlagsContainerVariable(
+        const TContainerType& rContainer,
+        const Variable<Flags>& rVariable,
+        std::ofstream& rFileStream) const;
+
+    /**
      * @brief Write the scalar GP variable results of rContainer.
      * @tparam TContainerType The type of container of the entity on which the results are to be written
      * @tparam TVarType The type of Variable of the entity on which the results are to be written


### PR DESCRIPTION
---
name: Remove bool() operator from flags
---

## **📝 Description**
Fix to #14727 

Removes the operator to avoid unintended cast from all classes deriving from `Flags`
The single usage of the `bool()` operator in `Flags` has been replaced by a explicit cast in the class `!` operator.
Fixed several instances of bugs due to incorrect usage of classes in several functions. See #14727   
