### PR TITLE
[Core] Fix BiCGSTAB discarding the solution on exact-preconditioner breakdown

### DIFF
--- a/kratos/linear_solvers/bicgstab_solver.h
+++ b/kratos/linear_solvers/bicgstab_solver.h
@@ -294,6 +294,10 @@ private:
         TSparseSpaceType::ScaleAndAdd(1.00, rB, -1.00, r);
 // KRATOS_WATCH("ln322");
         BaseType::mBNorm = TSparseSpaceType::TwoNorm(rB);
+        // Seed the residual norm from *this* solve. mResidualNorm is a member carried
+        // over from the previous Solve() call, so without this any early exit from the
+        // loop below would have IsConverged() judge the previous system, not this one.
+        BaseType::mResidualNorm = TSparseSpaceType::TwoNorm(r);
 // KRATOS_WATCH("ln324");
         VectorType p(r);
         VectorType s(size);
@@ -328,7 +332,21 @@ private:
 
             //if(omega == 0.00)
             if(fabs(omega) <= 1.0e-40)
+            {
+                // "Happy" breakdown: s = r - alpha*q has collapsed to (numerically) zero,
+                // which means rX + alpha*p already solves the system. That half step has to
+                // be committed before leaving -- dropping it makes a solve that has in fact
+                // converged return rX completely untouched, which the callers cannot detect
+                // and which silently degrades into a zero correction. It is reached on the
+                // very first iteration whenever the preconditioner is (near) exact, e.g.
+                // ILU0 on a tridiagonal matrix, where q == r and alpha == 1 to rounding.
+                TSparseSpaceType::ScaleAndAdd(alpha, p, 1.00, rX);
+                TSparseSpaceType::Copy(s, r);
+
+                BaseType::mResidualNorm = TSparseSpaceType::TwoNorm(r);
+                BaseType::mIterationsNumber++;
                 break;
+            }
 // KRATOS_WATCH("ln356");
             omega = TSparseSpaceType::Dot(qs,s) / omega;
 
@@ -337,6 +355,12 @@ private:
             TSparseSpaceType::ScaleAndAdd(-omega, qs, 1.00, s, r);
 
             roh1 = TSparseSpaceType::Dot(r,rs);
+
+            // Recorded before the breakdown check below: rX has already been updated at
+            // this point, so an exit that left the norm untouched would report a residual
+            // that does not belong to the returned solution.
+            BaseType::mResidualNorm = TSparseSpaceType::TwoNorm(r);
+            BaseType::mIterationsNumber++;
 
             //if((roh0 == 0.00) || (omega == 0.00))
             if((fabs(roh0) <= 1.0e-40) || (fabs(omega) <= 1.0e-40))
@@ -348,9 +372,6 @@ private:
             TSparseSpaceType::ScaleAndAdd(1.00, r, beta, q, p);
 
             roh0 = roh1;
-
-            BaseType::mResidualNorm =TSparseSpaceType::TwoNorm(r);
-            BaseType::mIterationsNumber++;
 
         }
         while(BaseType::IterationNeeded());

--- a/kratos/tests/auxiliar_files_for_python_unittest/sparse_matrix_files/tridiagonal_A.mm
+++ b/kratos/tests/auxiliar_files_for_python_unittest/sparse_matrix_files/tridiagonal_A.mm
@@ -1,0 +1,27 @@
+%%MatrixMarket matrix coordinate real general
+%=================================================================================
+%
+% A small tridiagonal system, of the shape a 1D transient groundwater flow problem
+% on three two-node line elements produces: a permeability (1D Laplacian) operator
+% scaled by k/mu = 9.084e-06 / 1.0e-03, with the first degree of freedom prescribed
+% (its row zeroed off the diagonal and its column zeroed in the other rows, as
+% ApplyDirichletConditions leaves it - the zeroed entries are kept explicitly so the
+% sparsity pattern matches the assembled one).
+%
+% The point of this matrix is that it is tridiagonal, so ILU0 drops no fill-in and
+% is an *exact* factorization of it. A Krylov method preconditioned with it reaches
+% the solution within the first iteration, which is the degenerate case ("happy"
+% breakdown) that iterative solvers have to commit rather than discard.
+%
+%=================================================================================
+4 4 10
+1 1 9.084e-03
+1 2 0.0
+2 1 0.0
+2 2 1.8168e-02
+2 3 -9.084e-03
+3 2 -9.084e-03
+3 3 1.8168e-02
+3 4 -9.084e-03
+4 3 -9.084e-03
+4 4 9.084e-03

--- a/kratos/tests/test_linear_solvers.py
+++ b/kratos/tests/test_linear_solvers.py
@@ -8,12 +8,15 @@ def GetFilePath(fileName):
 
 class TestLinearSolvers(KratosUnittest.TestCase):
 
-    def _RunParametrized(self, my_params_string ):
+    def _RunParametrized(self, my_params_string, matrix_name=None, rhs_scaling=1.0):
         all_settings = KratosMultiphysics.Parameters( my_params_string )
 
         for i in range(all_settings["test_list"].size()):
             settings = all_settings["test_list"][i]
