### PR TITLE
[ContactStructuralMechanicsApplication] Fallback solver when the dual LM condensation is not valid

### DIFF
--- a/applications/ContactStructuralMechanicsApplication/custom_linear_solvers/mixedulm_linear_solver.h
+++ b/applications/ContactStructuralMechanicsApplication/custom_linear_solvers/mixedulm_linear_solver.h
@@ -26,6 +26,7 @@
 #include "linear_solvers/reorderer.h"
 #include "linear_solvers/iterative_solver.h"
 #include "utilities/parallel_utilities.h"
+#include "utilities/reduction_utilities.h"
 #include "contact_structural_mechanics_application_variables.h"
 #include "utilities/sparse_matrix_multiplication_utility.h"
 #include "custom_utilities/logging_settings.hpp"
@@ -90,6 +91,9 @@ public:
 
     /// The flag that indicates if the solution is initialized
     KRATOS_DEFINE_LOCAL_FLAG( IS_INITIALIZED );
+
+    /// The flag that indicates if the dual LM condensation is valid (i.e. the mortar operator D is block-diagonal by node)
+    KRATOS_DEFINE_LOCAL_FLAG( DUAL_LM_IS_VALID );
 
     /// Pointer definition of MixedULMLinearSolver
     KRATOS_CLASS_POINTER_DEFINITION (MixedULMLinearSolver);
@@ -162,6 +166,7 @@ public:
         // Initializing the remaining variables
         mOptions.Set(BLOCKS_ARE_ALLOCATED, false);
         mOptions.Set(IS_INITIALIZED, false);
+        mOptions.Set(DUAL_LM_IS_VALID, true);
     }
 
     /**
@@ -187,8 +192,12 @@ public:
         this->SetTolerance( ThisParameters["tolerance"].GetDouble() );
         this->SetMaxIterationsNumber( ThisParameters["max_iteration_number"].GetInt() );
         mEchoLevel = ThisParameters["echo_level"].GetInt();
+        mCheckDualLMCondensation = ThisParameters["check_dual_lm_condensation"].GetBool();
+        mDualLMZeroRowTolerance = ThisParameters["dual_lm_zero_row_tolerance"].GetDouble();
+        mDualLMOffNodeTolerance = ThisParameters["dual_lm_off_node_tolerance"].GetDouble();
         mOptions.Set(BLOCKS_ARE_ALLOCATED, false);
         mOptions.Set(IS_INITIALIZED, false);
+        mOptions.Set(DUAL_LM_IS_VALID, true);
 
         KRATOS_CATCH("")
     }
@@ -224,7 +233,10 @@ public:
           mLMInactive(rOther.mLMInactive),
           mDisp(rOther.mDisp),
           mEchoLevel(rOther.mEchoLevel),
-          mFileCreated(rOther.mFileCreated)
+          mFileCreated(rOther.mFileCreated),
+          mCheckDualLMCondensation(rOther.mCheckDualLMCondensation),
+          mDualLMZeroRowTolerance(rOther.mDualLMZeroRowTolerance),
+          mDualLMOffNodeTolerance(rOther.mDualLMOffNodeTolerance)
     {
     }
 
@@ -315,7 +327,7 @@ public:
         // Solve u block
         if (static_cast<SizeType>(mDisp.size()) != total_disp_size)
             mDisp.resize(total_disp_size, false);
-        mpSolverDispBlock->Solve (mKDispModified, mDisp, mResidualDisp);
+        const bool disp_solved = mpSolverDispBlock->Solve (mKDispModified, mDisp, mResidualDisp);
 
         // Write back solution
         SetUPart(rX, mDisp);
@@ -347,7 +359,7 @@ public:
             SetLMIPart(rX, mLMInactive);
         }
 
-        return false;
+        return disp_solved && mOptions.Is(DUAL_LM_IS_VALID);
     }
 
     /**
@@ -404,6 +416,7 @@ public:
         mDisp.clear();       /// The solution of the displacement
 
         mOptions.Set(IS_INITIALIZED, false);
+        mOptions.Set(DUAL_LM_IS_VALID, true);
     }
 
     /**
@@ -438,7 +451,16 @@ public:
 
         this->InitializeSolutionStep (rA,rX,rB);
 
-        this->PerformSolutionStep (rA,rX,rB);
+        // FillBlockMatrices (called above) decides whether the condensation is legitimate. If it is not, we must
+        // not write the resulting garbage into rX: we report the failure so that a FallbackLinearSolver wrapping
+        // this solver can re-solve the full, non-condensed system instead
+        if (mOptions.IsNot(DUAL_LM_IS_VALID)) {
+            // The displacement block solver already had its solution step initialized, close it to keep it balanced
+            this->FinalizeSolutionStep (rA,rX,rB);
+            return false;
+        }
+
+        const bool solved = this->PerformSolutionStep (rA,rX,rB);
 
         this->FinalizeSolutionStep (rA,rX,rB);
 
@@ -459,7 +481,7 @@ public:
             mFileCreated++;
         }
 
-        return false;
+        return solved;
     }
 
     /**
@@ -578,6 +600,12 @@ public:
             mLMInactiveIndices.resize (n_lm_inactive_dofs,false);
         if (mLMActiveIndices.size() != n_lm_active_dofs)
             mLMActiveIndices.resize (n_lm_active_dofs,false);
+        if (mSlaveActiveNodeIds.size() != n_slave_active_dofs)
+            mSlaveActiveNodeIds.resize (n_slave_active_dofs,false);
+        if (mLMActiveNodeIds.size() != n_lm_active_dofs)
+            mLMActiveNodeIds.resize (n_lm_active_dofs,false);
+        if (mLMInactiveNodeIds.size() != n_lm_inactive_dofs)
+            mLMInactiveNodeIds.resize (n_lm_inactive_dofs,false);
 
         const SizeType n_other_dofs = tot_active_dofs - n_lm_inactive_dofs - n_lm_active_dofs - n_master_dofs - n_slave_inactive_dofs - n_slave_active_dofs;
         if (mOtherIndices.size() != n_other_dofs)
@@ -614,11 +642,13 @@ public:
                             mLMActiveIndices[lm_active_counter] = global_pos;
                             mGlobalToLocalIndexing[global_pos] = lm_active_counter;
                             mWhichBlockType[global_pos] = BlockType::LM_ACTIVE;
+                            mLMActiveNodeIds[lm_active_counter] = node_id;
                             ++lm_active_counter;
                         } else {
                             mLMInactiveIndices[lm_inactive_counter] = global_pos;
                             mGlobalToLocalIndexing[global_pos] = lm_inactive_counter;
                             mWhichBlockType[global_pos] = BlockType::LM_INACTIVE;
+                            mLMInactiveNodeIds[lm_inactive_counter] = node_id;
                             ++lm_inactive_counter;
                         }
                     } else if ( r_node.Is(INTERFACE) && IsDisplacementDof(i_dof)) {
@@ -632,6 +662,7 @@ public:
                                 mSlaveActiveIndices[slave_active_counter] = global_pos;
                                 mGlobalToLocalIndexing[global_pos] = slave_active_counter;
                                 mWhichBlockType[global_pos] = BlockType::SLAVE_ACTIVE;
+                                mSlaveActiveNodeIds[slave_active_counter] = node_id;
                                 ++slave_active_counter;
                             } else {
                                 mSlaveInactiveIndices[slave_inactive_counter] = global_pos;
@@ -664,11 +695,13 @@ public:
                         mLMActiveIndices[lm_active_counter] = global_pos;
                         mGlobalToLocalIndexing[global_pos] = lm_active_counter;
                         mWhichBlockType[global_pos] = BlockType::LM_ACTIVE;
+                        mLMActiveNodeIds[lm_active_counter] = node_id;
                         ++lm_active_counter;
                     } else {
                         mLMInactiveIndices[lm_inactive_counter] = global_pos;
                         mGlobalToLocalIndexing[global_pos] = lm_inactive_counter;
                         mWhichBlockType[global_pos] = BlockType::LM_INACTIVE;
+                        mLMInactiveNodeIds[lm_inactive_counter] = node_id;
                         ++lm_inactive_counter;
                     }
                 } else if ( r_node.Is(INTERFACE) && IsDisplacementDof(i_dof)) {
@@ -682,6 +715,7 @@ public:
                             mSlaveActiveIndices[slave_active_counter] = global_pos;
                             mGlobalToLocalIndexing[global_pos] = slave_active_counter;
                             mWhichBlockType[global_pos] = BlockType::SLAVE_ACTIVE;
+                            mSlaveActiveNodeIds[slave_active_counter] = node_id;
                             ++slave_active_counter;
                         } else {
                             mSlaveInactiveIndices[slave_inactive_counter] = global_pos;
@@ -776,6 +810,17 @@ public:
         return mDisplacementDofs;
     }
 
+    /**
+     * @brief Returns whether the dual LM condensation was valid on the last solve
+     * @details It is false when the mortar operator D was found not to be diagonal, i.e. the mortar cut was too
+     * distorted for the dual shape functions to be built and the condensation performed by this solver does not hold.
+     * @return True if the condensation is valid, false otherwise
+     */
+    bool IsDualLMValid() const
+    {
+        return mOptions.Is(DUAL_LM_IS_VALID);
+    }
+
     ///@}
     ///@name Inquiry
     ///@{
