### PR TITLE
[DamApplication] Use reference geometry in SmallDisplacementInterfaceElement

### DIFF
--- a/applications/DamApplication/custom_elements/small_displacement_interface_element.cpp
+++ b/applications/DamApplication/custom_elements/small_displacement_interface_element.cpp
@@ -33,6 +33,7 @@ void SmallDisplacementInterfaceElement<TDim,TNumNodes>::Initialize(const Process
 
     const PropertiesType& Prop = this->GetProperties();
     const GeometryType& Geom = this->GetGeometry();
+    GeometryType::Pointer p_reference_geometry = this->CreateReferenceGeometry(Geom);
     const unsigned int NumGPoints = Geom.IntegrationPointsNumber( mThisIntegrationMethod );
 
     if ( mConstitutiveLawVector.size() != NumGPoints )
@@ -43,7 +44,8 @@ void SmallDisplacementInterfaceElement<TDim,TNumNodes>::Initialize(const Process
         for ( unsigned int i = 0; i < mConstitutiveLawVector.size(); i++ )
         {
             mConstitutiveLawVector[i] = Prop[CONSTITUTIVE_LAW]->Clone();
-            mConstitutiveLawVector[i]->InitializeMaterial( Prop, Geom,row( Geom.ShapeFunctionsValues( mThisIntegrationMethod ), i ) );
+            mConstitutiveLawVector[i]->InitializeMaterial(
+                Prop, *p_reference_geometry, row(Geom.ShapeFunctionsValues(mThisIntegrationMethod), i));
         }
     }
     else
@@ -169,7 +171,7 @@ void SmallDisplacementInterfaceElement<TDim,TNumNodes>::CalculateMassMatrix(Matr
     array_1d<double,TNumNodes*TDim> DisplacementVector;
     PoroElementUtilities::GetNodalVariableVector(DisplacementVector,Geom,DISPLACEMENT);
     BoundedMatrix<double,TDim, TDim> RotationMatrix;
-    this->CalculateRotationMatrix(RotationMatrix,Geom);
+    this->CalculateCurrentRotationMatrix(RotationMatrix,Geom);
     BoundedMatrix<double,TDim, TNumNodes*TDim> Nu = ZeroMatrix(TDim, TNumNodes*TDim);
     array_1d<double,TDim> LocalRelDispVector;
     array_1d<double,TDim> RelDispVector;
@@ -237,11 +239,12 @@ void SmallDisplacementInterfaceElement<TDim,TNumNodes>::FinalizeSolutionStep(con
     //Defining necessary variables
     const PropertiesType& Prop = this->GetProperties();
     const GeometryType& Geom = this->GetGeometry();
+    GeometryType::Pointer p_reference_geometry = this->CreateReferenceGeometry(Geom);
     const Matrix& NContainer = Geom.ShapeFunctionsValues( mThisIntegrationMethod );
     array_1d<double,TNumNodes*TDim> DisplacementVector;
     PoroElementUtilities::GetNodalVariableVector(DisplacementVector,Geom,DISPLACEMENT);
     BoundedMatrix<double,TDim, TDim> RotationMatrix;
-    this->CalculateRotationMatrix(RotationMatrix,Geom);
+    this->CalculateReferenceRotationMatrix(RotationMatrix,Geom);
     BoundedMatrix<double,TDim, TNumNodes*TDim> Nu = ZeroMatrix(TDim, TNumNodes*TDim);
     array_1d<double,TDim> RelDispVector;
     const double& InitialJointWidth = Prop[INITIAL_JOINT_WIDTH];
@@ -255,7 +258,7 @@ void SmallDisplacementInterfaceElement<TDim,TNumNodes>::FinalizeSolutionStep(con
     Matrix GradNpT(TNumNodes,TDim);
     Matrix F = identity_matrix<double>(TDim);
     double detF = 1.0;
-    ConstitutiveLaw::Parameters ConstitutiveParameters(Geom, Prop, rCurrentProcessInfo);
+    ConstitutiveLaw::Parameters ConstitutiveParameters(*p_reference_geometry, Prop, rCurrentProcessInfo);
     ConstitutiveParameters.SetConstitutiveMatrix(ConstitutiveMatrix);
     ConstitutiveParameters.SetStressVector(StressVector);
     ConstitutiveParameters.SetStrainVector(StrainVector);
@@ -297,7 +300,7 @@ template< >
 void SmallDisplacementInterfaceElement<2,4>::ExtrapolateGPJointWidth (const std::vector<double>& JointWidthContainer)
 {
     auto& rGeom = this->GetGeometry();
-    const double& Area = rGeom.Area();
+    const double Area = this->CreateReferenceGeometry(rGeom)->Area();
 
     array_1d<double,4> NodalJointWidth;
     NodalJointWidth[0] = JointWidthContainer[0]*Area;
@@ -318,7 +321,7 @@ template< >
 void SmallDisplacementInterfaceElement<3,6>::ExtrapolateGPJointWidth (const std::vector<double>& JointWidthContainer)
 {
     auto& rGeom = this->GetGeometry();
-    const double& Area = rGeom.Area();
+    const double Area = this->CreateReferenceGeometry(rGeom)->Area();
 
     array_1d<double,6> NodalJointWidth;
     NodalJointWidth[0] = JointWidthContainer[0]*Area;
@@ -341,7 +344,7 @@ template< >
 void SmallDisplacementInterfaceElement<3,8>::ExtrapolateGPJointWidth (const std::vector<double>& JointWidthContainer)
 {
     auto& rGeom = this->GetGeometry();
-    const double& Area = rGeom.Area();
+    const double Area = this->CreateReferenceGeometry(rGeom)->Area();
 
     array_1d<double,8> NodalJointWidth;
     NodalJointWidth[0] = JointWidthContainer[0]*Area;
@@ -581,6 +584,7 @@ void SmallDisplacementInterfaceElement<TDim,TNumNodes>::CalculateOnIntegrationPo
     {
         //Variables computed on Lobatto points
         const GeometryType& Geom = this->GetGeometry();
+        GeometryType::Pointer p_reference_geometry = this->CreateReferenceGeometry(Geom);
         std::vector<array_1d<double,3>> GPValues(Geom.IntegrationPointsNumber( mThisIntegrationMethod ));
 
             if(rVariable == CONTACT_STRESS_VECTOR)
@@ -591,7 +595,7 @@ void SmallDisplacementInterfaceElement<TDim,TNumNodes>::CalculateOnIntegrationPo
                 array_1d<double,TNumNodes*TDim> DisplacementVector;
                 PoroElementUtilities::GetNodalVariableVector(DisplacementVector,Geom,DISPLACEMENT);
                 BoundedMatrix<double,TDim, TDim> RotationMatrix;
-                this->CalculateRotationMatrix(RotationMatrix,Geom);
+                this->CalculateReferenceRotationMatrix(RotationMatrix,Geom);
                 BoundedMatrix<double,TDim, TNumNodes*TDim> Nu = ZeroMatrix(TDim, TNumNodes*TDim);
                 array_1d<double,TDim> RelDispVector;
                 const double& InitialJointWidth = Prop[INITIAL_JOINT_WIDTH];
@@ -607,7 +611,8 @@ void SmallDisplacementInterfaceElement<TDim,TNumNodes>::CalculateOnIntegrationPo
                 Matrix GradNpT(TNumNodes,TDim);
                 Matrix F = identity_matrix<double>(TDim);
                 double detF = 1.0;
-                ConstitutiveLaw::Parameters ConstitutiveParameters(Geom,Prop,rCurrentProcessInfo);
+                ConstitutiveLaw::Parameters ConstitutiveParameters(
+                    *p_reference_geometry, Prop, rCurrentProcessInfo);
                 ConstitutiveParameters.Set(ConstitutiveLaw::COMPUTE_STRESS);
                 ConstitutiveParameters.Set(ConstitutiveLaw::USE_ELEMENT_PROVIDED_STRAIN);
                 ConstitutiveParameters.SetConstitutiveMatrix(ConstitutiveMatrix);
@@ -649,7 +654,7 @@ void SmallDisplacementInterfaceElement<TDim,TNumNodes>::CalculateOnIntegrationPo
                 array_1d<double,TNumNodes*TDim> DisplacementVector;
                 PoroElementUtilities::GetNodalVariableVector(DisplacementVector,Geom,DISPLACEMENT);
                 BoundedMatrix<double,TDim, TDim> RotationMatrix;
-                this->CalculateRotationMatrix(RotationMatrix,Geom);
+                this->CalculateReferenceRotationMatrix(RotationMatrix,Geom);
                 BoundedMatrix<double,TDim, TNumNodes*TDim> Nu = ZeroMatrix(TDim, TNumNodes*TDim);
                 array_1d<double,TDim> RelDispVector;
                 const double& InitialJointWidth = Prop[INITIAL_JOINT_WIDTH];
@@ -664,7 +669,8 @@ void SmallDisplacementInterfaceElement<TDim,TNumNodes>::CalculateOnIntegrationPo
                 Matrix GradNpT(TNumNodes,TDim);
                 Matrix F = identity_matrix<double>(TDim);
                 double detF = 1.0;
-                ConstitutiveLaw::Parameters ConstitutiveParameters(Geom,Prop,rCurrentProcessInfo);
+                ConstitutiveLaw::Parameters ConstitutiveParameters(
+                    *p_reference_geometry, Prop, rCurrentProcessInfo);
                 ConstitutiveParameters.Set(ConstitutiveLaw::COMPUTE_STRESS);
                 ConstitutiveParameters.Set(ConstitutiveLaw::USE_ELEMENT_PROVIDED_STRAIN);
                 ConstitutiveParameters.SetConstitutiveMatrix(ConstitutiveMatrix);
@@ -703,7 +709,7 @@ void SmallDisplacementInterfaceElement<TDim,TNumNodes>::CalculateOnIntegrationPo
                 array_1d<double,TNumNodes*TDim> DisplacementVector;
                 PoroElementUtilities::GetNodalVariableVector(DisplacementVector,Geom,DISPLACEMENT);
                 BoundedMatrix<double,TDim, TDim> RotationMatrix;
-                this->CalculateRotationMatrix(RotationMatrix,Geom);
+                this->CalculateReferenceRotationMatrix(RotationMatrix,Geom);
                 BoundedMatrix<double,TDim, TNumNodes*TDim> Nu = ZeroMatrix(TDim, TNumNodes*TDim);
                 array_1d<double,TDim> LocalRelDispVector;
                 array_1d<double,TDim> RelDispVector;
@@ -754,7 +760,7 @@ void SmallDisplacementInterfaceElement<2,4>::CalculateInitialGap(const GeometryT
     mInitialGap.resize(2);
 
     array_1d<double,3> Vx;
-    noalias(Vx) = Geom.GetPoint( 3 ) - Geom.GetPoint( 0 );
+    noalias(Vx) = Geom[3].GetInitialPosition().Coordinates() - Geom[0].GetInitialPosition().Coordinates();
     mInitialGap[0] = norm_2(Vx);
     if (mInitialGap[0] <= (InitialJointWidth+Tolerance)) {
         mInitialGap[0] = InitialJointWidth;
@@ -762,7 +768,7 @@ void SmallDisplacementInterfaceElement<2,4>::CalculateInitialGap(const GeometryT
         KRATOS_THROW_ERROR( std::invalid_argument, "The value of INITIAL_JOINT_WIDTH is smaller than the geometrical width.", "" )
     }
 
-    noalias(Vx) = Geom.GetPoint( 2 ) - Geom.GetPoint( 1 );
+    noalias(Vx) = Geom[2].GetInitialPosition().Coordinates() - Geom[1].GetInitialPosition().Coordinates();
     mInitialGap[1] = norm_2(Vx);
     if (mInitialGap[1] <= (InitialJointWidth+Tolerance)) {
         mInitialGap[1] = InitialJointWidth;
@@ -781,7 +787,7 @@ void SmallDisplacementInterfaceElement<3,6>::CalculateInitialGap(const GeometryT
     mInitialGap.resize(3);
 
     array_1d<double,3> Vx;
-    noalias(Vx) = Geom.GetPoint( 3 ) - Geom.GetPoint( 0 );
+    noalias(Vx) = Geom[3].GetInitialPosition().Coordinates() - Geom[0].GetInitialPosition().Coordinates();
     mInitialGap[0] = norm_2(Vx);
     if (mInitialGap[0] <= (InitialJointWidth+Tolerance)) {
         mInitialGap[0] = InitialJointWidth;
@@ -789,7 +795,7 @@ void SmallDisplacementInterfaceElement<3,6>::CalculateInitialGap(const GeometryT
         KRATOS_THROW_ERROR( std::invalid_argument, "The value of INITIAL_JOINT_WIDTH is smaller than the geometrical width.", "" )
     }
 
-    noalias(Vx) = Geom.GetPoint( 4 ) - Geom.GetPoint( 1 );
+    noalias(Vx) = Geom[4].GetInitialPosition().Coordinates() - Geom[1].GetInitialPosition().Coordinates();
     mInitialGap[1] = norm_2(Vx);
     if (mInitialGap[1] <= (InitialJointWidth+Tolerance)) {
         mInitialGap[1] = InitialJointWidth;
@@ -797,7 +803,7 @@ void SmallDisplacementInterfaceElement<3,6>::CalculateInitialGap(const GeometryT
         KRATOS_THROW_ERROR( std::invalid_argument, "The value of INITIAL_JOINT_WIDTH is smaller than the geometrical width.", "" )
     }
 
-    noalias(Vx) = Geom.GetPoint( 5 ) - Geom.GetPoint( 2 );
+    noalias(Vx) = Geom[5].GetInitialPosition().Coordinates() - Geom[2].GetInitialPosition().Coordinates();
     mInitialGap[2] = norm_2(Vx);
     if (mInitialGap[2] <= (InitialJointWidth+Tolerance)) {
         mInitialGap[2] = InitialJointWidth;
@@ -816,7 +822,7 @@ void SmallDisplacementInterfaceElement<3,8>::CalculateInitialGap(const GeometryT
     mInitialGap.resize(4);
 
     array_1d<double,3> Vx;
-    noalias(Vx) = Geom.GetPoint( 4 ) - Geom.GetPoint( 0 );
+    noalias(Vx) = Geom[4].GetInitialPosition().Coordinates() - Geom[0].GetInitialPosition().Coordinates();
     mInitialGap[0] = norm_2(Vx);
     if (mInitialGap[0] <= (InitialJointWidth+Tolerance)) {
         mInitialGap[0] = InitialJointWidth;
@@ -824,7 +830,7 @@ void SmallDisplacementInterfaceElement<3,8>::CalculateInitialGap(const GeometryT
         KRATOS_THROW_ERROR( std::invalid_argument, "The value of INITIAL_JOINT_WIDTH is smaller than the geometrical width.", "" )
     }
 
-    noalias(Vx) = Geom.GetPoint( 5 ) - Geom.GetPoint( 1 );
+    noalias(Vx) = Geom[5].GetInitialPosition().Coordinates() - Geom[1].GetInitialPosition().Coordinates();
     mInitialGap[1] = norm_2(Vx);
     if (mInitialGap[1] <= (InitialJointWidth+Tolerance)) {
         mInitialGap[1] = InitialJointWidth;
@@ -832,7 +838,7 @@ void SmallDisplacementInterfaceElement<3,8>::CalculateInitialGap(const GeometryT
         KRATOS_THROW_ERROR( std::invalid_argument, "The value of INITIAL_JOINT_WIDTH is smaller than the geometrical width.", "" )
     }
 
-    noalias(Vx) = Geom.GetPoint( 6 ) - Geom.GetPoint( 2 );
+    noalias(Vx) = Geom[6].GetInitialPosition().Coordinates() - Geom[2].GetInitialPosition().Coordinates();
     mInitialGap[2] = norm_2(Vx);
     if (mInitialGap[2] <= (InitialJointWidth+Tolerance)) {
         mInitialGap[2] = InitialJointWidth;
@@ -840,7 +846,7 @@ void SmallDisplacementInterfaceElement<3,8>::CalculateInitialGap(const GeometryT
         KRATOS_THROW_ERROR( std::invalid_argument, "The value of INITIAL_JOINT_WIDTH is smaller than the geometrical width.", "" )
     }
 
-    noalias(Vx) = Geom.GetPoint( 7 ) - Geom.GetPoint( 3 );
+    noalias(Vx) = Geom[7].GetInitialPosition().Coordinates() - Geom[3].GetInitialPosition().Coordinates();
     mInitialGap[3] = norm_2(Vx);
     if (mInitialGap[3] <= (InitialJointWidth+Tolerance)) {
         mInitialGap[3] = InitialJointWidth;
@@ -866,18 +872,18 @@ void SmallDisplacementInterfaceElement<TDim,TNumNodes>::CalculateStiffnessMatrix
     //Previous definitions
     const PropertiesType& Prop = this->GetProperties();
     const GeometryType& Geom = this->GetGeometry();
+    GeometryType::Pointer p_reference_geometry = this->CreateReferenceGeometry(Geom);
     const GeometryType::IntegrationPointsArrayType& integration_points = Geom.IntegrationPoints( mThisIntegrationMethod );
     const unsigned int NumGPoints = integration_points.size();
 
     //Containers of variables at all integration points
     const Matrix& NContainer = Geom.ShapeFunctionsValues( mThisIntegrationMethod );
-    GeometryType::JacobiansType JContainer(NumGPoints);
-    Geom.Jacobian( JContainer, mThisIntegrationMethod );
     Vector detJContainer(NumGPoints);
-    Geom.DeterminantOfJacobian(detJContainer,mThisIntegrationMethod);
+    this->CalculateReferenceJacobianDeterminants(detJContainer, Geom);
 
     //Constitutive Law parameters
-    ConstitutiveLaw::Parameters ConstitutiveParameters(Geom, Prop, CurrentProcessInfo);
+    ConstitutiveLaw::Parameters ConstitutiveParameters(
+        *p_reference_geometry, Prop, CurrentProcessInfo);
     ConstitutiveParameters.Set(ConstitutiveLaw::COMPUTE_CONSTITUTIVE_TENSOR);
 
     //Element variables
@@ -923,18 +929,18 @@ void SmallDisplacementInterfaceElement<TDim,TNumNodes>::CalculateAll( MatrixType
     //Previous definitions
     const PropertiesType& Prop = this->GetProperties();
     const GeometryType& Geom = this->GetGeometry();
+    GeometryType::Pointer p_reference_geometry = this->CreateReferenceGeometry(Geom);
     const GeometryType::IntegrationPointsArrayType& integration_points = Geom.IntegrationPoints( mThisIntegrationMethod );
     const unsigned int NumGPoints = integration_points.size();
 
     //Containers of variables at all integration points
     const Matrix& NContainer = Geom.ShapeFunctionsValues( mThisIntegrationMethod );
-    GeometryType::JacobiansType JContainer(NumGPoints);
-    Geom.Jacobian( JContainer, mThisIntegrationMethod );
     Vector detJContainer(NumGPoints);
-    Geom.DeterminantOfJacobian(detJContainer,mThisIntegrationMethod);
+    this->CalculateReferenceJacobianDeterminants(detJContainer, Geom);
 
     //Constitutive Law parameters
-    ConstitutiveLaw::Parameters ConstitutiveParameters(Geom, Prop, rCurrentProcessInfo);
+    ConstitutiveLaw::Parameters ConstitutiveParameters(
+        *p_reference_geometry, Prop, rCurrentProcessInfo);
     ConstitutiveParameters.Set(ConstitutiveLaw::COMPUTE_CONSTITUTIVE_TENSOR);
     ConstitutiveParameters.Set(ConstitutiveLaw::COMPUTE_STRESS);
     ConstitutiveParameters.Set(ConstitutiveLaw::USE_ELEMENT_PROVIDED_STRAIN);
@@ -989,18 +995,18 @@ void SmallDisplacementInterfaceElement<TDim,TNumNodes>::CalculateRHS(VectorType&
     //Previous definitions
     const PropertiesType& Prop = this->GetProperties();
     const GeometryType& Geom = this->GetGeometry();
+    GeometryType::Pointer p_reference_geometry = this->CreateReferenceGeometry(Geom);
     const GeometryType::IntegrationPointsArrayType& integration_points = Geom.IntegrationPoints( mThisIntegrationMethod );
     const unsigned int NumGPoints = integration_points.size();
 
     //Containers of variables at all integration points
     const Matrix& NContainer = Geom.ShapeFunctionsValues( mThisIntegrationMethod );
-    GeometryType::JacobiansType JContainer(NumGPoints);
-    Geom.Jacobian( JContainer, mThisIntegrationMethod );
     Vector detJContainer(NumGPoints);
-    Geom.DeterminantOfJacobian(detJContainer,mThisIntegrationMethod);
+    this->CalculateReferenceJacobianDeterminants(detJContainer, Geom);
 
     //Constitutive Law parameters
-    ConstitutiveLaw::Parameters ConstitutiveParameters(Geom, Prop, rCurrentProcessInfo);
+    ConstitutiveLaw::Parameters ConstitutiveParameters(
+        *p_reference_geometry, Prop, rCurrentProcessInfo);
     ConstitutiveParameters.Set(ConstitutiveLaw::COMPUTE_STRESS);
     ConstitutiveParameters.Set(ConstitutiveLaw::USE_ELEMENT_PROVIDED_STRAIN);
 
@@ -1057,7 +1063,7 @@ void SmallDisplacementInterfaceElement<TDim,TNumNodes>::InitializeElementVariabl
     PoroElementUtilities::GetNodalVariableVector(rVariables.VolumeAcceleration,Geom,VOLUME_ACCELERATION);
 
     //General Variables
-    this->CalculateRotationMatrix(rVariables.RotationMatrix,Geom);
+    this->CalculateReferenceRotationMatrix(rVariables.RotationMatrix,Geom);
     InterfaceElementUtilities::CalculateVoigtVector(rVariables.VoigtVector);
 
     //Variables computed at each GP
@@ -1084,146 +1090,123 @@ void SmallDisplacementInterfaceElement<TDim,TNumNodes>::InitializeElementVariabl
 
 //----------------------------------------------------------------------------------------
 
-template<>
-void SmallDisplacementInterfaceElement<2,4>::CalculateRotationMatrix(BoundedMatrix<double,2,2>& rRotationMatrix, const GeometryType& Geom)
+template< unsigned int TDim, unsigned int TNumNodes >
+void SmallDisplacementInterfaceElement<TDim,TNumNodes>::CalculateReferenceJacobianDeterminants(
+    Vector& rDetJContainer,
+    const GeometryType& Geom)
 {
-    KRATOS_TRY
+    const unsigned int number_of_integration_points = Geom.IntegrationPointsNumber(mThisIntegrationMethod);
+    GeometryType::JacobiansType reference_jacobians(number_of_integration_points);
+    Matrix delta_position(TNumNodes, TDim);
 
-    //Define mid-plane points for quadrilateral_interface_2d_4
-    array_1d<double, 3> pmid0;
-    array_1d<double, 3> pmid1;
-    noalias(pmid0) = 0.5 * (Geom.GetPoint( 0 ) + Geom.GetPoint( 3 ));
-    noalias(pmid1) = 0.5 * (Geom.GetPoint( 1 ) + Geom.GetPoint( 2 ));
+    for (unsigned int i = 0; i < TNumNodes; ++i) {
+        const auto& r_current_position = Geom[i].Coordinates();
+        const auto& r_initial_position = Geom[i].GetInitialPosition();
+        for (unsigned int j = 0; j < TDim; ++j) {
+            delta_position(i,j) = r_current_position[j] - r_initial_position[j];
+        }
+    }
 
-    //Unitary vector in local x direction
-    array_1d<double, 3> Vx;
-    noalias(Vx) = pmid1 - pmid0;
-    double inv_norm_x = 1.0/norm_2(Vx);
-    Vx[0] *= inv_norm_x;
-    Vx[1] *= inv_norm_x;
-
-    //Rotation Matrix
-    // We need to determine the unitary vector in local y direction pointing towards the TOP face of the joint
-    rRotationMatrix(0,0) = Vx[0];
-    rRotationMatrix(0,1) = Vx[1];
-
-    // NOTE. Assuming that the nodes in quadrilateral_interface_2d_4 are
-    // ordered counter-clockwise (GiD does so now), the rotation matrix is build like follows:
-    rRotationMatrix(1,0) = -Vx[1];
-    rRotationMatrix(1,1) = Vx[0];
-    // NOTE. Assuming that the nodes in quadrilateral_interface_2d_4 are
-    // ordered clockwise, the rotation matrix is build like follows:
-    // rRotationMatrix(1,0) = Vx[1];
-    // rRotationMatrix(1,1) = -Vx[0];
-
-    // NOTE. In zero-thickness quadrilateral_interface_2d_4 elements we are not able to know
-    // whether the nodes are ordered clockwise or counter-clockwise.
-
-    KRATOS_CATCH( "" )
+    Geom.Jacobian(reference_jacobians, mThisIntegrationMethod, delta_position);
+    if (rDetJContainer.size() != number_of_integration_points) {
+        rDetJContainer.resize(number_of_integration_points, false);
+    }
+    for (unsigned int i = 0; i < number_of_integration_points; ++i) {
+        rDetJContainer[i] = MathUtils<double>::GeneralizedDet(reference_jacobians[i]);
+    }
 }
 
 //----------------------------------------------------------------------------------------
 
-template<>
-void SmallDisplacementInterfaceElement<3,6>::CalculateRotationMatrix(BoundedMatrix<double,3,3>& rRotationMatrix, const GeometryType& Geom)
+template< unsigned int TDim, unsigned int TNumNodes >
+typename SmallDisplacementInterfaceElement<TDim,TNumNodes>::GeometryType::Pointer
+SmallDisplacementInterfaceElement<TDim,TNumNodes>::CreateReferenceGeometry(
+    const GeometryType& Geom) const
 {
-    KRATOS_TRY
-
-    //Define mid-plane points for prism_interface_3d_6
-    array_1d<double, 3> pmid0;
-    array_1d<double, 3> pmid1;
-    array_1d<double, 3> pmid2;
-    noalias(pmid0) = 0.5 * (Geom.GetPoint( 0 ) + Geom.GetPoint( 3 ));
-    noalias(pmid1) = 0.5 * (Geom.GetPoint( 1 ) + Geom.GetPoint( 4 ));
-    noalias(pmid2) = 0.5 * (Geom.GetPoint( 2 ) + Geom.GetPoint( 5 ));
-
-    //Unitary vector in local x direction
-    array_1d<double, 3> Vx;
-    noalias(Vx) = pmid1 - pmid0;
-    double inv_norm_x = 1.0/norm_2(Vx);
-    Vx[0] *= inv_norm_x;
-    Vx[1] *= inv_norm_x;
-    Vx[2] *= inv_norm_x;
-
-    //Unitary vector in local z direction
-    array_1d<double, 3> Vy;
-    noalias(Vy) = pmid2 - pmid0;
-    array_1d<double, 3> Vz;
-    MathUtils<double>::CrossProduct(Vz, Vx, Vy);
-    double inv_norm_z = 1.0/norm_2(Vz);
-    Vz[0] *= inv_norm_z;
-    Vz[1] *= inv_norm_z;
-    Vz[2] *= inv_norm_z;
-
-    //Unitary vector in local y direction
-    MathUtils<double>::CrossProduct( Vy, Vz, Vx);
-
-    //Rotation Matrix
-    rRotationMatrix(0,0) = Vx[0];
-    rRotationMatrix(0,1) = Vx[1];
-    rRotationMatrix(0,2) = Vx[2];
-
-    rRotationMatrix(1,0) = Vy[0];
-    rRotationMatrix(1,1) = Vy[1];
-    rRotationMatrix(1,2) = Vy[2];
-
-    rRotationMatrix(2,0) = Vz[0];
-    rRotationMatrix(2,1) = Vz[1];
-    rRotationMatrix(2,2) = Vz[2];
-
-    KRATOS_CATCH( "" )
+    // Interface laws use their parameter geometry to rotate nodal initial
+    // stresses. Give them a side-effect-free reference-configuration view.
+    typename GeometryType::PointsArrayType reference_points;
+    reference_points.reserve(TNumNodes);
+    for (unsigned int i = 0; i < TNumNodes; ++i) {
+        auto p_reference_node = Kratos::make_intrusive<typename GeometryType::PointType>(Geom[i]);
+        p_reference_node->Coordinates() = Geom[i].GetInitialPosition().Coordinates();
+        reference_points.push_back(p_reference_node);
+    }
+    return Geom.Create(reference_points);
 }
 
 //----------------------------------------------------------------------------------------
 
-template<>
-void SmallDisplacementInterfaceElement<3,8>::CalculateRotationMatrix(BoundedMatrix<double,3,3>& rRotationMatrix, const GeometryType& Geom)
+namespace
 {
-    KRATOS_TRY
+template<unsigned int TDim, unsigned int TNumNodes, class TCoordinateGetter>
+void CalculateInterfaceRotationMatrix(
+    BoundedMatrix<double,TDim,TDim>& rRotationMatrix,
+    TCoordinateGetter CoordinateGetter)
+{
+    array_1d<double, 3> mid_point_0;
+    array_1d<double, 3> mid_point_1;
+    array_1d<double, 3> mid_point_2;
 
-    //Define mid-plane points for hexahedra_interface_3d_8
-    array_1d<double, 3> pmid0;
-    array_1d<double, 3> pmid1;
-    array_1d<double, 3> pmid2;
-    noalias(pmid0) = 0.5 * (Geom.GetPoint( 0 ) + Geom.GetPoint( 4 ));
-    noalias(pmid1) = 0.5 * (Geom.GetPoint( 1 ) + Geom.GetPoint( 5 ));
-    noalias(pmid2) = 0.5 * (Geom.GetPoint( 2 ) + Geom.GetPoint( 6 ));
+    if constexpr (TDim == 2) {
+        noalias(mid_point_0) = 0.5 * (CoordinateGetter(0) + CoordinateGetter(3));
+        noalias(mid_point_1) = 0.5 * (CoordinateGetter(1) + CoordinateGetter(2));
+    } else {
+        constexpr unsigned int opposite_face_offset = TNumNodes / 2;
+        noalias(mid_point_0) = 0.5 * (CoordinateGetter(0) + CoordinateGetter(opposite_face_offset));
+        noalias(mid_point_1) = 0.5 * (CoordinateGetter(1) + CoordinateGetter(1 + opposite_face_offset));
+        noalias(mid_point_2) = 0.5 * (CoordinateGetter(2) + CoordinateGetter(2 + opposite_face_offset));
+    }
 
-    //Unitary vector in local x direction
-    array_1d<double, 3> Vx;
-    noalias(Vx) = pmid1 - pmid0;
-    double inv_norm_x = 1.0/norm_2(Vx);
-    Vx[0] *= inv_norm_x;
-    Vx[1] *= inv_norm_x;
-    Vx[2] *= inv_norm_x;
+    array_1d<double, 3> local_x = mid_point_1 - mid_point_0;
+    local_x /= norm_2(local_x);
 
-    //Unitary vector in local z direction
-    array_1d<double, 3> Vy;
-    noalias(Vy) = pmid2 - pmid0;
-    array_1d<double, 3> Vz;
-    MathUtils<double>::CrossProduct(Vz, Vx, Vy);
-    double inv_norm_z = 1.0/norm_2(Vz);
-    Vz[0] *= inv_norm_z;
-    Vz[1] *= inv_norm_z;
-    Vz[2] *= inv_norm_z;
+    if constexpr (TDim == 2) {
+        rRotationMatrix(0,0) = local_x[0];
+        rRotationMatrix(0,1) = local_x[1];
+        rRotationMatrix(1,0) = -local_x[1];
+        rRotationMatrix(1,1) = local_x[0];
+    } else {
+        const array_1d<double, 3> auxiliary_y = mid_point_2 - mid_point_0;
+        array_1d<double, 3> local_z;
+        MathUtils<double>::CrossProduct(local_z, local_x, auxiliary_y);
+        local_z /= norm_2(local_z);
 
-    //Unitary vector in local y direction
-    MathUtils<double>::CrossProduct( Vy, Vz, Vx);
+        array_1d<double, 3> local_y;
+        MathUtils<double>::CrossProduct(local_y, local_z, local_x);
+        for (unsigned int j = 0; j < 3; ++j) {
+            rRotationMatrix(0,j) = local_x[j];
+            rRotationMatrix(1,j) = local_y[j];
+            rRotationMatrix(2,j) = local_z[j];
+        }
+    }
+}
+}
 
-    //Rotation Matrix
-    rRotationMatrix(0,0) = Vx[0];
-    rRotationMatrix(0,1) = Vx[1];
-    rRotationMatrix(0,2) = Vx[2];
+template< unsigned int TDim, unsigned int TNumNodes >
+void SmallDisplacementInterfaceElement<TDim,TNumNodes>::CalculateCurrentRotationMatrix(
+    BoundedMatrix<double,TDim,TDim>& rRotationMatrix,
+    const GeometryType& Geom)
+{
+    CalculateInterfaceRotationMatrix<TDim,TNumNodes>(rRotationMatrix,
+        [&Geom](const unsigned int Index) -> const array_1d<double, 3>& {
+            return Geom[Index].Coordinates();
+        });
+}
 
-    rRotationMatrix(1,0) = Vy[0];
-    rRotationMatrix(1,1) = Vy[1];
-    rRotationMatrix(1,2) = Vy[2];
+//----------------------------------------------------------------------------------------
 
-    rRotationMatrix(2,0) = Vz[0];
-    rRotationMatrix(2,1) = Vz[1];
-    rRotationMatrix(2,2) = Vz[2];
-
-    KRATOS_CATCH( "" )
+template< unsigned int TDim, unsigned int TNumNodes >
+void SmallDisplacementInterfaceElement<TDim,TNumNodes>::CalculateReferenceRotationMatrix(
+    BoundedMatrix<double,TDim,TDim>& rRotationMatrix,
+    const GeometryType& Geom)
+{
+    // This is a small-displacement formulation: using the reference frame avoids
+    // unaccounted displacement derivatives of the interface orientation.
+    CalculateInterfaceRotationMatrix<TDim,TNumNodes>(rRotationMatrix,
+        [&Geom](const unsigned int Index) -> const array_1d<double, 3>& {
+            return Geom[Index].GetInitialPosition().Coordinates();
+        });
 }
 
 //----------------------------------------------------------------------------------------

--- a/applications/DamApplication/custom_elements/small_displacement_interface_element.hpp
+++ b/applications/DamApplication/custom_elements/small_displacement_interface_element.hpp
@@ -160,7 +160,13 @@ protected:
     void InitializeElementVariables(ElementVariables& rVariables,ConstitutiveLaw::Parameters& rConstitutiveParameters,
                                     const GeometryType& Geom, const PropertiesType& Prop, const ProcessInfo& CurrentProcessInfo);
 
-    void CalculateRotationMatrix(BoundedMatrix<double,TDim,TDim>& rRotationMatrix, const GeometryType& Geom);
+    void CalculateCurrentRotationMatrix(BoundedMatrix<double,TDim,TDim>& rRotationMatrix, const GeometryType& Geom);
+
+    void CalculateReferenceRotationMatrix(BoundedMatrix<double,TDim,TDim>& rRotationMatrix, const GeometryType& Geom);
+
+    void CalculateReferenceJacobianDeterminants(Vector& rDetJContainer, const GeometryType& Geom);
+
+    GeometryType::Pointer CreateReferenceGeometry(const GeometryType& Geom) const;
 
     void CalculateJointWidth(double& rJointWidth,const double& NormalRelDisp,const double& InitialJointWidth,const unsigned int& GPoint);
 

--- a/applications/DamApplication/custom_python/add_custom_strategies_to_python.cpp
+++ b/applications/DamApplication/custom_python/add_custom_strategies_to_python.cpp
@@ -71,8 +71,8 @@ void  AddCustomStrategiesToPython(pybind11::module& m)
     py::class_< DamPSchemeType, typename DamPSchemeType::Pointer, BaseSchemeType >
     (m, "DamPScheme")
     .def(py::init< double, double >());
+
 }
 
 }  // namespace Python.
 } // Namespace Kratos
-

--- a/applications/DamApplication/python_scripts/dam_analysis.py
+++ b/applications/DamApplication/python_scripts/dam_analysis.py
@@ -77,7 +77,6 @@ class DamAnalysis(AnalysisStage):
         self.add_temperature = self.project_parameters["transfer_results_process"]["add_temperature"].GetBool()
         self.add_reference_temperature = self.project_parameters["transfer_results_process"]["add_reference_temperature"].GetBool()
 
-
         # Time Units Converter
         if(self.time_scale=="Weeks"):               # Factor to pass from weeks to seconds
             self.time_unit_converter = 604800.0

--- a/applications/DamApplication/tests/test_DamApplication.py
+++ b/applications/DamApplication/tests/test_DamApplication.py
@@ -6,8 +6,11 @@ import KratosMultiphysics.KratosUnittest as KratosUnittest
 # Import the tests o test_classes to create the suits
 from generalTests import KratosDamGeneralTests
 from test_apply_load_vector_dam_processes import TestApplyLoadVectorDamProcesses
+from test_dam_linear_solver import TestDamLinearSolver
 from test_dam_nodal_young_modulus_process import TestImposeNodalYoungModulusProcess
 from test_dam_process_lifecycle import TestDamProcessLifetime
+from test_global_tangent_consistency import TestGlobalTangentConsistency
+from test_interface_tangent_consistency import TestSmallDisplacementInterfaceTangent
 
 
 def AssembleTestSuites():
@@ -48,7 +51,13 @@ def AssembleTestSuites():
     smallSuite.addTest(KratosDamGeneralTests("test_construction"))
     smallSuite.addTests(
         KratosUnittest.TestLoader().loadTestsFromTestCases(
-            [TestApplyLoadVectorDamProcesses, TestImposeNodalYoungModulusProcess]
+            [
+                TestApplyLoadVectorDamProcesses,
+                TestDamLinearSolver,
+                TestGlobalTangentConsistency,
+                TestImposeNodalYoungModulusProcess,
+                TestSmallDisplacementInterfaceTangent,
+            ]
         )
     )
     smallSuite.addTests(
@@ -71,8 +80,11 @@ def AssembleTestSuites():
             [
                 KratosDamGeneralTests,
                 TestApplyLoadVectorDamProcesses,
+                TestDamLinearSolver,
+                TestGlobalTangentConsistency,
                 TestImposeNodalYoungModulusProcess,
                 TestDamProcessLifetime,
+                TestSmallDisplacementInterfaceTangent,
             ]
         )
     )

--- a/applications/DamApplication/tests/test_dam_linear_solver.py
+++ b/applications/DamApplication/tests/test_dam_linear_solver.py
@@ -1,0 +1,108 @@
+import os
+
+import KratosMultiphysics as KM
+import KratosMultiphysics.DamApplication
+import KratosMultiphysics.KratosUnittest as KratosUnittest
+import KratosMultiphysics.PoromechanicsApplication as KratosPoro
+from KratosMultiphysics.DamApplication.dam_analysis import DamAnalysis
+
+
+class _DisplacementControlledInterfaceAnalysis(DamAnalysis):
+    displacement_history = (
+        2.0e-4, 5.0e-4, 2.0e-5, -2.0e-5,
+        -2.0e-4, -2.0e-5, 2.0e-5, 2.0e-4
+    )
+    boundary_node_ids = (7, 11, 12, 16, 20, 24)
+
+    def Initialize(self):
+        super().Initialize()
+        for node_id in self.boundary_node_ids:
+            self.main_model_part.GetNode(node_id).Fix(KM.DISPLACEMENT_X)
+
+    def RunMainTemporalLoop(self):
+        for step, prescribed_displacement in enumerate(self.displacement_history, 1):
+            self.time += self.delta_time
+            self.main_model_part.CloneTimeStep(self.time)
+            self.main_model_part.ProcessInfo[KM.STEP] = step
+            for node_id in self.boundary_node_ids:
+                self.main_model_part.GetNode(node_id).SetSolutionStepValue(
+                    KM.DISPLACEMENT_X, prescribed_displacement)
+            for process in self.list_of_processes:
+                process.ExecuteInitializeSolutionStep()
+            self.solver.Solve()
+            for process in self.list_of_processes:
+                process.ExecuteFinalizeSolutionStep()
+
+    def CaptureFinalState(self):
+        process_info = self.main_model_part.ProcessInfo
+        interface = self.main_model_part.GetElement(21)
+        return {
+            "displacements": {
+                node.Id: list(node.GetSolutionStepValue(KM.DISPLACEMENT))
+                for node in self.main_model_part.Nodes
+            },
+            "jump": list(interface.CalculateOnIntegrationPoints(
+                KratosPoro.LOCAL_RELATIVE_DISPLACEMENT_VECTOR, process_info)[0]),
+            "traction": list(interface.CalculateOnIntegrationPoints(
+                KratosPoro.LOCAL_STRESS_VECTOR, process_info)[0]),
+            "reaction": sum(
+                self.main_model_part.GetNode(node_id).GetSolutionStepValue(KM.REACTION_X)
+                for node_id in self.boundary_node_ids)
+        }
+
+
+class TestDamLinearSolver(KratosUnittest.TestCase):
+    def _GetParameters(self, use_direct_solver):
+        test_directory = os.path.dirname(os.path.realpath(__file__))
+        input_directory = os.path.join(
+            test_directory, "joint_elastic_cohesive_2d_normal")
+        with open(os.path.join(
+                input_directory,
+                "joint_elastic_cohesive_2d_normal_parameters.json"), "r") as parameter_file:
+            parameters = KM.Parameters(parameter_file.read())
+
+        parameters["problem_data"]["end_time"].SetDouble(
+            float(len(_DisplacementControlledInterfaceAnalysis.displacement_history)))
+        parameters["problem_data"]["time_step"].SetDouble(1.0)
+        parameters["problem_data"]["number_of_threads"].SetInt(1)
+        parameters["solver_settings"]["echo_level"].SetInt(0)
+        parameters["solver_settings"]["model_import_settings"]["input_filename"].SetString(
+            os.path.join(input_directory, "joint_elastic_cohesive_2d_normal"))
+        parameters["loads_process_list"][0]["Parameters"]["modulus"].SetString("0.0")
+        if use_direct_solver:
+            linear_settings = parameters["solver_settings"][
+                "mechanical_solver_settings"]["linear_solver_settings"]
+            linear_settings.RemoveValue("preconditioner_type")
+            linear_settings.RemoveValue("max_iteration")
+            linear_settings.RemoveValue("tolerance")
+            linear_settings.RemoveValue("scaling")
+            linear_settings["solver_type"].SetString(
+                "skyline_lu_factorization")
+        return parameters
+
+    def _RunCase(self, use_direct_solver):
+        analysis = _DisplacementControlledInterfaceAnalysis(
+            KM.Model(), self._GetParameters(use_direct_solver))
+        analysis.Run()
+        return analysis.CaptureFinalState()
+
+    def _AssertFinalStatesAlmostEqual(self, expected, actual):
+        for node_id, expected_displacement in expected["displacements"].items():
+            for expected_value, actual_value in zip(
+                    expected_displacement, actual["displacements"][node_id]):
+                self.assertAlmostEqual(actual_value, expected_value, delta=1.0e-12)
+        for variable_name in ("jump", "traction"):
+            for expected_value, actual_value in zip(
+                    expected[variable_name], actual[variable_name]):
+                self.assertAlmostEqual(actual_value, expected_value, delta=1.0e-10)
+        self.assertAlmostEqual(actual["reaction"], expected["reaction"], delta=1.0e-8)
+
+    def test_iterative_and_direct_solvers_produce_equivalent_solution(self):
+        with KratosUnittest.WorkFolderScope(".", __file__):
+            iterative_state = self._RunCase(False)
+            direct_state = self._RunCase(True)
+        self._AssertFinalStatesAlmostEqual(iterative_state, direct_state)
+
+
+if __name__ == "__main__":
+    KratosUnittest.main()

--- a/applications/DamApplication/tests/test_global_tangent_consistency.py
+++ b/applications/DamApplication/tests/test_global_tangent_consistency.py
@@ -1,0 +1,202 @@
+import math
+import os
+
+import KratosMultiphysics as Kratos
+import KratosMultiphysics.DamApplication as DamApplication
+import KratosMultiphysics.KratosUnittest as KratosUnittest
+import KratosMultiphysics.PoromechanicsApplication as PoromechanicsApplication
+
+from KratosMultiphysics.DamApplication.dam_analysis import DamAnalysis
+
+
+class _DisplacementControlledAnalysis(DamAnalysis):
+    boundary_node_ids = (7, 11, 12, 16, 20, 24)
+
+    def Initialize(self):
+        super().Initialize()
+        for node_id in self.boundary_node_ids:
+            self.main_model_part.GetNode(node_id).Fix(Kratos.DISPLACEMENT_X)
+
+
+class _AssembledTangentCheck:
+    interface_element_ids = range(21, 26)
+
+    def __init__(self, model_part):
+        self.model_part = model_part
+        self.scheme = DamApplication.IncrementalUpdateStaticSmoothingScheme()
+        self.space = Kratos.UblasSparseSpace()
+        self.builder = Kratos.ResidualBasedBlockBuilderAndSolver(
+            Kratos.SkylineLUFactorizationSolver())
+        self.A = self.space.CreateEmptyMatrixPointer()
+        self.Dx = self.space.CreateEmptyVectorPointer()
+        self.b = self.space.CreateEmptyVectorPointer()
+
+        self.scheme.Initialize(model_part)
+        self.scheme.InitializeElements(model_part)
+        self.scheme.InitializeConditions(model_part)
+        self.builder.SetUpDofSet(self.scheme, model_part)
+        self.builder.SetUpSystem(model_part)
+        self.builder.ResizeAndInitializeVectors(
+            self.scheme, self.A, self.Dx, self.b, model_part)
+        self.dofs = self.builder.GetDofSet()
+        self.free_equation_ids = [
+            dof.EquationId for dof in self.dofs if not dof.IsFixed()]
+
+    @staticmethod
+    def _norm(values):
+        return math.sqrt(sum(value * value for value in values))
+
+    def _move_mesh(self):
+        for node in self.model_part.Nodes:
+            displacement = node.GetSolutionStepValue(Kratos.DISPLACEMENT)
+            node.X = node.X0 + displacement[0]
+            node.Y = node.Y0 + displacement[1]
+            node.Z = node.Z0 + displacement[2]
+
+    def _jumps(self):
+        jumps = []
+        for element_id in self.interface_element_ids:
+            values = self.model_part.GetElement(element_id).CalculateOnIntegrationPoints(
+                PoromechanicsApplication.LOCAL_RELATIVE_DISPLACEMENT_VECTOR,
+                self.model_part.ProcessInfo)
+            jumps.extend(value[1] for value in values)
+        return jumps
+
+    def _snapshot(self):
+        return (
+            [dof.GetSolutionStepValue() for dof in self.dofs],
+            [(node.X, node.Y, node.Z) for node in self.model_part.Nodes])
+
+    def _restore(self, snapshot):
+        dof_values, coordinates = snapshot
+        for dof, value in zip(self.dofs, dof_values):
+            dof.SetSolutionStepValue(value)
+        for node, position in zip(self.model_part.Nodes, coordinates):
+            node.X, node.Y, node.Z = position
+
+    def _residual(self):
+        residual = Kratos.Vector(len(self.b))
+        self.space.SetToZeroVector(residual)
+        self.builder.BuildRHS(self.scheme, self.model_part, residual)
+        return residual
+
+    def _perturb(self, snapshot, direction, amount):
+        for dof, value in zip(self.dofs, snapshot[0]):
+            if not dof.IsFixed():
+                dof.SetSolutionStepValue(
+                    value + amount * direction[dof.EquationId])
+        self._move_mesh()
+
+    def evaluate(self):
+        self.space.SetToZeroMatrix(self.A)
+        self.space.SetToZeroVector(self.b)
+        self.builder.Build(self.scheme, self.model_part, self.A, self.b)
+
+        direction = [0.0] * len(self.dofs)
+        for dof in self.dofs:
+            if not dof.IsFixed():
+                equation_id = dof.EquationId
+                direction[equation_id] = float((equation_id * 37) % 17 - 8)
+        direction_norm = self._norm(direction)
+        direction = [value / direction_norm for value in direction]
+
+        tangent_product = Kratos.Vector(len(direction))
+        self.space.Mult(self.A, Kratos.Vector(direction), tangent_product)
+        tangent_product = [
+            tangent_product[i] for i in self.free_equation_ids]
+
+        snapshot = self._snapshot()
+        h = 2.0e-11
+        self._perturb(snapshot, direction, h)
+        plus_jumps = self._jumps()
+        plus_residual = self._residual()
+        self._restore(snapshot)
+        self._perturb(snapshot, direction, -h)
+        minus_jumps = self._jumps()
+        minus_residual = self._residual()
+        self._restore(snapshot)
+
+        switched_count = sum(
+            (plus < 0.0) != (minus < 0.0)
+            for plus, minus in zip(plus_jumps, minus_jumps))
+        all_jumps = plus_jumps + minus_jumps
+        if min(all_jumps) >= 0.0:
+            classification = "OPENING_ONLY"
+        elif max(all_jumps) < 0.0:
+            classification = "COMPRESSION_ONLY"
+        else:
+            classification = "MIXED_NO_CROSS"
+
+        derivative = [
+            (plus_residual[i] - minus_residual[i]) / (2.0 * h)
+            for i in self.free_equation_ids]
+        error = [
+            tangent_i + derivative_i
+            for tangent_i, derivative_i in zip(tangent_product, derivative)]
+        relative_error = self._norm(error) / max(
+            self._norm(tangent_product), self._norm(derivative), 1.0e-30)
+        return classification, switched_count, relative_error
+
+
+class TestGlobalTangentConsistency(KratosUnittest.TestCase):
+    displacement_history = (2.0e-4, 5.0e-4, 2.0e-5, -2.0e-5, -2.0e-4)
+
+    @staticmethod
+    def _parameters():
+        case_directory = os.path.join(
+            os.path.dirname(os.path.realpath(__file__)),
+            "joint_elastic_cohesive_2d_normal")
+        with open(os.path.join(
+                case_directory,
+                "joint_elastic_cohesive_2d_normal_parameters.json")) as parameter_file:
+            parameters = Kratos.Parameters(parameter_file.read())
+        parameters["problem_data"]["end_time"].SetDouble(5.0)
+        parameters["problem_data"]["time_step"].SetDouble(1.0)
+        parameters["problem_data"]["number_of_threads"].SetInt(1)
+        parameters["solver_settings"]["echo_level"].SetInt(0)
+        parameters["solver_settings"]["mechanical_solver_settings"][
+            "move_mesh_flag"].SetBool(True)
+        parameters["solver_settings"]["model_import_settings"][
+            "input_filename"].SetString(os.path.join(
+                case_directory, "joint_elastic_cohesive_2d_normal"))
+        parameters["loads_process_list"][0]["Parameters"][
+            "modulus"].SetString("0.0")
+        return parameters
+
+    def test_opening_and_mixed_state_assembled_tangents(self):
+        analysis = _DisplacementControlledAnalysis(
+            Kratos.Model(), self._parameters())
+        previous_severity = Kratos.Logger.GetDefaultOutput().GetSeverity()
+        Kratos.Logger.GetDefaultOutput().SetSeverity(Kratos.Logger.Severity.WARNING)
+        try:
+            analysis.Initialize()
+            tangent_check = _AssembledTangentCheck(analysis.main_model_part)
+            results = {}
+            for step, prescribed_displacement in enumerate(
+                    self.displacement_history, 1):
+                analysis.time += analysis.delta_time
+                analysis.main_model_part.CloneTimeStep(analysis.time)
+                analysis.main_model_part.ProcessInfo[Kratos.STEP] = step
+                for node_id in analysis.boundary_node_ids:
+                    analysis.main_model_part.GetNode(node_id).SetSolutionStepValue(
+                        Kratos.DISPLACEMENT_X, prescribed_displacement)
+                for process in analysis.list_of_processes:
+                    process.ExecuteInitializeSolutionStep()
+                analysis.solver.Solve()
+                if step in (2, 5):
+                    results[step] = tangent_check.evaluate()
+                for process in analysis.list_of_processes:
+                    process.ExecuteFinalizeSolutionStep()
+
+            self.assertEqual(results[2][0], "OPENING_ONLY")
+            self.assertEqual(results[5][0], "MIXED_NO_CROSS")
+            for classification, switched_count, relative_error in results.values():
+                self.assertEqual(switched_count, 0, classification)
+                self.assertLess(relative_error, 1.0e-6)
+        finally:
+            analysis.Finalize()
+            Kratos.Logger.GetDefaultOutput().SetSeverity(previous_severity)
+
+
+if __name__ == "__main__":
+    KratosUnittest.main()

--- a/applications/DamApplication/tests/test_interface_tangent_consistency.py
+++ b/applications/DamApplication/tests/test_interface_tangent_consistency.py
@@ -1,0 +1,326 @@
+import math
+import os
+
+import KratosMultiphysics as KM
+import KratosMultiphysics.DamApplication
+import KratosMultiphysics.PoromechanicsApplication as KratosPoro
+import KratosMultiphysics.KratosUnittest as KratosUnittest
+from KratosMultiphysics.DamApplication.dam_analysis import DamAnalysis
+
+
+class TestSmallDisplacementInterfaceTangent(KratosUnittest.TestCase):
+    """Directional finite-difference diagnostics for ElasticCohesive2DLaw.
+
+    CalculateLocalSystem returns the positive stiffness matrix and the negative
+    internal-force residual.  Consequently this test compares d(RHS)/du to
+    ``-LHS * p``.  States that straddle zero normal jump are intentionally
+    recorded but not asserted: the elastic cohesive law is discontinuously
+    differentiable at that point.
+    """
+
+    _eps_scales = (1.0e-4, 1.0e-3, 1.0e-2)
+
+    def _make_element(self, distort_current_coordinates_before_initialize=False):
+        model = KM.Model()
+        model_part = model.CreateModelPart("interface", 2)
+        model_part.AddNodalSolutionStepVariable(KM.DISPLACEMENT)
+        model_part.AddNodalSolutionStepVariable(KM.VOLUME_ACCELERATION)
+        model_part.AddNodalSolutionStepVariable(KratosPoro.INITIAL_STRESS_TENSOR)
+        model_part.AddNodalSolutionStepVariable(KratosPoro.NODAL_JOINT_WIDTH)
+        model_part.AddNodalSolutionStepVariable(KratosPoro.NODAL_JOINT_AREA)
+
+        # A unit, zero-thickness vertical interface. Nodes 1--2 and 3--4 are
+        # its two faces; the local normal is x and the local tangent is y.
+        for node_id, x, y in ((1, 0.0, 0.0), (2, 0.0, 1.0),
+                              (3, 0.0, 1.0), (4, 0.0, 0.0)):
+            node = model_part.CreateNewNode(node_id, x, y, 0.0)
+            node.AddDof(KM.DISPLACEMENT_X)
+            node.AddDof(KM.DISPLACEMENT_Y)
+            node.SetSolutionStepValue(KM.DISPLACEMENT, KM.Array3())
+            node.SetSolutionStepValue(KM.VOLUME_ACCELERATION, KM.Array3())
+            initial_stress = KM.Matrix(2, 2)
+            for i in range(2):
+                for j in range(2):
+                    initial_stress[i, j] = 0.0
+            node.SetSolutionStepValue(KratosPoro.INITIAL_STRESS_TENSOR, initial_stress)
+
+        properties = model_part.CreateNewProperties(1)
+        properties.SetValue(KM.DENSITY, 0.0)
+        properties.SetValue(KM.THICKNESS, 1.0)
+        # These legacy Poromechanics variables are registered globally rather
+        # than exported as Python module attributes.
+        properties.SetValue(KM.KratosGlobals.GetVariable("INITIAL_JOINT_WIDTH"), 0.0)
+        properties.SetValue(KM.KratosGlobals.GetVariable("NORMAL_STIFFNESS"), 3.0e5)
+        properties.SetValue(KM.KratosGlobals.GetVariable("SHEAR_STIFFNESS"), 3.0e5)
+        properties.SetValue(KM.KratosGlobals.GetVariable("PENALTY_STIFFNESS"), 1.0e3)
+        properties.SetValue(KM.CONSTITUTIVE_LAW, KratosPoro.ElasticCohesive2DLaw())
+        element = model_part.CreateNewElement(
+            "SmallDisplacementInterfaceElement2D4N", 1, [1, 2, 3, 4], properties)
+        model_part.ProcessInfo.SetValue(KratosPoro.IS_CONVERGED, True)
+        if distort_current_coordinates_before_initialize:
+            model_part.GetNode(3).X += 1.0e-2
+            model_part.GetNode(4).X += 1.0e-2
+        element.Initialize(model_part.ProcessInfo)
+        return model_part, element
+
+    @staticmethod
+    def _set_displacement(model_part, direction, scale):
+        for i, node in enumerate(model_part.Nodes):
+            displacement = KM.Array3()
+            displacement[0] = scale * direction[2 * i]
+            displacement[1] = scale * direction[2 * i + 1]
+            node.SetSolutionStepValue(KM.DISPLACEMENT, displacement)
+
+    @staticmethod
+    def _local_normal_jump(element, process_info):
+        jumps = element.CalculateOnIntegrationPoints(
+            KratosPoro.LOCAL_RELATIVE_DISPLACEMENT_VECTOR, process_info)
+        return sum(value[1] for value in jumps) / len(jumps)
+
+    @staticmethod
+    def _norm(vector):
+        return math.sqrt(sum(value * value for value in vector))
+
+    def _rhs(self, element, process_info):
+        lhs = KM.Matrix()
+        rhs = KM.Vector()
+        element.CalculateLocalSystem(lhs, rhs, process_info)
+        return rhs
+
+    @staticmethod
+    def _local_system(element, process_info):
+        lhs = KM.Matrix()
+        rhs = KM.Vector()
+        element.CalculateLocalSystem(lhs, rhs, process_info)
+        return lhs, rhs
+
+    def _assert_matrix_near(self, first, second, tolerance=1.0e-12):
+        self.assertEqual(first.Size1(), second.Size1())
+        self.assertEqual(first.Size2(), second.Size2())
+        for i in range(first.Size1()):
+            for j in range(first.Size2()):
+                self.assertAlmostEqual(first[i, j], second[i, j], delta=tolerance)
+
+    def _assert_vector_near(self, first, second, tolerance=1.0e-12):
+        self.assertEqual(len(first), len(second))
+        for first_i, second_i in zip(first, second):
+            self.assertAlmostEqual(first_i, second_i, delta=tolerance)
+
+    def _error(self, model_part, element, direction, normal_jump, epsilon):
+        self._set_displacement(model_part, direction, normal_jump + epsilon)
+        rhs_plus = self._rhs(element, model_part.ProcessInfo)
+        self._set_displacement(model_part, direction, normal_jump - epsilon)
+        rhs_minus = self._rhs(element, model_part.ProcessInfo)
+        self._set_displacement(model_part, direction, normal_jump)
+        lhs = KM.Matrix()
+        rhs = KM.Vector()
+        element.CalculateLocalSystem(lhs, rhs, model_part.ProcessInfo)
+
+        finite_difference = [(rhs_plus[i] - rhs_minus[i]) / (2.0 * epsilon)
+                             for i in range(len(rhs))]
+        analytical = [-sum(lhs[i, j] * direction[j] for j in range(len(rhs)))
+                      for i in range(len(rhs))]
+        difference = [a - b for a, b in zip(finite_difference, analytical)]
+        return self._norm(difference) / max(self._norm(finite_difference), self._norm(analytical), 1.0)
+
+    def test_tangent_is_consistent_inside_opening_and_compression_branches(self):
+        model_part, element = self._make_element()
+
+        # Apply opposite face displacements. Flip the direction once, if
+        # necessary, so positive scale is definitively the opening branch.
+        direction = [-1.0, 0.0, -1.0, 0.0, 1.0, 0.0, 1.0, 0.0]
+        self._set_displacement(model_part, direction, 1.0)
+        if self._local_normal_jump(element, model_part.ProcessInfo) < 0.0:
+            direction = [-value for value in direction]
+
+        # The small states and epsilons stay in their branch. The zero state
+        # is not asserted because its central perturbation crosses the switch.
+        for state in (1.0e-3, 1.0e-5, -1.0e-5, -1.0e-3):
+            branch = "opening" if state > 0.0 else "compression"
+            for epsilon_scale in self._eps_scales:
+                epsilon = max(abs(state), 1.0e-5) * epsilon_scale
+                error = self._error(model_part, element, direction, state, epsilon)
+                KM.Logger.PrintInfo("InterfaceTangentDiagnostic",
+                    "state={} branch={} epsilon={} crossing_zero=false relative_error={}".format(
+                        state, branch, epsilon, error))
+                self.assertLess(error, 1.0e-6,
+                    "Tangent inconsistency at normal jump {} and epsilon {}".format(state, epsilon))
+
+        for epsilon_scale in self._eps_scales:
+            epsilon = 1.0e-5 * epsilon_scale
+            crossing_error = self._error(model_part, element, direction, 0.0, epsilon)
+            KM.Logger.PrintInfo("InterfaceTangentDiagnostic",
+                "state=0.0 branch=boundary epsilon={} crossing_zero=true relative_error={}".format(
+                    epsilon, crossing_error))
+            self.assertGreater(crossing_error, 1.0e-3,
+                "The zero-jump diagnostic must continue to cross the constitutive switch")
+
+    def test_displacement_controlled_cycle_exercises_both_branches(self):
+        test_directory = os.path.dirname(os.path.realpath(__file__))
+        parameter_file = os.path.join(test_directory,
+            "joint_elastic_cohesive_2d_normal",
+            "joint_elastic_cohesive_2d_normal_parameters.json")
+        with open(parameter_file, "r") as parameters_stream:
+            parameters = KM.Parameters(parameters_stream.read())
+
+        history = (2.0e-4, 5.0e-4, 2.0e-5, -2.0e-5,
+                   -2.0e-4, -2.0e-5, 2.0e-5, 2.0e-4)
+        parameters["problem_data"]["end_time"].SetDouble(float(len(history)))
+        parameters["problem_data"]["time_step"].SetDouble(1.0)
+        parameters["solver_settings"]["model_import_settings"]["input_filename"].SetString(
+            os.path.join(test_directory, "joint_elastic_cohesive_2d_normal",
+                         "joint_elastic_cohesive_2d_normal"))
+        parameters["loads_process_list"][0]["Parameters"]["modulus"].SetString("0.0")
+
+        class DisplacementControlledAnalysis(DamAnalysis):
+            boundary_node_ids = (7, 11, 12, 16, 20, 24)
+
+            def Initialize(self):
+                super().Initialize()
+                self.normal_jumps = []
+                for node_id in self.boundary_node_ids:
+                    self.main_model_part.GetNode(node_id).Fix(KM.DISPLACEMENT_X)
+
+            def RunMainTemporalLoop(self):
+                for step, prescribed_displacement in enumerate(history, 1):
+                    self.time += self.delta_time
+                    self.main_model_part.CloneTimeStep(self.time)
+                    self.main_model_part.ProcessInfo[KM.STEP] = step
+                    for node_id in self.boundary_node_ids:
+                        self.main_model_part.GetNode(node_id).SetSolutionStepValue(
+                            KM.DISPLACEMENT_X, prescribed_displacement)
+                    for process in self.list_of_processes:
+                        process.ExecuteInitializeSolutionStep()
+                    self.solver.Solve()
+                    interface = self.main_model_part.GetElement(21)
+                    local_jumps = interface.CalculateOnIntegrationPoints(
+                        KratosPoro.LOCAL_RELATIVE_DISPLACEMENT_VECTOR,
+                        self.main_model_part.ProcessInfo)
+                    self.normal_jumps.append(local_jumps[0][1])
+                    for process in self.list_of_processes:
+                        process.ExecuteFinalizeSolutionStep()
+
+        analysis = DisplacementControlledAnalysis(KM.Model(), parameters)
+        analysis.Run()
+        branches = [jump > 0.0 for jump in analysis.normal_jumps]
+        self.assertTrue(any(branches), "Cycle did not exercise opening")
+        self.assertTrue(any(not branch for branch in branches), "Cycle did not exercise compression")
+        self.assertTrue(any(branches[i-1] and not branches[i] for i in range(1, len(branches))))
+        self.assertTrue(any(not branches[i-1] and branches[i] for i in range(1, len(branches))))
+
+    def test_reference_geometry_is_invariant_while_opening_remains_live(self):
+        model_part, element = self._make_element()
+
+        # Besides opening the two faces, distort the moved mid-plane enough
+        # that a current-geometry rotation and measure would visibly change.
+        opening_displacements = (
+            (-1.0e-3, 0.0), (9.0e-2, 2.0e-1),
+            (9.2e-2, 2.0e-1), (1.0e-3, 0.0))
+        for node, displacement in zip(model_part.Nodes, opening_displacements):
+            value = KM.Array3()
+            value[0], value[1] = displacement
+            node.SetSolutionStepValue(KM.DISPLACEMENT, value)
+
+        trial_jump = element.CalculateOnIntegrationPoints(
+            KratosPoro.LOCAL_RELATIVE_DISPLACEMENT_VECTOR,
+            model_part.ProcessInfo)
+        if sum(value[1] for value in trial_jump) < 0.0:
+            for node in model_part.Nodes:
+                displacement = node.GetSolutionStepValue(KM.DISPLACEMENT)
+                displacement[0] *= -1.0
+                displacement[1] *= -1.0
+                node.SetSolutionStepValue(KM.DISPLACEMENT, displacement)
+
+        reference_lhs, reference_rhs = self._local_system(
+            element, model_part.ProcessInfo)
+        reference_jump = element.CalculateOnIntegrationPoints(
+            KratosPoro.LOCAL_RELATIVE_DISPLACEMENT_VECTOR,
+            model_part.ProcessInfo)
+
+        for node in model_part.Nodes:
+            displacement = node.GetSolutionStepValue(KM.DISPLACEMENT)
+            node.X = node.X0 + displacement[0]
+            node.Y = node.Y0 + displacement[1]
+
+        moved_lhs, moved_rhs = self._local_system(element, model_part.ProcessInfo)
+        moved_jump = element.CalculateOnIntegrationPoints(
+            KratosPoro.LOCAL_RELATIVE_DISPLACEMENT_VECTOR,
+            model_part.ProcessInfo)
+        opening_stress = element.CalculateOnIntegrationPoints(
+            KratosPoro.LOCAL_STRESS_VECTOR, model_part.ProcessInfo)
+
+        self._assert_matrix_near(reference_lhs, moved_lhs)
+        self._assert_vector_near(reference_rhs, moved_rhs)
+        for reference_value, moved_value in zip(reference_jump, moved_jump):
+            self._assert_vector_near(reference_value, moved_value)
+
+        opening_normal_jump = sum(value[1] for value in moved_jump) / len(moved_jump)
+        self.assertGreater(opening_normal_jump, 0.0)
+        opening_joint_width = max(opening_normal_jump, 0.0)
+
+        for node in model_part.Nodes:
+            displacement = node.GetSolutionStepValue(KM.DISPLACEMENT)
+            displacement[0] *= -1.0
+            displacement[1] *= -1.0
+            node.SetSolutionStepValue(KM.DISPLACEMENT, displacement)
+            node.X = node.X0 + displacement[0]
+            node.Y = node.Y0 + displacement[1]
+
+        compressed_jump = element.CalculateOnIntegrationPoints(
+            KratosPoro.LOCAL_RELATIVE_DISPLACEMENT_VECTOR,
+            model_part.ProcessInfo)
+        compressed_stress = element.CalculateOnIntegrationPoints(
+            KratosPoro.LOCAL_STRESS_VECTOR, model_part.ProcessInfo)
+        compressed_normal_jump = sum(value[1] for value in compressed_jump) / len(compressed_jump)
+        compressed_joint_width = max(compressed_normal_jump, 0.0)
+        opening_normal_stress = sum(value[1] for value in opening_stress) / len(opening_stress)
+        compressed_normal_stress = sum(value[1] for value in compressed_stress) / len(compressed_stress)
+
+        self.assertLess(compressed_normal_jump, 0.0)
+        self.assertGreater(opening_joint_width, compressed_joint_width)
+        self.assertEqual(compressed_joint_width, 0.0)
+        self.assertGreater(opening_normal_stress, 0.0)
+        self.assertLess(compressed_normal_stress, 0.0)
+        self.assertGreater(
+            abs(compressed_normal_stress), 100.0 * abs(opening_normal_stress))
+
+    def test_initial_gap_uses_reference_geometry(self):
+        reference_model_part, reference_element = self._make_element()
+        moved_model_part, moved_element = self._make_element(True)
+
+        direction = [-1.0, 0.0, -1.0, 0.0, 1.0, 0.0, 1.0, 0.0]
+        self._set_displacement(reference_model_part, direction, 1.0e-4)
+        self._set_displacement(moved_model_part, direction, 1.0e-4)
+
+        reference_lhs, reference_rhs = self._local_system(
+            reference_element, reference_model_part.ProcessInfo)
+        moved_lhs, moved_rhs = self._local_system(
+            moved_element, moved_model_part.ProcessInfo)
+        self._assert_matrix_near(reference_lhs, moved_lhs)
+        self._assert_vector_near(reference_rhs, moved_rhs)
+
+    def test_nonzero_initial_stress_uses_reference_frame(self):
+        model_part, element = self._make_element()
+        initial_stress = KM.Matrix(2, 2)
+        initial_stress[0, 0] = 4.0
+        initial_stress[0, 1] = 1.0
+        initial_stress[1, 0] = 1.0
+        initial_stress[1, 1] = 2.0
+        for node in model_part.Nodes:
+            node.SetSolutionStepValue(KratosPoro.INITIAL_STRESS_TENSOR, initial_stress)
+
+        reference_lhs, reference_rhs = self._local_system(
+            element, model_part.ProcessInfo)
+        reference_stress = element.CalculateOnIntegrationPoints(
+            KratosPoro.LOCAL_STRESS_VECTOR, model_part.ProcessInfo)
+
+        model_part.GetNode(2).X += 2.0e-1
+        model_part.GetNode(3).X += 2.0e-1
+        moved_lhs, moved_rhs = self._local_system(element, model_part.ProcessInfo)
+        moved_stress = element.CalculateOnIntegrationPoints(
+            KratosPoro.LOCAL_STRESS_VECTOR, model_part.ProcessInfo)
+
+        self._assert_matrix_near(reference_lhs, moved_lhs)
+        self._assert_vector_near(reference_rhs, moved_rhs)
+        for reference_value, moved_value in zip(reference_stress, moved_stress):
+            self._assert_vector_near(reference_value, moved_value)


### PR DESCRIPTION
## **📝 Description**
This PR makes the quasi-static formulation of `SmallDisplacementInterfaceElement` consistently use the reference configuration.

Previously, the local interface frame and integration measure were computed from the current nodal coordinates. Since DamApplication normally uses `move_mesh_flag = true`, these quantities changed during the Newton iterations, while the corresponding geometric derivatives were not included in the tangent matrix. This resulted in an inconsistent assembled tangent, especially noticeable for compressed interfaces with large penalty stiffness.

The element originates from the Poromechanics small-strain interface-element family, where this geometry dependence is normally masked by the standard fixed-mesh configuration (`move_mesh_flag = false`). In DamApplication, the moved-mesh configuration exposed this implicit dependency.

### **Key changes**

- Use the reference configuration for the interface local frame and displacement-jump transformation.
- Use the reference Jacobian and integration measure in the quasi-static formulation.
- Compute the initial gap from the initial nodal positions.
- Use the reference geometry consistently for initial-stress transformations, local/contact stress outputs, constitutive finalization, and joint-width calculations.
- Keep interface opening/closure displacement-dependent, i.e. `jump_local = R0 * Nu * u`.
- Keep the existing current-geometry behavior of the mass matrix and Rayleigh-alpha contribution, which are outside the scope of this PR.

### **Validation**

- Verified the analytical tangent against finite differences in smooth opening and compression states.
- Verified the assembled tangent with `move_mesh_flag = true` in both opening and mixed opening/compression configurations.
- The mixed-state tangent error is reduced from approximately `1e-5` to `1e-9`.
- The nonlinear iteration count no longer increases with penalty stiffness in the tested range from `1e3` to `1e10`.
- Physical differences with respect to the previous formulation are negligible and consistent with the small-displacement assumption.
- Existing DamApplication interface reference results remain unchanged.
- DamApplication `small`, `nightly`, and `all` test suites pass.

## **🆕 Changelog**
- Fixed `SmallDisplacementInterfaceElement` to consistently use reference geometry in its quasi-static formulation.
- Removed the implicit dependency of the interface formulation on `move_mesh_flag`.
- Improved tangent consistency and robustness for compressed interfaces with high penalty stiffness.