-            self._auxiliary_test_function(settings)
+            if matrix_name is None:
+                self._auxiliary_test_function(settings, rhs_scaling=rhs_scaling)
+            else:
+                self._auxiliary_test_function(settings, matrix_name, rhs_scaling)
 
     def _auxiliary_test_function(self, settings, matrix_name="auxiliar_files_for_python_unittest/sparse_matrix_files/A.mm"):
         space = KratosMultiphysics.UblasSparseSpace()
@@ -160,6 +163,39 @@ class TestLinearSolvers(KratosUnittest.TestCase):
                 ]
             }
             """)
+
+    def test_bicgstab_exactly_preconditioned(self):
+        """A tridiagonal system, on which ILU0 drops no fill-in and is therefore an exact
+        factorization. The preconditioned Krylov iteration then reaches the solution within
+        its first iteration, so the update it accumulated there is the whole answer: a solver
+        that treats that degenerate case as a failure and leaves the unknowns untouched
+        returns a zero correction, which no caller can distinguish from "nothing to do".
+
+        Covered with scaling both off and on, since the scaled variant is what the
+        GeoMechanics transient groundwater flow tests exercise.
+        """
+        self._RunParametrized("""
+            {
+                "test_list" : [
+                    {
+                        "solver_type" : "bicgstab",
+                        "tolerance" : 1.0e-6,
+                        "max_iteration" : 500,
+                        "preconditioner_type" : "ilu0",
+                        "scaling": false
+                    },
+                    {
+                        "solver_type" : "bicgstab",
+                        "tolerance" : 1.0e-6,
+                        "max_iteration" : 500,
+                        "preconditioner_type" : "ilu0",
+                        "scaling": true
+                    }
+                ]
+            }
+            """,
+            "auxiliar_files_for_python_unittest/sparse_matrix_files/tridiagonal_A.mm",
+            rhs_scaling=1.0e-8)
 
     def test_skyline_lu(self):
         self._RunParametrized("""

--- a/kratos/tests/test_linear_solvers.py
+++ b/kratos/tests/test_linear_solvers.py
@@ -18,7 +18,7 @@ class TestLinearSolvers(KratosUnittest.TestCase):
             else:
                 self._auxiliary_test_function(settings, matrix_name, rhs_scaling)
 
-    def _auxiliary_test_function(self, settings, matrix_name="auxiliar_files_for_python_unittest/sparse_matrix_files/A.mm"):
+    def _auxiliary_test_function(self, settings, matrix_name="auxiliar_files_for_python_unittest/sparse_matrix_files/A.mm", rhs_scaling=1.0):
         space = KratosMultiphysics.UblasSparseSpace()
 
         #read the matrices
@@ -33,7 +33,7 @@ class TestLinearSolvers(KratosUnittest.TestCase):
         space.SetToZeroVector(b)
 
         for i in range(len(b)):
-            b[i] = i/len(b)
+            b[i] = rhs_scaling * i/len(b)
 
         x = KratosMultiphysics.Vector(n)
         #KratosMultiphysics.ReadMatrixMarketVector("b.mm",b)


### PR DESCRIPTION
## Summary

`BICGSTABSolver::IterativeSolve` silently returns a wrong "solved" system whenever the preconditioned residual collapses to (numerically) zero on the very first iteration, the "happy breakdown" case, which is exactly what happens whenever the preconditioner is an **exact** factorization of the system (e.g. ILU(0) on a tridiagonal matrix, which has no fill-in to drop).

Concretely, on that breakdown:

- The half-step update `rX += alpha*p` that was already computed is **discarded**, the loop `break`s before applying it, so `rX` comes back completely untouched.
- `mResidualNorm` is a member left over from whatever the *previous* `Solve()` call converged to (or its default-constructed `0`), so `IsConverged()` reports success anyway.

The net effect: for a system where this solver should converge in one iteration, it instead returns the caller's initial guess unchanged while claiming convergence. Any Newton loop built on it never gets a real correction and just marks the (unsolved) system as converged.

This is not related to any specific backend, reproduced with the plain `UblasSparseSpace`/`bicgstab`/`ilu0` combination already on `master`, with both `"scaling": true` and `false`.

I found it while chasing an unrelated CI failure on a eigen backend branch.

## Fix

`kratos/linear_solvers/bicgstab_solver.h`:
- Seed `mResidualNorm` from *this* solve's initial residual, instead of leaving it as whatever the previous `Solve()` call (or default construction) set it to.
- On the `omega` breakdown, commit the pending `rX += alpha*p` update and set `r = s` before breaking, instead of discarding it.
- Record `mResidualNorm`/`mIterationsNumber` right after `rX` is updated inside the loop, rather than after the subsequent `roh0`/`omega` breakdown check, so an exit there also reports the residual that actually belongs to the returned solution.