@@ -799,6 +844,30 @@ public:
     /// Print object's data.
     void PrintData (std::ostream& rOStream) const override
     {
+        rOStream << "Displacement block solver: " << mpSolverDispBlock->Info() << "\n";
+
+        // The block structure the system has been split into
+        rOStream << "Block sizes:"
+                 << "\n\tOther (not interface) DoFs : " << mOtherIndices.size()
+                 << "\n\tMaster DoFs               : " << mMasterIndices.size()
+                 << "\n\tSlave inactive DoFs       : " << mSlaveInactiveIndices.size()
+                 << "\n\tSlave active DoFs         : " << mSlaveActiveIndices.size()
+                 << "\n\tLM inactive DoFs          : " << mLMInactiveIndices.size()
+                 << "\n\tLM active DoFs            : " << mLMActiveIndices.size() << "\n";
+
+        // State of the solver
+        rOStream << "Blocks are allocated: " << (mOptions.Is(BLOCKS_ARE_ALLOCATED) ? "yes" : "no") << "\n"
+                 << "Is initialized: " << (mOptions.Is(IS_INITIALIZED) ? "yes" : "no") << "\n";
+
+        // Validity of the condensation, which is the whole point of this solver
+        rOStream << "Dual LM condensation is checked: " << (mCheckDualLMCondensation ? "yes" : "no") << "\n"
+                 << "Dual LM condensation is valid: " << (mOptions.Is(DUAL_LM_IS_VALID) ? "yes" : "no") << "\n";
+        if (mCheckDualLMCondensation) {
+            rOStream << "\tZero row tolerance: " << mDualLMZeroRowTolerance << "\n"
+                     << "\tOff-diagonal tolerance: " << mDualLMOffNodeTolerance << "\n";
+        }
+
+        rOStream << "Echo level: " << mEchoLevel << std::endl;
     }
 
     ///@}
@@ -1099,18 +1168,26 @@ protected:
         CreateMatrix(KLMILMI, lm_inactive_size, lm_inactive_size, KLMILMI_ptr, aux_index2_KLMILMI, aux_val_KLMILMI);
         CreateMatrix(KLMALMA, lm_active_size, lm_active_size, KLMALMA_ptr, aux_index2_KLMALMA, aux_val_KLMALMA);
 
+        // The condensation performed below is only legitimate while the mortar operator D is diagonal, which is
+        // exactly what the dual LM formulation buys us. A distorted cut breaks it, so we check it here
+        mOptions.Set(DUAL_LM_IS_VALID, true);
+
         // We compute directly the inverse of the KSALMA matrix
         // KSALMA it is supposed to be a diagonal matrix (in fact it is the key point of this formulation)
         // (NOTE: technically it is not a stiffness matrix, we give that name)
         if (lm_active_size > 0) {
-            ComputeDiagonalByLumping(KSALMA, mKLMAModified, ZeroTolerance);
+            double max_off_node_ratio = 0.0;
+            const SizeType offending_rows = ComputeDiagonalByLumping(KSALMA, mKLMAModified, mSlaveActiveNodeIds, mLMActiveNodeIds, max_off_node_ratio);
+            CheckDualLMCondensation("KSALMA (active LM)", offending_rows, lm_active_size, max_off_node_ratio);
         }
 
         // We compute directly the inverse of the KLMILMI matrix
         // KLMILMI it is supposed to be a diagonal matrix (in fact it is the key point of this formulation)
         // (NOTE: technically it is not a stiffness matrix, we give that name)
         if (lm_inactive_size > 0) {
-            ComputeDiagonalByLumping(KLMILMI, mKLMIModified, ZeroTolerance);
+            double max_off_node_ratio = 0.0;
+            const SizeType offending_rows = ComputeDiagonalByLumping(KLMILMI, mKLMIModified, mLMInactiveNodeIds, mLMInactiveNodeIds, max_off_node_ratio);
+            CheckDualLMCondensation("KLMILMI (inactive LM)", offending_rows, lm_inactive_size, max_off_node_ratio);
         }
 
         // Compute the P and C operators
@@ -1363,6 +1440,14 @@ private:
 
     IndexType mEchoLevel = 0;       /// The echo level of the solver
     IndexType mFileCreated = 0;     /// The index used to identify the file created
+
+    IndexVectorType mSlaveActiveNodeIds;  /// The id of the node each active slave DoF belongs to (local ordering)
+    IndexVectorType mLMActiveNodeIds;     /// The id of the node each active LM DoF belongs to (local ordering)
+    IndexVectorType mLMInactiveNodeIds;   /// The id of the node each inactive LM DoF belongs to (local ordering)
+
+    bool mCheckDualLMCondensation = true;        /// If the validity of the dual LM condensation is checked on each solve
+    double mDualLMZeroRowTolerance = 1.0e-12;    /// Fraction of the block scale below which a row of D is considered structurally empty
+    double mDualLMOffNodeTolerance = 1.0e-6; /// Maximum fraction of a row mass of D allowed to couple a different node
 
     ///@}
     ///@name Private Operators
