### PR TITLE
[Several] Introduce `default_interface.h` as unified linear-algebra backend header

### DIFF
--- a/applications/CableNetApplication/cable_net_application_variables.h
+++ b/applications/CableNetApplication/cable_net_application_variables.h
@@ -20,7 +20,7 @@
 // Project includes
 #include "includes/define.h"
 #include "containers/variable.h"
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 
 namespace Kratos
 {

--- a/applications/CompressiblePotentialFlowApplication/custom_utilities/potential_flow_utilities.h
+++ b/applications/CompressiblePotentialFlowApplication/custom_utilities/potential_flow_utilities.h
@@ -15,7 +15,7 @@
 
 // Project includes
 #include "containers/array_1d.h"
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 #include "utilities/geometry_utilities.h"
 
 namespace Kratos

--- a/applications/CompressiblePotentialFlowApplication/tests/cpp_tests/test_utilities.h
+++ b/applications/CompressiblePotentialFlowApplication/tests/cpp_tests/test_utilities.h
@@ -11,7 +11,7 @@
 //
 
 #include "containers/array_1d.h"
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 
 namespace Kratos
 {

--- a/applications/ConstitutiveLawsApplication/custom_utilities/advanced_constitutive_law_utilities.h
+++ b/applications/ConstitutiveLawsApplication/custom_utilities/advanced_constitutive_law_utilities.h
@@ -18,7 +18,7 @@
 // External includes
 
 // Project includes
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 #include "includes/node.h"
 #include "includes/constitutive_law.h"
 #include "geometries/geometry.h"

--- a/applications/ContactMechanicsApplication/custom_conditions/beam_contact/beam_point_rigid_contact_condition.hpp
+++ b/applications/ContactMechanicsApplication/custom_conditions/beam_contact/beam_point_rigid_contact_condition.hpp
@@ -10,17 +10,14 @@
 #define  KRATOS_BEAM_POINT_RIGID_CONTACT_CONDITION_H_INCLUDED
 
 
-
 // System includes
 
 // External includes
-#include "boost/smart_ptr.hpp"
 
 // Project includes
-#include "includes/define.h"
 #include "includes/serializer.h"
 #include "includes/condition.h"
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 #include "includes/variables.h"
 #include "utilities/beam_math_utilities.hpp"
 

--- a/applications/ContactMechanicsApplication/custom_conditions/rigid_contact/point_rigid_contact_condition.hpp
+++ b/applications/ContactMechanicsApplication/custom_conditions/rigid_contact/point_rigid_contact_condition.hpp
@@ -13,13 +13,11 @@
 // System includes
 
 // External includes
-#include "boost/smart_ptr.hpp"
 
 // Project includes
-#include "includes/define.h"
 #include "includes/serializer.h"
 #include "includes/condition.h"
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 #include "includes/variables.h"
 
 #include "custom_bounding/spatial_bounding_box.hpp"

--- a/applications/ContactMechanicsApplication/custom_conditions/thermal_contact/thermal_contact_domain_condition.hpp
+++ b/applications/ContactMechanicsApplication/custom_conditions/thermal_contact/thermal_contact_domain_condition.hpp
@@ -15,15 +15,12 @@
 #include <iomanip>
 
 // External includes
-#include "boost/smart_ptr.hpp"
-
 
 // Project includes
-#include "includes/define.h"
 #include "includes/element.h"
 #include "includes/serializer.h"
 #include "includes/condition.h"
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 #include "includes/variables.h"
 #include "includes/constitutive_law.h"
 #include "includes/condition.h"

--- a/applications/ConvectionDiffusionApplication/custom_elements/conv_diff_2d.h
+++ b/applications/ConvectionDiffusionApplication/custom_elements/conv_diff_2d.h
@@ -17,9 +17,8 @@
 // External includes
 
 // Project includes
-#include "includes/define.h"
 #include "includes/element.h"
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 #include "includes/variables.h"
 #include "includes/serializer.h"
 

--- a/applications/ConvectionDiffusionApplication/custom_elements/conv_diff_3d.h
+++ b/applications/ConvectionDiffusionApplication/custom_elements/conv_diff_3d.h
@@ -16,11 +16,9 @@
 
 // External includes
 
-
 // Project includes
-#include "includes/define.h"
 #include "includes/element.h"
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 #include "includes/variables.h"
 
 #include "includes/serializer.h"

--- a/applications/ConvectionDiffusionApplication/custom_elements/conv_diff_change_of_phase_2d.h
+++ b/applications/ConvectionDiffusionApplication/custom_elements/conv_diff_change_of_phase_2d.h
@@ -17,9 +17,8 @@
 // External includes
 
 // Project includes
-#include "includes/define.h"
 #include "includes/element.h"
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 #include "includes/variables.h"
 
 #include "includes/serializer.h"

--- a/applications/ConvectionDiffusionApplication/custom_elements/eulerian_conv_diff.h
+++ b/applications/ConvectionDiffusionApplication/custom_elements/eulerian_conv_diff.h
@@ -12,24 +12,18 @@
 #if !defined(KRATOS_EULERIAN_CONVECTION_DIFFUSION_ELEMENT_INCLUDED )
 #define  KRATOS_EULERIAN_CONVECTION_DIFFUSION_ELEMENT_INCLUDED
 
-
 // System includes
-
 
 // External includes
 
-
 // Project includes
-#include "includes/define.h"
 #include "includes/element.h"
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 #include "includes/variables.h"
 #include "includes/cfd_variables.h"
 #include "includes/serializer.h"
 #include "utilities/math_utils.h"
 #include "utilities/geometry_utilities.h"
-
-
 
 namespace Kratos
 {

--- a/applications/ConvectionDiffusionApplication/custom_elements/eulerian_diff.h
+++ b/applications/ConvectionDiffusionApplication/custom_elements/eulerian_diff.h
@@ -13,17 +13,13 @@
 #if !defined(KRATOS_EULERIAN_DIFFUSION_ELEMENT_INCLUDED )
 #define  KRATOS_EULERIAN_DIFFUSION_ELEMENT_INCLUDED
 
-
 // System includes
-
 
 // External includes
 
-
 // Project includes
-#include "includes/define.h"
 #include "includes/element.h"
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 #include "includes/variables.h"
 #include "includes/cfd_variables.h"
 #include "includes/serializer.h"
@@ -31,8 +27,6 @@
 #include "includes/convection_diffusion_settings.h"
 #include "utilities/math_utils.h"
 #include "utilities/geometry_utilities.h"
-
-
 
 namespace Kratos
 {

--- a/applications/ConvectionDiffusionApplication/custom_elements/laplacian_element.h
+++ b/applications/ConvectionDiffusionApplication/custom_elements/laplacian_element.h
@@ -17,11 +17,9 @@
 // External includes
 
 // Project includes
-#include "includes/define.h"
 #include "includes/element.h"
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 #include "includes/variables.h"
-
 
 namespace Kratos
 {

--- a/applications/ConvectionDiffusionApplication/custom_elements/laplacian_shifted_boundary_element.cpp
+++ b/applications/ConvectionDiffusionApplication/custom_elements/laplacian_shifted_boundary_element.cpp
@@ -15,9 +15,8 @@
 
 // Project includes
 #include "includes/checks.h"
-#include "includes/define.h"
 #include "includes/kratos_flags.h"
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 #include "includes/variables.h"
 #include "includes/convection_diffusion_settings.h"
 #include "utilities/geometry_utilities.h"

--- a/applications/ConvectionDiffusionApplication/custom_elements/mixed_laplacian_element.h
+++ b/applications/ConvectionDiffusionApplication/custom_elements/mixed_laplacian_element.h
@@ -17,9 +17,8 @@
 // External includes
 
 // Project includes
-#include "includes/define.h"
 #include "includes/element.h"
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 #include "includes/variables.h"
 
 namespace Kratos

--- a/applications/ConvectionDiffusionApplication/custom_elements/mixed_laplacian_shifted_boundary_element.cpp
+++ b/applications/ConvectionDiffusionApplication/custom_elements/mixed_laplacian_shifted_boundary_element.cpp
@@ -15,9 +15,8 @@
 
 // Project includes
 #include "includes/checks.h"
-#include "includes/define.h"
 #include "includes/kratos_flags.h"
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 #include "includes/variables.h"
 #include "includes/convection_diffusion_settings.h"
 #include "utilities/geometry_utilities.h"

--- a/applications/DEMApplication/custom_elements/Particle_Contact_Element.h
+++ b/applications/DEMApplication/custom_elements/Particle_Contact_Element.h
@@ -5,21 +5,15 @@
 #if !defined(KRATOS_PARTICLE_CONTACT_ELEMENT_H_INCLUDED )
 #define  KRATOS_PARTICLE_CONTACT_ELEMENT_H_INCLUDED
 
-
-
 // System includes
-
 
 // External includes
 
-
 // Project includes
-#include "includes/define.h"
 #include "includes/serializer.h"
 #include "includes/element.h"
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 #include "includes/variables.h"
-//#include "includes/constitutive_law.h"
 
 namespace Kratos
 {

--- a/applications/FSIApplication/custom_utilities/ibqn_mvqn_convergence_accelerator.h
+++ b/applications/FSIApplication/custom_utilities/ibqn_mvqn_convergence_accelerator.h
@@ -18,7 +18,7 @@
 // External includes
 
 // Project includes
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 #include "utilities/math_utils.h"
 #include "utilities/dense_householder_qr_decomposition.h"
 #include "utilities/parallel_utilities.h"

--- a/applications/FSIApplication/custom_utilities/mvqn_convergence_accelerator.hpp
+++ b/applications/FSIApplication/custom_utilities/mvqn_convergence_accelerator.hpp
@@ -18,7 +18,7 @@
 // External includes
 
 // Project includes
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 #include "solving_strategies/convergence_accelerators/convergence_accelerator.h"
 #include "utilities/svd_utils.h"
 #include "utilities/parallel_utilities.h"

--- a/applications/FSIApplication/custom_utilities/mvqn_recursive_convergence_accelerator.hpp
+++ b/applications/FSIApplication/custom_utilities/mvqn_recursive_convergence_accelerator.hpp
@@ -16,7 +16,7 @@
 /* External includes */
 
 /* Project includes */
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 #include "solving_strategies/convergence_accelerators/convergence_accelerator.h"
 #include "utilities/dense_householder_qr_decomposition.h"
 #include "utilities/svd_utils.h"

--- a/applications/FSIApplication/custom_utilities/nodal_update_utilities.h
+++ b/applications/FSIApplication/custom_utilities/nodal_update_utilities.h
@@ -18,14 +18,13 @@
 /* External includes */
 
 /* Project includes */
-#include "includes/define.h"
 #include "includes/variables.h"
 #include "includes/mesh_moving_variables.h"
 #include "includes/fsi_variables.h"
 #include "containers/array_1d.h"
 #include "includes/model_part.h"
 #include "includes/communicator.h"
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 #include "utilities/openmp_utils.h"
 #include "utilities/variable_utils.h"
 

--- a/applications/FSIApplication/custom_utilities/partitioned_fsi_utilities.hpp
+++ b/applications/FSIApplication/custom_utilities/partitioned_fsi_utilities.hpp
@@ -21,14 +21,13 @@
 /* External includes */
 
 /* Project includes */
-#include "includes/define.h"
 #include "includes/variables.h"
 #include "includes/mesh_moving_variables.h"
 #include "includes/fsi_variables.h"
 #include "containers/array_1d.h"
 #include "includes/model_part.h"
 #include "includes/communicator.h"
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 #include "utilities/binbased_fast_point_locator.h"
 #include "utilities/math_utils.h"
 #include "utilities/normal_calculation_utils.h"

--- a/applications/FemToDemApplication/custom_utilities/constitutive_law_utilities.h
+++ b/applications/FemToDemApplication/custom_utilities/constitutive_law_utilities.h
@@ -19,7 +19,7 @@
 // External includes
 
 // Project includes
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 #include "includes/node.h"
 #include "geometries/geometry.h"
 #include "includes/constitutive_law.h"

--- a/applications/FluidDynamicsApplication/custom_elements/data_containers/fluid_adjoint_derivatives.h
+++ b/applications/FluidDynamicsApplication/custom_elements/data_containers/fluid_adjoint_derivatives.h
@@ -19,7 +19,7 @@
 // External includes
 
 // Project includes
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 
 // Application includes
 

--- a/applications/FluidDynamicsApplication/custom_elements/data_containers/qs_vms/qs_vms_derivative_utilities.h
+++ b/applications/FluidDynamicsApplication/custom_elements/data_containers/qs_vms/qs_vms_derivative_utilities.h
@@ -24,7 +24,7 @@
 #include "includes/constitutive_law.h"
 #include "includes/node.h"
 #include "includes/process_info.h"
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 #include "utilities/time_discretization.h"
 
 // Application includes

--- a/applications/FluidDynamicsApplication/custom_elements/data_containers/qs_vms/qs_vms_residual_derivatives.h
+++ b/applications/FluidDynamicsApplication/custom_elements/data_containers/qs_vms/qs_vms_residual_derivatives.h
@@ -23,7 +23,7 @@
 #include "includes/constitutive_law.h"
 #include "includes/node.h"
 #include "includes/process_info.h"
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 #include "utilities/time_discretization.h"
 
 // Application includes

--- a/applications/FluidDynamicsApplication/custom_elements/two_fluid_navier_stokes_fractional_convection.h
+++ b/applications/FluidDynamicsApplication/custom_elements/two_fluid_navier_stokes_fractional_convection.h
@@ -19,7 +19,7 @@
 // External includes
 
 // Project includes
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 #include "includes/variables.h"
 #include "includes/cfd_variables.h"
 #include "includes/convection_diffusion_settings.h"

--- a/applications/FluidDynamicsApplication/custom_elements/two_fluid_navier_stokes_fractional_convection_element.h
+++ b/applications/FluidDynamicsApplication/custom_elements/two_fluid_navier_stokes_fractional_convection_element.h
@@ -19,7 +19,7 @@
 // External includes
 
 // Project includes
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 #include "includes/variables.h"
 #include "includes/cfd_variables.h"
 #include "includes/convection_diffusion_settings.h"

--- a/applications/FluidDynamicsApplication/custom_elements/vms_adjoint_element.h
+++ b/applications/FluidDynamicsApplication/custom_elements/vms_adjoint_element.h
@@ -21,10 +21,9 @@
 #include <array>
 
 // Project includes
-#include "includes/define.h"
 #include "includes/kratos_flags.h"
 #include "includes/element.h"
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 #include "includes/cfd_variables.h"
 #include "geometries/triangle_2d_3.h"
 #include "geometries/tetrahedra_3d_4.h"

--- a/applications/FluidDynamicsApplication/custom_response_functions/drag_response_function.h
+++ b/applications/FluidDynamicsApplication/custom_response_functions/drag_response_function.h
@@ -19,9 +19,8 @@
 // External includes
 
 // Project includes
-#include "includes/define.h"
 #include "includes/kratos_parameters.h"
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 #include "response_functions/adjoint_response_function.h"
 #include "utilities/variable_utils.h"
 

--- a/applications/FluidDynamicsApplication/custom_response_functions/velocity_pressure_norm_square_response_function.h
+++ b/applications/FluidDynamicsApplication/custom_response_functions/velocity_pressure_norm_square_response_function.h
@@ -21,10 +21,9 @@
 // Project includes
 #include "containers/model.h"
 #include "geometries/geometry_data.h"
-#include "includes/define.h"
 #include "includes/kratos_parameters.h"
 #include "includes/model_part.h"
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 #include "response_functions/adjoint_response_function.h"
 #include "utilities/element_size_calculator.h"
 #include "utilities/parallel_utilities.h"

--- a/applications/FluidDynamicsApplication/custom_strategies/schemes/velocity_bossak_sensitivity_builder_scheme.h
+++ b/applications/FluidDynamicsApplication/custom_strategies/schemes/velocity_bossak_sensitivity_builder_scheme.h
@@ -19,8 +19,7 @@
 // External includes
 
 // Project includes
-#include "includes/define.h"
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 #include "utilities/openmp_utils.h"
 
 // Application includes

--- a/applications/FluidDynamicsApplication/custom_utilities/fluid_adjoint_slip_utilities.cpp
+++ b/applications/FluidDynamicsApplication/custom_utilities/fluid_adjoint_slip_utilities.cpp
@@ -16,10 +16,8 @@
 
 // Project includes
 #include "geometries/geometry.h"
-#include "includes/define.h"
 #include "includes/kratos_flags.h"
-#include "includes/node.h"
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 #include "includes/variables.h"
 #include "utilities/coordinate_transformation_utilities.h"
 

--- a/applications/FluidDynamicsApplication/custom_utilities/fluid_adjoint_slip_utilities.h
+++ b/applications/FluidDynamicsApplication/custom_utilities/fluid_adjoint_slip_utilities.h
@@ -20,7 +20,7 @@
 // Project includes
 #include "geometries/geometry.h"
 #include "includes/node.h"
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 #include "utilities/coordinate_transformation_utilities.h"
 
 // Application includes

--- a/applications/FluidDynamicsApplication/custom_utilities/fluid_auxiliary_utilities.h
+++ b/applications/FluidDynamicsApplication/custom_utilities/fluid_auxiliary_utilities.h
@@ -21,7 +21,7 @@
 #include "geometries/geometry.h"
 #include "includes/node.h"
 #include "includes/model_part.h"
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 #include "modified_shape_functions/modified_shape_functions.h"
 
 // Application includes

--- a/applications/FluidDynamicsApplication/custom_utilities/fluid_calculation_utilities.h
+++ b/applications/FluidDynamicsApplication/custom_utilities/fluid_calculation_utilities.h
@@ -22,7 +22,7 @@
 // Project includes
 #include "geometries/geometry.h"
 #include "includes/node.h"
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 
 namespace Kratos
 {

--- a/applications/FluidDynamicsApplication/custom_utilities/statistics_record.h
+++ b/applications/FluidDynamicsApplication/custom_utilities/statistics_record.h
@@ -21,8 +21,7 @@
 
 // Project includes
 #include "containers/pointer_vector.h"
-#include "includes/define.h"
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 #include "statistics_utilities.h"
 
 namespace Kratos

--- a/applications/FluidDynamicsApplication/custom_utilities/statistics_utilities.h
+++ b/applications/FluidDynamicsApplication/custom_utilities/statistics_utilities.h
@@ -22,9 +22,8 @@
 // External includes
 
 // Project includes
-#include "includes/define.h"
 #include "includes/node.h"
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 #include "geometries/geometry.h"
 
 namespace Kratos

--- a/applications/FluidDynamicsHydraulicsApplication/custom_utilities/hydraulic_fluid_auxiliary_utilities.h
+++ b/applications/FluidDynamicsHydraulicsApplication/custom_utilities/hydraulic_fluid_auxiliary_utilities.h
@@ -19,7 +19,7 @@
 #include "geometries/geometry.h"
 #include "includes/node.h"
 #include "includes/model_part.h"
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 #include "includes/global_pointer_variables.h"
 #include "modified_shape_functions/modified_shape_functions.h"
 #include "../../FluidDynamicsApplication/custom_utilities/fluid_auxiliary_utilities.h"

--- a/applications/GeoMechanicsApplication/custom_constitutive/constitutive_law_dimension.h
+++ b/applications/GeoMechanicsApplication/custom_constitutive/constitutive_law_dimension.h
@@ -12,7 +12,7 @@
 #pragma once
 
 #include "containers/flags.h"
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 
 #include <cstddef>
 #include <memory>

--- a/applications/GeoMechanicsApplication/custom_constitutive/p_q.hpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/p_q.hpp
@@ -14,7 +14,7 @@
 
 #include "includes/exception.h"
 #include "includes/kratos_export_api.h"
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 
 #include <algorithm>
 

--- a/applications/GeoMechanicsApplication/custom_constitutive/principal_stresses.hpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/principal_stresses.hpp
@@ -14,7 +14,7 @@
 
 #include "includes/exception.h"
 #include "includes/kratos_export_api.h"
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 
 #include <algorithm>
 

--- a/applications/GeoMechanicsApplication/custom_constitutive/sigma_tau.hpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/sigma_tau.hpp
@@ -14,7 +14,7 @@
 
 #include "includes/exception.h"
 #include "includes/kratos_export_api.h"
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 
 #include <algorithm>
 

--- a/applications/GeoMechanicsApplication/custom_constitutive/tension_cutoff.h
+++ b/applications/GeoMechanicsApplication/custom_constitutive/tension_cutoff.h
@@ -17,7 +17,7 @@
 #include "custom_constitutive/principal_stresses.hpp"
 #include "includes/kratos_export_api.h"
 #include "includes/smart_pointers.h"
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 
 namespace Kratos
 {

--- a/applications/GeoMechanicsApplication/custom_elements/U_Pw_interface_element.h
+++ b/applications/GeoMechanicsApplication/custom_elements/U_Pw_interface_element.h
@@ -21,7 +21,7 @@
 #include "custom_elements/contribution_calculators/up_coupling_calculator.hpp"
 #include "geo_aliases.h"
 #include "includes/element.h"
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 #include "integration_coefficients_calculator.hpp"
 #include "integration_scheme.h"
 #include "stress_state_policy.h"

--- a/applications/GeoMechanicsApplication/custom_elements/contribution_calculators/compressibility_calculator.hpp
+++ b/applications/GeoMechanicsApplication/custom_elements/contribution_calculators/compressibility_calculator.hpp
@@ -19,7 +19,7 @@
 #include "geo_aliases.h"
 #include "geo_mechanics_application_variables.h"
 #include "includes/properties.h"
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 
 #include <utility>
 #include <vector>

--- a/applications/GeoMechanicsApplication/custom_elements/contribution_calculators/contribution_calculator.h
+++ b/applications/GeoMechanicsApplication/custom_elements/contribution_calculators/contribution_calculator.h
@@ -11,7 +11,7 @@
 //
 #pragma once
 
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 
 #include <optional>
 

--- a/applications/GeoMechanicsApplication/custom_elements/contribution_calculators/filter_compressibility_calculator.hpp
+++ b/applications/GeoMechanicsApplication/custom_elements/contribution_calculators/filter_compressibility_calculator.hpp
@@ -17,7 +17,7 @@
 #include "geo_aliases.h"
 #include "geo_mechanics_application_variables.h"
 #include "includes/properties.h"
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 
 #include <utility>
 #include <vector>

--- a/applications/GeoMechanicsApplication/custom_elements/contribution_calculators/fluid_body_flow_calculator.hpp
+++ b/applications/GeoMechanicsApplication/custom_elements/contribution_calculators/fluid_body_flow_calculator.hpp
@@ -17,7 +17,7 @@
 #include "geo_aliases.h"
 #include "includes/cfd_variables.h"
 #include "includes/properties.h"
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 
 #include <utility>
 #include <vector>

--- a/applications/GeoMechanicsApplication/custom_elements/contribution_calculators/stiffness_calculator.hpp
+++ b/applications/GeoMechanicsApplication/custom_elements/contribution_calculators/stiffness_calculator.hpp
@@ -18,7 +18,7 @@
 #include "geo_aliases.h"
 #include "includes/constitutive_law.h"
 #include "includes/properties.h"
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 
 #include <utility>
 

--- a/applications/GeoMechanicsApplication/custom_elements/integration_coefficients_calculator.hpp
+++ b/applications/GeoMechanicsApplication/custom_elements/integration_coefficients_calculator.hpp
@@ -14,7 +14,7 @@
 
 #include "geo_aliases.h"
 #include "geometries/geometry.h"
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 
 namespace Kratos
 {

--- a/applications/GeoMechanicsApplication/custom_elements/small_strain_U_Pw_diff_order_element.h
+++ b/applications/GeoMechanicsApplication/custom_elements/small_strain_U_Pw_diff_order_element.h
@@ -16,7 +16,7 @@
 #include "custom_elements/U_Pw_base_element.h"
 #include "includes/kratos_export_api.h"
 #include "includes/smart_pointers.h"
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 
 #include <iosfwd>
 #include <memory>

--- a/applications/GeoMechanicsApplication/custom_elements/stress_state_policy.h
+++ b/applications/GeoMechanicsApplication/custom_elements/stress_state_policy.h
@@ -15,7 +15,7 @@
 #include "geo_mechanics_application_constants.h"
 #include "geometries/geometry.h"
 #include "includes/node.h"
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 
 namespace Kratos
 {

--- a/applications/GeoMechanicsApplication/custom_processes/apply_final_stresses_of_previous_stage_to_initial_state.cpp
+++ b/applications/GeoMechanicsApplication/custom_processes/apply_final_stresses_of_previous_stage_to_initial_state.cpp
@@ -17,7 +17,7 @@
 #include "includes/initial_state.h"
 #include "includes/kratos_parameters.h"
 #include "includes/model_part.h"
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 #include "includes/variables.h"
 
 #include <vector>

--- a/applications/GeoMechanicsApplication/custom_utilities/equation_of_motion_utilities.hpp
+++ b/applications/GeoMechanicsApplication/custom_utilities/equation_of_motion_utilities.hpp
@@ -18,7 +18,7 @@
 #include "geometries/geometry.h"
 #include "geometries/geometry_data.h"
 #include "includes/node.h"
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 
 namespace Kratos
 {

--- a/applications/GeoMechanicsApplication/custom_utilities/extrapolation_utilities.h
+++ b/applications/GeoMechanicsApplication/custom_utilities/extrapolation_utilities.h
@@ -14,7 +14,7 @@
 #pragma once
 
 #include "includes/kratos_export_api.h"
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 
 #include <optional>
 #include <vector>

--- a/applications/GeoMechanicsApplication/custom_utilities/generic_utilities.hpp
+++ b/applications/GeoMechanicsApplication/custom_utilities/generic_utilities.hpp
@@ -14,7 +14,7 @@
 #pragma once
 
 #include "includes/kratos_export_api.h"
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 
 #include <algorithm>
 #include <cstdlib>

--- a/applications/GeoMechanicsApplication/custom_utilities/geometry_utilities.h
+++ b/applications/GeoMechanicsApplication/custom_utilities/geometry_utilities.h
@@ -16,7 +16,7 @@
 #include "geometries/geometry.h"
 #include "includes/kratos_export_api.h"
 #include "includes/node.h"
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 
 namespace Kratos
 {

--- a/applications/GeoMechanicsApplication/custom_utilities/hydraulic_discharge.cpp
+++ b/applications/GeoMechanicsApplication/custom_utilities/hydraulic_discharge.cpp
@@ -13,7 +13,7 @@
 #include "hydraulic_discharge.h"
 #include "custom_utilities/node_utilities.h"
 #include "geo_mechanics_application_variables.h"
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 
 namespace Kratos
 {

--- a/applications/GeoMechanicsApplication/custom_utilities/math_utilities.hpp
+++ b/applications/GeoMechanicsApplication/custom_utilities/math_utilities.hpp
@@ -13,7 +13,7 @@
 #pragma once
 
 #include "includes/kratos_export_api.h"
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 
 #include <algorithm>
 #include <cstdlib>

--- a/applications/GeoMechanicsApplication/custom_utilities/nodal_extrapolator.h
+++ b/applications/GeoMechanicsApplication/custom_utilities/nodal_extrapolator.h
@@ -14,7 +14,7 @@
 #include "geo_aliases.h"
 #include "geometries/geometry.h"
 #include "includes/node.h"
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 
 namespace Kratos
 {

--- a/applications/GeoMechanicsApplication/custom_utilities/stress_strain_utilities.h
+++ b/applications/GeoMechanicsApplication/custom_utilities/stress_strain_utilities.h
@@ -19,8 +19,7 @@
 #include "custom_constitutive/p_q.hpp"
 #include "custom_constitutive/principal_stresses.hpp"
 #include "includes/constitutive_law.h"
-#include "includes/define.h"
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 
 namespace Kratos
 {

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_constitutive/test_thermal_dispersion_law.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_constitutive/test_thermal_dispersion_law.cpp
@@ -12,7 +12,7 @@
 
 #include "custom_constitutive/thermal_dispersion_law.h"
 #include "geo_mechanics_application.h"
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 #include "tests/cpp_tests/geo_mechanics_fast_suite.h"
 
 namespace Kratos::Testing

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_constitutive/test_thermal_filter_law.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_constitutive/test_thermal_filter_law.cpp
@@ -12,7 +12,7 @@
 
 #include "custom_constitutive/thermal_filter_law.h"
 #include "geo_mechanics_application.h"
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 #include "tests/cpp_tests/geo_mechanics_fast_suite.h"
 
 namespace Kratos::Testing

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/custom_processes/test_apply_final_stresses_of_previous_stage_to_initial_state.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/custom_processes/test_apply_final_stresses_of_previous_stage_to_initial_state.cpp
@@ -21,8 +21,7 @@
 #include "includes/model_part.h"
 #include "includes/node.h"
 #include "includes/process_info.h"
-#include "includes/ublas_interface.h"
-#include "includes/variables.h"
+#include "includes/default_interface.h"
 #include "tests/cpp_tests/custom_constitutive/mock_constitutive_law.hpp"
 #include "tests/cpp_tests/geo_mechanics_fast_suite.h"
 

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/test_utilities.h
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/test_utilities.h
@@ -12,7 +12,7 @@
 
 #pragma once
 
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 
 #include <gtest/gtest.h>
 

--- a/applications/HDF5Application/hdf5_application_define.h
+++ b/applications/HDF5Application/hdf5_application_define.h
@@ -20,7 +20,7 @@
 //extern "C" {
 #include "hdf5.h"
 //}
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 
 // Project includes
 #include "includes/io.h"

--- a/applications/IgaApplication/custom_elements/navier_stokes_element.h
+++ b/applications/IgaApplication/custom_elements/navier_stokes_element.h
@@ -17,9 +17,8 @@
 // External includes
 
 // Project includes
-#include "includes/define.h"
 #include "includes/element.h"
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 #include "includes/variables.h"
 #include "iga_application_variables.h"
 

--- a/applications/IgaApplication/custom_elements/stokes_element.h
+++ b/applications/IgaApplication/custom_elements/stokes_element.h
@@ -17,9 +17,8 @@
 // External includes
 
 // Project includes
-#include "includes/define.h"
 #include "includes/element.h"
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 #include "includes/variables.h"
 #include "iga_application_variables.h"
 

--- a/applications/IgaApplication/custom_strategies/custom_schemes/eigensolver_nitsche_stabilization_scheme.hpp
+++ b/applications/IgaApplication/custom_strategies/custom_schemes/eigensolver_nitsche_stabilization_scheme.hpp
@@ -15,11 +15,10 @@
 // External includes
 
 // Project includes
-#include "includes/define.h"
 #include "includes/element.h"
 #include "includes/condition.h"
 #include "includes/process_info.h"
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 #include "solving_strategies/schemes/scheme.h"
 
 // Application includes

--- a/applications/LinearSolversApplication/custom_solvers/eigen_direct_solver.h
+++ b/applications/LinearSolversApplication/custom_solvers/eigen_direct_solver.h
@@ -17,7 +17,7 @@
 #include "custom_utilities/ublas_wrapper.h"
 #include "factories/standard_linear_solver_factory.h"
 #include "includes/ublas_complex_interface.h"
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 #include "linear_solvers/direct_solver.h"
 #include "spaces/ublas_space.h"
 

--- a/applications/LinearSolversApplication/custom_solvers/eigen_pardiso_ldlt_solver.h
+++ b/applications/LinearSolversApplication/custom_solvers/eigen_pardiso_ldlt_solver.h
@@ -20,7 +20,7 @@
 #include "linear_solvers_define.h"
 #include "linear_solvers/direct_solver.h"
 #include "spaces/ublas_space.h"
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 #include "includes/ublas_complex_interface.h"
 #include "custom_utilities/mkl_utilities.h"
 

--- a/applications/LinearSolversApplication/custom_solvers/eigen_pardiso_llt_solver.h
+++ b/applications/LinearSolversApplication/custom_solvers/eigen_pardiso_llt_solver.h
@@ -20,7 +20,7 @@
 #include "linear_solvers_define.h"
 #include "linear_solvers/direct_solver.h"
 #include "spaces/ublas_space.h"
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 #include "includes/ublas_complex_interface.h"
 #include "custom_utilities/mkl_utilities.h"
 

--- a/applications/LinearSolversApplication/custom_solvers/eigen_pardiso_lu_solver.h
+++ b/applications/LinearSolversApplication/custom_solvers/eigen_pardiso_lu_solver.h
@@ -20,7 +20,7 @@
 #include "linear_solvers_define.h"
 #include "linear_solvers/direct_solver.h"
 #include "spaces/ublas_space.h"
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 #include "includes/ublas_complex_interface.h"
 #include "custom_utilities/mkl_utilities.h"
 

--- a/applications/LinearSolversApplication/custom_solvers/eigen_sparse_cg_solver.h
+++ b/applications/LinearSolversApplication/custom_solvers/eigen_sparse_cg_solver.h
@@ -18,7 +18,7 @@
 #include "linear_solvers_define.h"
 #include "linear_solvers/direct_solver.h"
 #include "spaces/ublas_space.h"
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 #include "includes/ublas_complex_interface.h"
 
 namespace Kratos {

--- a/applications/LinearSolversApplication/custom_solvers/eigen_sparse_lu_solver.h
+++ b/applications/LinearSolversApplication/custom_solvers/eigen_sparse_lu_solver.h
@@ -18,7 +18,7 @@
 #include "linear_solvers_define.h"
 #include "linear_solvers/direct_solver.h"
 #include "spaces/ublas_space.h"
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 #include "includes/ublas_complex_interface.h"
 
 namespace Kratos {

--- a/applications/LinearSolversApplication/custom_solvers/eigen_sparse_qr_solver.h
+++ b/applications/LinearSolversApplication/custom_solvers/eigen_sparse_qr_solver.h
@@ -19,7 +19,7 @@
 #include "linear_solvers_define.h"
 #include "linear_solvers/direct_solver.h"
 #include "spaces/ublas_space.h"
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 #include "includes/ublas_complex_interface.h"
 
 namespace Kratos {

--- a/applications/LinearSolversApplication/custom_solvers/feast_eigensystem_solver.h
+++ b/applications/LinearSolversApplication/custom_solvers/feast_eigensystem_solver.h
@@ -16,7 +16,7 @@
 #include "includes/define.h"
 #include "includes/kratos_parameters.h"
 #include "linear_solvers/linear_solver.h"
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 #include "includes/ublas_complex_interface.h"
 
 extern "C" {

--- a/applications/MPMApplication/custom_constitutive/flow_rules/borja_cam_clay_plastic_flow_rule.cpp
+++ b/applications/MPMApplication/custom_constitutive/flow_rules/borja_cam_clay_plastic_flow_rule.cpp
@@ -16,7 +16,7 @@
 #include <cmath>
 
 // External includes
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 #include "includes/mat_variables.h"
 
 // Project includes

--- a/applications/MPMApplication/custom_constitutive/flow_rules/mc_plastic_flow_rule.cpp
+++ b/applications/MPMApplication/custom_constitutive/flow_rules/mc_plastic_flow_rule.cpp
@@ -16,7 +16,7 @@
 #include <cmath>
 
 // External includes
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 
 // Project includes
 #include "custom_constitutive/flow_rules/mc_plastic_flow_rule.hpp"

--- a/applications/MPMApplication/custom_constitutive/flow_rules/mc_strain_softening_plastic_flow_rule.cpp
+++ b/applications/MPMApplication/custom_constitutive/flow_rules/mc_strain_softening_plastic_flow_rule.cpp
@@ -16,7 +16,7 @@
 #include <cmath>
 
 // External includes
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 
 // Project includes
 #include "custom_constitutive/flow_rules/mc_strain_softening_plastic_flow_rule.hpp"

--- a/applications/MPMApplication/custom_constitutive/hencky_plastic_3D_law.hpp
+++ b/applications/MPMApplication/custom_constitutive/hencky_plastic_3D_law.hpp
@@ -21,7 +21,7 @@
 // Project includes
 #include "custom_constitutive/hyperelastic_3D_law.hpp"
 #include "custom_constitutive/flow_rules/mpm_flow_rule.hpp"
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 
 namespace Kratos
 {

--- a/applications/MPMApplication/custom_constitutive/hencky_plastic_UP_3D_law.hpp
+++ b/applications/MPMApplication/custom_constitutive/hencky_plastic_UP_3D_law.hpp
@@ -20,7 +20,7 @@
 
 // Project includes
 #include "custom_constitutive/hencky_plastic_3D_law.hpp"
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 
 namespace Kratos
 {

--- a/applications/MPMApplication/custom_elements/mpm_updated_lagrangian.hpp
+++ b/applications/MPMApplication/custom_elements/mpm_updated_lagrangian.hpp
@@ -18,10 +18,9 @@
 // External includes
 
 // Project includes
-#include "includes/define.h"
 #include "includes/element.h"
 #include "includes/serializer.h"
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 #include "includes/variables.h"
 #include "includes/constitutive_law.h"
 

--- a/applications/MPMApplication/mpm_application.h
+++ b/applications/MPMApplication/mpm_application.h
@@ -23,13 +23,12 @@
 #include "mpm_application_variables.h"
 
 // Project includes
-#include "includes/define.h"
 #include "includes/serializer.h"
 #include "includes/constitutive_law.h"
 #include "includes/kratos_application.h"
 
 #include "includes/condition.h"
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 
 #include "containers/flags.h"
 

--- a/applications/OptimizationApplication/custom_elements/adjoint_small_displacement_element.h
+++ b/applications/OptimizationApplication/custom_elements/adjoint_small_displacement_element.h
@@ -18,11 +18,10 @@
 // External includes
 
 // Project includes
-#include "includes/define.h"
 #include "includes/element.h"
 #include "utilities/integration_utilities.h"
 #include "utilities/geometry_utilities.h"
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 #include "includes/variables.h"
 #include "optimization_application_variables.h"
 

--- a/applications/OptimizationApplication/custom_elements/helmholtz_bulk_element.h
+++ b/applications/OptimizationApplication/custom_elements/helmholtz_bulk_element.h
@@ -18,11 +18,10 @@
 // External includes
 
 // Project includes
-#include "includes/define.h"
 #include "includes/element.h"
 #include "utilities/integration_utilities.h"
 #include "utilities/geometry_utilities.h"
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 #include "includes/variables.h"
 #include "optimization_application_variables.h"
 

--- a/applications/OptimizationApplication/custom_elements/helmholtz_bulk_shape_element.h
+++ b/applications/OptimizationApplication/custom_elements/helmholtz_bulk_shape_element.h
@@ -18,11 +18,10 @@
 // External includes
 
 // Project includes
-#include "includes/define.h"
 #include "includes/element.h"
 #include "utilities/integration_utilities.h"
 #include "utilities/geometry_utilities.h"
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 #include "includes/variables.h"
 #include "optimization_application_variables.h"
 

--- a/applications/OptimizationApplication/custom_elements/helmholtz_element.h
+++ b/applications/OptimizationApplication/custom_elements/helmholtz_element.h
@@ -18,9 +18,8 @@
 // External includes
 
 // Project includes
-#include "includes/define.h"
 #include "includes/element.h"
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 
 // Application includes
 

--- a/applications/OptimizationApplication/custom_elements/helmholtz_surf_shape_element.h
+++ b/applications/OptimizationApplication/custom_elements/helmholtz_surf_shape_element.h
@@ -18,13 +18,12 @@
 // External includes
 
 // Project includes
-#include "includes/define.h"
 #include "includes/element.h"
 #include "utilities/integration_utilities.h"
 #include "utilities/geometry_utilities.h"
 #include "geometries/tetrahedra_3d_4.h"
 #include "geometries/pyramid_3d_5.h"
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 #include "includes/variables.h"
 #include "optimization_application_variables.h"
 

--- a/applications/OptimizationApplication/custom_elements/helmholtz_surf_thickness_element.h
+++ b/applications/OptimizationApplication/custom_elements/helmholtz_surf_thickness_element.h
@@ -18,13 +18,12 @@
 // External includes
 
 // Project includes
-#include "includes/define.h"
 #include "includes/element.h"
 #include "utilities/integration_utilities.h"
 #include "utilities/geometry_utilities.h"
 #include "geometries/pyramid_3d_5.h"
 #include "geometries/tetrahedra_3d_4.h"
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 #include "includes/variables.h"
 #include "optimization_application_variables.h"
 

--- a/applications/OptimizationApplication/custom_utilities/entity_calculation_utils.h
+++ b/applications/OptimizationApplication/custom_utilities/entity_calculation_utils.h
@@ -18,7 +18,7 @@
 // Project includes
 #include "geometries/geometry.h"
 #include "includes/node.h"
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 
 // Application includes
 

--- a/applications/OptimizationApplication/custom_utilities/filtering/explicit_filter_utils.h
+++ b/applications/OptimizationApplication/custom_utilities/filtering/explicit_filter_utils.h
@@ -21,9 +21,8 @@
 #include "nanoflann/include/nanoflann.hpp"
 
 // Project includes
-#include "includes/define.h"
 #include "includes/model_part.h"
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 #include "tensor_adaptors/tensor_adaptor.h"
 
 // Application includes

--- a/applications/PFEM2Application/custom_conditions/fixed_pressure_2d.h
+++ b/applications/PFEM2Application/custom_conditions/fixed_pressure_2d.h
@@ -2,13 +2,11 @@
 #define  KRATOS_FIXED_PRESSURE_CONDITION_H_INCLUDED
 
 // External includes
-#include "boost/smart_ptr.hpp"
 
 // Project includes
-#include "includes/define.h"
 #include "includes/serializer.h"
 #include "includes/condition.h"
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 
 
 namespace Kratos

--- a/applications/PFEM2Application/custom_conditions/fixed_pressure_3d.h
+++ b/applications/PFEM2Application/custom_conditions/fixed_pressure_3d.h
@@ -2,14 +2,11 @@
 #define  KRATOS_FIXED_PRESSURE_3D_CONDITION_H_INCLUDED
 
 // External includes
-#include "boost/smart_ptr.hpp"
 
 // Project includes
-#include "includes/define.h"
 #include "includes/serializer.h"
 #include "includes/condition.h"
-#include "includes/ublas_interface.h"
-
+#include "includes/default_interface.h"
 
 namespace Kratos
 {

--- a/applications/PFEM2Application/custom_conditions/fixed_velocity_2d.h
+++ b/applications/PFEM2Application/custom_conditions/fixed_velocity_2d.h
@@ -2,13 +2,11 @@
 #define  KRATOS_FIXED_VELOCITY_CONDITION_H_INCLUDED
 
 // External includes
-#include "boost/smart_ptr.hpp"
 
 // Project includes
-#include "includes/define.h"
 #include "includes/serializer.h"
 #include "includes/condition.h"
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 
 
 namespace Kratos

--- a/applications/PFEM2Application/custom_conditions/fixed_velocity_3d.h
+++ b/applications/PFEM2Application/custom_conditions/fixed_velocity_3d.h
@@ -2,13 +2,11 @@
 #define  KRATOS_FIXED_VELOCITY_CONDITION_3D_H_INCLUDED
 
 // External includes
-#include "boost/smart_ptr.hpp"
 
 // Project includes
-#include "includes/define.h"
 #include "includes/serializer.h"
 #include "includes/condition.h"
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 
 
 namespace Kratos

--- a/applications/PFEM2Application/custom_conditions/water_fixed_velocity_2d.h
+++ b/applications/PFEM2Application/custom_conditions/water_fixed_velocity_2d.h
@@ -1,14 +1,12 @@
 #if !defined(KRATOS_WATER_FIXED_VELOCITY_CONDITION_H_INCLUDED )
 #define  KRATOS_WATER_FIXED_VELOCITY_CONDITION_H_INCLUDED
 
-// External includes 
-#include "boost/smart_ptr.hpp"
+// External includes
 
 // Project includes
-#include "includes/define.h"
 #include "includes/serializer.h"
 #include "includes/condition.h"
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 
 
 namespace Kratos

--- a/applications/PFEM2Application/custom_elements/fractional_step_pfem_2_2d.h
+++ b/applications/PFEM2Application/custom_elements/fractional_step_pfem_2_2d.h
@@ -11,15 +11,11 @@
 
 // System includes
 
-
 // External includes
-#include "boost/smart_ptr.hpp"
-
 
 // Project includes
-#include "includes/define.h"
 #include "includes/element.h"
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 
 
 namespace Kratos

--- a/applications/PFEM2Application/custom_elements/fractional_step_pfem_2_3d.h
+++ b/applications/PFEM2Application/custom_elements/fractional_step_pfem_2_3d.h
@@ -13,13 +13,10 @@
 
 
 // External includes
-#include "boost/smart_ptr.hpp"
-
 
 // Project includes
-#include "includes/define.h"
 #include "includes/element.h"
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 
 
 namespace Kratos

--- a/applications/PFEM2Application/custom_elements/monolithic_2fluid_2d.h
+++ b/applications/PFEM2Application/custom_elements/monolithic_2fluid_2d.h
@@ -13,13 +13,10 @@
 
 
 // External includes
-#include "boost/smart_ptr.hpp"
-
 
 // Project includes
-#include "includes/define.h"
 #include "includes/element.h"
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 #include "custom_utilities/pfem_particle_fluidonly.h"
 
 

--- a/applications/PFEM2Application/custom_elements/monolithic_2fluid_2d_partintegration.h
+++ b/applications/PFEM2Application/custom_elements/monolithic_2fluid_2d_partintegration.h
@@ -13,13 +13,10 @@
 
 
 // External includes
-#include "boost/smart_ptr.hpp"
-
 
 // Project includes
-#include "includes/define.h"
 #include "includes/element.h"
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 
 
 namespace Kratos

--- a/applications/PFEM2Application/custom_elements/monolithic_2fluid_3d.h
+++ b/applications/PFEM2Application/custom_elements/monolithic_2fluid_3d.h
@@ -11,16 +11,11 @@
 
 // System includes
 
-
 // External includes
-#include "boost/smart_ptr.hpp"
-
 
 // Project includes
-#include "includes/define.h"
 #include "includes/element.h"
-#include "includes/ublas_interface.h"
-
+#include "includes/default_interface.h"
 
 namespace Kratos
 {

--- a/applications/PFEM2Application/custom_elements/monolithic_2fluid_3d_partintegration.h
+++ b/applications/PFEM2Application/custom_elements/monolithic_2fluid_3d_partintegration.h
@@ -11,16 +11,11 @@
 
 // System includes
 
-
 // External includes
-#include "boost/smart_ptr.hpp"
-
 
 // Project includes
-#include "includes/define.h"
 #include "includes/element.h"
-#include "includes/ublas_interface.h"
-
+#include "includes/default_interface.h"
 
 namespace Kratos
 {

--- a/applications/PFEM2Application/custom_elements/monolithic_3fluid_2d.h
+++ b/applications/PFEM2Application/custom_elements/monolithic_3fluid_2d.h
@@ -11,16 +11,11 @@
 
 // System includes
 
-
 // External includes
-#include "boost/smart_ptr.hpp"
-
 
 // Project includes
-#include "includes/define.h"
 #include "includes/element.h"
-#include "includes/ublas_interface.h"
-
+#include "includes/default_interface.h"
 
 namespace Kratos
 {

--- a/applications/PFEM2Application/custom_elements/monolithic_3fluid_3d.h
+++ b/applications/PFEM2Application/custom_elements/monolithic_3fluid_3d.h
@@ -13,13 +13,10 @@
 
 
 // External includes
-#include "boost/smart_ptr.hpp"
-
 
 // Project includes
-#include "includes/define.h"
 #include "includes/element.h"
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 
 
 namespace Kratos

--- a/applications/PFEM2Application/custom_elements/nonewtonian_2fluid_2d.h
+++ b/applications/PFEM2Application/custom_elements/nonewtonian_2fluid_2d.h
@@ -41,13 +41,10 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #define  KRATOS_MONOLITHIC_NONEWTONIAN_PFEM2_2D_ELEM_H_INCLUDED
 
 // External includes
-#include "boost/smart_ptr.hpp"
-
 
 // Project includes
-#include "includes/define.h"
 #include "includes/element.h"
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 #include "custom_elements/monolithic_2fluid_2d.h"
 
 

--- a/applications/PFEM2Application/custom_elements/nonewtonian_2fluid_3d.h
+++ b/applications/PFEM2Application/custom_elements/nonewtonian_2fluid_3d.h
@@ -41,13 +41,11 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #define  KRATOS_MONOLITHIC_NONEWTONIAN_PFEM2_3D_ELEM_H_INCLUDED
 
 // External includes
-#include "boost/smart_ptr.hpp"
 
 
 // Project includes
-#include "includes/define.h"
 #include "includes/element.h"
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 #include "custom_elements/monolithic_2fluid_3d.h"
 
 

--- a/applications/PFEM2Application/custom_elements/qfluid_2d.h
+++ b/applications/PFEM2Application/custom_elements/qfluid_2d.h
@@ -27,13 +27,11 @@
 
 
 // External includes
-#include "boost/smart_ptr.hpp"
 
 
 // Project includes
-#include "includes/define.h"
 #include "includes/element.h"
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 #include "includes/serializer.h"
 
 

--- a/applications/PFEM2Application/custom_elements/qfluid_3d.h
+++ b/applications/PFEM2Application/custom_elements/qfluid_3d.h
@@ -27,13 +27,10 @@
 
 
 // External includes
-#include "boost/smart_ptr.hpp"
-
 
 // Project includes
-#include "includes/define.h"
 #include "includes/element.h"
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 
 
 namespace Kratos

--- a/applications/PFEM2Application/custom_elements/vel_enriched_2fluid_2d.h
+++ b/applications/PFEM2Application/custom_elements/vel_enriched_2fluid_2d.h
@@ -11,15 +11,11 @@
 
 // System includes
 
-
 // External includes
-#include "boost/smart_ptr.hpp"
-
 
 // Project includes
-#include "includes/define.h"
 #include "includes/element.h"
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 #include "custom_utilities/pfem_particle_fluidonly.h"
 
 

--- a/applications/PFEM2Application/custom_utilities/add_fixed_velocity_condition.h
+++ b/applications/PFEM2Application/custom_utilities/add_fixed_velocity_condition.h
@@ -14,6 +14,7 @@
 #include "utilities/math_utils.h"
 #include "utilities/geometry_utilities.h" 
 #include "includes/default_interface.h"
+#include "includes/variables.h"
 #include "includes/model_part.h"
 #include "includes/node.h"
 #include "includes/element.h"

--- a/applications/PFEM2Application/custom_utilities/add_fixed_velocity_condition.h
+++ b/applications/PFEM2Application/custom_utilities/add_fixed_velocity_condition.h
@@ -9,13 +9,11 @@
 #include <algorithm>
 
 // Project includes 
-#include "includes/define.h"
 #include "custom_conditions/fixed_velocity_2d.h"
 #include "pfem_2_application_variables.h"
 #include "utilities/math_utils.h"
 #include "utilities/geometry_utilities.h" 
-#include "includes/ublas_interface.h"
-#include "includes/variables.h" 
+#include "includes/default_interface.h"
 #include "includes/model_part.h"
 #include "includes/node.h"
 #include "includes/element.h"

--- a/applications/PFEM2Application/custom_utilities/calculate_water_fraction.h
+++ b/applications/PFEM2Application/custom_utilities/calculate_water_fraction.h
@@ -7,11 +7,10 @@
 #include <algorithm>
 
 // Project includes
-#include "includes/define.h"
 #include "pfem_2_application_variables.h"
 #include "utilities/math_utils.h"
 #include "utilities/geometry_utilities.h"
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 #include "includes/variables.h"
 #include "includes/model_part.h"
 #include "includes/node.h"

--- a/applications/PFEM2Application/custom_utilities/visualization.h
+++ b/applications/PFEM2Application/custom_utilities/visualization.h
@@ -9,11 +9,10 @@
 #include <algorithm>
 
 // Project includes 
-#include "includes/define.h"
 #include "pfem_2_application_variables.h"
 #include "utilities/math_utils.h"
 #include "utilities/geometry_utilities.h" 
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 #include "includes/variables.h" 
 #include "includes/model_part.h"
 #include "includes/node.h"

--- a/applications/PFEM2Application/pfem_2_application.h
+++ b/applications/PFEM2Application/pfem_2_application.h
@@ -21,9 +21,8 @@
 
 
 // Project includes
-#include "includes/define.h"
 #include "includes/kratos_application.h"
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 
 #include "custom_elements/fractional_step_pfem_2_2d.h" //including the file for the element
 #include "custom_elements/fractional_step_pfem_2_3d.h" //including the file for the element

--- a/applications/PfemApplication/pfem_application.h
+++ b/applications/PfemApplication/pfem_application.h
@@ -26,7 +26,7 @@
 
 // Project includes
 #include "includes/variables.h"
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 #include "includes/kratos_application.h"
 
 //elements

--- a/applications/PfemFluidDynamicsApplication/pfem_fluid_dynamics_application.h
+++ b/applications/PfemFluidDynamicsApplication/pfem_fluid_dynamics_application.h
@@ -55,7 +55,7 @@
 //constitutive laws
 #include "containers/flags.h"
 #include "includes/variables.h"
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 
 #include "geometries/triangle_3d_3.h"
 

--- a/applications/PfemSolidMechanicsApplication/custom_constitutive/custom_flow_rules/non_associative_explicit_flow_rule.cpp
+++ b/applications/PfemSolidMechanicsApplication/custom_constitutive/custom_flow_rules/non_associative_explicit_flow_rule.cpp
@@ -9,10 +9,10 @@
 
 // System includes
 #include <iostream>
-#include<cmath>
+#include <cmath>
 
 // External includes
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 
 // Project includes
 #include "custom_constitutive/custom_flow_rules/non_associative_explicit_flow_rule.hpp"

--- a/applications/PfemSolidMechanicsApplication/pfem_solid_mechanics_application.h
+++ b/applications/PfemSolidMechanicsApplication/pfem_solid_mechanics_application.h
@@ -67,7 +67,7 @@
 //constitutive laws
 #include "containers/flags.h"
 #include "includes/variables.h"
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 
 // yield Criteria
 #include "custom_constitutive/custom_yield_criteria/cam_clay_yield_criterion.hpp"

--- a/applications/RANSApplication/custom_conditions/data_containers/k_epsilon/epsilon_k_based_wall_condition_data.h
+++ b/applications/RANSApplication/custom_conditions/data_containers/k_epsilon/epsilon_k_based_wall_condition_data.h
@@ -20,7 +20,7 @@
 #include "geometries/geometry_data.h"
 #include "includes/node.h"
 #include "includes/process_info.h"
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 
 // Application includes
 #include "custom_conditions/scalar_wall_flux_condition_data.h"

--- a/applications/RANSApplication/custom_conditions/data_containers/k_epsilon/epsilon_u_based_wall_condition_data.h
+++ b/applications/RANSApplication/custom_conditions/data_containers/k_epsilon/epsilon_u_based_wall_condition_data.h
@@ -20,7 +20,7 @@
 #include "geometries/geometry_data.h"
 #include "includes/node.h"
 #include "includes/process_info.h"
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 
 // Application includes
 #include "custom_conditions/scalar_wall_flux_condition_data.h"

--- a/applications/RANSApplication/custom_conditions/data_containers/k_omega/omega_k_based_wall_condition_data.h
+++ b/applications/RANSApplication/custom_conditions/data_containers/k_omega/omega_k_based_wall_condition_data.h
@@ -20,7 +20,7 @@
 #include "geometries/geometry_data.h"
 #include "includes/node.h"
 #include "includes/process_info.h"
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 
 // Application includes
 #include "custom_conditions/scalar_wall_flux_condition_data.h"

--- a/applications/RANSApplication/custom_conditions/data_containers/k_omega/omega_u_based_wall_condition_data.h
+++ b/applications/RANSApplication/custom_conditions/data_containers/k_omega/omega_u_based_wall_condition_data.h
@@ -20,7 +20,7 @@
 #include "geometries/geometry_data.h"
 #include "includes/node.h"
 #include "includes/process_info.h"
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 
 // Application includes
 #include "custom_conditions/scalar_wall_flux_condition_data.h"

--- a/applications/RANSApplication/custom_conditions/scalar_wall_flux_condition_data.h
+++ b/applications/RANSApplication/custom_conditions/scalar_wall_flux_condition_data.h
@@ -24,7 +24,7 @@
 #include "includes/node.h"
 #include "includes/process_info.h"
 #include "includes/properties.h"
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 
 // Application includes
 

--- a/applications/RANSApplication/custom_elements/convection_diffusion_reaction_stabilization_utilities.h
+++ b/applications/RANSApplication/custom_elements/convection_diffusion_reaction_stabilization_utilities.h
@@ -19,7 +19,7 @@
 // External includes
 
 // Project includes
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 
 // Application includes
 #include "custom_utilities/rans_calculation_utilities.h"

--- a/applications/RANSApplication/custom_elements/data_containers/k_epsilon/element_data_utilities.h
+++ b/applications/RANSApplication/custom_elements/data_containers/k_epsilon/element_data_utilities.h
@@ -16,7 +16,7 @@
 // System includes
 
 // Project includes
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 
 // Application includes
 

--- a/applications/RANSApplication/custom_elements/data_containers/k_epsilon/epsilon_element_data.h
+++ b/applications/RANSApplication/custom_elements/data_containers/k_epsilon/epsilon_element_data.h
@@ -20,7 +20,7 @@
 #include "geometries/geometry_data.h"
 #include "includes/node.h"
 #include "includes/process_info.h"
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 
 // Application includes
 #include "custom_elements/convection_diffusion_reaction_element_data.h"

--- a/applications/RANSApplication/custom_elements/data_containers/k_epsilon/k_element_data.h
+++ b/applications/RANSApplication/custom_elements/data_containers/k_epsilon/k_element_data.h
@@ -20,7 +20,7 @@
 #include "geometries/geometry_data.h"
 #include "includes/node.h"
 #include "includes/process_info.h"
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 
 // Application includes
 #include "custom_elements/convection_diffusion_reaction_element_data.h"

--- a/applications/RANSApplication/custom_elements/data_containers/k_omega/k_element_data.h
+++ b/applications/RANSApplication/custom_elements/data_containers/k_omega/k_element_data.h
@@ -24,7 +24,7 @@
 #include "geometries/geometry_data.h"
 #include "includes/node.h"
 #include "includes/process_info.h"
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 
 // Application includes
 #include "custom_elements/convection_diffusion_reaction_element_data.h"

--- a/applications/RANSApplication/custom_elements/data_containers/k_omega/omega_element_data.h
+++ b/applications/RANSApplication/custom_elements/data_containers/k_omega/omega_element_data.h
@@ -24,7 +24,7 @@
 #include "geometries/geometry_data.h"
 #include "includes/node.h"
 #include "includes/process_info.h"
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 
 // Application includes
 #include "custom_elements/convection_diffusion_reaction_element_data.h"

--- a/applications/RANSApplication/custom_elements/data_containers/k_omega_sst/element_data_utilities.h
+++ b/applications/RANSApplication/custom_elements/data_containers/k_omega_sst/element_data_utilities.h
@@ -17,7 +17,7 @@
 
 // Project includes
 #include "containers/array_1d.h"
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 
 // Application includes
 

--- a/applications/RANSApplication/custom_elements/data_containers/k_omega_sst/k_element_data.h
+++ b/applications/RANSApplication/custom_elements/data_containers/k_omega_sst/k_element_data.h
@@ -21,7 +21,7 @@
 #include "geometries/geometry_data.h"
 #include "includes/node.h"
 #include "includes/process_info.h"
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 
 // Application includes
 #include "custom_elements/convection_diffusion_reaction_element_data.h"

--- a/applications/RANSApplication/custom_elements/data_containers/k_omega_sst/omega_element_data.h
+++ b/applications/RANSApplication/custom_elements/data_containers/k_omega_sst/omega_element_data.h
@@ -21,7 +21,7 @@
 #include "geometries/geometry_data.h"
 #include "includes/node.h"
 #include "includes/process_info.h"
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 
 // Application includes
 #include "custom_elements/convection_diffusion_reaction_element_data.h"

--- a/applications/RANSApplication/custom_utilities/test_utilities.cpp
+++ b/applications/RANSApplication/custom_utilities/test_utilities.cpp
@@ -20,8 +20,7 @@
 #include "containers/model.h"
 #include "containers/global_pointers_vector.h"
 #include "includes/checks.h"
-#include "includes/model_part.h"
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 #include "includes/cfd_variables.h"
 
 // Application includes

--- a/applications/RomApplication/custom_utilities/rom_auxiliary_utilities.h
+++ b/applications/RomApplication/custom_utilities/rom_auxiliary_utilities.h
@@ -24,7 +24,7 @@
 #include "includes/key_hash.h"
 #include "includes/node.h"
 #include "includes/model_part.h"
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 #include "modified_shape_functions/modified_shape_functions.h"
 #include "processes/find_nodal_neighbours_process.h"
 

--- a/applications/SPHApplication/custom_utilities/compute_kernel_correction_utilities.h
+++ b/applications/SPHApplication/custom_utilities/compute_kernel_correction_utilities.h
@@ -14,7 +14,7 @@
 
 #include <cmath>
 #include "includes/model_part.h"
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 #include "sph_application_variables.h"
 #include "custom_utilities/custom_kernels/kernel_factory.h"
 

--- a/applications/SPHApplication/custom_utilities/compute_volume_utilities.h
+++ b/applications/SPHApplication/custom_utilities/compute_volume_utilities.h
@@ -2,7 +2,7 @@
 #pragma once 
 
 #include "includes/model_part.h"
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 #include "sph_application_variables.h"
 
 /**

--- a/applications/SPHApplication/custom_utilities/custom_kernels/cubic_kernel_2d.h
+++ b/applications/SPHApplication/custom_utilities/custom_kernels/cubic_kernel_2d.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "includes/ublas_interface.h" // to include the boost interface
+#include "includes/default_interface.h" // to include the boost interface
 #include "includes/global_variables.h"
 
 /**

--- a/applications/SPHApplication/custom_utilities/custom_kernels/cubic_kernel_3d.h
+++ b/applications/SPHApplication/custom_utilities/custom_kernels/cubic_kernel_3d.h
@@ -1,6 +1,6 @@
 #pragma once 
 
-#include "includes/ublas_interface.h" // to include the boost interface
+#include "includes/default_interface.h" // to include the boost interface
 #include "includes/global_variables.h"
 
 /**

--- a/applications/SPHApplication/custom_utilities/sph_element_utilities.h
+++ b/applications/SPHApplication/custom_utilities/sph_element_utilities.h
@@ -3,7 +3,7 @@
 
 #include <cmath>
 #include "includes/model_part.h"
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 #include "sph_application_variables.h"
 
 /**

--- a/applications/SolidMechanicsApplication/custom_solvers/solution_schemes/eigensolver_scheme.hpp
+++ b/applications/SolidMechanicsApplication/custom_solvers/solution_schemes/eigensolver_scheme.hpp
@@ -17,11 +17,10 @@
 // External includes
 
 // Project includes
-#include "includes/define.h"
 #include "includes/element.h"
 #include "includes/condition.h"
 #include "includes/process_info.h"
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 #include "custom_solvers/solution_schemes/solution_scheme.hpp"
 
 // Application includes

--- a/applications/SolidMechanicsApplication/solid_mechanics_application.h
+++ b/applications/SolidMechanicsApplication/solid_mechanics_application.h
@@ -27,9 +27,8 @@
 // External includes
 
 // Project includes
-#include "includes/define.h"
 #include "includes/constitutive_law.h"
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 #include "includes/kratos_application.h"
 #include "containers/flags.h"
 

--- a/applications/StatisticsApplication/custom_utilities/method_utilities.cpp
+++ b/applications/StatisticsApplication/custom_utilities/method_utilities.cpp
@@ -17,8 +17,7 @@
 
 // Project includes
 #include "containers/array_1d.h"
-#include "includes/define.h"
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 
 // Application includes
 

--- a/applications/StructuralMechanicsApplication/custom_elements/nodal_elements/bushing_element.h
+++ b/applications/StructuralMechanicsApplication/custom_elements/nodal_elements/bushing_element.h
@@ -17,7 +17,7 @@
 
 // Project includes
 #include "includes/element.h"
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 
 namespace Kratos
 {

--- a/applications/StructuralMechanicsApplication/custom_elements/solid_elements/small_displacement_shifted_boundary_element.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/solid_elements/small_displacement_shifted_boundary_element.cpp
@@ -15,9 +15,8 @@
 
 // Project includes
 #include "includes/checks.h"
-#include "includes/define.h"
 #include "includes/kratos_flags.h"
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 #include "includes/variables.h"
 #include "utilities/geometry_utilities.h"
 

--- a/applications/StructuralMechanicsApplication/custom_strategies/custom_schemes/eigensolver_dynamic_scheme.hpp
+++ b/applications/StructuralMechanicsApplication/custom_strategies/custom_schemes/eigensolver_dynamic_scheme.hpp
@@ -19,11 +19,10 @@
 // External includes
 
 // Project includes
-#include "includes/define.h"
 #include "includes/element.h"
 #include "includes/condition.h"
 #include "includes/process_info.h"
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 #include "solving_strategies/schemes/scheme.h"
 
 // Application includes

--- a/applications/StructuralMechanicsApplication/custom_strategies/custom_strategies/direct_harmonic_analysis_strategy.hpp
+++ b/applications/StructuralMechanicsApplication/custom_strategies/custom_strategies/direct_harmonic_analysis_strategy.hpp
@@ -10,7 +10,7 @@
 // Project includes
 #include "solving_strategies/strategies/implicit_solving_strategy.h"
 #include "linear_solvers/linear_solver.h"
-#include "spaces/default_spaces.h"
+#include "spaces/ublas_space.h"
 #include "utilities/builtin_timer.h"
 #include "utilities/atomic_utilities.h"
 #include "utilities/entities_utilities.h"

--- a/applications/StructuralMechanicsApplication/custom_strategies/custom_strategies/direct_harmonic_analysis_strategy.hpp
+++ b/applications/StructuralMechanicsApplication/custom_strategies/custom_strategies/direct_harmonic_analysis_strategy.hpp
@@ -6,14 +6,11 @@
 #include <vector>
 
 // External includes
-#include <boost/numeric/ublas/matrix_sparse.hpp>
-#include <boost/numeric/ublas/vector.hpp>
-#include <boost/numeric/ublas/matrix.hpp>
 
 // Project includes
 #include "solving_strategies/strategies/implicit_solving_strategy.h"
 #include "linear_solvers/linear_solver.h"
-#include "spaces/ublas_space.h"
+#include "spaces/default_spaces.h"
 #include "utilities/builtin_timer.h"
 #include "utilities/atomic_utilities.h"
 #include "utilities/entities_utilities.h"

--- a/applications/StructuralMechanicsApplication/custom_strategies/custom_strategies/mechanical_explicit_strategy.hpp
+++ b/applications/StructuralMechanicsApplication/custom_strategies/custom_strategies/mechanical_explicit_strategy.hpp
@@ -22,7 +22,7 @@
 #include "utilities/variable_utils.h"
 #include "utilities/constraint_utilities.h"
 #include "utilities/parallel_utilities.h"
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 #include "includes/variables.h"
 
 namespace Kratos {

--- a/applications/StructuralMechanicsApplication/custom_utilities/constitutive_law_utilities.h
+++ b/applications/StructuralMechanicsApplication/custom_utilities/constitutive_law_utilities.h
@@ -18,7 +18,7 @@
 
 // Project includes
 
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 #include "includes/node.h"
 #include "geometries/geometry.h"
 #include "includes/constitutive_law.h"

--- a/applications/SwimmingDEMApplication/custom_elements/shell_rigid.h
+++ b/applications/SwimmingDEMApplication/custom_elements/shell_rigid.h
@@ -59,10 +59,9 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // External includes
 
 // Project includes
-#include "includes/define.h"
 #include "includes/serializer.h"
 #include "includes/element.h"
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 
 namespace Kratos
 {

--- a/applications/SystemIdentificationApplication/custom_sensors/displacement_sensor.h
+++ b/applications/SystemIdentificationApplication/custom_sensors/displacement_sensor.h
@@ -17,7 +17,7 @@
 // External includes
 
 // Project includes
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 #include "includes/element.h"
 
 // Application includes

--- a/applications/TrilinosApplication/custom_utilities/trilinos_mvqn_recursive_convergence_accelerator.hpp
+++ b/applications/TrilinosApplication/custom_utilities/trilinos_mvqn_recursive_convergence_accelerator.hpp
@@ -16,11 +16,9 @@
 #include "Epetra_SerialDenseSolver.h"
 
 /* Project includes */
-#include "includes/define.h"
 #include "includes/variables.h"
 #include "includes/kratos_parameters.h"
-#include "includes/ublas_interface.h"
-#include "solving_strategies/convergence_accelerators/convergence_accelerator.h"
+#include "includes/default_interface.h"
 
 namespace Kratos
 {

--- a/applications/TrilinosApplication/trilinos_space.h
+++ b/applications/TrilinosApplication/trilinos_space.h
@@ -36,7 +36,7 @@
 
 // Project includes
 #include "trilinos_application.h"
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 #include "spaces/ublas_space.h"
 #include "includes/data_communicator.h"
 #include "mpi/includes/mpi_data_communicator.h"

--- a/applications/TrilinosApplication/trilinos_space_experimental.h
+++ b/applications/TrilinosApplication/trilinos_space_experimental.h
@@ -39,7 +39,7 @@
 #include "trilinos_application.h"
 #include "custom_utilities/trilinos_matrix_market_io.h"
 #include "custom_utilities/trilinos_dof_updater_experimental.h"
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 #include "spaces/ublas_space.h"
 #include "includes/data_communicator.h"
 #include "mpi/includes/mpi_data_communicator.h"

--- a/kratos/benchmarks/mathutils_benchmark.cpp
+++ b/kratos/benchmarks/mathutils_benchmark.cpp
@@ -17,7 +17,7 @@
 
 // Project includes
 #include "utilities/math_utils.h"
-#include "includes/ublas_interface.h"  // Provides ZeroVector and Vector
+#include "includes/default_interface.h"  // Provides ZeroVector and Vector
 
 namespace Kratos
 {

--- a/kratos/containers/distributed_sparse_graph.h
+++ b/kratos/containers/distributed_sparse_graph.h
@@ -15,7 +15,13 @@
 // System includes
 #include <iostream>
 #include <mutex>
-#include "includes/ublas_interface.h"
+#include <unordered_map>
+#include <unordered_set>
+
+// External includes
+
+// Project includes
+#include "includes/default_interface.h"
 #include "includes/serializer.h"
 #include "includes/parallel_environment.h"
 #include "containers/distributed_numbering.h"
@@ -23,14 +29,6 @@
 #include "containers/sparse_graph.h"
 #include "containers/sparse_contiguous_row_graph.h"
 #include "utilities/parallel_utilities.h"
-
-// External includes
-#include <unordered_map>
-#include <unordered_set>
-
-// Project includes
-#include "includes/define.h"
-
 
 namespace Kratos
 {

--- a/kratos/containers/nd_data.h
+++ b/kratos/containers/nd_data.h
@@ -20,8 +20,7 @@
 #include <span/span.hpp>
 
 // Project includes
-#include "includes/define.h"
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 
 namespace Kratos {
 

--- a/kratos/containers/sparse_contiguous_row_graph.h
+++ b/kratos/containers/sparse_contiguous_row_graph.h
@@ -21,8 +21,7 @@
 #include <span/span.hpp>
 
 // Project includes
-#include "includes/define.h"
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 #include "includes/serializer.h"
 #include "includes/lock_object.h"
 #include "includes/parallel_environment.h"

--- a/kratos/containers/sparse_graph.h
+++ b/kratos/containers/sparse_graph.h
@@ -23,9 +23,8 @@
 #include <span/span.hpp>
 
 // Project includes
-#include "includes/define.h"
 #include "utilities/parallel_utilities.h"
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 #include "includes/serializer.h"
 #include "includes/parallel_environment.h"
 

--- a/kratos/elements/levelset_convection_element_simplex.h
+++ b/kratos/elements/levelset_convection_element_simplex.h
@@ -20,9 +20,8 @@
 // External includes
 
 // Project includes
-#include "includes/define.h"
 #include "includes/element.h"
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 #include "includes/variables.h"
 #include "includes/serializer.h"
 #include "includes/cfd_variables.h"

--- a/kratos/future/linear_solvers/amgcl_solver.h
+++ b/kratos/future/linear_solvers/amgcl_solver.h
@@ -28,15 +28,13 @@
 // External includes
 #include <boost/range/iterator_range.hpp>
 #include <boost/property_tree/json_parser.hpp>
+#include <amgcl/coarsening/rigid_body_modes.hpp>
 
 // Project includes
 #include "future/containers/linear_system.h"
 #include "future/linear_solvers/linear_solver.h"
-#include "includes/define.h"
 #include "includes/kratos_parameters.h"
-#include "includes/ublas_interface.h"
-
-#include <amgcl/coarsening/rigid_body_modes.hpp>
+#include "includes/default_interface.h"
 
 namespace Kratos::Future
 {

--- a/kratos/geometries/geometry_data.h
+++ b/kratos/geometries/geometry_data.h
@@ -18,7 +18,7 @@
 // External includes
 
 // Project includes
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 #include "integration/integration_point.h"
 #include "geometries/geometry_dimension.h"
 #include "geometries/geometry_shape_function_container.h"

--- a/kratos/geometries/geometry_shape_function_container.h
+++ b/kratos/geometries/geometry_shape_function_container.h
@@ -22,8 +22,7 @@
 // External includes
 
 // Project includes
-#include "includes/define.h"
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 #include "includes/serializer.h"
 #include "integration/integration_point.h"
 

--- a/kratos/includes/constitutive_law.h
+++ b/kratos/includes/constitutive_law.h
@@ -20,7 +20,6 @@
 /* External includes */
 
 /* Project includes */
-#include "includes/define.h"
 #include "includes/serializer.h"
 #include "includes/variables.h"
 #include "includes/node.h"
@@ -28,7 +27,7 @@
 #include "geometries/geometry.h"
 #include "utilities/math_utils.h"
 #include "includes/process_info.h"
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 #include "includes/kratos_parameters.h"
 #include "containers/data_value_container.h"
 #include "containers/flags.h"

--- a/kratos/includes/default_interface.h
+++ b/kratos/includes/default_interface.h
@@ -1,0 +1,33 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
+//
+//  Main authors:    Vicente Mataix Ferrandiz
+//
+
+#pragma once
+
+// The Kratos dense/sparse linear-algebra interface (Matrix, Vector,
+// DenseMatrix, BoundedMatrix, array_1d-compatible operations, CompressedMatrix,
+// prod/trans/noalias/..., the proxies and the lazy factories), resolved at
+// configure time through the KRATOS_LINEAR_ALGEBRA_BACKEND CMake option:
+// "eigen" (which defines KRATOS_USE_EIGEN_BACKEND) selects the Eigen-backed
+// types and the pure-Eigen implementation of the uBLAS idiom, "ublas" (the
+// default) keeps the boost::numeric::ublas types. This is the header to
+// include; it is the counterpart of spaces/default_spaces.h for the containers.
+//
+// NOTE: the backend define changes the meaning of the aliases and hence the
+// mangled names of everything instantiated with them. The define is set
+// globally by the root CMakeLists.txt; never mix binaries compiled with
+// different KRATOS_LINEAR_ALGEBRA_BACKEND values.
+
+#ifdef KRATOS_USE_EIGEN_BACKEND
+#include "includes/eigen_interface.h"
+#else
+#include "includes/ublas_interface.h"
+#endif

--- a/kratos/includes/default_interface.h
+++ b/kratos/includes/default_interface.h
@@ -12,22 +12,4 @@
 
 #pragma once
 
-// The Kratos dense/sparse linear-algebra interface (Matrix, Vector,
-// DenseMatrix, BoundedMatrix, array_1d-compatible operations, CompressedMatrix,
-// prod/trans/noalias/..., the proxies and the lazy factories), resolved at
-// configure time through the KRATOS_LINEAR_ALGEBRA_BACKEND CMake option:
-// "eigen" (which defines KRATOS_USE_EIGEN_BACKEND) selects the Eigen-backed
-// types and the pure-Eigen implementation of the uBLAS idiom, "ublas" (the
-// default) keeps the boost::numeric::ublas types. This is the header to
-// include; it is the counterpart of spaces/default_spaces.h for the containers.
-//
-// NOTE: the backend define changes the meaning of the aliases and hence the
-// mangled names of everything instantiated with them. The define is set
-// globally by the root CMakeLists.txt; never mix binaries compiled with
-// different KRATOS_LINEAR_ALGEBRA_BACKEND values.
-
-#ifdef KRATOS_USE_EIGEN_BACKEND
-#include "includes/eigen_interface.h"
-#else
 #include "includes/ublas_interface.h"
-#endif

--- a/kratos/includes/dem_variables.h
+++ b/kratos/includes/dem_variables.h
@@ -20,7 +20,7 @@
 #include "includes/define.h"
 #include "containers/variable.h"
 #include "includes/kratos_components.h"
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 #include "containers/array_1d.h"
 
 #undef  KRATOS_EXPORT_MACRO

--- a/kratos/includes/kratos.h
+++ b/kratos/includes/kratos.h
@@ -4,15 +4,14 @@
 //   _|\_\_|  \__,_|\__|\___/ ____/
 //                   Multi-Physics 
 //
-//  License:		 BSD License 
-//					 Kratos default license: kratos/license.txt
+//  License:         BSD License 
+//                   Kratos default license: kratos/license.txt
 //
 //  Main authors:    Pooyan Dadvand
 //                    
 //
 
-#if !defined(KRATOS_KRATOS_H_INCLUDED )
-#define  KRATOS_KRATOS_H_INCLUDED
+#pragma once
 
 ///@defgroup KratosCore Kratos Core
 ///@brief The Kratos core comprises a basic set of classes used by all applications.
@@ -22,8 +21,7 @@
 // External includes
 
 // Project includes
-#include "includes/define.h"
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 #include "geometries/point.h"
 
 namespace Kratos
@@ -32,6 +30,3 @@ namespace Kratos
 
 
 }  // namespace Kratos.
-
-#endif // KRATOS_KRATOS_H_INCLUDED  defined 
-

--- a/kratos/includes/kratos_parameters.h
+++ b/kratos/includes/kratos_parameters.h
@@ -21,7 +21,7 @@
 
 // Project includes
 #include "includes/serializer.h"
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 
 namespace Kratos
 {

--- a/kratos/includes/mat_variables.h
+++ b/kratos/includes/mat_variables.h
@@ -21,7 +21,7 @@
 #include "includes/define.h"
 #include "containers/variable.h"
 #include "includes/kratos_components.h"
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 #include "containers/array_1d.h"
 
 #undef  KRATOS_EXPORT_MACRO

--- a/kratos/includes/variables.h
+++ b/kratos/includes/variables.h
@@ -18,7 +18,7 @@
 
 // Project includes
 #include "includes/kratos_components.h"
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 #include "containers/array_1d.h"
 #include "containers/global_pointers_vector.h"
 #include "containers/periodic_variables_container.h"

--- a/kratos/linear_solvers/amgcl_ns_solver.h
+++ b/kratos/linear_solvers/amgcl_ns_solver.h
@@ -24,7 +24,7 @@
 #include <iostream>
 #include <utility>
 
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 
 // Project includes
 #include "includes/define.h"

--- a/kratos/modeler/internals/skin_intersection.h
+++ b/kratos/modeler/internals/skin_intersection.h
@@ -17,7 +17,7 @@
 // External includes
 
 // Project includes
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 #include "utilities/divide_triangle_3d_3.h"
 
 namespace Kratos::Internals {

--- a/kratos/processes/graph_coloring_process.h
+++ b/kratos/processes/graph_coloring_process.h
@@ -20,9 +20,8 @@
 // External includes
 
 // Project includes
-#include "includes/define.h"
 #include "processes/process.h"
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 
 namespace Kratos
 {

--- a/kratos/processes/structured_mesh_generator_process.cpp
+++ b/kratos/processes/structured_mesh_generator_process.cpp
@@ -25,7 +25,7 @@
 #include "geometries/tetrahedra_3d_4.h"
 #include "includes/checks.h"
 #include "processes/skin_detection_process.h"
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 
 namespace Kratos
 {

--- a/kratos/python/add_matrix_market_interface_to_python.cpp
+++ b/kratos/python/add_matrix_market_interface_to_python.cpp
@@ -18,7 +18,7 @@
 // Project includes
 #include "includes/define_python.h"
 #include "includes/matrix_market_interface.h"
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 #include "includes/ublas_complex_interface.h"
 #include "python/add_matrix_market_interface_to_python.h"
 

--- a/kratos/python/add_matrix_to_python.cpp
+++ b/kratos/python/add_matrix_to_python.cpp
@@ -17,7 +17,7 @@
 
 // Project includes
 #include "includes/define_python.h"
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 #include "includes/ublas_complex_interface.h"
 #include "add_matrix_to_python.h"
 #include "containers/array_1d.h"

--- a/kratos/python/add_sparse_matrices_to_python.cpp
+++ b/kratos/python/add_sparse_matrices_to_python.cpp
@@ -17,7 +17,7 @@
 
 // Project includes
 #include "includes/define_python.h"
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 #include "python/add_sparse_matrices_to_python.h"
 #include "python/numpy_utils.h"
 #include "containers/nd_data.h"

--- a/kratos/python/add_vector_to_python.cpp
+++ b/kratos/python/add_vector_to_python.cpp
@@ -18,7 +18,7 @@
 
 // Project includes
 #include "includes/define_python.h"
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 #include "includes/ublas_complex_interface.h"
 #include "containers/array_1d.h"
 #include "python/add_vector_to_python.h"

--- a/kratos/response_functions/adjoint_response_function.h
+++ b/kratos/response_functions/adjoint_response_function.h
@@ -4,8 +4,8 @@
 //   _|\_\_|  \__,_|\__|\___/ ____/
 //                   Multi-Physics
 //
-//  License:		 BSD License
-//					 Kratos default license: kratos/license.txt
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
 //
 //  Main authors:
 //
@@ -18,11 +18,10 @@
 // External includes
 
 // Project includes
-#include "includes/define.h"
 #include "includes/element.h"
 #include "includes/condition.h"
 #include "includes/process_info.h"
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 #include "containers/array_1d.h"
 #include "containers/variable.h"
 

--- a/kratos/solving_strategies/schemes/residual_based_adjoint_static_scheme.h
+++ b/kratos/solving_strategies/schemes/residual_based_adjoint_static_scheme.h
@@ -4,8 +4,8 @@
 //   _|\_\_|  \__,_|\__|\___/ ____/
 //                   Multi-Physics
 //
-//  License:		 BSD License
-//					 Kratos default license: kratos/license.txt
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
 //
 //  Main authors:
 //
@@ -19,8 +19,7 @@
 // External includes
 
 // Project includes
-#include "includes/define.h"
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 #include "utilities/openmp_utils.h"
 #include "solving_strategies/schemes/scheme.h"
 #include "response_functions/adjoint_response_function.h"

--- a/kratos/sources/matrix_market_interface.cpp
+++ b/kratos/sources/matrix_market_interface.cpp
@@ -15,7 +15,7 @@
 // External includes
 
 // Project includes
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 #include "includes/ublas_complex_interface.h"
 #include "spaces/ublas_space.h"
 #include "includes/matrix_market_interface.h"

--- a/kratos/spaces/kratos_space.h
+++ b/kratos/spaces/kratos_space.h
@@ -4,8 +4,8 @@
 //   _|\_\_|  \__,_|\__|\___/ ____/
 //                   Multi-Physics
 //
-//  License:		 BSD License
-//					 Kratos default license: kratos/license.txt
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
 //
 //  Main authors:    Riccardo Rossi
 //
@@ -14,23 +14,16 @@
 #if !defined(KRATOS_SPACE_H_INCLUDED )
 #define  KRATOS_SPACE_H_INCLUDED
 
-
-
 // System includes
 #include <string>
 #include <iostream>
 #include <cstddef>
 #include <numeric>
 
-
-
-
 // External includes
 
-
 // Project includes
-#include "includes/define.h"
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 #include "includes/matrix_market_interface.h"
 #include "utilities/dof_updater.h"
 #include "containers/csr_matrix.h"

--- a/kratos/tensor_adaptors/connectivity_ids_tensor_adaptor.h
+++ b/kratos/tensor_adaptors/connectivity_ids_tensor_adaptor.h
@@ -19,7 +19,7 @@
 
 // Project includes
 #include "tensor_adaptor.h"
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 #include "utilities/data_type_traits.h"
 
 namespace Kratos {

--- a/kratos/tensor_adaptors/fixity_tensor_adaptor.h
+++ b/kratos/tensor_adaptors/fixity_tensor_adaptor.h
@@ -19,7 +19,7 @@
 
 // Project includes
 #include "tensor_adaptor.h"
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 #include "utilities/data_type_traits.h"
 
 namespace Kratos {

--- a/kratos/tensor_adaptors/geometries_tensor_adaptor.h
+++ b/kratos/tensor_adaptors/geometries_tensor_adaptor.h
@@ -20,7 +20,7 @@
 // Project includes
 #include "geometries/geometry_data.h"
 #include "tensor_adaptor.h"
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 #include "utilities/data_type_traits.h"
 
 namespace Kratos

--- a/kratos/tests/cpp_tests/geometries/cross_check_shape_functions_values.h
+++ b/kratos/tests/cpp_tests/geometries/cross_check_shape_functions_values.h
@@ -21,7 +21,7 @@
 // Project includes
 #include "geometries/geometry.h"
 #include "includes/node.h"
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 
 namespace Kratos {
 namespace Testing {

--- a/kratos/tests/cpp_tests/geometries/test_nurbs_curve_shape_functions.cpp
+++ b/kratos/tests/cpp_tests/geometries/test_nurbs_curve_shape_functions.cpp
@@ -17,7 +17,7 @@
 // External includes
 
 // Project includes
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 #include "testing/testing.h"
 #include "geometries/nurbs_shape_function_utilities/nurbs_curve_shape_functions.h"
 

--- a/kratos/tests/cpp_tests/geometries/test_nurbs_surface_shape_functions.cpp
+++ b/kratos/tests/cpp_tests/geometries/test_nurbs_surface_shape_functions.cpp
@@ -17,7 +17,7 @@
 // External includes
 
 // Project includes
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 #include "testing/testing.h"
 #include "geometries/nurbs_shape_function_utilities/nurbs_surface_shape_functions.h"
 

--- a/kratos/tests/cpp_tests/geometries/test_shape_function_derivatives.h
+++ b/kratos/tests/cpp_tests/geometries/test_shape_function_derivatives.h
@@ -21,7 +21,7 @@
 // Project includes
 #include "geometries/geometry.h"
 #include "includes/node.h"
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 
 namespace Kratos {
 namespace Testing {

--- a/kratos/tests/cpp_tests/strategies/strategies/explicit_strategy_testing_utils.h
+++ b/kratos/tests/cpp_tests/strategies/strategies/explicit_strategy_testing_utils.h
@@ -19,12 +19,10 @@
 
 /* Project includes */
 #include "containers/array_1d.h"
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 #include "testing/testing.h"
 #include "containers/model.h"
 #include "geometries/point_3d.h"
-#include "includes/define.h"
-#include "includes/model_part.h"
 #include "spaces/ublas_space.h"
 #include "tests/test_utilities/test_element.h"
 #include "solving_strategies/builder_and_solvers/residualbased_block_builder_and_solver.h"

--- a/kratos/tests/cpp_tests/utilities/test_debug_helpers.cpp
+++ b/kratos/tests/cpp_tests/utilities/test_debug_helpers.cpp
@@ -13,7 +13,7 @@
 
 // Project includes
 #include "includes/debug_helpers.h"
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 #include "testing/testing.h"
 
 namespace Kratos

--- a/kratos/utilities/data_type_traits.h
+++ b/kratos/utilities/data_type_traits.h
@@ -21,7 +21,7 @@
 
 // Project includes
 #include "containers/array_1d.h"
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 
 namespace Kratos {
 

--- a/kratos/utilities/geometrical_sensitivity_utility.h
+++ b/kratos/utilities/geometrical_sensitivity_utility.h
@@ -20,7 +20,7 @@
 
 // Project includes
 #include "includes/define.h"
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 
 // Application includes
 

--- a/kratos/utilities/geometrical_transformation_utilities.h
+++ b/kratos/utilities/geometrical_transformation_utilities.h
@@ -20,7 +20,7 @@
 
 // Project includes
 #include "includes/define.h"
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 
 namespace Kratos
 {

--- a/kratos/utilities/math_utils.h
+++ b/kratos/utilities/math_utils.h
@@ -25,7 +25,7 @@
 
 // Project includes
 #include "input_output/logger.h"
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 #include "includes/global_variables.h"
 #include "containers/array_1d.h"
 
@@ -94,7 +94,7 @@ public:
     using IndexType = std::size_t;
 
     /// The indirect array type
-    using IndirectArrayType = boost::numeric::ublas::indirect_array<DenseVector<std::size_t>>;
+    using IndirectArrayType = indirect_array<DenseVector<std::size_t>>;
 
     /// The machine precision
     static constexpr double ZeroTolerance = std::numeric_limits<double>::epsilon();
@@ -623,7 +623,6 @@ public:
                 return Det4(rA);
             default:
                 double det = 1.0;
-                using namespace boost::numeric::ublas;
                 typedef permutation_matrix<SizeType> pmatrix;
                 Matrix Aux(rA);
                 pmatrix pm(Aux.size1());

--- a/kratos/utilities/mls_shape_functions_utility.h
+++ b/kratos/utilities/mls_shape_functions_utility.h
@@ -21,7 +21,7 @@
 // Project includes
 #include "containers/array_1d.h"
 #include "includes/define.h"
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 
 namespace Kratos
 {

--- a/kratos/utilities/sensitivity_builder.cpp
+++ b/kratos/utilities/sensitivity_builder.cpp
@@ -20,7 +20,7 @@
 #include "containers/global_pointers_vector.h"
 #include "includes/kratos_parameters.h"
 #include "includes/parallel_environment.h"
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 #include "input_output/logger.h"
 #include "solving_strategies/schemes/sensitivity_builder_scheme.h"
 #include "utilities/openmp_utils.h"

--- a/kratos/utilities/tessellation_utilities/curve_tessellation.h
+++ b/kratos/utilities/tessellation_utilities/curve_tessellation.h
@@ -22,7 +22,7 @@
 #include "geometries/geometry.h"
 #include "geometries/nurbs_curve_geometry.h"
 
-#include "includes/ublas_interface.h"
+#include "includes/default_interface.h"
 #include "containers/array_1d.h"
 
 namespace Kratos {


### PR DESCRIPTION
---
name: ✨ Feature
about: Introduce `default_interface.h` as unified linear-algebra backend header

---

## **📝 Description**

- Adds `kratos/includes/default_interface.h`, a single indirection header that currently includes `includes/ublas_interface.h` (mirrors the intent of `spaces/default_spaces.h`).
- Replaces `#include "includes/ublas_interface.h"` with `#include "includes/default_interface.h"` across the core and applications (~190 files).
- Simplifies `kratos/includes/kratos.h` to include `default_interface.h` instead of `define.h` + `ublas_interface.h` directly, and switches its include guard to `#pragma once`.

### Why

Prep work for decoupling Kratos from a hardcoded uBLAS backend: routing every include through one header lets the backend be swapped (e.g. to Eigen) in a follow-up PR without touching call sites again. This PR only introduces the indirection, no behavior change, uBLAS remains the backend.

## **🆕 Changelog**

- [Replace `ublas_interface` with `default_interface` across the codebase](https://github.com/KratosMultiphysics/Kratos/commit/b72efc8325aadfd8b6e518907a67c2d6b7873d73)