@@ -1927,57 +2012,126 @@ private:
     }
 
     /**
-     * @brief This method is intended to lump an existing matrix
-     * @param rA The matrix to be lumped
-     * @param rdiagA The resulting matrix
-     * @param Tolerance The tolerance considered to check if the values are almost 0
-     * @todo Improve the lumping in case of not pure diagonal matrix
+     * @brief Evaluates the outcome of a diagonal inversion and invalidates the condensation if needed
+     * @details Logs a warning naming the block, since nothing upstream reports a degenerate mortar cut today.
+     * @param BlockName The name of the block checked, for the log message
+     * @param OffendingRows The number of rows violating the dual LM assumption
+     * @param TotalRows The total number of rows of the block
+     * @param MaxOffNodeRatio The largest fraction of a row mass found on a different node
      */
-    void ComputeDiagonalByLumping (
+    void CheckDualLMCondensation(
+        const std::string& rBlockName,
+        const SizeType OffendingRows,
+        const SizeType TotalRows,
+        const double MaxOffNodeRatio
+        )
+    {
+        if (!mCheckDualLMCondensation || OffendingRows == 0) return;
+
+        mOptions.Set(DUAL_LM_IS_VALID, false);
+
+        KRATOS_WARNING("MixedULMLinearSolver") << "The dual LM condensation is not valid: " << OffendingRows
+            << " of " << TotalRows << " rows of the " << rBlockName << " block couple different nodes (worst off-node ratio: "
+            << MaxOffNodeRatio << ", tolerance: " << mDualLMOffNodeTolerance << "). This usually means the mortar "
+            << "cut is too distorted to build the dual shape functions. The condensed solution would be wrong, so this "
+            << "solver reports failure; wrap it in a FallbackLinearSolver to solve the full system instead." << std::endl;
+    }
+
+    /**
+     * @brief This method inverts the diagonal of an existing matrix, checking that the dual LM assumption holds
+     * @details The condensation performed by this solver is only legitimate while the mortar operator D is
+     * block-diagonal by node, which is exactly what the dual LM formulation buys us: the biorthogonality of the
+     * dual shape functions makes D couple a slave node with its own Lagrange multiplier and with no other node.
+     * When the mortar cut is too distorted the dual shape functions cannot be built
+     * (DualLagrangeMultiplierOperators::CalculateAe falls back to Ae = Identity), the conditions integrate
+     * standard shape functions instead, and D picks up couplings between neighbouring nodes of the slave
+     * element. Condensing regardless would silently produce a wrong solution, so those rows are counted and
+     * reported to the caller.
+     * @note What is measured is the mass coupling DIFFERENT nodes, not the off-diagonal mass of the row. Within
+     * a node the block is only diagonal in the frictionless, axis-aligned case: a frictional formulation writes
+     * the contact contribution in the local normal/tangent basis, which populates the whole nodal sub-block
+     * without breaking duality at all.
+     * @note Structurally empty rows are legitimate and are NOT reported: in a frictionless formulation only the
+     * normal direction is constrained, so the rows of the remaining LM components are empty by construction. For
+     * those the inverse is set to the auxiliary value 1.0, as it has always been done.
+     * @param rA The matrix to be inverted
+     * @param rdiagA The resulting inverted diagonal matrix
+     * @param rRowNodeIds The id of the node each row of rA belongs to
+     * @param rColNodeIds The id of the node each column of rA belongs to
+     * @param rMaxOffNodeRatio Output, the largest fraction of a row mass found on a different node
+     * @return The number of rows violating the dual LM assumption (0 if the condensation is valid)
+     */
+    SizeType ComputeDiagonalByLumping (
         const SparseMatrixType& rA,
         SparseMatrixType& rdiagA,
-        const double Tolerance = ZeroTolerance
+        const IndexVectorType& rRowNodeIds,
+        const IndexVectorType& rColNodeIds,
+        double& rMaxOffNodeRatio
         )
     {
         // Aux values
         const std::size_t size_A = rA.size1();
-//         VectorType diagA_vector(size_A);
-//
-//         // In case of not pure lumped matrix
-//         if (rA.nnz() > size_A) {
-//             // Get access to A data
-//             const std::size_t* index1 = rA.index1_data().begin();
-//             const double* values = rA.value_data().begin();
-//
-//             IndexPartition<std::size_t>(size_A).for_each([&](std::size_t i) {
-//                 const std::size_t row_begin = index1[i];
-//                 const std::size_t row_end   = index1[i+1];
-//                 double temp = 0.0;
-//                 for (std::size_t j=row_begin; j<row_end; j++)
-//                     temp += values[j]*values[j];
-//
-//                 diagA_vector[i] = std::sqrt(temp);
-//             });
-//         } else { // Otherwise
-//             IndexPartition<std::size_t>(size_A).for_each([&](std::size_t i) {
-//                 diagA_vector[i] = rA(i, i);
-//             });
-//         }
+
+        // Get access to A data
+        const std::size_t* index1 = rA.index1_data().begin();
+        const std::size_t* index2 = rA.index2_data().begin();
+        const double* values = rA.value_data().begin();
 
         IndexType* ptr = new IndexType[size_A + 1];
         ptr[0] = 0;
         IndexType* aux_index2 = new IndexType[size_A];
         double* aux_val = new double[size_A];
 
-        IndexPartition<std::size_t>(size_A).for_each([&](std::size_t i) {
+        // The scale of the block, used to tell a structurally empty row from a populated one
+        const double max_row_sum = IndexPartition<std::size_t>(size_A).for_each<MaxReduction<double>>([&](std::size_t i) {
+            double row_sum = 0.0;
+            for (std::size_t j = index1[i]; j < index1[i+1]; ++j) {
+                row_sum += std::abs(values[j]);
+            }
+            return row_sum;
+        });
+        const double empty_row_tolerance = mDualLMZeroRowTolerance * max_row_sum;
+
+        // The diagonal is inverted while, at the same time, every row is checked against the dual LM assumption
+        SizeType number_of_offending_rows = 0;
+        double max_off_node_ratio = 0.0;
+        using TwoReduction = CombinedReduction<SumReduction<SizeType>, MaxReduction<double>>;
+        std::tie(number_of_offending_rows, max_off_node_ratio) = IndexPartition<std::size_t>(size_A).for_each<TwoReduction>([&](std::size_t i) {
             ptr[i+1] = i+1;
             aux_index2[i] = i;
-            const double value = rA(i, i);
-//             const double value = diagA_vector[i];
-            if (std::abs(value) > Tolerance)
-                aux_val[i] = 1.0/value;
-            else // Auxiliary value
+
+            // Accumulate the mass of the row, splitting what belongs to this very node from what does not
+            const IndexType row_node_id = rRowNodeIds[i];
+            double diagonal_value = 0.0;
+            double row_sum = 0.0;
+            double off_node_sum = 0.0;
+            for (std::size_t j = index1[i]; j < index1[i+1]; ++j) {
+                const std::size_t column = index2[j];
+                const double abs_value = std::abs(values[j]);
+                row_sum += abs_value;
+                if (column == i) diagonal_value = values[j];
+                if (rColNodeIds[column] != row_node_id) off_node_sum += abs_value;
+            }
+            const double abs_diagonal_value = std::abs(diagonal_value);
+
+            // Invert the diagonal (the auxiliary value keeps the legacy behaviour for degenerate entries)
+            if (abs_diagonal_value > ZeroTolerance) {
+                aux_val[i] = 1.0/diagonal_value;
+            } else { // Auxiliary value
                 aux_val[i] = 1.0;
+            }
+
+            // An empty row carries no constraint at all, so there is nothing to condense and nothing to check
+            if (row_sum <= empty_row_tolerance) {
+                return std::make_tuple(static_cast<SizeType>(0), 0.0);
+            }
+
+            // The fraction of the row mass coupling a different node. It is zero for a truly dual LM formulation
+            // and grows as the mortar cut degenerates
+            const double off_node_ratio = off_node_sum/row_sum;
+            const SizeType is_offending = (off_node_ratio > mDualLMOffNodeTolerance) ? 1 : 0;
+
+            return std::make_tuple(is_offending, off_node_ratio);
         });
 
         SparseMatrixMultiplicationUtility::CreateSolutionMatrix(rdiagA, size_A, size_A, ptr, aux_index2, aux_val);
@@ -1985,6 +2139,9 @@ private:
         delete[] ptr;
         delete[] aux_index2;
         delete[] aux_val;
+
+        rMaxOffNodeRatio = max_off_node_ratio;
+        return number_of_offending_rows;
     }
 
     /**
@@ -2030,10 +2187,13 @@ private:
     {
         Parameters default_parameters( R"(
         {
-            "solver_type"          : "mixed_ulm_linear_solver",
-            "tolerance"            : 1.0e-6,
-            "max_iteration_number" : 200,
-            "echo_level"           : 0
+            "solver_type"                    : "mixed_ulm_linear_solver",
+            "tolerance"                      : 1.0e-6,
+            "max_iteration_number"           : 200,
+            "check_dual_lm_condensation"     : true,
+            "dual_lm_zero_row_tolerance"     : 1.0e-12,
+            "dual_lm_off_node_tolerance" : 1.0e-6,
+            "echo_level"                     : 0
         }  )" );
 
         return default_parameters;
@@ -2059,6 +2219,8 @@ template<class TSparseSpaceType, class TDenseSpaceType, class TPreconditionerTyp
 const Kratos::Flags MixedULMLinearSolver<TSparseSpaceType, TDenseSpaceType,TPreconditionerType, TReordererType>::BLOCKS_ARE_ALLOCATED(Kratos::Flags::Create(0));
 template<class TSparseSpaceType, class TDenseSpaceType, class TPreconditionerType, class TReordererType>
 const Kratos::Flags MixedULMLinearSolver<TSparseSpaceType, TDenseSpaceType,TPreconditionerType, TReordererType>::IS_INITIALIZED(Kratos::Flags::Create(1));
+template<class TSparseSpaceType, class TDenseSpaceType, class TPreconditionerType, class TReordererType>
+const Kratos::Flags MixedULMLinearSolver<TSparseSpaceType, TDenseSpaceType,TPreconditionerType, TReordererType>::DUAL_LM_IS_VALID(Kratos::Flags::Create(2));
 
 ///@}
 ///@name Input and output

--- a/applications/ContactStructuralMechanicsApplication/python_scripts/auxiliary_methods_solvers.py
+++ b/applications/ContactStructuralMechanicsApplication/python_scripts/auxiliary_methods_solvers.py
@@ -1,6 +1,7 @@
 # Importing the Kratos Library
 import KratosMultiphysics as KM
 import KratosMultiphysics.ContactStructuralMechanicsApplication as CSMA
+from KratosMultiphysics import python_linear_solver_factory
 
 # Import sys
 import sys
@@ -44,12 +45,16 @@ def  AuxiliaryContactSettings():
             "simplified_semi_smooth_newton"                           : false,
             "rescale_linear_solver"                                   : false,
             "use_mixed_ulm_solver"                                    : true,
+            "fallback_if_dual_lm_not_valid"                           : true,
             "mixed_ulm_solver_parameters" :
             {
-                "solver_type"          : "mixed_ulm_linear_solver",
-                "tolerance"            : 1.0e-6,
-                "max_iteration_number" : 200,
-                "echo_level"           : 0
+                "solver_type"                    : "mixed_ulm_linear_solver",
+                "tolerance"                      : 1.0e-6,
+                "max_iteration_number"           : 200,
+                "echo_level"                     : 0,
+                "check_dual_lm_condensation"     : true,
+                "dual_lm_zero_row_tolerance"     : 1.0e-12,
+                "dual_lm_off_node_tolerance" : 1.0e-6
             }
         }
     }
@@ -266,7 +271,30 @@ def  AuxiliaryCreateLinearSolver(main_model_part, settings, contact_settings, li
                             linear_solver_settings.RecursivelyValidateAndAssignDefaults(amgcl_param)
                             linear_solver = KM.AMGCLSolver(linear_solver_settings)
                     mixed_ulm_solver = CSMA.MixedULMLinearSolver(linear_solver, contact_settings["mixed_ulm_solver_parameters"])
-                    return mixed_ulm_solver
+                    if not contact_settings["fallback_if_dual_lm_not_valid"].GetBool():
+                        return mixed_ulm_solver
+                    if not linear_solver_settings.Has("solver_type"):
+                        KM.Logger.PrintWarning("::[Contact Mechanical Solver]:: ", "No solver_type defined in linear_solver_settings, cannot build the fallback solver. Using the MixedULMLinearSolver alone")
+                        return mixed_ulm_solver
+                    # The condensation performed by the MixedULMLinearSolver is only valid while the mortar
+                    # operator D couples each slave node with its own Lagrange multiplier and with no other node,
+                    # which stops being true when the mortar cut is too distorted to build the dual shape
+                    # functions. In that case the solver reports failure and this wrapper re-solves the full,
+                    # non-condensed system with a regular linear solver.
+                    # NOTE: a fresh solver instance is required, linear_solver is already owned by mixed_ulm_solver
+                    # as its displacement-block solver and is driven with block-sized matrices
+                    fallback_solver = python_linear_solver_factory.ConstructSolver(linear_solver_settings)
+                    if contact_settings["rescale_linear_solver"].GetBool():
+                        fallback_solver = KM.ScalingSolver(fallback_solver, False)
+                    # reset_solver_each_try is required: the active set changes between iterations, so a cut that
+                    # is degenerate now may well be fine on the next solve
+                    fallback_parameters = KM.Parameters("""
+                    {
+                        "solver_type"           : "fallback_linear_solver",
+                        "reset_solver_each_try" : true
+                    }
+                    """)
+                    return KM.FallbackLinearSolver([mixed_ulm_solver, fallback_solver], fallback_parameters)
                 else:
                     return linear_solver
             else:

--- a/applications/ContactStructuralMechanicsApplication/tests/cpp_tests/linear_solvers/test_mixedulm_linear_solver.cpp
+++ b/applications/ContactStructuralMechanicsApplication/tests/cpp_tests/linear_solvers/test_mixedulm_linear_solver.cpp
@@ -32,6 +32,7 @@
 #include "linear_solvers/linear_solver.h"
 #include "linear_solvers/skyline_lu_factorization_solver.h"
 #include "linear_solvers/amgcl_solver.h"
+#include "linear_solvers/fallback_linear_solver.h"
 #include "custom_linear_solvers/mixedulm_linear_solver.h"
 
 namespace Kratos::Testing
@@ -48,6 +49,7 @@ using AMGCLSolverType = AMGCLSolver<SparseSpaceType, LocalSpaceType>;
 using SkylineLUFactorizationSolverType = SkylineLUFactorizationSolver<SparseSpaceType, LocalSpaceType, ReordererType>;
 using PreconditionerType = Preconditioner<SparseSpaceType, LocalSpaceType>;
 using MixedULMLinearSolverType = MixedULMLinearSolver<SparseSpaceType, LocalSpaceType, PreconditionerType, ReordererType>;
+using FallbackLinearSolverType = FallbackLinearSolver<SparseSpaceType, LocalSpaceType, ReordererType>;
 
 // Dof arrays
 using DofsArrayType = ModelPart::DofsArrayType;
@@ -1009,4 +1011,274 @@ KRATOS_TEST_CASE_IN_SUITE(MixedULMLinearSolverRealSystem, KratosContactStructura
         KRATOS_EXPECT_VECTOR_NEAR(Dx, ref_Dx, tolerance);
     }
 }
+
+/**
+* @brief Sets up the model part of the real system used by the dual LM validity tests
+* @details Same layout as MixedULMLinearSolverRealSystem: nodes 2 and 3 are active slaves carrying the LM,
+* nodes 4 and 5 are masters. The resulting DoF set is returned through rDoFs/rDofTemp.
+*/
+void SetUpRealSystemModelPart(
+    ModelPart& rModelPart,
+    std::vector<Dof<double>::Pointer>& rDoFs,
+    DofsArrayType& rDofTemp
+    )
+{
+    rModelPart.AddNodalSolutionStepVariable(DISPLACEMENT);
+    rModelPart.AddNodalSolutionStepVariable(VECTOR_LAGRANGE_MULTIPLIER);
+
+    Node::Pointer pnode1 = rModelPart.CreateNewNode(1, 0.0, 0.0, 0.0);
+    Node::Pointer pnode2 = rModelPart.CreateNewNode(2, 0.0, 0.0, 0.0);
+    pnode2->Set(INTERFACE, true);
+    pnode2->Set(ACTIVE, true);
+    pnode2->Set(MASTER, false);
+    pnode2->Set(SLAVE, true);
+    Node::Pointer pnode3 = rModelPart.CreateNewNode(3, 0.0, 0.0, 0.0);
+    pnode3->Set(INTERFACE, true);
+    pnode3->Set(ACTIVE, true);
+    pnode3->Set(MASTER, false);
+    pnode3->Set(SLAVE, true);
+    Node::Pointer pnode4 = rModelPart.CreateNewNode(4, 0.0, 0.0, 0.0);
+    pnode4->Set(INTERFACE, true);
+    pnode4->Set(MASTER, true);
+    pnode4->Set(SLAVE, false);
+    Node::Pointer pnode5 = rModelPart.CreateNewNode(5, 0.0, 0.0, 0.0);
+    pnode5->Set(INTERFACE, true);
+    pnode5->Set(MASTER, true);
+    pnode5->Set(SLAVE, false);
+    Node::Pointer pnode6 = rModelPart.CreateNewNode(6, 0.0, 0.0, 0.0);
+
+    pnode1->AddDof(DISPLACEMENT_X);
+    pnode1->AddDof(DISPLACEMENT_Y);
+    pnode2->AddDof(DISPLACEMENT_X);
+    pnode2->AddDof(DISPLACEMENT_Y);
+    pnode2->AddDof(VECTOR_LAGRANGE_MULTIPLIER_X);
+    pnode2->AddDof(VECTOR_LAGRANGE_MULTIPLIER_Y);
+    pnode3->AddDof(DISPLACEMENT_X);
+    pnode3->AddDof(DISPLACEMENT_Y);
+    pnode3->AddDof(VECTOR_LAGRANGE_MULTIPLIER_X);
+    pnode3->AddDof(VECTOR_LAGRANGE_MULTIPLIER_Y);
+    pnode4->AddDof(DISPLACEMENT_X);
+    pnode4->AddDof(DISPLACEMENT_Y);
+    pnode5->AddDof(DISPLACEMENT_X);
+    pnode5->AddDof(DISPLACEMENT_Y);
+    pnode6->AddDof(DISPLACEMENT_X);
+    pnode6->AddDof(DISPLACEMENT_Y);
+
+    rDoFs.reserve(16);
+    rDoFs.push_back(pnode1->pGetDof(DISPLACEMENT_X));
+    rDoFs.push_back(pnode1->pGetDof(DISPLACEMENT_Y));
+    rDoFs.push_back(pnode2->pGetDof(DISPLACEMENT_X));
+    rDoFs.push_back(pnode2->pGetDof(DISPLACEMENT_Y));
+    rDoFs.push_back(pnode2->pGetDof(VECTOR_LAGRANGE_MULTIPLIER_X));
+    rDoFs.push_back(pnode2->pGetDof(VECTOR_LAGRANGE_MULTIPLIER_Y));
+    rDoFs.push_back(pnode3->pGetDof(DISPLACEMENT_X));
+    rDoFs.push_back(pnode3->pGetDof(DISPLACEMENT_Y));
+    rDoFs.push_back(pnode3->pGetDof(VECTOR_LAGRANGE_MULTIPLIER_X));
+    rDoFs.push_back(pnode3->pGetDof(VECTOR_LAGRANGE_MULTIPLIER_Y));
+    rDoFs.push_back(pnode4->pGetDof(DISPLACEMENT_X));
+    rDoFs.push_back(pnode4->pGetDof(DISPLACEMENT_Y));
+    rDoFs.push_back(pnode5->pGetDof(DISPLACEMENT_X));
+    rDoFs.push_back(pnode5->pGetDof(DISPLACEMENT_Y));
+    rDoFs.push_back(pnode6->pGetDof(DISPLACEMENT_X));
+    rDoFs.push_back(pnode6->pGetDof(DISPLACEMENT_Y));
+
+    // Set initial solution
+    (pnode1->FastGetSolutionStepValue(DISPLACEMENT)).clear();
+    (pnode2->FastGetSolutionStepValue(DISPLACEMENT)).clear();
+    (pnode2->FastGetSolutionStepValue(VECTOR_LAGRANGE_MULTIPLIER)).clear();
+    (pnode3->FastGetSolutionStepValue(DISPLACEMENT)).clear();
+    (pnode3->FastGetSolutionStepValue(VECTOR_LAGRANGE_MULTIPLIER)).clear();
+    (pnode4->FastGetSolutionStepValue(DISPLACEMENT)).clear();
+    (pnode5->FastGetSolutionStepValue(DISPLACEMENT)).clear();
+    (pnode6->FastGetSolutionStepValue(DISPLACEMENT)).clear();
+
+    rDofTemp.reserve(rDoFs.size());
+    for (auto it = rDoFs.begin(); it != rDoFs.end(); it++)
+        rDofTemp.push_back( *it );
+}
+
+/**
+* @brief Reads the real system dumped from an actual contact problem
+* @return True if both the matrix and the vector could be read
+*/
+bool ReadRealSystem(
+    CompressedMatrix& rA,
+    Vector& rB
+    )
+{
+    CreateAuxiliaryFiles();
+    std::filesystem::path file_path_a = std::filesystem::current_path() / "A_testing_condensation.mm";
+    const bool read_a = Kratos::ReadMatrixMarketMatrix(file_path_a.string().c_str(), rA);
+    std::filesystem::path file_path_b = std::filesystem::current_path() / "b_testing_condensation.rhs";
+    const bool read_b = Kratos::ReadMatrixMarketVector(file_path_b.string().c_str(), rB);
+
+    // Removing files
+    std::filesystem::remove(file_path_a);
+    std::filesystem::remove(file_path_b);
+
+    return read_a && read_b;
+}
+
+/**
+* @brief Breaks the duality of the mortar operator D of the real system
+* @details Global DoF 7 (the Y displacement of the active slave node 3) is coupled with global DoF 5 (the Y
+* Lagrange multiplier of the active slave node 2). In the dual LM formulation the biorthogonality of the dual
+* shape functions makes D couple a node only with its OWN Lagrange multiplier, so a coupling between two
+* different nodes is exactly what appears when the mortar cut is too distorted for the dual shape functions to be
+* built and Ae falls back to the identity. Note this is not the same as the nodal sub-block being non diagonal,
+* which happens legitimately in a frictional formulation. Both entries already exist in the sparsity pattern
+* (stored as explicit zeros), so no reallocation takes place.
+*/
+void BreakDualLagrangeMultiplier(CompressedMatrix& rA)
+{
+    constexpr double off_diagonal_value = -5.0e10; // Roughly half of the diagonal entry, -1.0345e+11
+    rA(7, 5) = off_diagonal_value;
+    rA(5, 7) = off_diagonal_value;
+}
+
+/**
+* Checks that the MixedULM solver reports success, and a valid condensation, on a well posed dual LM system
+*/
+KRATOS_TEST_CASE_IN_SUITE(MixedULMLinearSolverValidDualLM, KratosContactStructuralMechanicsFastSuite)
+{
+    Model this_model;
+    ModelPart& r_model_part = this_model.CreateModelPart("Main", 3);
+
+    LinearSolverType::Pointer psolver = LinearSolverType::Pointer( new SkylineLUFactorizationSolverType() );
+    MixedULMLinearSolverType::Pointer pmixed_solver = Kratos::make_shared<MixedULMLinearSolverType>(psolver);
+
+    std::vector< Dof<double>::Pointer > DoF;
+    DofsArrayType Doftemp;
+    SetUpRealSystemModelPart(r_model_part, DoF, Doftemp);
+
+    const std::size_t system_size = 16;
+    CompressedMatrix A(system_size, system_size);
+    Vector Dx = ZeroVector(system_size);
+    Vector b = ZeroVector(system_size);
+
+    if (ReadRealSystem(A, b)) {
+        pmixed_solver->ProvideAdditionalData(A, Dx, b, Doftemp, r_model_part);
+        const bool solved = pmixed_solver->Solve(A, Dx, b);
+
+        // The system comes from an actual contact problem, so the condensation must hold
+        KRATOS_EXPECT_TRUE(pmixed_solver->IsDualLMValid());
+        KRATOS_EXPECT_TRUE(solved);
+    }
+}
+
+/**
+* Checks that the MixedULM solver detects a mortar operator D that is no longer diagonal and reports failure
+*/
+KRATOS_TEST_CASE_IN_SUITE(MixedULMLinearSolverDetectsBrokenDualLM, KratosContactStructuralMechanicsFastSuite)
+{
+    Model this_model;
+    ModelPart& r_model_part = this_model.CreateModelPart("Main", 3);
+
+    LinearSolverType::Pointer psolver = LinearSolverType::Pointer( new SkylineLUFactorizationSolverType() );
+    MixedULMLinearSolverType::Pointer pmixed_solver = Kratos::make_shared<MixedULMLinearSolverType>(psolver);
+
+    std::vector< Dof<double>::Pointer > DoF;
+    DofsArrayType Doftemp;
+    SetUpRealSystemModelPart(r_model_part, DoF, Doftemp);
+
+    const std::size_t system_size = 16;
+    CompressedMatrix A(system_size, system_size);
+    Vector Dx = ZeroVector(system_size);
+    Vector b = ZeroVector(system_size);
+
+    if (ReadRealSystem(A, b)) {
+        BreakDualLagrangeMultiplier(A);
+
+        pmixed_solver->ProvideAdditionalData(A, Dx, b, Doftemp, r_model_part);
+        const bool solved = pmixed_solver->Solve(A, Dx, b);
+
+        // The condensation does not hold any more, so the solver must say so instead of returning garbage
+        KRATOS_EXPECT_FALSE(pmixed_solver->IsDualLMValid());
+        KRATOS_EXPECT_FALSE(solved);
+
+        // No solution may have been written, otherwise a wrong result would silently be used
+        KRATOS_EXPECT_VECTOR_NEAR(Dx, ZeroVector(system_size), std::numeric_limits<double>::epsilon());
+    }
+}
+
+/**
+* Checks that the check can be switched off, recovering the legacy behaviour
+*/
+KRATOS_TEST_CASE_IN_SUITE(MixedULMLinearSolverBrokenDualLMCheckDisabled, KratosContactStructuralMechanicsFastSuite)
+{
+    Model this_model;
+    ModelPart& r_model_part = this_model.CreateModelPart("Main", 3);
+
+    Parameters parameters = Parameters(R"({"check_dual_lm_condensation" : false})");
+    LinearSolverType::Pointer psolver = LinearSolverType::Pointer( new SkylineLUFactorizationSolverType() );
+    MixedULMLinearSolverType::Pointer pmixed_solver = Kratos::make_shared<MixedULMLinearSolverType>(psolver, parameters);
+
+    std::vector< Dof<double>::Pointer > DoF;
+    DofsArrayType Doftemp;
+    SetUpRealSystemModelPart(r_model_part, DoF, Doftemp);
+
+    const std::size_t system_size = 16;
+    CompressedMatrix A(system_size, system_size);
+    Vector Dx = ZeroVector(system_size);
+    Vector b = ZeroVector(system_size);
+
+    if (ReadRealSystem(A, b)) {
+        BreakDualLagrangeMultiplier(A);
+
+        pmixed_solver->ProvideAdditionalData(A, Dx, b, Doftemp, r_model_part);
+        pmixed_solver->Solve(A, Dx, b);
+
+        // The check is disabled, so the condensation is performed regardless
+        KRATOS_EXPECT_TRUE(pmixed_solver->IsDualLMValid());
+    }
+}
+
+/**
+* Checks that a FallbackLinearSolver recovers the right solution when the dual LM condensation is not valid
+*/
+KRATOS_TEST_CASE_IN_SUITE(MixedULMLinearSolverFallback, KratosContactStructuralMechanicsFastSuite)
+{
+    constexpr double tolerance = 1e-3;
+
+    Model this_model;
+    ModelPart& r_model_part = this_model.CreateModelPart("Main", 3);
+
+    LinearSolverType::Pointer psolver = LinearSolverType::Pointer( new SkylineLUFactorizationSolverType() );
+    MixedULMLinearSolverType::Pointer pmixed_solver = Kratos::make_shared<MixedULMLinearSolverType>(psolver);
+
+    // The fallback solver must be an independent instance, psolver is already owned by the mixed solver
+    LinearSolverType::Pointer pfallback_solver = LinearSolverType::Pointer( new SkylineLUFactorizationSolverType() );
+
+    // reset_solver_each_try is what makes the condensation be retried on every solve
+    Parameters fallback_parameters = Parameters(R"({"reset_solver_each_try" : true})");
+    std::vector<LinearSolverType::Pointer> solvers = {pmixed_solver, pfallback_solver};
+    FallbackLinearSolverType fallback_solver(solvers, fallback_parameters);
+
+    std::vector< Dof<double>::Pointer > DoF;
+    DofsArrayType Doftemp;
+    SetUpRealSystemModelPart(r_model_part, DoF, Doftemp);
+
+    const std::size_t system_size = 16;
+    CompressedMatrix A(system_size, system_size);
+    Vector ref_Dx = ZeroVector(system_size);
+    Vector Dx = ZeroVector(system_size);
+    Vector b = ZeroVector(system_size);
+
+    if (ReadRealSystem(A, b)) {
+        BreakDualLagrangeMultiplier(A);
+
+        // The reference solution of the full, non-condensed system
+        LinearSolverType::Pointer preference_solver = LinearSolverType::Pointer( new SkylineLUFactorizationSolverType() );
+        preference_solver->Solve(A, ref_Dx, b);
+
+        fallback_solver.ProvideAdditionalData(A, Dx, b, Doftemp, r_model_part);
+        const bool solved = fallback_solver.Solve(A, Dx, b);
+
+        // The mixed solver rejects the system, so the second solver of the list is the one that solves it
+        KRATOS_EXPECT_TRUE(solved);
+        KRATOS_EXPECT_EQ(fallback_solver.GetCurrentSolverIndex(), 1);
+        KRATOS_EXPECT_VECTOR_RELATIVE_NEAR(Dx, ref_Dx, tolerance);
+    }
+}
+
 } // namespace Kratos::Testing

--- a/applications/ContactStructuralMechanicsApplication/tests/cpp_tests/linear_solvers/test_mixedulm_linear_solver.cpp
+++ b/applications/ContactStructuralMechanicsApplication/tests/cpp_tests/linear_solvers/test_mixedulm_linear_solver.cpp
@@ -1197,7 +1197,8 @@ KRATOS_TEST_CASE_IN_SUITE(MixedULMLinearSolverDetectsBrokenDualLM, KratosContact
         KRATOS_EXPECT_FALSE(solved);
 
         // No solution may have been written, otherwise a wrong result would silently be used
-        KRATOS_EXPECT_VECTOR_NEAR(Dx, ZeroVector(system_size), std::numeric_limits<double>::epsilon());
+        const Vector zero_reference = ZeroVector(system_size);
+        KRATOS_EXPECT_VECTOR_NEAR(Dx, zero_reference, std::numeric_limits<double>::epsilon());
     }
 }
 

--- a/kratos/linear_solvers/fallback_linear_solver.h
+++ b/kratos/linear_solvers/fallback_linear_solver.h
@@ -279,6 +279,9 @@ public:
                 // First, update the counter
                 UpdateSolverIndex();
 
+                // If all the solvers have been tried there is nothing else to do
+                if (mCurrentSolverIndex >= mSolvers.size()) break;
+
                 // Call initialize methods
                 InitializeSolutionStep(rA, rX, rB);
 
@@ -316,6 +319,9 @@ public:
             if (!success) {
                 // First, update the counter
                 UpdateSolverIndex();
+
+                // If all the solvers have been tried there is nothing else to do
+                if (mCurrentSolverIndex >= mSolvers.size()) break;
 
                 // // Call initialize methods (NOTE: does not exist the method for dense matrices)
                 // InitializeSolutionStep(rA, rX, rB);
@@ -729,7 +735,8 @@ protected:
         if (mCurrentSolverIndex < mSolvers.size()) {
             KRATOS_INFO("FallbackLinearSolver") << "Current solver " << GetCurrentSolver()->Info() << " failed with the following settings: " << mParameters["solvers"][mCurrentSolverIndex].PrettyPrintJsonString() << std::endl;
         } else {
-            KRATOS_WARNING("FallbackLinearSolver") << "Solver index cannot be updated as all potential linear solvers has been already tried. Sticking to current solver "  << GetCurrentSolver()->Info() << std::endl;
+            // NOTE: GetCurrentSolver() cannot be called here, the index is already out of range
+            KRATOS_WARNING("FallbackLinearSolver") << "Solver index cannot be updated as all the " << mSolvers.size() << " potential linear solvers have been already tried" << std::endl;
             return;
         }
 
@@ -740,7 +747,8 @@ protected:
         if (mCurrentSolverIndex < mSolvers.size()) {
             KRATOS_INFO("FallbackLinearSolver") << "Switching to new solver " << GetCurrentSolver()->Info() << " with the following settings: " << mParameters["solvers"][mCurrentSolverIndex].PrettyPrintJsonString() << std::endl;
         } else {
-            KRATOS_WARNING("FallbackLinearSolver") << "Solver index cannot be updated as all potential linear solvers has been already tried. Sticking to current solver "  << GetCurrentSolver()->Info() << std::endl;
+            // NOTE: GetCurrentSolver() cannot be called here, the index is already out of range
+            KRATOS_WARNING("FallbackLinearSolver") << "All the " << mSolvers.size() << " potential linear solvers have been already tried and all of them failed" << std::endl;
             return;
         }
     }

--- a/kratos/tests/cpp_tests/linear_solvers/test_fallback_linear_solver.cpp
+++ b/kratos/tests/cpp_tests/linear_solvers/test_fallback_linear_solver.cpp
@@ -177,4 +177,32 @@ KRATOS_TEST_CASE_IN_SUITE(FallbackLinearSolverConstructorParameters, KratosCoreF
     KRATOS_EXPECT_EQ(simple_fallback_solver.GetCurrentSolverIndex(), 0);
 }
 
+KRATOS_TEST_CASE_IN_SUITE(FallbackLinearSolverAllSolversFail, KratosCoreFastSuite)
+{
+    // Create the solvers, none of which can solve anything
+    auto p_solver1 = Kratos::make_shared<DummyLinearSolverType>();
+    auto p_solver2 = Kratos::make_shared<DummyLinearSolverType>();
+
+    // Create the matrix and vectors
+    const std::size_t size = 3;
+    SparseMatrixType A(size, size);
+    // Push back 1.0 in the diagonal
+    for (std::size_t i = 0; i < size; ++i) {
+        A.push_back(i, i, 1.0);
+    }
+    A.set_filled(size + 1, size);
+    VectorType b = ZeroVector(size);
+    VectorType x = ZeroVector(size);
+
+    // Create a simple fallback solver
+    std::vector<LinearSolverType::Pointer> solvers = {p_solver1, p_solver2};
+    FallbackLinearSolverType simple_fallback_solver(solvers);
+
+    // Exhausting the list must be reported as a failure, not throw
+    const auto solved = simple_fallback_solver.Solve(A, x, b);
+
+    // Check that the system was not solved
+    KRATOS_EXPECT_FALSE(solved);
+}
+
 } // namespace Kratos::Testing


### PR DESCRIPTION
## **📝 Description**

<img width="1105" height="840" alt="image" src="https://github.com/user-attachments/assets/2f996bcc-a250-42bc-9cad-64b2d0e24892" />

`MixedULMLinearSolver` condenses the Lagrange multipliers out of the contact system. That condensation is only legitimate because the dual LM formulation makes the mortar operator `D` block-diagonal *by node* — the solver inverts it by taking reciprocals of the diagonal in `ComputeDiagonalByLumping`.

When the mortar cut is too distorted, `DualLagrangeMultiplierOperators::CalculateAe` finds `Me` ill-conditioned and returns `false` with `Ae = Identity`. The conditions then integrate standard shape functions instead of dual ones, `D` picks up couplings between neighbouring slave nodes, and **the condensation silently produces a wrong solution**.

Nothing reported this today. All three places where the situation is detected are silent: `CheckConditionNumber` is called with its verbose flag off, the "bad shape" warning in `MortarUtilities::HeronCheck` is commented out, and `ComputeDiagonalByLumping` silently substitutes `1.0` for a degenerate diagonal entry.

This PR detects the situation, reports it, and lets a `FallbackLinearSolver` re-solve the full non-condensed system with a regular linear solver.

### **Key changes**

**Detection (`mixedulm_linear_solver.h`).** `ComputeDiagonalByLumping` now measures, per row of the `KSALMA`/`KLMILMI` blocks, the fraction of the row mass that couples a **different node**. Offending rows clear a new `DUAL_LM_IS_VALID` local flag and emit a warning naming the block, the number of offending rows and the worst ratio. `ProvideAdditionalData` now also records the node each active/inactive LM and active slave DoF belongs to, which is what makes the check node-aware.

Two things the check deliberately does *not* flag:

- **Nodal sub-blocks that are not diagonal.** A frictional formulation writes the contact contribution in the local normal/tangent basis, which populates the whole nodal sub-block without breaking duality at all. Only inter-node coupling indicates a degenerate cut.
- **Structurally empty rows.** In a frictionless formulation only the normal direction is constrained, so the rows of the remaining LM components are empty by construction; the `1.0` substitution for those is deliberate, not an error path.

**Honest failure reporting (`mixedulm_linear_solver.h`) ¯\_(ツ)_/¯.** `Solve` and `PerformSolutionStep` returned `false` unconditionally, and `PerformSolutionStep` discarded the return of the displacement-block solve. They now return the real outcome. `Solve` bails out before `PerformSolutionStep` when the condensation is invalid, so no knowingly-wrong solution is written into `rX`.

**Fallback wiring (`auxiliary_methods_solvers.py`).** When `use_mixed_ulm_solver` is on, the mixed solver is returned wrapped in `FallbackLinearSolver([mixed_ulm, plain_solver])` with `reset_solver_each_try: true`, behind a new `fallback_if_dual_lm_not_valid` setting (default `true`). The second solver is a **fresh instance** built from `linear_solver_settings` — reusing the existing one would corrupt it, since the mixed solver already owns it as its displacement-block solver and drives it with block-sized matrices. `reset_solver_each_try` matters: the active set changes between iterations, so a cut that is degenerate now may well be fine on the next solve.

**Two pre-existing `FallbackLinearSolver` bugs (`fallback_linear_solver.h`).** Whenever the *last* solver in the list failed, `UpdateSolverIndex` called `GetCurrentSolver()` with an out-of-range index, throwing `Invalid solver index` instead of returning `false`; `Solve` then also indexed `mRequiresAdditionalData` out of bounds. Both overloads now stop once the list is exhausted.

**`PrintData`** of `MixedULMLinearSolver` was empty; it now reports the inner solver, the six block sizes, the allocation/initialisation state, the condensation validity with its tolerances, and the echo level.

New settings, all with backward-compatible defaults (`check_dual_lm_condensation: false` restores the previous behaviour exactly):

| Setting                                                  | Default   |
| -------------------------------------------------------- | --------- |
| `contact_settings.fallback_if_dual_lm_not_valid`         | `true`    |
| `mixed_ulm_solver_parameters.check_dual_lm_condensation` | `true`    |
| `mixed_ulm_solver_parameters.dual_lm_zero_row_tolerance` | `1.0e-12` |
| `mixed_ulm_solver_parameters.dual_lm_off_node_tolerance` | `1.0e-6`  |

### **Validation**

New C++ tests in `test_mixedulm_linear_solver.cpp`, built on the existing real system dumped from an actual contact problem:

- `MixedULMLinearSolverValidDualLM` — the untouched real system reports success and a valid condensation.
- `MixedULMLinearSolverDetectsBrokenDualLM` — a coupling introduced between one node's displacement and another node's multiplier is detected; `Solve` returns `false` and leaves `rX` untouched.
- `MixedULMLinearSolverBrokenDualLMCheckDisabled` — `check_dual_lm_condensation: false` recovers the legacy behaviour.
- `MixedULMLinearSolverFallback` — the same broken system wrapped in a `FallbackLinearSolver` recovers the reference direct solution and ends on solver index 1.

New `FallbackLinearSolverAllSolversFail` in `test_fallback_linear_solver.cpp` covers the exhaustion fix; it was confirmed to throw `Invalid solver index: 2` without it.

Suites run locally:

```
KratosContactStructuralMechanicsCoreTest         95/95 pass
KratosCoreTest                                   1612 pass, 4 pre-existing skips
test_ContactStructuralMechanicsApplication -l small     39/39 pass
test_ContactStructuralMechanicsApplication -l nightly   85/85 pass
```

The feature also fires on a real case in the existing suite: `ComponentsALMThreeDSimplestPatchTestQuadTriContact` (3D quad-to-tri non-matching patch) trips the check on its first iteration, falls back to the full solve, and resumes the condensed solve on later iterations — the test still passes.

> Note for reviewers: an earlier iteration of this check used scalar diagonality of `D` and broke `ALMStaticEvolutionLoadFrictionTestContact` (verified passing on `master`), because in that frictional case the nodal sub-block legitimately carries a 0.56 off-diagonal ratio. That is what motivated the node-aware criterion.

## **🆕 Changelog**

- Added detection of an invalid dual LM condensation in `MixedULMLinearSolver`, exposed through the new `DUAL_LM_IS_VALID` flag and the `IsDualLMValid()` accessor
- Added `check_dual_lm_condensation`, `dual_lm_zero_row_tolerance` and `dual_lm_off_node_tolerance` to the `MixedULMLinearSolver` parameters
- Added `fallback_if_dual_lm_not_valid` contact setting, wrapping the mixed solver in a `FallbackLinearSolver` so the full system is re-solved when the condensation does not hold
- Fixed `MixedULMLinearSolver::Solve` and `PerformSolutionStep` always returning `false` and ignoring the displacement-block solver result
- Fixed `FallbackLinearSolver` throwing `Invalid solver index` instead of reporting failure when all solvers have been tried
- Extended `MixedULMLinearSolver::PrintData`, which was empty